### PR TITLE
feat: Dialog module (iframe, popup, noop)

### DIFF
--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -83,6 +83,95 @@ describe('Dialog.iframe', () => {
     handle.close()
     expect(document.body.style.overflow).toBe('auto')
   })
+
+  test('behavior: open is idempotent', () => {
+    const { handle } = setup()
+    handle.open()
+    expect(() => handle.open()).not.toThrow()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+    expect(dialog.open).toBe(true)
+    handle.close()
+  })
+
+  test('behavior: close without open does not throw', () => {
+    const { handle } = setup()
+    expect(() => handle.close()).not.toThrow()
+  })
+
+  test('behavior: destroy restores body scroll', () => {
+    const { handle } = setup()
+    document.body.style.overflow = 'auto'
+    handle.open()
+    handle.destroy()
+    expect(document.body.style.overflow).toBe('auto')
+  })
+
+  test('behavior: destroy closes open dialog', () => {
+    const { handle } = setup()
+    handle.open()
+    handle.destroy()
+    expect(document.querySelector('dialog[data-tempo-connect]')).toBeNull()
+  })
+
+  test('behavior: native cancel event restores body scroll', () => {
+    const { handle } = setup()
+    document.body.style.overflow = 'auto'
+    handle.open()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+    dialog.dispatchEvent(new Event('cancel'))
+    expect(document.body.style.overflow).toBe('auto')
+  })
+
+  test('behavior: focus restored to previous element on close', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    button.focus()
+    expect(document.activeElement).toBe(button)
+
+    const { handle } = setup()
+    handle.open()
+    handle.close()
+
+    expect(document.activeElement).toBe(button)
+    button.remove()
+  })
+
+  test('behavior: backdrop click closes dialog', () => {
+    const { handle } = setup()
+    handle.open()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+
+    // Clicking the dialog element itself (not a child) simulates backdrop click
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(dialog.open).toBe(false)
+    expect(document.body.style.overflow).not.toBe('hidden')
+  })
+
+  test('behavior: click inside iframe does not close dialog', () => {
+    const { handle } = setup()
+    handle.open()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+    const iframe = dialog.querySelector('iframe')!
+
+    iframe.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(dialog.open).toBe(true)
+  })
+
+  test('behavior: 1Password inert attribute stripped from dialog', async () => {
+    const { handle } = setup()
+    handle.open()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+
+    dialog.setAttribute('inert', '')
+
+    // MutationObserver fires asynchronously
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(dialog.hasAttribute('inert')).toBe(false)
+    handle.close()
+  })
 })
 
 describe('Dialog.popup', () => {
@@ -141,6 +230,18 @@ describe('Dialog.popup', () => {
     expect(popupClose).toHaveBeenCalledOnce()
 
     handle.destroy()
+    openSpy.mockRestore()
+  })
+
+  test('behavior: open throws if popup blocked', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    const messenger = Messenger.noop()
+    const dialog = Dialog.popup()
+    const handle = dialog.setup({ host, messenger })
+
+    expect(() => handle.open()).toThrow('Failed to open popup')
+
     openSpy.mockRestore()
   })
 

--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import * as Dialog from './Dialog.js'
 import * as Messenger from './Messenger.js'
@@ -82,5 +82,99 @@ describe('Dialog.iframe', () => {
     handle.open()
     handle.close()
     expect(document.body.style.overflow).toBe('auto')
+  })
+})
+
+describe('Dialog.popup', () => {
+  test('default: window.open called with correct URL', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      close: vi.fn(),
+    } as unknown as Window)
+
+    const messenger = Messenger.noop()
+    const dialog = Dialog.popup()
+    const handle = dialog.setup({ host, messenger })
+    handle.open()
+
+    expect(openSpy).toHaveBeenCalledOnce()
+    expect(openSpy.mock.calls[0]![0]).toBe(host)
+
+    handle.destroy()
+    openSpy.mockRestore()
+  })
+
+  test('behavior: window.open called with centered position', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      close: vi.fn(),
+    } as unknown as Window)
+
+    const messenger = Messenger.noop()
+    const dialog = Dialog.popup()
+    const handle = dialog.setup({ host, messenger })
+    handle.open()
+
+    const features = openSpy.mock.calls[0]![2] as string
+    expect(features).toContain('width=')
+    expect(features).toContain('height=')
+    expect(features).toContain('left=')
+    expect(features).toContain('top=')
+
+    handle.destroy()
+    openSpy.mockRestore()
+  })
+
+  test('behavior: close calls popup.close()', () => {
+    const popupClose = vi.fn()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      close: popupClose,
+    } as unknown as Window)
+
+    const messenger = Messenger.noop()
+    const dialog = Dialog.popup()
+    const handle = dialog.setup({ host, messenger })
+    handle.open()
+    handle.close()
+
+    expect(popupClose).toHaveBeenCalledOnce()
+
+    handle.destroy()
+    openSpy.mockRestore()
+  })
+
+  test('behavior: destroy cleans up', () => {
+    const popupClose = vi.fn()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      close: popupClose,
+    } as unknown as Window)
+
+    const messenger = Messenger.noop()
+    const dialog = Dialog.popup()
+    const handle = dialog.setup({ host, messenger })
+    handle.open()
+    handle.destroy()
+
+    expect(popupClose).toHaveBeenCalled()
+
+    openSpy.mockRestore()
+  })
+})
+
+describe('Dialog.noop', () => {
+  test('default: open, close, destroy are callable without error', () => {
+    const dialog = Dialog.noop()
+    const handle = dialog.setup({ host, messenger: Messenger.noop() })
+    expect(() => handle.open()).not.toThrow()
+    expect(() => handle.close()).not.toThrow()
+    expect(() => handle.destroy()).not.toThrow()
+  })
+})
+
+describe('isSafari', () => {
+  test('default: returns false in non-Safari environment', () => {
+    expect(Dialog.isSafari()).toBe(false)
   })
 })

--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'vitest'
+
+import * as Dialog from './Dialog.js'
+import * as Messenger from './Messenger.js'
+
+const host = 'https://auth.tempo.xyz'
+
+function setup() {
+  const messenger = Messenger.noop()
+  const dialog = Dialog.iframe()
+  const handle = dialog.setup({ host, messenger })
+  return { handle, messenger }
+}
+
+afterEach(() => {
+  document.querySelectorAll('dialog[data-tempo-connect]').forEach((el) => el.remove())
+  document.body.style.overflow = ''
+})
+
+describe('Dialog.iframe', () => {
+  test('default: appends dialog and iframe to document.body', () => {
+    setup()
+    const dialog = document.querySelector('dialog[data-tempo-connect]')
+    expect(dialog).not.toBeNull()
+    const iframe = dialog!.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+  })
+
+  test('behavior: iframe has correct sandbox attributes', () => {
+    setup()
+    const iframe = document.querySelector('dialog[data-tempo-connect] iframe')!
+    expect(iframe.getAttribute('sandbox')).toMatchInlineSnapshot(
+      `"allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"`,
+    )
+  })
+
+  test('behavior: iframe has correct allow attributes', () => {
+    setup()
+    const iframe = document.querySelector('dialog[data-tempo-connect] iframe')!
+    const allow = iframe.getAttribute('allow')!
+    expect(allow).toContain('publickey-credentials-get')
+    expect(allow).toContain('publickey-credentials-create')
+  })
+
+  test('behavior: iframe src points to host', () => {
+    setup()
+    const iframe = document.querySelector('dialog[data-tempo-connect] iframe') as HTMLIFrameElement
+    expect(iframe.src).toMatchInlineSnapshot(`"https://auth.tempo.xyz/"`)
+    expect(iframe.src).toContain(host)
+  })
+
+  test('behavior: open shows dialog', () => {
+    const { handle } = setup()
+    handle.open()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+    expect(dialog.open).toBe(true)
+  })
+
+  test('behavior: close hides dialog', () => {
+    const { handle } = setup()
+    handle.open()
+    handle.close()
+    const dialog = document.querySelector('dialog[data-tempo-connect]') as HTMLDialogElement
+    expect(dialog.open).toBe(false)
+  })
+
+  test('behavior: destroy removes dialog from DOM', () => {
+    const { handle } = setup()
+    handle.destroy()
+    expect(document.querySelector('dialog[data-tempo-connect]')).toBeNull()
+  })
+
+  test('behavior: body scroll locked on open', () => {
+    const { handle } = setup()
+    handle.open()
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  test('behavior: body scroll restored on close', () => {
+    const { handle } = setup()
+    document.body.style.overflow = 'auto'
+    handle.open()
+    handle.close()
+    expect(document.body.style.overflow).toBe('auto')
+  })
+})

--- a/src/core/Dialog.test-d.ts
+++ b/src/core/Dialog.test-d.ts
@@ -1,0 +1,18 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import type * as Dialog from './Dialog.js'
+import type * as Messenger from './Messenger.js'
+
+describe('Dialog', () => {
+  test('has name and setup returning open, close, destroy', () => {
+    expectTypeOf<Dialog.setup.Parameters>().toEqualTypeOf<{
+      host: string
+      messenger: Messenger.Bridge
+    }>()
+    expectTypeOf<Dialog.setup.ReturnType>().toEqualTypeOf<{
+      open: () => void
+      close: () => void
+      destroy: () => void
+    }>()
+  })
+})

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -1,0 +1,96 @@
+import type * as Messenger from './Messenger.js'
+
+/** Dialog interface — manages the iframe/popup lifecycle for cross-origin auth. */
+export type Dialog = {
+  /** Identifier for the dialog type (e.g. `'iframe'`, `'popup'`). */
+  name: string
+  /** Initialize the dialog with the given host and messenger. */
+  setup: (parameters: setup.Parameters) => setup.ReturnType
+}
+
+export declare namespace setup {
+  type Parameters = {
+    /** URL of the Tempo Auth app. */
+    host: string
+    /** Bridge messenger for cross-frame communication. */
+    messenger: Messenger.Bridge
+  }
+
+  type ReturnType = {
+    /** Close the dialog (hide iframe / close popup). */
+    close: () => void
+    /** Destroy the dialog (remove DOM elements, clean up). */
+    destroy: () => void
+    /** Open the dialog (show iframe / open popup). */
+    open: () => void
+  }
+}
+
+/** Creates a dialog from a custom implementation. */
+export function from(dialog: Dialog): Dialog {
+  return dialog
+}
+
+/** Creates an iframe dialog that embeds the auth app in a `<dialog>` element. */
+export function iframe(): Dialog {
+  if (typeof window === 'undefined') return noop()
+
+  return from({
+    name: 'iframe',
+    setup(parameters) {
+      const { host } = parameters
+      const hostUrl = new URL(host)
+
+      const root = document.createElement('dialog')
+      root.dataset.tempoConnect = ''
+
+      const frame = document.createElement('iframe')
+      frame.setAttribute(
+        'sandbox',
+        'allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox',
+      )
+      frame.setAttribute(
+        'allow',
+        [
+          `publickey-credentials-get ${hostUrl.origin}`,
+          `publickey-credentials-create ${hostUrl.origin}`,
+        ].join('; '),
+      )
+      frame.src = host
+
+      root.appendChild(frame)
+      document.body.appendChild(root)
+
+      let savedOverflow = ''
+
+      return {
+        open() {
+          savedOverflow = document.body.style.overflow
+          document.body.style.overflow = 'hidden'
+          root.showModal()
+        },
+        close() {
+          root.close()
+          document.body.style.overflow = savedOverflow
+        },
+        destroy() {
+          root.remove()
+        },
+      }
+    },
+  })
+}
+
+/** Returns a no-op dialog for SSR environments. */
+export function noop(): Dialog {
+  return from({
+    name: 'noop',
+    setup() {
+      return {
+        open() {},
+        close() {},
+        destroy() {},
+      }
+    },
+  })
+}

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -81,6 +81,66 @@ export function iframe(): Dialog {
   })
 }
 
+/** Opens the auth app in a new browser window. */
+export function popup(options: popup.Options = {}): Dialog {
+  if (typeof window === 'undefined') return noop()
+
+  const { size = { width: 360, height: 440 } } = options
+
+  return from({
+    name: 'popup',
+    setup(parameters) {
+      const { host } = parameters
+
+      let win: Window | null = null
+      let pollTimer: ReturnType<typeof setInterval> | undefined
+
+      return {
+        open() {
+          const left = Math.round((window.innerWidth - size.width) / 2 + window.screenX)
+          const top = Math.round(window.screenY + 100)
+          const features = `width=${size.width},height=${size.height},left=${left},top=${top}`
+          win = window.open(host, '_blank', features)
+
+          pollTimer = setInterval(() => {
+            if (win?.closed) {
+              clearInterval(pollTimer)
+              pollTimer = undefined
+              win = null
+            }
+          }, 100)
+        },
+        close() {
+          win?.close()
+          win = null
+        },
+        destroy() {
+          win?.close()
+          win = null
+          if (pollTimer) {
+            clearInterval(pollTimer)
+            pollTimer = undefined
+          }
+        },
+      }
+    },
+  })
+}
+
+export declare namespace popup {
+  type Options = {
+    /** Popup window dimensions. @default `{ width: 360, height: 440 }` */
+    size?: { width: number; height: number } | undefined
+  }
+}
+
+/** Detects Safari (which does not support WebAuthn in cross-origin iframes). */
+export function isSafari(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const ua = navigator.userAgent
+  return /Safari/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua)
+}
+
 /** Returns a no-op dialog for SSR environments. */
 export function noop(): Dialog {
   return from({

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -61,19 +61,46 @@ export function iframe(): Dialog {
       root.appendChild(frame)
       document.body.appendChild(root)
 
+      let isOpen = false
       let savedOverflow = ''
+      let opener: HTMLElement | null = null
+
+      function close() {
+        if (!isOpen) return
+        isOpen = false
+        root.close()
+        document.body.style.overflow = savedOverflow
+        opener?.focus()
+        opener = null
+      }
+
+      root.addEventListener('cancel', () => close())
+
+      root.addEventListener('click', (event) => {
+        if (event.target === root) close()
+      })
+
+      const inertObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.attributeName === 'inert') root.removeAttribute('inert')
+        }
+      })
+      inertObserver.observe(root, { attributes: true })
 
       return {
         open() {
+          if (isOpen) return
+          isOpen = true
+          if (document.activeElement instanceof HTMLElement)
+            opener = document.activeElement
           savedOverflow = document.body.style.overflow
           document.body.style.overflow = 'hidden'
           root.showModal()
         },
-        close() {
-          root.close()
-          document.body.style.overflow = savedOverflow
-        },
+        close,
         destroy() {
+          close()
+          inertObserver.disconnect()
           root.remove()
         },
       }
@@ -101,6 +128,7 @@ export function popup(options: popup.Options = {}): Dialog {
           const top = Math.round(window.screenY + 100)
           const features = `width=${size.width},height=${size.height},left=${left},top=${top}`
           win = window.open(host, '_blank', features)
+          if (!win) throw new Error('Failed to open popup')
 
           pollTimer = setInterval(() => {
             if (win?.closed) {
@@ -137,8 +165,8 @@ export declare namespace popup {
 /** Detects Safari (which does not support WebAuthn in cross-origin iframes). */
 export function isSafari(): boolean {
   if (typeof navigator === 'undefined') return false
-  const ua = navigator.userAgent
-  return /Safari/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua)
+  const ua = navigator.userAgent.toLowerCase()
+  return ua.includes('safari') && !ua.includes('chrome')
 }
 
 /** Returns a no-op dialog for SSR environments. */


### PR DESCRIPTION
Phase 2 of the connect adapter implementation plan.

## What

Adds `Dialog` module (`src/core/Dialog.ts`) — manages iframe/popup lifecycle for cross-origin auth with the Tempo Auth app.

### Factories
- `Dialog.iframe()` — `<dialog>` + `<iframe>` with sandbox/allow attrs, scroll locking, focus restore, backdrop click, native cancel handling, 1Password inert workaround
- `Dialog.popup()` — centered `window.open` with closed-window polling, throws on popup blocked
- `Dialog.noop()` — SSR-safe no-op
- `Dialog.isSafari()` — detects Safari for WebAuthn iframe restriction fallback

### Edge cases (audited against Porto)
- Idempotent open/close guards
- Focus restore to previous element on close
- Backdrop click closes dialog
- Native `cancel` event (Escape) restores scroll
- `destroy()` closes dialog + restores scroll before removing DOM
- 1Password `inert` attribute stripped via MutationObserver
- Popup blocked (`window.open` returns null) throws

### Tests
- 25 browser tests + type tests
- `tsc -b` clean