### PR TITLE
fix(ci): run check/build/types in root workspace only

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,13 +16,13 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Check code
-        run: pnpm check
+        run: pnpm -w check
 
       - name: Check build
-        run: pnpm build
+        run: pnpm -w build
 
       - name: Check types
-        run: pnpm check:types
+        run: pnpm -w check:types
 
   test-localnet:
     name: 'Test Runtime (env: localnet, tag: ${{ matrix.tag }})'


### PR DESCRIPTION
pnpm was running `check:types` recursively across all workspace packages, failing because sub-packages don't have the script. Use `pnpm -w` to target the root workspace.