### PR TITLE
feat: add Messenger module for cross-frame communication

### DIFF
--- a/src/core/Messenger.test-d.ts
+++ b/src/core/Messenger.test-d.ts
@@ -1,0 +1,42 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import type * as Messenger from './Messenger.js'
+
+describe('Payload', () => {
+  test('ready resolves to undefined', () => {
+    expectTypeOf<Messenger.Payload<'ready'>>().toEqualTypeOf<undefined>()
+  })
+
+  test('rpc-request resolves to RpcRequest shape', () => {
+    expectTypeOf<Messenger.Payload<'rpc-request'>>().toEqualTypeOf<{
+      id: number
+      jsonrpc: '2.0'
+      method: string
+      params?: unknown
+    }>()
+  })
+
+  test('rpc-response includes _request', () => {
+    expectTypeOf<Messenger.Payload<'rpc-response'>>().toMatchTypeOf<{
+      _request: { id: number; method: string }
+    }>()
+  })
+
+  test('close resolves to undefined', () => {
+    expectTypeOf<Messenger.Payload<'close'>>().toEqualTypeOf<undefined>()
+  })
+
+  test('__internal is a discriminated union on type', () => {
+    type Internal = Messenger.Payload<'__internal'>
+    expectTypeOf<Extract<Internal, { type: 'init' }>>().toMatchTypeOf<{
+      type: 'init'
+      mode: 'iframe' | 'popup'
+      referrer: { title: string; icon?: string | undefined }
+    }>()
+    expectTypeOf<Extract<Internal, { type: 'resize' }>>().toMatchTypeOf<{
+      type: 'resize'
+      height?: number | undefined
+      width?: number | undefined
+    }>()
+  })
+})

--- a/src/core/Messenger.test.ts
+++ b/src/core/Messenger.test.ts
@@ -29,15 +29,7 @@ describe('fromWindow', () => {
 
   test('behavior: filters by targetOrigin', () => {
     const listeners: Array<(event: MessageEvent) => void> = []
-    const mockWindow = {
-      addEventListener(_: string, handler: (event: MessageEvent) => void) {
-        listeners.push(handler)
-      },
-      removeEventListener() {},
-      postMessage() {},
-    } as unknown as Window
-
-    const messenger = Messenger.fromWindow(mockWindow, {
+    const messenger = Messenger.fromWindow(fakeWindow(listeners), {
       targetOrigin: 'https://auth.tempo.xyz',
     })
 
@@ -113,6 +105,188 @@ describe('fromWindow', () => {
         resolve()
       }, 50)
     })
+  })
+
+  test('behavior: ignores messages without _tempo marker', () => {
+    const listeners: Array<(event: MessageEvent) => void> = []
+    const w = fakeWindow(listeners)
+
+    const messenger = Messenger.fromWindow(w)
+    const fn = vi.fn()
+    messenger.on('rpc-request', fn)
+
+    for (const listener of listeners)
+      listener({
+        data: { topic: 'rpc-request', payload: { id: 1 } },
+      } as MessageEvent)
+
+    expect(fn).not.toHaveBeenCalled()
+    messenger.destroy()
+  })
+
+  test('behavior: ignores non-object and malformed event.data', () => {
+    const listeners: Array<(event: MessageEvent) => void> = []
+    const w = fakeWindow(listeners)
+
+    const messenger = Messenger.fromWindow(w)
+    const fn = vi.fn()
+    messenger.on('rpc-request', fn)
+
+    for (const data of [null, undefined, 42, 'hello', [], { _tempo: true }])
+      for (const listener of listeners) listener({ data } as MessageEvent)
+
+    expect(fn).not.toHaveBeenCalled()
+    messenger.destroy()
+  })
+
+  test('behavior: filters by expectedSource', () => {
+    const listeners: Array<(event: MessageEvent) => void> = []
+    const w = fakeWindow(listeners)
+    const trustedSource = {} as MessageEventSource
+
+    const messenger = Messenger.fromWindow(w, { expectedSource: trustedSource })
+    const fn = vi.fn()
+    messenger.on('rpc-request', fn)
+
+    // Wrong source.
+    for (const listener of listeners)
+      listener({
+        data: {
+          topic: 'rpc-request',
+          payload: { id: 1, jsonrpc: '2.0', method: 'test' },
+          _tempo: true,
+        },
+        origin: '',
+        source: {} as MessageEventSource,
+      } as MessageEvent)
+
+    expect(fn).not.toHaveBeenCalled()
+
+    // Correct source.
+    for (const listener of listeners)
+      listener({
+        data: {
+          topic: 'rpc-request',
+          payload: { id: 1, jsonrpc: '2.0', method: 'test' },
+          _tempo: true,
+        },
+        origin: '',
+        source: trustedSource,
+      } as MessageEvent)
+
+    expect(fn).toHaveBeenCalledOnce()
+    messenger.destroy()
+  })
+
+  test('behavior: enforces both targetOrigin and expectedSource', () => {
+    const listeners: Array<(event: MessageEvent) => void> = []
+    const w = fakeWindow(listeners)
+    const trustedSource = {} as MessageEventSource
+
+    const messenger = Messenger.fromWindow(w, {
+      targetOrigin: 'https://auth.tempo.xyz',
+      expectedSource: trustedSource,
+    })
+    const fn = vi.fn()
+    messenger.on('rpc-request', fn)
+
+    const msg = {
+      topic: 'rpc-request',
+      payload: { id: 1, jsonrpc: '2.0', method: 'test' },
+      _tempo: true,
+    }
+
+    // Right origin, wrong source.
+    for (const listener of listeners)
+      listener({
+        data: msg,
+        origin: 'https://auth.tempo.xyz',
+        source: {} as MessageEventSource,
+      } as MessageEvent)
+    expect(fn).not.toHaveBeenCalled()
+
+    // Wrong origin, right source.
+    for (const listener of listeners)
+      listener({
+        data: msg,
+        origin: 'https://evil.com',
+        source: trustedSource,
+      } as MessageEvent)
+    expect(fn).not.toHaveBeenCalled()
+
+    // Both correct.
+    for (const listener of listeners)
+      listener({
+        data: msg,
+        origin: 'https://auth.tempo.xyz',
+        source: trustedSource,
+      } as MessageEvent)
+    expect(fn).toHaveBeenCalledOnce()
+    messenger.destroy()
+  })
+
+  test('behavior: wrong-topic messages do not notify unrelated listeners', () => {
+    const [a, b] = createPair()
+
+    const fn = vi.fn()
+    a.on('rpc-response', fn)
+
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
+
+    expect(fn).not.toHaveBeenCalled()
+    a.destroy()
+    b.destroy()
+  })
+
+  test('behavior: same listener registered twice fires twice', () => {
+    const [a, b] = createPair()
+
+    const calls: number[] = []
+    const fn = () => calls.push(1)
+    a.on('rpc-request', fn)
+    a.on('rpc-request', fn)
+
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        1,
+        1,
+      ]
+    `)
+    a.destroy()
+    b.destroy()
+  })
+
+  test('behavior: each unsubscribe removes only its own registration', () => {
+    const [a, b] = createPair()
+
+    const calls: string[] = []
+    const fn = () => calls.push('called')
+    const off1 = a.on('rpc-request', fn)
+    a.on('rpc-request', fn)
+
+    off1()
+
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        "called",
+      ]
+    `)
+    a.destroy()
+    b.destroy()
+  })
+
+  test('behavior: unsubscribe is idempotent', () => {
+    const [a] = createPair()
+
+    const off = a.on('rpc-request', () => {})
+    off()
+    expect(() => off()).not.toThrow()
+    a.destroy()
+    expect(() => off()).not.toThrow()
   })
 })
 
@@ -277,15 +451,142 @@ describe('bridge', () => {
     await expect(readyPromise).rejects.toThrow('Bridge destroyed')
   })
 
-  test('behavior: destroy cleans up', () => {
+  test('behavior: send after destroy does not deliver', () => {
+    const [from] = createPair()
+    const [toRemote, to] = createPair()
+
+    const b = Messenger.bridge({ from, to })
+
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
+
+    b.destroy()
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
+
+    expect(sent).toMatchInlineSnapshot('[]')
+  })
+
+  test('behavior: destroy is idempotent', () => {
     const [from] = createPair()
     const [, to] = createPair()
 
     const b = Messenger.bridge({ from, to })
 
-    // Should not throw after destroy.
     b.destroy()
+    expect(() => b.destroy()).not.toThrow()
+  })
+
+  test('behavior: duplicate ready flushes buffered queue exactly once', () => {
+    const [from, fromRemote] = createPair()
+    const [toRemote, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
+
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'first' })
+
+    fromRemote.send('ready', undefined)
+    fromRemote.send('ready', undefined)
+
+    expect(sent).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 1,
+          "jsonrpc": "2.0",
+          "method": "first",
+        },
+      ]
+    `)
+
+    b.destroy()
+  })
+
+  test('behavior: buffered sends are dropped if destroyed before ready', () => {
+    const [from] = createPair()
+    const [toRemote, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
+
     b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
+    b.destroy()
+
+    expect(sent).toMatchInlineSnapshot('[]')
+  })
+
+  test('behavior: buffered sends preserve FIFO order across ready', () => {
+    const [from, fromRemote] = createPair()
+    const [toRemote, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const sent: string[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload.method))
+
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'A' })
+    b.send('rpc-request', { id: 2, jsonrpc: '2.0', method: 'B' })
+
+    fromRemote.send('ready', undefined)
+
+    b.send('rpc-request', { id: 3, jsonrpc: '2.0', method: 'C' })
+
+    expect(sent).toMatchInlineSnapshot(`
+      [
+        "A",
+        "B",
+        "C",
+      ]
+    `)
+
+    b.destroy()
+  })
+
+  test('behavior: multiple waitForReady callers all resolve', async () => {
+    const [from, fromRemote] = createPair()
+    const [, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const p1 = b.waitForReady()
+    const p2 = b.waitForReady()
+
+    fromRemote.send('ready', undefined)
+
+    await Promise.all([p1, p2])
+
+    b.destroy()
+  })
+
+  test('behavior: multiple waitForReady callers all reject on destroy', async () => {
+    const [from] = createPair()
+    const [, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const p1 = b.waitForReady()
+    const p2 = b.waitForReady()
+
+    b.destroy()
+
+    await expect(p1).rejects.toThrow('Bridge destroyed')
+    await expect(p2).rejects.toThrow('Bridge destroyed')
+  })
+
+  test('behavior: waitForReady called after ready resolves immediately', async () => {
+    const [from, fromRemote] = createPair()
+    const [, to] = createPair()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    fromRemote.send('ready', undefined)
+
+    await b.waitForReady()
+
+    b.destroy()
   })
 })
 
@@ -314,6 +615,16 @@ describe('noop', () => {
     await b.waitForReady()
   })
 })
+
+function fakeWindow(listeners: Array<(event: MessageEvent) => void>) {
+  return {
+    addEventListener(_: string, handler: (event: MessageEvent) => void) {
+      listeners.push(handler)
+    },
+    removeEventListener() {},
+    postMessage() {},
+  } as unknown as Window
+}
 
 /** Creates a pair of synchronous in-memory messengers wired together. */
 function createPair(): [Messenger.Messenger, Messenger.Messenger] {

--- a/src/core/Messenger.test.ts
+++ b/src/core/Messenger.test.ts
@@ -4,7 +4,6 @@ import * as Messenger from './Messenger.js'
 
 describe('fromWindow', () => {
   test('default: sends and receives messages on a topic', () => {
-    // Use a MessageChannel to simulate two ends of a window pair.
     const channel = new MessageChannel()
     const sender = Messenger.fromWindow(channel.port1 as never)
     const receiver = Messenger.fromWindow(channel.port2 as never)
@@ -45,7 +44,6 @@ describe('fromWindow', () => {
     const fn = vi.fn()
     messenger.on('rpc-request', fn)
 
-    // Simulate a message from a different origin.
     for (const listener of listeners)
       listener({
         data: {
@@ -71,7 +69,6 @@ describe('fromWindow', () => {
     const fn = vi.fn()
     const off = receiver.on('rpc-request', fn)
 
-    // Unsubscribe before sending.
     off()
 
     return new Promise<void>((resolve) => {
@@ -81,7 +78,6 @@ describe('fromWindow', () => {
         method: 'test',
       })
 
-      // Give the message time to arrive (it shouldn't call fn).
       setTimeout(() => {
         expect(fn).not.toHaveBeenCalled()
         sender.destroy()
@@ -102,7 +98,6 @@ describe('fromWindow', () => {
     const fn = vi.fn()
     receiver.on('rpc-request', fn)
 
-    // Destroy receiver.
     receiver.destroy()
 
     return new Promise<void>((resolve) => {
@@ -122,35 +117,63 @@ describe('fromWindow', () => {
 })
 
 describe('bridge', () => {
-  test('default: on delegates to from, send delegates to to', () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+  test('default: sends and receives through bridge', () => {
+    const [from, fromRemote] = createPair()
+    const [toRemote, to] = createPair()
 
     const b = Messenger.bridge({ from, to })
 
-    const fn = vi.fn()
-    b.on('rpc-request', fn)
-    expect(from.on).toHaveBeenCalledWith('rpc-request', fn)
+    const received: unknown[] = []
+    b.on('rpc-request', (payload) => received.push(payload))
+
+    // Simulate the remote side sending a message.
+    fromRemote.send('rpc-request', {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_chainId',
+    })
+
+    expect(received).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 1,
+          "jsonrpc": "2.0",
+          "method": "eth_chainId",
+        },
+      ]
+    `)
+
+    // Send through bridge and verify it arrives on the remote side.
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
 
     b.send('rpc-request', {
-      id: 1,
+      id: 2,
       jsonrpc: '2.0',
-      method: 'test',
+      method: 'personal_sign',
     })
-    expect(to.send).toHaveBeenCalledWith('rpc-request', {
-      id: 1,
-      jsonrpc: '2.0',
-      method: 'test',
-    })
+
+    expect(sent).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 2,
+          "jsonrpc": "2.0",
+          "method": "personal_sign",
+        },
+      ]
+    `)
 
     b.destroy()
   })
 
-  test('behavior: waitForReady delays sends until ready', async () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+  test('behavior: waitForReady delays sends until ready', () => {
+    const [from, fromRemote] = createPair()
+    const [toRemote, to] = createPair()
 
     const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
 
     b.send('rpc-request', {
       id: 1,
@@ -158,39 +181,34 @@ describe('bridge', () => {
       method: 'test',
     })
 
-    // to.send should NOT have been called yet (only from.on for 'ready').
-    expect(to.send).not.toHaveBeenCalledWith('rpc-request', expect.anything())
+    // Not yet delivered — waiting for ready.
+    expect(sent).toMatchInlineSnapshot('[]')
 
-    // Simulate the remote frame signaling ready.
-    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
-      (c) => c[0] === 'ready',
-    )?.[1] as () => void
-    readyListener()
+    // Remote side signals ready.
+    fromRemote.send('ready', undefined)
 
-    // Wait for the ready promise microtask to flush.
-    await new Promise((r) => setTimeout(r, 10))
-
-    expect(to.send).toHaveBeenCalledWith('rpc-request', {
-      id: 1,
-      jsonrpc: '2.0',
-      method: 'test',
-    })
+    // Now the buffered send should have been delivered.
+    expect(sent).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 1,
+          "jsonrpc": "2.0",
+          "method": "test",
+        },
+      ]
+    `)
 
     b.destroy()
   })
 
   test('behavior: waitForReady resolves', async () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+    const [from, fromRemote] = createPair()
+    const [, to] = createPair()
 
     const b = Messenger.bridge({ from, to, waitForReady: true })
 
     const readyPromise = b.waitForReady()
-
-    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
-      (c) => c[0] === 'ready',
-    )?.[1] as () => void
-    readyListener()
+    fromRemote.send('ready', undefined)
 
     await readyPromise
 
@@ -198,49 +216,58 @@ describe('bridge', () => {
   })
 
   test('behavior: ready sends ready topic', () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+    const [from] = createPair()
+    const [toRemote, to] = createPair()
 
     const b = Messenger.bridge({ from, to })
 
+    const received: unknown[] = []
+    toRemote.on('ready', (payload) => received.push(payload))
+
     b.ready()
 
-    expect(to.send).toHaveBeenCalledWith('ready', undefined)
+    expect(received).toMatchInlineSnapshot(`
+      [
+        undefined,
+      ]
+    `)
 
     b.destroy()
   })
 
-  test('behavior: sends after ready go directly without buffering', async () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+  test('behavior: sends after ready go directly without buffering', () => {
+    const [from, fromRemote] = createPair()
+    const [toRemote, to] = createPair()
 
     const b = Messenger.bridge({ from, to, waitForReady: true })
 
-    // Simulate ready.
-    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
-      (c) => c[0] === 'ready',
-    )?.[1] as () => void
-    readyListener()
+    fromRemote.send('ready', undefined)
 
-    // Send after ready — should go directly to `to.send`.
+    const sent: unknown[] = []
+    toRemote.on('rpc-request', (payload) => sent.push(payload))
+
     b.send('rpc-request', {
       id: 2,
       jsonrpc: '2.0',
       method: 'post-ready',
     })
 
-    expect(to.send).toHaveBeenCalledWith('rpc-request', {
-      id: 2,
-      jsonrpc: '2.0',
-      method: 'post-ready',
-    })
+    expect(sent).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 2,
+          "jsonrpc": "2.0",
+          "method": "post-ready",
+        },
+      ]
+    `)
 
     b.destroy()
   })
 
   test('behavior: destroy rejects pending waitForReady', async () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+    const [from] = createPair()
+    const [, to] = createPair()
 
     const b = Messenger.bridge({ from, to, waitForReady: true })
 
@@ -251,14 +278,14 @@ describe('bridge', () => {
   })
 
   test('behavior: destroy cleans up', () => {
-    const from = mockMessenger()
-    const to = mockMessenger()
+    const [from] = createPair()
+    const [, to] = createPair()
 
     const b = Messenger.bridge({ from, to })
-    b.destroy()
 
-    expect(from.destroy).toHaveBeenCalled()
-    expect(to.destroy).toHaveBeenCalled()
+    // Should not throw after destroy.
+    b.destroy()
+    b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' })
   })
 })
 
@@ -288,10 +315,30 @@ describe('noop', () => {
   })
 })
 
-function mockMessenger(): Messenger.Messenger {
-  return {
-    destroy: vi.fn(),
-    on: vi.fn(() => () => {}),
-    send: vi.fn(),
+/** Creates a pair of synchronous in-memory messengers wired together. */
+function createPair(): [Messenger.Messenger, Messenger.Messenger] {
+  type Listener = { topic: string; fn: (payload: unknown) => void }
+  const aListeners: Listener[] = []
+  const bListeners: Listener[] = []
+
+  function create(own: Listener[], peer: Listener[]): Messenger.Messenger {
+    return Messenger.from({
+      destroy() {
+        own.length = 0
+      },
+      on(topic, listener) {
+        const entry = { topic, fn: listener as (payload: unknown) => void }
+        own.push(entry)
+        return () => {
+          const idx = own.indexOf(entry)
+          if (idx >= 0) own.splice(idx, 1)
+        }
+      },
+      send(topic, payload) {
+        for (const l of [...peer]) if (l.topic === topic) l.fn(payload)
+      },
+    })
   }
+
+  return [create(aListeners, bListeners), create(bListeners, aListeners)]
 }

--- a/src/core/Messenger.test.ts
+++ b/src/core/Messenger.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import * as Messenger from './Messenger.js'
+
+describe('fromWindow', () => {
+  test('default: sends and receives messages on a topic', () => {
+    // Use a MessageChannel to simulate two ends of a window pair.
+    const channel = new MessageChannel()
+    const sender = Messenger.fromWindow(channel.port1 as never)
+    const receiver = Messenger.fromWindow(channel.port2 as never)
+
+    channel.port1.start()
+    channel.port2.start()
+
+    return new Promise<void>((resolve) => {
+      const request = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'eth_chainId',
+      }
+      receiver.on('rpc-request', (payload) => {
+        expect(payload).toEqual(request)
+        sender.destroy()
+        receiver.destroy()
+        resolve()
+      })
+      sender.send('rpc-request', request)
+    })
+  })
+
+  test('behavior: filters by targetOrigin', () => {
+    const listeners: Array<(event: MessageEvent) => void> = []
+    const mockWindow = {
+      addEventListener(_: string, handler: (event: MessageEvent) => void) {
+        listeners.push(handler)
+      },
+      removeEventListener() {},
+      postMessage() {},
+    } as unknown as Window
+
+    const messenger = Messenger.fromWindow(mockWindow, {
+      targetOrigin: 'https://auth.tempo.xyz',
+    })
+
+    const fn = vi.fn()
+    messenger.on('rpc-request', fn)
+
+    // Simulate a message from a different origin.
+    for (const listener of listeners)
+      listener({
+        data: {
+          topic: 'rpc-request',
+          payload: { id: 1, jsonrpc: '2.0', method: 'test' },
+          _tempo: true,
+        },
+        origin: 'https://evil.com',
+      } as MessageEvent)
+
+    expect(fn).not.toHaveBeenCalled()
+    messenger.destroy()
+  })
+
+  test('behavior: on returns unsubscribe function', () => {
+    const channel = new MessageChannel()
+    const sender = Messenger.fromWindow(channel.port1 as never)
+    const receiver = Messenger.fromWindow(channel.port2 as never)
+
+    channel.port1.start()
+    channel.port2.start()
+
+    const fn = vi.fn()
+    const off = receiver.on('rpc-request', fn)
+
+    // Unsubscribe before sending.
+    off()
+
+    return new Promise<void>((resolve) => {
+      sender.send('rpc-request', {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'test',
+      })
+
+      // Give the message time to arrive (it shouldn't call fn).
+      setTimeout(() => {
+        expect(fn).not.toHaveBeenCalled()
+        sender.destroy()
+        receiver.destroy()
+        resolve()
+      }, 50)
+    })
+  })
+
+  test('behavior: destroy removes all listeners', () => {
+    const channel = new MessageChannel()
+    const sender = Messenger.fromWindow(channel.port1 as never)
+    const receiver = Messenger.fromWindow(channel.port2 as never)
+
+    channel.port1.start()
+    channel.port2.start()
+
+    const fn = vi.fn()
+    receiver.on('rpc-request', fn)
+
+    // Destroy receiver.
+    receiver.destroy()
+
+    return new Promise<void>((resolve) => {
+      sender.send('rpc-request', {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'test',
+      })
+
+      setTimeout(() => {
+        expect(fn).not.toHaveBeenCalled()
+        sender.destroy()
+        resolve()
+      }, 50)
+    })
+  })
+})
+
+describe('bridge', () => {
+  test('default: on delegates to from, send delegates to to', () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to })
+
+    const fn = vi.fn()
+    b.on('rpc-request', fn)
+    expect(from.on).toHaveBeenCalledWith('rpc-request', fn)
+
+    b.send('rpc-request', {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'test',
+    })
+    expect(to.send).toHaveBeenCalledWith('rpc-request', {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'test',
+    })
+
+    b.destroy()
+  })
+
+  test('behavior: waitForReady delays sends until ready', async () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    b.send('rpc-request', {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'test',
+    })
+
+    // to.send should NOT have been called yet (only from.on for 'ready').
+    expect(to.send).not.toHaveBeenCalledWith('rpc-request', expect.anything())
+
+    // Simulate the remote frame signaling ready.
+    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === 'ready',
+    )?.[1] as () => void
+    readyListener()
+
+    // Wait for the ready promise microtask to flush.
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(to.send).toHaveBeenCalledWith('rpc-request', {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'test',
+    })
+
+    b.destroy()
+  })
+
+  test('behavior: waitForReady resolves', async () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const readyPromise = b.waitForReady()
+
+    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === 'ready',
+    )?.[1] as () => void
+    readyListener()
+
+    await readyPromise
+
+    b.destroy()
+  })
+
+  test('behavior: ready sends ready topic', () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to })
+
+    b.ready()
+
+    expect(to.send).toHaveBeenCalledWith('ready', undefined)
+
+    b.destroy()
+  })
+
+  test('behavior: sends after ready go directly without buffering', async () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    // Simulate ready.
+    const readyListener = (from.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === 'ready',
+    )?.[1] as () => void
+    readyListener()
+
+    // Send after ready — should go directly to `to.send`.
+    b.send('rpc-request', {
+      id: 2,
+      jsonrpc: '2.0',
+      method: 'post-ready',
+    })
+
+    expect(to.send).toHaveBeenCalledWith('rpc-request', {
+      id: 2,
+      jsonrpc: '2.0',
+      method: 'post-ready',
+    })
+
+    b.destroy()
+  })
+
+  test('behavior: destroy rejects pending waitForReady', async () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to, waitForReady: true })
+
+    const readyPromise = b.waitForReady()
+    b.destroy()
+
+    await expect(readyPromise).rejects.toThrow('Bridge destroyed')
+  })
+
+  test('behavior: destroy cleans up', () => {
+    const from = mockMessenger()
+    const to = mockMessenger()
+
+    const b = Messenger.bridge({ from, to })
+    b.destroy()
+
+    expect(from.destroy).toHaveBeenCalled()
+    expect(to.destroy).toHaveBeenCalled()
+  })
+})
+
+describe('noop', () => {
+  test('default: send resolves without error', () => {
+    const b = Messenger.noop()
+    expect(() =>
+      b.send('rpc-request', { id: 1, jsonrpc: '2.0', method: 'test' }),
+    ).not.toThrow()
+  })
+
+  test('default: on returns noop unsubscribe', () => {
+    const b = Messenger.noop()
+    const off = b.on('rpc-request', () => {})
+    expect(typeof off).toBe('function')
+    expect(() => off()).not.toThrow()
+  })
+
+  test('default: destroy is callable', () => {
+    const b = Messenger.noop()
+    expect(() => b.destroy()).not.toThrow()
+  })
+
+  test('default: waitForReady resolves', async () => {
+    const b = Messenger.noop()
+    await b.waitForReady()
+  })
+})
+
+function mockMessenger(): Messenger.Messenger {
+  return {
+    destroy: vi.fn(),
+    on: vi.fn(() => () => {}),
+    send: vi.fn(),
+  }
+}

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -1,0 +1,217 @@
+/** Messenger interface for cross-frame communication. */
+export type Messenger = {
+  /** Tear down all listeners. */
+  destroy: () => void
+  /** Subscribe to a topic. Returns an unsubscribe function. */
+  on: <const topic extends Topic>(
+    topic: topic,
+    listener: (payload: Payload<topic>) => void,
+  ) => () => void
+  /** Send a message on a topic. */
+  send: <const topic extends Topic>(topic: topic, payload: Payload<topic>) => void
+}
+
+/** Bridge messenger that waits for a `ready` signal from the remote frame. */
+export type Bridge = Messenger & {
+  /** Signal readiness (called by the remote frame). */
+  ready: () => void
+  /** Promise that resolves when the remote frame signals ready. */
+  waitForReady: () => Promise<void>
+}
+
+/** Message schema for cross-frame communication. */
+export type Schema = [
+  {
+    topic: 'ready'
+    payload: undefined
+  },
+  {
+    topic: 'rpc-request'
+    payload: {
+      id: number
+      jsonrpc: '2.0'
+      method: string
+      params?: unknown
+    }
+  },
+  {
+    topic: 'rpc-response'
+    payload: {
+      id: number
+      jsonrpc: '2.0'
+      result?: unknown
+      error?: { code: number; message: string }
+      _request: { id: number; method: string }
+    }
+  },
+  {
+    topic: 'close'
+    payload: undefined
+  },
+  {
+    topic: '__internal'
+    payload:
+      | {
+          type: 'init'
+          mode: 'iframe' | 'popup'
+          referrer: { title: string; icon?: string | undefined }
+        }
+      | {
+          type: 'resize'
+          height?: number | undefined
+          width?: number | undefined
+        }
+  },
+]
+
+/** Union of all topic strings. */
+export type Topic = Schema[number]['topic']
+
+/** Payload for a given topic. */
+export type Payload<topic extends Topic> = Extract<Schema[number], { topic: topic }>['payload']
+
+type Message<topic extends Topic = Topic> = {
+  topic: topic
+  payload: Payload<topic>
+  /** Namespace to avoid collisions with other postMessage users. */
+  _tempo: true
+}
+
+/** Creates a messenger from a custom implementation. */
+export function from(messenger: Messenger): Messenger {
+  return messenger
+}
+
+/**
+ * Creates a messenger backed by `window.postMessage` / `addEventListener('message')`.
+ * Filters messages by `targetOrigin` when provided.
+ */
+export function fromWindow(
+  w: Window,
+  options: fromWindow.Options = {},
+): Messenger {
+  const { expectedSource, targetOrigin } = options
+  const listeners = new Set<(event: MessageEvent) => void>()
+
+  function handler(event: MessageEvent) {
+    for (const listener of listeners) listener(event)
+  }
+  w.addEventListener('message', handler)
+
+  return {
+    destroy() {
+      w.removeEventListener('message', handler)
+      listeners.clear()
+    },
+    on(topic, listener) {
+      function onMessage(event: MessageEvent) {
+        const data = event.data as Message | undefined
+        if (!data?._tempo) return
+        if (data.topic !== topic) return
+        if (targetOrigin && event.origin !== targetOrigin) return
+        if (expectedSource && event.source !== expectedSource) return
+        listener(data.payload as never)
+      }
+      listeners.add(onMessage)
+      return () => {
+        listeners.delete(onMessage)
+      }
+    },
+    send(topic, payload) {
+      const message: Message = { topic, payload, _tempo: true } as never
+      if (targetOrigin) w.postMessage(message, targetOrigin)
+      else w.postMessage(message)
+    },
+  }
+}
+
+export declare namespace fromWindow {
+  type Options = {
+    /** Expected `event.source` — rejects messages from other frames. */
+    expectedSource?: MessageEventSource | undefined
+    /** Only accept messages from this origin. Also used as the `targetOrigin` for `postMessage`. */
+    targetOrigin?: string | undefined
+  }
+}
+
+/**
+ * Bridges two window messengers. The bridge waits for a `ready` signal
+ * before sending messages when `waitForReady` is `true`.
+ */
+export function bridge(parameters: bridge.Parameters): Bridge {
+  const { from, to, waitForReady } = parameters
+
+  const { promise: readyPromise, resolve: resolveReady, reject: rejectReady } =
+    Promise.withResolvers<void>()
+  readyPromise.catch(() => {})
+
+  let destroyed = false
+  let readyReceived = false
+  
+  const pending: Array<() => void> = []
+
+  const offReady = from.on('ready', () => {
+    if (readyReceived) return
+    readyReceived = true
+    resolveReady()
+    for (const send of pending) send()
+    pending.length = 0
+  })
+
+  return {
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+      offReady()
+      from.destroy()
+      to.destroy()
+      pending.length = 0
+      rejectReady(new Error('Bridge destroyed'))
+    },
+    on(topic, listener) {
+      return from.on(topic, listener)
+    },
+    send(topic, payload) {
+      if (destroyed) return
+      if (waitForReady && !readyReceived) {
+        pending.push(() => {
+          if (!destroyed) to.send(topic, payload)
+        })
+        return
+      }
+      to.send(topic, payload)
+    },
+    ready() {
+      to.send('ready', undefined)
+    },
+    waitForReady() {
+      return readyPromise
+    },
+  }
+}
+
+export declare namespace bridge {
+  type Parameters = {
+    /** Listens on this messenger. */
+    from: Messenger
+    /** Sends to this messenger. */
+    to: Messenger
+    /** Buffer sends until `ready` is received. */
+    waitForReady?: boolean | undefined
+  }
+}
+
+/** Returns a no-op bridge for SSR environments. */
+export function noop(): Bridge {
+  return {
+    destroy() {},
+    on() {
+      return () => {}
+    },
+    send() {},
+    ready() {},
+    waitForReady() {
+      return Promise.resolve()
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * as Ceremony from './core/Ceremony.js'
+export * as Messenger from './core/Messenger.js'
 export * as Provider from './core/Provider.js'
 export * as Expiry from './core/Expiry.js'
 export * as Rpc from './core/zod/rpc.js'


### PR DESCRIPTION
Phase 1 of the connect adapter ([spec](./tasks/connect-adapter-spec.md)).

Adds `Messenger` — a typed transport layer for cross-frame JSON-RPC communication between windows (iframe/popup ↔ app).

### API

- `Messenger.from(messenger)` — define a custom messenger
- `Messenger.fromWindow(window, options?)` — `postMessage`-backed messenger with origin + source filtering
- `Messenger.bridge({ from, to, waitForReady? })` — bridges two messengers with ready-handshake buffering
- `Messenger.noop()` — SSR-safe no-op bridge

### Tests

- 15 unit tests (`Messenger.test.ts`)
- 5 type tests (`Messenger.test-d.ts`)

### Exported from `@tempoxyz/accounts`