### PR TITLE
fix: update prerelease build command

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,6 +19,6 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm changeset:publish
+        run: pnpm zile publish:prepare
 
       - run: pnpx pkg-pr-new publish --pnpm


### PR DESCRIPTION
Updates prerelease workflow build step from `pnpm changeset:publish` to `pnpm zile publish:prepare`.