### PR TITLE
refactor: align Adapter types with Dialog pattern, minor formatting

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,5 +1,5 @@
 ---
-"tempodk": patch
+'tempodk': patch
 ---
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ export const wagmiConfig = createConfig({
 
 ## Adapters
 
-| Adapter        | Description                                                                        |
-| -------------- | ---------------------------------------------------------------------------------- |
-| `tempoWallet` 🚧 | Adapter for the Tempo Wallet dialog (an embedded iframe/popup dialog).               |
-| `webAuthn`     | App-bound passkey accounts using WebAuthn registration and authentication flows.   |
-| `local`        | Key agnostic adapter to define arbitrary account/key types and signing mechanisms. |
+| Adapter          | Description                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `tempoWallet` 🚧 | Adapter for the Tempo Wallet dialog (an embedded iframe/popup dialog).             |
+| `webAuthn`       | App-bound passkey accounts using WebAuthn registration and authentication flows.   |
+| `local`          | Key agnostic adapter to define arbitrary account/key types and signing mechanisms. |
 
 ## Development
 

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -16,10 +16,10 @@ type EncodedRequest<encoded extends { method: unknown; params: unknown }> = Pick
 >
 
 /** Adapter interface for the provider. */
-export type Adapter = AdapterFn & Meta
+export type Adapter = SetupFn & Meta
 
 /** The setup function an adapter must implement. */
-export type AdapterFn = (params: setup.Parameters) => ReturnType
+export type SetupFn = (params: SetupFn.Parameters) => Instance
 
 /** Static metadata attached to an adapter function. */
 export type Meta = {
@@ -31,8 +31,7 @@ export type Meta = {
   rdns?: string | undefined
 }
 
-/** Value returned from an adapter's setup function. */
-export type ReturnType = {
+export type Instance = {
   /** Adapter actions dispatched by the provider's `request()` method. */
   actions: {
     /** Grant an access key for the active account. */
@@ -93,19 +92,9 @@ export type ReturnType = {
   cleanup?: (() => void) | undefined
 }
 
-/** Creates an adapter from metadata and a setup function. */
-export function define(meta: Meta, fn: AdapterFn): Adapter {
-  const { name, ...rest } = meta
-  Object.defineProperty(fn, 'name', { value: name, configurable: true })
-  return Object.assign(fn, rest) as Adapter
-}
-
-/** Spreads decoded params. */
-export type ActionRequest<item extends Schema.Item> =
-  Schema.Decoded<item>['params'] extends readonly [infer first] ? first : never
-
-export declare namespace setup {
-  type Parameters = {
+export declare namespace SetupFn {
+  /** Parameters passed to an adapter's setup function. */
+  export type Parameters = {
     /** Returns the rehydrated local account for the given address, or the active account if omitted. */
     getAccount: Account.Find
     /** Get the viem client for a given chain ID. Defaults to the active chain. */
@@ -115,7 +104,21 @@ export declare namespace setup {
     /** Reactive state store. */
     store: Store.Store
   }
+
+  /** Value returned from an adapter's setup function. */
+  export type ReturnType = Instance
 }
+
+/** Creates an adapter from metadata and a setup function. */
+export function define(meta: Meta, fn: SetupFn): Adapter {
+  const { name, ...rest } = meta
+  Object.defineProperty(fn, 'name', { value: name, configurable: true })
+  return Object.assign(fn, rest) as Adapter
+}
+
+/** Spreads decoded params. */
+export type ActionRequest<item extends Schema.Item> =
+  Schema.Decoded<item>['params'] extends readonly [infer first] ? first : never
 
 export declare namespace getClient {
   type Options = {

--- a/src/core/Dialog.test-d.ts
+++ b/src/core/Dialog.test-d.ts
@@ -5,11 +5,11 @@ import type * as Store from './Store.js'
 
 describe('Dialog', () => {
   test('has name and setup returning open, close, destroy, syncRequests', () => {
-    expectTypeOf<Dialog.setup.Parameters>().toEqualTypeOf<{
+    expectTypeOf<Dialog.SetupFn.Parameters>().toEqualTypeOf<{
       host: string
       store: Store.Store
     }>()
-    expectTypeOf<Dialog.setup.ReturnType>().toMatchTypeOf<{
+    expectTypeOf<Dialog.Instance>().toMatchTypeOf<{
       open: () => void
       close: () => void
       destroy: () => void

--- a/test/webauthn.setup.global.ts
+++ b/test/webauthn.setup.global.ts
@@ -6,7 +6,6 @@ import { hooksPort, port } from './webauthn.constants.js'
 
 export default async function () {
   const kv = Kv.memory()
-
   const server = Http.createServer((req, res) => {
     // Origin varies per Playwright run; extract from request header.
     const origin = req.headers.origin ?? 'http://localhost'


### PR DESCRIPTION
- Rename `AdapterFn` → `SetupFn`, `ReturnType` → `Instance`, `setup.Parameters` → `SetupFn.Parameters` to match Dialog conventions
- Fix README table alignment
- Minor formatting cleanup in changeset and test setup