### PR TITLE
fix(ci): use pnpm -r --if-present for check:types

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm -w build
 
       - name: Check types
-        run: pnpm -w check:types
+        run: pnpm -r --if-present check:types
 
   test-localnet:
     name: 'Test Runtime (env: localnet, tag: ${{ matrix.tag }})'


### PR DESCRIPTION
Recurse across all workspace packages for type checking, skipping packages that don't have the script.