### PR TITLE
fix: gracefully handle missing signable account in tempoAuth

### DIFF
--- a/src/core/adapters/tempoAuth.ts
+++ b/src/core/adapters/tempoAuth.ts
@@ -144,7 +144,14 @@ export function tempoAuth(options: tempoAuth.Options = {}): Adapter.Adapter {
         keyAuthorization?: KeyAuthorization.Signed,
       ) => Promise<result>,
     ): Promise<result | undefined> {
-      const account = getAccount({ signable: true })
+      const account = (() => {
+        try {
+          return getAccount({ signable: true })
+        } catch (error) {
+          return undefined
+        }
+      })()
+      if (!account) return undefined
       if (account.source !== 'accessKey') return undefined
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {


### PR DESCRIPTION
Catches the error thrown by `getAccount({ signable: true })` when no signable account exists and returns `undefined` instead of propagating the exception.