### PR TITLE
fix(ci): grant contents:read to prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,8 @@
 name: Prerelease
 on: [push, pull_request]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
`permissions: {}` stripped all permissions including `contents: read`, causing checkout to fail with 'Repository not found' on a private repo.