### PR TITLE
feat(dialog): fee payer support

### DIFF
--- a/.changeset/dialog-fee-payer.md
+++ b/.changeset/dialog-fee-payer.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added fee payer support for the dialog adapter. When `feePayerUrl` is configured, transactions sent through the dialog embed now use `withFeePayer` transports for preparation and sending.

--- a/.changeset/dialog-fee-payer.md
+++ b/.changeset/dialog-fee-payer.md
@@ -1,5 +1,5 @@
 ---
-"accounts": patch
+'accounts': patch
 ---
 
 Added fee payer support for the dialog adapter. When `feePayerUrl` is configured, transactions sent through the dialog embed now use `withFeePayer` transports for preparation and sending.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -112,11 +112,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     return merged
   }
 
-  /** Resolves the `feePayer` field from a transaction request into a URL string or `undefined`. */
+  /** Resolves the `feePayer` field from a transaction request into an absolute URL string or `undefined`. */
   function resolveFeePayer(feePayer: string | boolean | undefined): string | undefined {
-    if (typeof feePayer === 'string') return feePayer
-    if (feePayer === true) return feePayerUrl
-    return undefined
+    const url = typeof feePayer === 'string' ? feePayer : feePayer === true ? feePayerUrl : undefined
+    if (!url) return undefined
+    if (url.startsWith('http://') || url.startsWith('https://')) return url
+    if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
+    return url
   }
 
   const provider = Object.assign(
@@ -191,7 +193,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.sendTransaction(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer),
+                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
                       },
                       request,
                     )) satisfies Rpc.eth_sendTransaction.Encoded['returns']
@@ -203,7 +205,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.signTransaction(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer),
+                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
                       },
                       request,
                     )) satisfies Rpc.eth_signTransaction.Encoded['returns']
@@ -215,7 +217,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.sendTransactionSync(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer),
+                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
                       },
                       request,
                     )) satisfies Rpc.eth_sendTransactionSync.Encoded['returns']

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -114,7 +114,8 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   /** Resolves the `feePayer` field from a transaction request into an absolute URL string or `undefined`. */
   function resolveFeePayer(feePayer: string | boolean | undefined): string | undefined {
-    const url = typeof feePayer === 'string' ? feePayer : feePayer === true ? feePayerUrl : undefined
+    const url =
+      typeof feePayer === 'string' ? feePayer : feePayer === true ? feePayerUrl : undefined
     if (!url) return undefined
     if (url.startsWith('http://') || url.startsWith('https://')) return url
     if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
@@ -193,7 +194,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.sendTransaction(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
+                        feePayer: resolveFeePayer(decoded.feePayer),
                       },
                       request,
                     )) satisfies Rpc.eth_sendTransaction.Encoded['returns']
@@ -205,7 +206,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.signTransaction(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
+                        feePayer: resolveFeePayer(decoded.feePayer),
                       },
                       request,
                     )) satisfies Rpc.eth_signTransaction.Encoded['returns']
@@ -217,7 +218,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return (await actions.sendTransactionSync(
                       {
                         ...decoded,
-                        feePayer: resolveFeePayer(decoded.feePayer ?? (feePayerUrl ? true : undefined)),
+                        feePayer: resolveFeePayer(decoded.feePayer),
                       },
                       request,
                     )) satisfies Rpc.eth_sendTransactionSync.Encoded['returns']

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -289,7 +289,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             return await account.signTransaction(prepared as never)
           })
           if (result !== undefined) return result
-          return await provider.request(request)
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
+          })
         },
 
         async signTypedData(_params, request) {
@@ -316,7 +319,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             })
           })
           if (result !== undefined) return result
-          return await provider.request(request)
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
+          })
         },
 
         async sendTransactionSync(parameters, request) {
@@ -339,7 +345,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             })
           })
           if (result !== undefined) return result
-          return await provider.request(request)
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
+          })
         },
 
         async authorizeAccessKey(parameters, request) {

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -67,7 +67,7 @@ export const transactionRequest = z.object({
   ),
   calls: z.optional(z.readonly(z.array(call))),
   chainId: z.optional(u.number()),
-  feePayer: z.optional(z.union([z.boolean(), z.url()])),
+  feePayer: z.optional(z.union([z.boolean(), z.string()])),
   feeToken: z.optional(u.address()),
   from: z.optional(u.address()),
   gas: z.optional(u.bigint()),


### PR DESCRIPTION
## Changes

- **resolveFeePayer**: Resolve relative paths (e.g. `/fee-payer`) to absolute URLs via `window.location.origin`
- **Provider**: Auto-inject `feePayerUrl` for `eth_sendTransaction`, `eth_signTransaction`, and `eth_sendTransactionSync` when configured (matching `wallet_sendCalls` behavior)
- **Dialog adapter**: Re-encode params with resolved `feePayer` in fallthrough requests to the embed so the URL survives
- **RPC schema**: Allow `string` (not just `url`) for `feePayer` to support relative paths

### Dialog (tempoxyz/app#1145)

- Preparation: `useQuery` + viem `prepareTransactionRequest` with `withFeePayer` client
- Sending: Pass `feePayer` URL through to wagmi send → connector Provider → local adapter → `withFeePayer` transport