### PR TITLE
fix: return pending status when transaction receipt is null

### DIFF
--- a/.changeset/fix-calls-status-pending.md
+++ b/.changeset/fix-calls-status-pending.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `wallet_getCallsStatus` returning status 500 for pending transactions. Now returns status 100 when `eth_getTransactionReceipt` is null, allowing `waitForCallsStatus` to continue polling until inclusion.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -339,7 +339,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                       chainId,
                       id,
                       receipts: receipt ? [receipt as never] : [],
-                      status: receipt?.status === '0x1' ? 200 : 500,
+                      status: (() => {
+                        if (!receipt) return 100 // pending
+                        if (receipt.status === '0x1') return 200 // success
+                        return 500 // failed
+                      })(),
                       version: '2.0.0',
                     } satisfies Rpc.wallet_getCallsStatus.Encoded['returns']
                   }


### PR DESCRIPTION
**Problem:** `wallet_getCallsStatus` returned status `500` when `eth_getTransactionReceipt` returned `null` (pending transaction). This caused `waitForCallsStatus` to stop polling immediately with empty receipts, resulting in `"No transaction receipt returned."` errors in mppx.

**Fix:** Return status `100` (pending) when receipt is `null`, so polling continues until the transaction is included in a block.

```
100 = pending (receipt is null)
200 = success (receipt.status === '0x1')
500 = failure (receipt exists but status !== '0x1')
```