### PR TITLE
fix: update stale tempodk references after rename to accounts

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,5 +1,5 @@
 ---
-'tempodk': patch
+'accounts': patch
 ---
 
 Initial release.

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
   },
   "[!start-pkg]": "",
   "name": "accounts",
-  "description": "Accounts Development Kit for Tempo",
+  "description": "Tempo Accounts SDK",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.4.0",
   "dependencies": {
     "@remix-run/fetch-router": "~0.17.0",
     "idb-keyval": "^6.2.2",

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "types": ["vp/client", "node"],
     "paths": {
+      "accounts": ["../src/index.ts"],
       "accounts/*": ["../src/*"]
     }
   },


### PR DESCRIPTION
Fixes CI failures after the `tempodk` → `accounts` rename:

- **playground/tsconfig.json**: Added bare `"accounts"` path mapping — the `accounts/*` glob doesn't match `from 'accounts'` imports, causing `Provider.store` to resolve as `never`
- **.changeset/initial-release.md**: Updated package name from `tempodk` to `accounts`