### PR TITLE
refactor: consolidate fee payer handler & bump ox

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "idb-keyval": "^6.2.2",
     "mipd": "^0.0.7",
     "mppx": "^0.4.0",
-    "ox": "~0.14.0",
+    "ox": "~0.14.5",
     "webauthx": "https://pkg.pr.new/wevm/webauthx@a8d08a7",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -10,7 +10,7 @@ import { type Chain, type Client, createClient, http, type Transport } from 'vie
 import type { LocalAccount } from 'viem/accounts'
 import { signTransaction } from 'viem/actions'
 import { tempo, tempoModerato } from 'viem/chains'
-import { Formatters, Transaction } from 'viem/tempo'
+import { Transaction } from 'viem/tempo'
 import {
   Authentication,
   Registration,
@@ -271,68 +271,53 @@ export function feePayer(options: feePayer.Options) {
     try {
       await onRequest?.(request)
 
-      if (request.method === 'eth_signTransaction') {
-        const transactionRequest = Formatters.formatTransaction(request.params?.[0] as never)
-        const client = getClient(transactionRequest.chainId)
-
-        const serializedTransaction = await signTransaction(client, {
-          ...transactionRequest,
-          account,
-          // @ts-expect-error
-          feePayer: account,
-        })
-
-        return Response.json(RpcResponse.from({ result: serializedTransaction }, { request }))
-      }
-
-      if ((request as any).method === 'eth_signRawTransaction') {
-        const serialized = request.params?.[0] as `0x76${string}`
-        const transaction = Transaction.deserialize(serialized)
-        const client = getClient(transaction.chainId)
-
-        const serializedTransaction = await signTransaction(client, {
-          ...transaction,
-          account,
-          // @ts-expect-error
-          feePayer: account,
-        })
-
-        return Response.json(RpcResponse.from({ result: serializedTransaction }, { request }))
-      }
-
+      const method = request.method as string
       if (
-        request.method === 'eth_sendRawTransaction' ||
-        request.method === 'eth_sendRawTransactionSync'
-      ) {
-        const serialized = request.params?.[0] as `0x76${string}`
-        const transaction = Transaction.deserialize(serialized)
-        const client = getClient(transaction.chainId)
-
-        const serializedTransaction = await signTransaction(client, {
-          ...transaction,
-          account,
-          // @ts-expect-error
-          feePayer: account,
-        })
-
-        const result = await client.request({
-          method: request.method,
-          params: [serializedTransaction],
-        })
-
-        return Response.json(RpcResponse.from({ result }, { request }))
-      }
-
-      return Response.json(
-        RpcResponse.from(
-          {
-            error: new RpcResponse.MethodNotSupportedError({
-              message: `Method not supported: ${request.method}`,
-            }),
-          },
-          { request },
-        ),
+        method !== 'eth_signRawTransaction' &&
+        method !== 'eth_sendRawTransaction' &&
+        method !== 'eth_sendRawTransactionSync'
       )
+        return Response.json(
+          RpcResponse.from(
+            {
+              error: new RpcResponse.MethodNotSupportedError({
+                message: `Method not supported: ${request.method}`,
+              }),
+            },
+            { request },
+          ),
+        )
+
+      const serialized = request.params?.[0] as `0x76${string}`
+
+      if (!serialized?.startsWith('0x76') && !serialized?.startsWith('0x78'))
+        throw new RpcResponse.InvalidParamsError({
+          message: 'Only Tempo (0x76/0x78) transactions are supported.',
+        })
+
+      const transaction = Transaction.deserialize(serialized) as any
+
+      if (!transaction.signature || !transaction.from)
+        throw new RpcResponse.InvalidParamsError({
+          message: 'Transaction must be signed by the sender before fee payer signing.',
+        })
+
+      const client = getClient(transaction.chainId)
+      const serializedTransaction = await signTransaction(client, {
+        ...transaction,
+        account,
+        feePayer: account,
+      })
+
+      if (method === 'eth_signRawTransaction')
+        return Response.json(RpcResponse.from({ result: serializedTransaction }, { request }))
+
+      const result = await (client as any).request({
+        method,
+        params: [serializedTransaction],
+      })
+
+      return Response.json(RpcResponse.from({ result }, { request }))
     } catch (error) {
       return Response.json(
         RpcResponse.from(


### PR DESCRIPTION
- Bumps `ox` from `~0.14.0` to `~0.14.5`
- Consolidates the fee payer handler: removes separate `eth_signTransaction` path, unifies `eth_signRawTransaction` / `eth_sendRawTransaction` / `eth_sendRawTransactionSync` into a single code path
- Validates that only Tempo (0x76/0x78) transactions are accepted
- Requires transactions to be pre-signed by sender before fee payer signing
- Removes unused `Formatters` import