### PR TITLE
fix: React hydration clearing dialog element

### DIFF
--- a/.changeset/fix-dialog-react-hydration.md
+++ b/.changeset/fix-dialog-react-hydration.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed iframe dialog being silently removed by React 19 hydration in Next.js App Router. A `MutationObserver` now detects removal and re-appends the dialog with a fresh messenger bridge.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -90,8 +90,6 @@ export function iframe(): Dialog {
       position: 'fixed',
     })
 
-    document.body.appendChild(root)
-
     const frame = document.createElement('iframe')
     frame.dataset.testid = 'tempo-wallet'
     frame.setAttribute(
@@ -128,15 +126,34 @@ export function iframe(): Dialog {
     root.appendChild(style)
     root.appendChild(frame)
 
-    const messenger = Messenger.bridge({
-      from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
-      to: Messenger.fromWindow(frame.contentWindow!, {
-        targetOrigin: hostUrl.origin,
-      }),
-      waitForReady: true,
-    })
+    function createMessenger() {
+      const m = Messenger.bridge({
+        from: Messenger.fromWindow(window, { targetOrigin: hostUrl.origin }),
+        to: Messenger.fromWindow(frame.contentWindow!, {
+          targetOrigin: hostUrl.origin,
+        }),
+        waitForReady: true,
+      })
+      m.on('rpc-response', (response) => handleResponse(store, response))
+      return m
+    }
 
-    messenger.on('rpc-response', (response) => handleResponse(store, response))
+    document.body.appendChild(root)
+    let messenger = createMessenger()
+
+    // Re-mount if removed (e.g. React hydration clears non-server-rendered elements).
+    // The iframe reloads on re-append, so the messenger must be re-established.
+    new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.removedNodes) {
+          if (node !== root) continue
+          document.body.appendChild(root)
+          messenger.destroy()
+          messenger = createMessenger()
+          return
+        }
+      }
+    }).observe(document.body, { childList: true })
 
     let savedOverflow = ''
     let opener: HTMLElement | null = null


### PR DESCRIPTION
React 19's `clearContainerSparingly` removes non-server-rendered elements from `document.body` during hydration (e.g. Next.js App Router).

This caused the iframe dialog to be silently removed from the DOM, leaving transactions hanging forever with no error — the request would queue but the dialog never opened.

**Fix:** Use a `MutationObserver` to detect when the dialog element is removed from the DOM and immediately re-append it with a fresh messenger bridge.

**Root cause:** In Next.js App Router, React manages `<body>` as part of its tree. During hydration, `clearContainerSparingly` removes any children that don't match the server-rendered HTML. Since the dialog iframe is appended to `document.body` at runtime (not server-rendered), React removes it.

**Why the messenger must be re-created:** When a DOM element is removed and re-appended, any contained `<iframe>` reloads. The previous `contentWindow` reference becomes stale, so the postMessage bridge must be re-established.