### PR TITLE
fix: forward remaining options from dialog connector to setup

### DIFF
--- a/.changeset/fix-dialog-forward-options.md
+++ b/.changeset/fix-dialog-forward-options.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `dialog` wagmi connector dropping `Provider.create` options like `authorizeAccessKey` and `feePayerUrl`. Now forwards all remaining options to `setup()`.

--- a/src/wagmi/Connector.ts
+++ b/src/wagmi/Connector.ts
@@ -276,8 +276,9 @@ export declare namespace webAuthn {
  * ```
  */
 export function dialog(options: dialog.Options = {}) {
-  const { dialog: dialogOption, host, icon, name, rdns } = options
+  const { dialog: dialogOption, host, icon, name, rdns, ...rest } = options
   return setup({
+    ...rest,
     adapter: core_dialog({ dialog: dialogOption, host, icon, name, rdns }),
   })
 }


### PR DESCRIPTION
The `dialog()` wagmi connector was destructuring only dialog-specific fields (`dialog`, `host`, `icon`, `name`, `rdns`) and dropping the rest. This meant `Provider.create` options like `authorizeAccessKey` and `feePayerUrl` were silently ignored.

Now uses `...rest` to forward all remaining options to `setup()`.