### PR TITLE
feat: insecure context warning

### DIFF
--- a/.changeset/insecure-context-warning.md
+++ b/.changeset/insecure-context-warning.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Warn when dialog adapter is initialized on a non-secure (HTTP) origin.

--- a/.changeset/insecure-context-warning.md
+++ b/.changeset/insecure-context-warning.md
@@ -1,5 +1,5 @@
 ---
-"accounts": patch
+'accounts': patch
 ---
 
-Warn when dialog adapter is initialized on a non-secure (HTTP) origin.
+Added warning when dialog adapter is initialized on a non-secure (HTTP) origin.

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -33,6 +33,13 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     rdns = 'xyz.tempo',
   } = options
 
+  if (typeof window !== 'undefined' && !window.isSecureContext)
+    console.warn(
+      '[accounts] Detected insecure context (HTTP).',
+      `\n\nThe Tempo Wallet iframe dialog is not supported on HTTP origins (${window.location.origin})`,
+      'due to lack of WebAuthn passkey support in non-secure contexts.',
+    )
+
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()
     const requestStore = ox_RpcRequest.createStore()


### PR DESCRIPTION
## Changes

### SDK (`accounts`)
- Warn on insecure context (HTTP) when the dialog adapter initializes, since WebAuthn passkeys won't work in iframe contexts without HTTPS.
