### PR TITLE
refactor: Dialog from object-with-setup to function-with-meta pattern

### DIFF
--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -12,7 +12,7 @@ function setup() {
     storage: Storage.memory({ key: 'dialog-test' }),
   })
   const dialog = Dialog.iframe()
-  const handle = dialog.setup({ host, store })
+  const handle = dialog({ host, store })
   return { handle, store }
 }
 
@@ -195,7 +195,7 @@ describe('Dialog.popup', () => {
       storage: Storage.memory({ key: 'popup-test' }),
     })
     const dialog = Dialog.popup()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
     handle.open()
 
     expect(openSpy).toHaveBeenCalledOnce()
@@ -216,7 +216,7 @@ describe('Dialog.popup', () => {
       storage: Storage.memory({ key: 'popup-test' }),
     })
     const dialog = Dialog.popup()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
     handle.open()
 
     const features = openSpy.mock.calls[0]![2] as string
@@ -241,7 +241,7 @@ describe('Dialog.popup', () => {
       storage: Storage.memory({ key: 'popup-test' }),
     })
     const dialog = Dialog.popup()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
     handle.open()
     handle.close()
 
@@ -259,7 +259,7 @@ describe('Dialog.popup', () => {
       storage: Storage.memory({ key: 'popup-test' }),
     })
     const dialog = Dialog.popup()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
 
     expect(() => handle.open()).toThrow('Failed to open popup')
 
@@ -278,7 +278,7 @@ describe('Dialog.popup', () => {
       storage: Storage.memory({ key: 'popup-test' }),
     })
     const dialog = Dialog.popup()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
     handle.open()
     handle.destroy()
 
@@ -295,7 +295,7 @@ describe('Dialog.noop', () => {
       storage: Storage.memory({ key: 'noop-test' }),
     })
     const dialog = Dialog.noop()
-    const handle = dialog.setup({ host, store })
+    const handle = dialog({ host, store })
     expect(() => handle.open()).not.toThrow()
     expect(() => handle.close()).not.toThrow()
     expect(() => handle.destroy()).not.toThrow()

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -2,38 +2,44 @@ import * as Messenger from './Messenger.js'
 import type * as Store from './Store.js'
 
 /** Dialog interface — manages the iframe/popup lifecycle for cross-origin auth. */
-export type Dialog = {
+export type Dialog = SetupFn & Meta
+
+/** Static metadata attached to a dialog function. */
+export type Meta = {
   /** Identifier for the dialog type (e.g. `'iframe'`, `'popup'`). */
-  name: string
-  /** Initialize the dialog with the given host and store. */
-  setup: (parameters: setup.Parameters) => setup.ReturnType
+  name?: string | undefined
 }
 
-export declare namespace setup {
+export type Instance = {
+  /** Close the dialog (hide iframe / close popup). */
+  close: () => void
+  /** Destroy the dialog (remove DOM elements, clean up). */
+  destroy: () => void
+  /** Open the dialog (show iframe / open popup). */
+  open: () => void
+  /** Sync the pending request queue to the remote auth app. */
+  syncRequests: (requests: readonly Store.QueuedRequest[]) => Promise<void>
+}
+
+/** The setup function a dialog must implement. */
+export type SetupFn = (parameters: SetupFn.Parameters) => Instance
+
+export declare namespace SetupFn {
   type Parameters = {
     /** URL of the Tempo Auth app. */
     host: string
     /** Reactive state store. */
     store: Store.Store
   }
-
-  type ReturnType = {
-    /** Close the dialog (hide iframe / close popup). */
-    close: () => void
-    /** Destroy the dialog (remove DOM elements, clean up). */
-    destroy: () => void
-    /** Open the dialog (show iframe / open popup). */
-    open: () => void
-    /** Sync the pending request queue to the remote auth app. */
-    syncRequests: (requests: readonly Store.QueuedRequest[]) => Promise<void>
-  }
 }
 
 export const defaultSize = { height: 440, width: 360 }
 
-/** Creates a dialog from a custom implementation. */
-export function from(dialog: Dialog): Dialog {
-  return dialog
+/** Creates a dialog from metadata and a setup function. */
+export function define(meta: Meta, fn: SetupFn): Dialog {
+  const { name, ...rest } = meta
+  Object.defineProperty(fn, 'name', { value: name, configurable: true })
+  return Object.assign(fn, rest) as Dialog
 }
 
 /** Detects Safari (which does not support WebAuthn in cross-origin iframes). */
@@ -47,215 +53,210 @@ export function isSafari(): boolean {
 export function iframe(): Dialog {
   if (typeof window === 'undefined') return noop()
 
-  return from({
-    name: 'iframe',
-    setup(parameters) {
-      const { host, store } = parameters
+  return define({ name: 'iframe' }, (parameters) => {
+    const { host, store } = parameters
 
-      const fallback = popup().setup(parameters)
+    const fallback = popup()(parameters)
 
-      let open = false
+    let open = false
 
-      const referrer = getReferrer()
+    const referrer = getReferrer()
 
-      const hostUrl = new URL(host)
-      hostUrl.searchParams.set('chainId', String(store.getState().chainId))
-      hostUrl.searchParams.set('mode', 'iframe')
-      if (referrer.icon) {
-        if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
-        else {
-          hostUrl.searchParams.set('icon', referrer.icon.light)
-          hostUrl.searchParams.set('iconDark', referrer.icon.dark)
-        }
+    const hostUrl = new URL(host)
+    hostUrl.searchParams.set('chainId', String(store.getState().chainId))
+    hostUrl.searchParams.set('mode', 'iframe')
+    if (referrer.icon) {
+      if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
+      else {
+        hostUrl.searchParams.set('icon', referrer.icon.light)
+        hostUrl.searchParams.set('iconDark', referrer.icon.dark)
       }
+    }
 
-      const root = document.createElement('dialog')
-      root.dataset.tempoWallet = ''
+    const root = document.createElement('dialog')
+    root.dataset.tempoWallet = ''
 
-      root.setAttribute('role', 'dialog')
-      root.setAttribute('aria-closed', 'true')
-      root.setAttribute('aria-label', 'Tempo Auth')
-      root.setAttribute('hidden', 'until-found')
+    root.setAttribute('role', 'dialog')
+    root.setAttribute('aria-closed', 'true')
+    root.setAttribute('aria-label', 'Tempo Auth')
+    root.setAttribute('hidden', 'until-found')
 
-      Object.assign(root.style, {
-        background: 'transparent',
-        border: '0',
-        outline: '0',
-        padding: '0',
-        position: 'fixed',
-      })
+    Object.assign(root.style, {
+      background: 'transparent',
+      border: '0',
+      outline: '0',
+      padding: '0',
+      position: 'fixed',
+    })
 
-      document.body.appendChild(root)
+    document.body.appendChild(root)
 
-      const frame = document.createElement('iframe')
-      frame.dataset.testid = 'tempo-wallet'
-      frame.setAttribute(
-        'sandbox',
-        'allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox',
-      )
-      frame.setAttribute(
-        'allow',
-        [
-          `publickey-credentials-get ${hostUrl.origin}`,
-          `publickey-credentials-create ${hostUrl.origin}`,
-        ].join('; '),
-      )
-      frame.setAttribute('allowtransparency', 'true')
-      frame.setAttribute('tabindex', '0')
-      frame.setAttribute('title', 'Tempo Auth')
-      frame.src = hostUrl.toString()
+    const frame = document.createElement('iframe')
+    frame.dataset.testid = 'tempo-wallet'
+    frame.setAttribute(
+      'sandbox',
+      'allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox',
+    )
+    frame.setAttribute(
+      'allow',
+      [
+        `publickey-credentials-get ${hostUrl.origin}`,
+        `publickey-credentials-create ${hostUrl.origin}`,
+      ].join('; '),
+    )
+    frame.setAttribute('allowtransparency', 'true')
+    frame.setAttribute('tabindex', '0')
+    frame.setAttribute('title', 'Tempo Auth')
+    frame.src = hostUrl.toString()
 
-      Object.assign(frame.style, {
-        backgroundColor: 'transparent',
-        border: '0',
-        colorScheme: 'light dark',
-        height: '100%',
-        left: '0',
-        position: 'fixed',
-        top: '0',
-        width: '100%',
-      })
+    Object.assign(frame.style, {
+      backgroundColor: 'transparent',
+      border: '0',
+      colorScheme: 'light dark',
+      height: '100%',
+      left: '0',
+      position: 'fixed',
+      top: '0',
+      width: '100%',
+    })
 
-      const style = document.createElement('style')
-      style.innerHTML = `
+    const style = document.createElement('style')
+    style.innerHTML = `
         dialog[data-tempo-wallet]::backdrop {
           background: transparent!important;
         }
       `
 
-      root.appendChild(style)
-      root.appendChild(frame)
+    root.appendChild(style)
+    root.appendChild(frame)
 
-      const messenger = Messenger.bridge({
-        from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
-        to: Messenger.fromWindow(frame.contentWindow!, {
-          targetOrigin: hostUrl.origin,
-        }),
-        waitForReady: true,
-      })
+    const messenger = Messenger.bridge({
+      from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
+      to: Messenger.fromWindow(frame.contentWindow!, {
+        targetOrigin: hostUrl.origin,
+      }),
+      waitForReady: true,
+    })
 
-      messenger.on('rpc-response', (response) => handleResponse(store, response))
+    messenger.on('rpc-response', (response) => handleResponse(store, response))
 
-      let savedOverflow = ''
-      let opener: HTMLElement | null = null
+    let savedOverflow = ''
+    let opener: HTMLElement | null = null
 
-      const onBlur = () => handleBlur(store)
+    const onBlur = () => handleBlur(store)
 
-      // 1Password extension adds `inert` attribute to `dialog` rendering it unusable.
-      const inertObserver = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-          if (mutation.type !== 'attributes') continue
-          if (mutation.attributeName !== 'inert') continue
-          root.removeAttribute('inert')
+    // 1Password extension adds `inert` attribute to `dialog` rendering it unusable.
+    const inertObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type !== 'attributes') continue
+        if (mutation.attributeName !== 'inert') continue
+        root.removeAttribute('inert')
+      }
+    })
+    inertObserver.observe(root, { attributeOldValue: true, attributes: true })
+
+    // dialog/page interactivity (no visibility change)
+    let dialogActive = false
+    const activatePage = () => {
+      if (!dialogActive) return
+      dialogActive = false
+
+      root.removeEventListener('cancel', onBlur)
+      root.removeEventListener('click', onBlur)
+      root.style.pointerEvents = 'none'
+      opener?.focus()
+      opener = null
+
+      document.body.style.overflow = savedOverflow
+    }
+    const activateDialog = () => {
+      if (dialogActive) return
+      dialogActive = true
+
+      root.addEventListener('cancel', onBlur)
+      root.addEventListener('click', onBlur)
+      frame.focus()
+      root.style.pointerEvents = 'auto'
+
+      savedOverflow = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+    }
+
+    // dialog visibility
+    let visible = false
+    const showDialog = () => {
+      if (visible) return
+      visible = true
+
+      if (document.activeElement instanceof HTMLElement) opener = document.activeElement
+
+      root.removeAttribute('hidden')
+      root.removeAttribute('aria-closed')
+      root.showModal()
+    }
+    const hideDialog = () => {
+      if (!visible) return
+      visible = false
+      root.setAttribute('hidden', 'true')
+      root.setAttribute('aria-closed', 'true')
+      root.close()
+
+      // 1Password extension sometimes adds `inert` to dialog siblings
+      // and does not clean up when dialog closes.
+      for (const sibling of root.parentNode ? Array.from(root.parentNode.children) : []) {
+        if (sibling === root) continue
+        if (!sibling.hasAttribute('inert')) continue
+        sibling.removeAttribute('inert')
+      }
+    }
+
+    return {
+      close() {
+        fallback.close()
+        open = false
+
+        hideDialog()
+        activatePage()
+      },
+      destroy() {
+        fallback.close()
+        open = false
+
+        activatePage()
+        hideDialog()
+
+        fallback.destroy()
+        messenger.destroy()
+        root.remove()
+        inertObserver.disconnect()
+      },
+      open() {
+        if (open) return
+        open = true
+
+        showDialog()
+        activateDialog()
+      },
+      async syncRequests(requests) {
+        // Safari does not support WebAuthn credential creation in iframes.
+        // Fall back to popup dialog.
+        const unsupported =
+          isSafari() &&
+          requests.some((x) => ['wallet_connect', 'eth_requestAccounts'].includes(x.request.method))
+
+        if (unsupported) {
+          fallback.syncRequests(requests)
+        } else {
+          const requiresConfirm = requests.some((x) => x.status === 'pending')
+          if (!open && requiresConfirm) this.open()
+          messenger.send('rpc-requests', {
+            account: getAccount(store),
+            chainId: store.getState().chainId,
+            requests,
+          })
         }
-      })
-      inertObserver.observe(root, { attributeOldValue: true, attributes: true })
-
-      // dialog/page interactivity (no visibility change)
-      let dialogActive = false
-      const activatePage = () => {
-        if (!dialogActive) return
-        dialogActive = false
-
-        root.removeEventListener('cancel', onBlur)
-        root.removeEventListener('click', onBlur)
-        root.style.pointerEvents = 'none'
-        opener?.focus()
-        opener = null
-
-        document.body.style.overflow = savedOverflow
-      }
-      const activateDialog = () => {
-        if (dialogActive) return
-        dialogActive = true
-
-        root.addEventListener('cancel', onBlur)
-        root.addEventListener('click', onBlur)
-        frame.focus()
-        root.style.pointerEvents = 'auto'
-
-        savedOverflow = document.body.style.overflow
-        document.body.style.overflow = 'hidden'
-      }
-
-      // dialog visibility
-      let visible = false
-      const showDialog = () => {
-        if (visible) return
-        visible = true
-
-        if (document.activeElement instanceof HTMLElement) opener = document.activeElement
-
-        root.removeAttribute('hidden')
-        root.removeAttribute('aria-closed')
-        root.showModal()
-      }
-      const hideDialog = () => {
-        if (!visible) return
-        visible = false
-        root.setAttribute('hidden', 'true')
-        root.setAttribute('aria-closed', 'true')
-        root.close()
-
-        // 1Password extension sometimes adds `inert` to dialog siblings
-        // and does not clean up when dialog closes.
-        for (const sibling of root.parentNode ? Array.from(root.parentNode.children) : []) {
-          if (sibling === root) continue
-          if (!sibling.hasAttribute('inert')) continue
-          sibling.removeAttribute('inert')
-        }
-      }
-
-      return {
-        close() {
-          fallback.close()
-          open = false
-
-          hideDialog()
-          activatePage()
-        },
-        destroy() {
-          fallback.close()
-          open = false
-
-          activatePage()
-          hideDialog()
-
-          fallback.destroy()
-          messenger.destroy()
-          root.remove()
-          inertObserver.disconnect()
-        },
-        open() {
-          if (open) return
-          open = true
-
-          showDialog()
-          activateDialog()
-        },
-        async syncRequests(requests) {
-          // Safari does not support WebAuthn credential creation in iframes.
-          // Fall back to popup dialog.
-          const unsupported =
-            isSafari() &&
-            requests.some((x) =>
-              ['wallet_connect', 'eth_requestAccounts'].includes(x.request.method),
-            )
-
-          if (unsupported) {
-            fallback.syncRequests(requests)
-          } else {
-            const requiresConfirm = requests.some((x) => x.status === 'pending')
-            if (!open && requiresConfirm) this.open()
-            messenger.send('rpc-requests', {
-              account: getAccount(store),
-              chainId: store.getState().chainId,
-              requests,
-            })
-          }
-        },
-      }
-    },
+      },
+    }
   })
 }
 
@@ -265,87 +266,84 @@ export function popup(options: popup.Options = {}): Dialog {
 
   const { size = defaultSize } = options
 
-  return from({
-    name: 'popup',
-    setup(parameters) {
-      const { host, store } = parameters
+  return define({ name: 'popup' }, (parameters) => {
+    const { host, store } = parameters
 
-      let win: Window | null = null
+    let win: Window | null = null
 
-      function onBlur() {
-        if (win) handleBlur(store)
-      }
+    function onBlur() {
+      if (win) handleBlur(store)
+    }
 
-      const offDetectClosed = (() => {
-        const timer = setInterval(() => {
-          if (win?.closed) handleBlur(store)
-        }, 100)
-        return () => clearInterval(timer)
-      })()
+    const offDetectClosed = (() => {
+      const timer = setInterval(() => {
+        if (win?.closed) handleBlur(store)
+      }, 100)
+      return () => clearInterval(timer)
+    })()
 
-      let messenger: Messenger.Bridge | undefined
+    let messenger: Messenger.Bridge | undefined
 
-      return {
-        close() {
-          if (!win) return
-          win.close()
-          win = null
-        },
-        destroy() {
-          this.close()
-          window.removeEventListener('focus', onBlur)
-          messenger?.destroy()
-          offDetectClosed()
-        },
-        open() {
-          const referrer = getReferrer()
+    return {
+      close() {
+        if (!win) return
+        win.close()
+        win = null
+      },
+      destroy() {
+        this.close()
+        window.removeEventListener('focus', onBlur)
+        messenger?.destroy()
+        offDetectClosed()
+      },
+      open() {
+        const referrer = getReferrer()
 
-          const hostUrl = new URL(host)
-          hostUrl.searchParams.set('chainId', String(store.getState().chainId))
-          hostUrl.searchParams.set('mode', 'popup')
-          if (referrer.icon) {
-            if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
-            else {
-              hostUrl.searchParams.set('icon', referrer.icon.light)
-              hostUrl.searchParams.set('iconDark', referrer.icon.dark)
-            }
+        const hostUrl = new URL(host)
+        hostUrl.searchParams.set('chainId', String(store.getState().chainId))
+        hostUrl.searchParams.set('mode', 'popup')
+        if (referrer.icon) {
+          if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
+          else {
+            hostUrl.searchParams.set('icon', referrer.icon.light)
+            hostUrl.searchParams.set('iconDark', referrer.icon.dark)
           }
+        }
 
-          const left = (window.innerWidth - size.width) / 2 + window.screenX
-          const top = window.screenY + 100
+        const left = (window.innerWidth - size.width) / 2 + window.screenX
+        const top = window.screenY + 100
 
-          win = window.open(
-            hostUrl.toString(),
-            '_blank',
-            `width=${size.width},height=${size.height},left=${left},top=${top}`,
-          )
-          if (!win) throw new Error('Failed to open popup')
+        win = window.open(
+          hostUrl.toString(),
+          '_blank',
+          `width=${size.width},height=${size.height},left=${left},top=${top}`,
+        )
+        if (!win) throw new Error('Failed to open popup')
 
-          messenger = Messenger.bridge({
-            from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
-            to: Messenger.fromWindow(win, { targetOrigin: hostUrl.origin }),
-            waitForReady: true,
-          })
+        messenger = Messenger.bridge({
+          from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
+          to: Messenger.fromWindow(win, { targetOrigin: hostUrl.origin }),
+          waitForReady: true,
+        })
 
-          messenger.on('rpc-response', (response) => handleResponse(store, response))
+        messenger.on('rpc-response', (response) => handleResponse(store, response))
 
-          window.removeEventListener('focus', onBlur)
-          window.addEventListener('focus', onBlur)
-        },
-        async syncRequests(requests) {
-          const requiresConfirm = requests.some((x) => x.status === 'pending')
-          if (requiresConfirm) {
-            if (!win || win.closed) this.open()
-            win?.focus()
-          }
-          messenger?.send('rpc-requests', {
-            account: getAccount(store),
-            chainId: store.getState().chainId,
-            requests,
-          })
-        },
-      }
-    },
+        window.removeEventListener('focus', onBlur)
+        window.addEventListener('focus', onBlur)
+      },
+      async syncRequests(requests) {
+        const requiresConfirm = requests.some((x) => x.status === 'pending')
+        if (requiresConfirm) {
+          if (!win || win.closed) this.open()
+          win?.focus()
+        }
+        messenger?.send('rpc-requests', {
+          account: getAccount(store),
+          chainId: store.getState().chainId,
+          requests,
+        })
+      },
+    }
   })
 }
 
@@ -358,17 +356,12 @@ export declare namespace popup {
 
 /** Returns a no-op dialog for SSR environments. */
 export function noop(): Dialog {
-  return from({
-    name: 'noop',
-    setup() {
-      return {
-        open() {},
-        close() {},
-        destroy() {},
-        async syncRequests() {},
-      }
-    },
-  })
+  return define({ name: 'noop' }, () => ({
+    open() {},
+    close() {},
+    destroy() {},
+    async syncRequests() {},
+  }))
 }
 
 /** Updates the store with an RPC response from the remote auth app. */

--- a/src/core/adapters/tempoWallet.ts
+++ b/src/core/adapters/tempoWallet.ts
@@ -34,8 +34,6 @@ export function tempoWallet(options: tempoWallet.Options = {}): Adapter.Adapter 
   } = options
 
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
-    let dialogHandle: Dialog.setup.ReturnType | undefined
-
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()
     const requestStore = ox_RpcRequest.createStore()
 
@@ -164,7 +162,7 @@ export function tempoWallet(options: tempoWallet.Options = {}): Adapter.Adapter 
       }
     }
 
-    dialogHandle = dialog.setup({ host, store })
+    const dialogInstance = dialog({ host, store })
 
     // Sync store → dialog: whenever the request queue changes, notify
     // listeners and sync pending requests to the dialog.
@@ -177,16 +175,15 @@ export function tempoWallet(options: tempoWallet.Options = {}): Adapter.Adapter 
           (x): x is Store.QueuedRequest & { status: 'pending' } => x.status === 'pending',
         )
 
-        dialogHandle?.syncRequests(pending)
-        if (pending.length === 0) dialogHandle?.close()
+        dialogInstance?.syncRequests(pending)
+        if (pending.length === 0) dialogInstance?.close()
       },
     )
 
     return {
       cleanup() {
         unsubscribe()
-        dialogHandle?.destroy()
-        dialogHandle = undefined
+        dialogInstance?.destroy()
       },
       actions: {
         async createAccount(parameters, request) {


### PR DESCRIPTION
Aligns `Dialog` with the `Adapter` pattern:

- `Dialog` is now a callable function (setup fn) with metadata attached
- `from()` → `define()` matching `Adapter.define()`
- `dialog.setup({...})` → `dialog({...})` at call sites