### PR TITLE
feat(cli-adapter): support `authorizeAccessKey`

### DIFF
--- a/.changeset/cli-authorize-access-key.md
+++ b/.changeset/cli-authorize-access-key.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+Added `wallet_authorizeAccessKey` support to the CLI adapter, allowing access keys to be authorized independently from `wallet_connect`. The `wallet_authorizeAccessKey` return type is now wrapped in a `{ keyAuthorization, rootAddress }` envelope.

--- a/.changeset/cli-authorize-access-key.md
+++ b/.changeset/cli-authorize-access-key.md
@@ -1,5 +1,5 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
-Added `wallet_authorizeAccessKey` support to the CLI adapter, allowing access keys to be authorized independently from `wallet_connect`. The `wallet_authorizeAccessKey` return type is now wrapped in a `{ keyAuthorization, rootAddress }` envelope.
+Added `wallet_authorizeAccessKey` support to the CLI adapter, allowing access keys to be authorized independently from `wallet_connect`. 

--- a/src/cli/Provider.test.ts
+++ b/src/cli/Provider.test.ts
@@ -11,17 +11,27 @@ import * as Provider from './Provider.js'
 
 const root = accounts[0]!
 const accessKey = accounts[1]!
+const accessKey_2 = accounts[2]!
 const expiry = Math.floor(Date.now() / 1000) + 3_600
+const expiry_2 = expiry + 60
 
-async function authorize(code: string) {
+async function authorize(
+  code: string,
+  options: {
+    accessKey?: typeof accessKey | undefined
+    expiry?: number | undefined
+  } = {},
+) {
+  const { accessKey: key = accessKey, expiry: expiry_ = expiry } = options
+
   const signed = await root.signKeyAuthorization(
     {
-      accessKeyAddress: accessKey.address,
-      keyType: accessKey.keyType,
+      accessKeyAddress: key.address,
+      keyType: key.keyType,
     },
     {
       chainId: BigInt(chain.id),
-      expiry,
+      expiry: expiry_,
     },
   )
   const keyAuthorization = KeyAuthorization.toRpc(signed)
@@ -36,15 +46,23 @@ async function authorize(code: string) {
   })
 }
 
-function connectRequest() {
+function connectRequest(
+  options: {
+    accessKey?: typeof accessKey | undefined
+    expiry?: number | undefined
+  } = {},
+) {
+  const { accessKey: key = accessKey, expiry: expiry_ = expiry } = options
+
   return {
     method: 'wallet_connect',
     params: [
       {
         capabilities: {
           authorizeAccessKey: {
-            expiry,
-            publicKey: accessKey.publicKey,
+            expiry: expiry_,
+            keyType: key.keyType,
+            publicKey: key.publicKey,
           },
         },
       },
@@ -53,6 +71,8 @@ function connectRequest() {
 }
 
 function createHandler() {
+  let random = 0
+
   return Handler.codeAuth({
     path: '/cli-auth',
     chainId: chain.id,
@@ -65,7 +85,11 @@ function createHandler() {
         }
       },
     },
-    random: () => new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]),
+    random: () => {
+      const out = new Uint8Array(Array.from({ length: 8 }, (_, i) => random + i))
+      random += 8
+      return out
+    },
   })
 }
 
@@ -77,6 +101,7 @@ describe('Provider.create', () => {
 
     try {
       const provider = Provider.create({
+        chains: [chain],
         open: async (url) => {
           opened.push(url)
           const code = new URL(url).searchParams.get('code')!
@@ -139,6 +164,7 @@ describe('Provider.create', () => {
 
     try {
       const provider = Provider.create({
+        chains: [chain],
         open() {
           throw new Error('browser unavailable')
         },
@@ -173,6 +199,7 @@ describe('Provider.create', () => {
 
     try {
       const provider = Provider.create({
+        chains: [chain],
         open() {},
         pollIntervalMs: 1,
         host: `${server.url}/cli-auth`,
@@ -201,12 +228,146 @@ describe('Provider.create', () => {
     }
   })
 
-  test('behavior: rejects non-bootstrap RPCs', async () => {
+  test('behavior: authorizes an access key while disconnected when publicKey is provided', async () => {
+    const handler = createHandler()
+    const server = await createServer(handler.listener)
+    const opened: string[] = []
+
+    try {
+      const provider = Provider.create({
+        chains: [chain],
+        open: async (url) => {
+          opened.push(url)
+          const code = new URL(url).searchParams.get('code')!
+          try {
+            await fetch(`${server.url}/cli-auth`, {
+              body: JSON.stringify(
+                await authorize(code, { accessKey: accessKey_2, expiry: expiry_2 }),
+              ),
+              headers: { 'content-type': 'application/json' },
+              method: 'POST',
+            })
+          } catch (error) {}
+        },
+        host: `${server.url}/cli-auth`,
+      })
+
+      const result = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [
+          { expiry: expiry_2, keyType: accessKey_2.keyType, publicKey: accessKey_2.publicKey },
+        ],
+      })
+      const keyAuthorization = {
+        ...result.keyAuthorization,
+        signature: {
+          type: result.keyAuthorization.signature.type,
+        },
+      }
+
+      expect({
+        keyAuthorization,
+        rootAddress: result.rootAddress,
+        opened: opened.map((url) => url.replace(server.url, 'http://service')),
+      }).toMatchInlineSnapshot(`
+        {
+          "keyAuthorization": {
+            "address": "${accessKey_2.address}",
+            "chainId": "${Hex.fromNumber(chain.id)}",
+            "expiry": "${Hex.fromNumber(expiry_2)}",
+            "keyId": "${accessKey_2.address}",
+            "keyType": "secp256k1",
+            "signature": {
+              "type": "secp256k1",
+            },
+          },
+          "opened": [
+            "http://service/cli-auth?code=ABCDEFGH",
+          ],
+          "rootAddress": "${root.address}",
+        }
+      `)
+    } finally {
+      await server.closeAsync()
+    }
+  })
+
+  test('behavior: authorizes an access key for the active account', async () => {
+    const handler = createHandler()
+    const server = await createServer(handler.listener)
+    const opened: string[] = []
+
+    try {
+      const approvals = [
+        (code: string) => authorize(code),
+        (code: string) => authorize(code, { accessKey: accessKey_2, expiry: expiry_2 }),
+      ]
+      const provider = Provider.create({
+        chains: [chain],
+        open: async (url) => {
+          opened.push(url)
+          const approve = approvals.shift()
+          if (!approve) throw new Error('Unexpected device-code approval request.')
+          const code = new URL(url).searchParams.get('code')!
+          await fetch(`${server.url}/cli-auth`, {
+            body: JSON.stringify(await approve(code)),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          })
+        },
+        host: `${server.url}/cli-auth`,
+      })
+
+      await provider.request(connectRequest())
+
+      const result = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [
+          { expiry: expiry_2, keyType: accessKey_2.keyType, publicKey: accessKey_2.publicKey },
+        ],
+      })
+      const keyAuthorization = {
+        ...result.keyAuthorization,
+        signature: {
+          type: result.keyAuthorization.signature.type,
+        },
+      }
+
+      expect({
+        keyAuthorization,
+        rootAddress: result.rootAddress,
+        opened: opened.map((url) => url.replace(server.url, 'http://service')),
+      }).toMatchInlineSnapshot(`
+        {
+          "keyAuthorization": {
+            "address": "${accessKey_2.address}",
+            "chainId": "${Hex.fromNumber(chain.id)}",
+            "expiry": "${Hex.fromNumber(expiry_2)}",
+            "keyId": "${accessKey_2.address}",
+            "keyType": "secp256k1",
+            "signature": {
+              "type": "secp256k1",
+            },
+          },
+          "opened": [
+            "http://service/cli-auth?code=ABCDEFGH",
+            "http://service/cli-auth?code=JKLMNPQR",
+          ],
+          "rootAddress": "${root.address}",
+        }
+      `)
+    } finally {
+      await server.closeAsync()
+    }
+  })
+
+  test('behavior: rejects unsupported revokeAccessKey after bootstrap', async () => {
     const handler = createHandler()
     const server = await createServer(handler.listener)
 
     try {
       const provider = Provider.create({
+        chains: [chain],
         open: async (url) => {
           const code = new URL(url).searchParams.get('code')!
           await fetch(`${server.url}/cli-auth`, {
@@ -222,11 +383,11 @@ describe('Provider.create', () => {
 
       await expect(
         provider.request({
-          method: 'wallet_authorizeAccessKey',
-          params: [{ expiry, keyType: accessKey.keyType, publicKey: accessKey.publicKey }],
+          method: 'wallet_revokeAccessKey',
+          params: [{ accessKeyAddress: accessKey.address, address: root.address }],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `[Provider.UnsupportedMethodError: \`authorizeAccessKey\` not supported by adapter.]`,
+        `[Provider.UnsupportedMethodError: \`wallet_revokeAccessKey\` not supported by CLI adapter.]`,
       )
     } finally {
       await server.closeAsync()

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -8,76 +8,110 @@ import * as CliAuth from '../server/CliAuth.js'
 
 /**
  * Creates a CLI bootstrap adapter backed by the device-code protocol.
- *
- * Only `wallet_connect` is supported in v1.
  */
 export function cli(options: cli.Options): Adapter.Adapter {
   const { name = 'Tempo CLI', rdns = 'xyz.tempo.cli' } = options
 
-  return Adapter.define({ name, rdns }, () => ({
-    actions: {
-      async createAccount(params, request) {
-        return this.loadAccounts(params, request)
-      },
-      async loadAccounts(parameters) {
-        const {
-          host,
-          open = defaultOpen,
-          pollIntervalMs = 2_000,
-          timeoutMs = 5 * 60 * 1_000,
-        } = options
-        const authorizeAccessKey = parameters?.authorizeAccessKey
+  return Adapter.define({ name, rdns }, ({ store }) => {
+    async function authorize(request: {
+      account?: Adapter.authorizeAccessKey.ReturnType['rootAddress'] | undefined
+      authorizeAccessKey: Adapter.authorizeAccessKey.Parameters | undefined
+      method: 'wallet_authorizeAccessKey' | 'wallet_connect'
+    }) {
+      const {
+        host,
+        open = defaultOpen,
+        pollIntervalMs = 2_000,
+        timeoutMs = 5 * 60 * 1_000,
+      } = options
+      const { account, authorizeAccessKey, method } = request
 
-        if (!authorizeAccessKey?.publicKey)
-          throw new RpcResponse.InvalidParamsError({
-            message:
-              '`wallet_connect` on the CLI adapter requires `capabilities.authorizeAccessKey.publicKey`.',
-          })
-        if (parameters?.digest)
-          throw unsupported('`wallet_connect` digest signing not supported by CLI adapter.')
-
-        const codeVerifier = createCodeVerifier()
-        const codeChallenge = createCodeChallenge(codeVerifier)
-        const created = await post({
-          body: {
-            codeChallenge,
-            ...(typeof authorizeAccessKey.expiry !== 'undefined'
-              ? { expiry: authorizeAccessKey.expiry }
-              : {}),
-            ...(authorizeAccessKey.keyType ? { keyType: authorizeAccessKey.keyType } : {}),
-            ...(authorizeAccessKey.limits ? { limits: authorizeAccessKey.limits } : {}),
-            pubKey: authorizeAccessKey.publicKey,
-          } satisfies z.output<typeof CliAuth.createRequest>,
-          request: CliAuth.createRequest,
-          response: CliAuth.createResponse,
-          url: getApiUrl(host, 'code'),
+      if (!authorizeAccessKey?.publicKey)
+        throw new RpcResponse.InvalidParamsError({
+          message:
+            method === 'wallet_connect'
+              ? '`wallet_connect` on the CLI adapter requires `capabilities.authorizeAccessKey.publicKey`.'
+              : '`wallet_authorizeAccessKey` on the CLI adapter requires `publicKey`.',
         })
-        const url = getBrowserUrl(host, created.code)
 
-        try {
-          await open(url)
-        } catch (error) {
-          throw new OpenError(url, created.code, error)
+      const codeVerifier = createCodeVerifier()
+      const codeChallenge = createCodeChallenge(codeVerifier)
+      const created = await post({
+        body: {
+          ...(account ? { account } : {}),
+          chainId: BigInt(store.getState().chainId),
+          codeChallenge,
+          ...(typeof authorizeAccessKey.expiry !== 'undefined'
+            ? { expiry: authorizeAccessKey.expiry }
+            : {}),
+          ...(authorizeAccessKey.keyType ? { keyType: authorizeAccessKey.keyType } : {}),
+          ...(authorizeAccessKey.limits ? { limits: authorizeAccessKey.limits } : {}),
+          pubKey: authorizeAccessKey.publicKey,
+        } satisfies z.output<typeof CliAuth.createRequest>,
+        request: CliAuth.createRequest,
+        response: CliAuth.createResponse,
+        url: getApiUrl(host, 'code'),
+      })
+      const url = getBrowserUrl(host, created.code)
+
+      try {
+        await open(url)
+      } catch (error) {
+        throw new OpenError(url, created.code, error)
+      }
+
+      const startedAt = Date.now()
+
+      while (Date.now() - startedAt < timeoutMs) {
+        const result = await post({
+          body: {
+            codeVerifier,
+          } satisfies z.output<typeof CliAuth.pollRequest>,
+          request: CliAuth.pollRequest,
+          response: CliAuth.pollResponse,
+          url: getApiUrl(host, `poll/${created.code}`),
+        })
+
+        if (result.status === 'pending') {
+          await sleep(pollIntervalMs)
+          continue
         }
+        if (result.status === 'expired')
+          throw new Error('Device code expired before authorization completed.')
 
-        const startedAt = Date.now()
+        return result
+      }
 
-        while (Date.now() - startedAt < timeoutMs) {
-          const result = await post({
-            body: {
-              codeVerifier,
-            } satisfies z.output<typeof CliAuth.pollRequest>,
-            request: CliAuth.pollRequest,
-            response: CliAuth.pollResponse,
-            url: getApiUrl(host, `poll/${created.code}`),
+      throw new TimeoutError(url, created.code)
+    }
+
+    return {
+      actions: {
+        async authorizeAccessKey(parameters) {
+          const { accounts, activeAccount } = store.getState()
+          const account = accounts[activeAccount]?.address
+          const result = await authorize({
+            ...(account ? { account } : {}),
+            authorizeAccessKey: parameters,
+            method: 'wallet_authorizeAccessKey',
           })
 
-          if (result.status === 'pending') {
-            await sleep(pollIntervalMs)
-            continue
+          return {
+            keyAuthorization: z.encode(CliAuth.keyAuthorization, result.keyAuthorization),
+            rootAddress: result.accountAddress,
           }
-          if (result.status === 'expired')
-            throw new Error('Device code expired before authorization completed.')
+        },
+        async createAccount(params, request) {
+          return this.loadAccounts(params, request)
+        },
+        async loadAccounts(parameters) {
+          if (parameters?.digest)
+            throw unsupported('`wallet_connect` digest signing not supported by CLI adapter.')
+
+          const result = await authorize({
+            authorizeAccessKey: parameters?.authorizeAccessKey,
+            method: 'wallet_connect',
+          })
 
           return {
             accounts: [
@@ -88,30 +122,28 @@ export function cli(options: cli.Options): Adapter.Adapter {
             ],
             keyAuthorization: z.encode(CliAuth.keyAuthorization, result.keyAuthorization),
           }
-        }
-
-        throw new TimeoutError(url, created.code)
+        },
+        async revokeAccessKey() {
+          throw unsupported('`wallet_revokeAccessKey` not supported by CLI adapter.')
+        },
+        async sendTransaction() {
+          throw unsupported('`eth_sendTransaction` not supported by CLI adapter.')
+        },
+        async sendTransactionSync() {
+          throw unsupported('`eth_sendTransactionSync` not supported by CLI adapter.')
+        },
+        async signPersonalMessage() {
+          throw unsupported('`personal_sign` not supported by CLI adapter.')
+        },
+        async signTransaction() {
+          throw unsupported('`eth_signTransaction` not supported by CLI adapter.')
+        },
+        async signTypedData() {
+          throw unsupported('`eth_signTypedData_v4` not supported by CLI adapter.')
+        },
       },
-      async revokeAccessKey() {
-        throw unsupported('`wallet_revokeAccessKey` not supported by CLI adapter.')
-      },
-      async sendTransaction() {
-        throw unsupported('`eth_sendTransaction` not supported by CLI adapter.')
-      },
-      async sendTransactionSync() {
-        throw unsupported('`eth_sendTransactionSync` not supported by CLI adapter.')
-      },
-      async signPersonalMessage() {
-        throw unsupported('`personal_sign` not supported by CLI adapter.')
-      },
-      async signTransaction() {
-        throw unsupported('`eth_signTransaction` not supported by CLI adapter.')
-      },
-      async signTypedData() {
-        throw unsupported('`eth_signTypedData_v4` not supported by CLI adapter.')
-      },
-    },
-  }))
+    }
+  })
 }
 
 export declare namespace cli {
@@ -133,7 +165,7 @@ export declare namespace cli {
 
 class OpenError extends Error {
   code: string
-  cause?: unknown | undefined
+  override cause?: unknown | undefined
   url: string
 
   constructor(url: string, code: string, cause?: unknown) {

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -145,7 +145,7 @@ export declare namespace createAccount {
   type ReturnType = {
     accounts: readonly Store.Account[]
     /** Signed key authorization, if an access key was granted. */
-    keyAuthorization?: authorizeAccessKey.ReturnType | undefined
+    keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Signature over the digest, if one was provided. */
     signature?: Hex | undefined
   }
@@ -166,7 +166,7 @@ export declare namespace loadAccounts {
     /** Loaded accounts. */
     accounts: readonly Store.Account[]
     /** Signed key authorization, if an access key was granted. */
-    keyAuthorization?: authorizeAccessKey.ReturnType | undefined
+    keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Signature over the digest, if one was provided. */
     signature?: Hex | undefined
   }
@@ -206,7 +206,10 @@ export declare namespace authorizeAccessKey {
     signature?: Hex | undefined
   }
 
-  type ReturnType = KeyAuthorization.Rpc
+  type ReturnType = {
+    keyAuthorization: KeyAuthorization.Rpc
+    rootAddress: Address
+  }
 }
 
 export declare namespace revokeAccessKey {

--- a/src/core/Provider.browser.test.ts
+++ b/src/core/Provider.browser.test.ts
@@ -521,13 +521,14 @@ describe('eth_signTypedData_v4', () => {
 describe('wallet_authorizeAccessKey', () => {
   test('default: grants an access key and returns its address', async () => {
     const provider = getProvider({ chains: [chain] })
-    await connect(provider)
+    const rootAddress = await connect(provider)
 
     const result = await provider.request({
       method: 'wallet_authorizeAccessKey',
       params: [{ expiry: Expiry.days(1) }],
     })
-    expect(result.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    expect(result.keyAuthorization.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    expect(result.rootAddress).toBe(rootAddress)
   })
 
   test('behavior: granted access key is used for sendTransactionSync', async () => {
@@ -556,8 +557,8 @@ describe('wallet_authorizeAccessKey', () => {
       method: 'wallet_authorizeAccessKey',
       params: [{ expiry }],
     })
-    expect(result.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
-    expect(result.expiry).toBe(Hex.fromNumber(expiry))
+    expect(result.keyAuthorization.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    expect(result.keyAuthorization.expiry).toBe(Hex.fromNumber(expiry))
   })
 
   test('behavior: with limits option', async () => {
@@ -574,7 +575,7 @@ describe('wallet_authorizeAccessKey', () => {
         },
       ],
     })
-    expect(result.limits).toMatchInlineSnapshot(`
+    expect(result.keyAuthorization.limits).toMatchInlineSnapshot(`
       [
         {
           "limit": "0x4c4b40",
@@ -597,14 +598,14 @@ describe('wallet_revokeAccessKey', () => {
     await connect(provider)
 
     const connected = (await provider.request({ method: 'eth_accounts' }))[0]!
-    const { address: keyAddress } = await provider.request({
+    const { keyAuthorization } = await provider.request({
       method: 'wallet_authorizeAccessKey',
       params: [{ expiry: Expiry.days(1) }],
     })
 
     await provider.request({
       method: 'wallet_revokeAccessKey',
-      params: [{ address: connected, accessKeyAddress: keyAddress }],
+      params: [{ address: connected, accessKeyAddress: keyAuthorization.keyId }],
     })
 
     await fundAccount(connected)

--- a/src/core/Provider.connect.browser.test.ts
+++ b/src/core/Provider.connect.browser.test.ts
@@ -309,7 +309,7 @@ describe('wallet_authorizeAccessKey', () => {
         await iframe.getByTestId('confirm').click()
       },
     )
-    expect(result.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    expect(result.keyAuthorization.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
   })
 })
 
@@ -318,7 +318,7 @@ describe('wallet_revokeAccessKey', () => {
     provider = getProvider()
     const address = await connectViaIframe(provider)
 
-    const { address: keyAddress } = await interact(
+    const { keyAuthorization } = await interact(
       provider.request({
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry: Expiry.days(1) }],
@@ -331,7 +331,7 @@ describe('wallet_revokeAccessKey', () => {
     await interact(
       provider.request({
         method: 'wallet_revokeAccessKey',
-        params: [{ address, accessKeyAddress: keyAddress }],
+        params: [{ address, accessKeyAddress: keyAuthorization.keyId }],
       }),
       async (iframe) => {
         await iframe.getByTestId('confirm').click()

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -998,15 +998,29 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
   })
 
   describe('wallet_authorizeAccessKey', () => {
+    test('behavior: without publicKey or address requires a connected account', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+
+      await expect(
+        provider.request({
+          method: 'wallet_authorizeAccessKey',
+          params: [{ expiry: Expiry.days(1) }],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Provider.DisconnectedError: No active account.]`,
+      )
+    })
+
     test('default: grants an access key and returns its address', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
-      await connect(provider)
+      const rootAddress = await connect(provider)
 
       const result = await provider.request({
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry: Expiry.days(1) }],
       })
-      expect(result.keyId).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(result.keyAuthorization.keyId).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(result.rootAddress).toBe(rootAddress)
     })
 
     test('behavior: granted access key is used for sendTransactionSync', async () => {
@@ -1035,8 +1049,8 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry }],
       })
-      expect(result.keyId).toMatch(/^0x[0-9a-fA-F]{40}$/)
-      expect(result.expiry).toBe(Hex.fromNumber(expiry))
+      expect(result.keyAuthorization.keyId).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(result.keyAuthorization.expiry).toBe(Hex.fromNumber(expiry))
     })
 
     test('behavior: expired access key falls back to root account', async () => {
@@ -1086,7 +1100,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           },
         ],
       })
-      expect(result.limits).toMatchInlineSnapshot(`
+      expect(result.keyAuthorization.limits).toMatchInlineSnapshot(`
         [
           {
             "limit": "0x4c4b40",
@@ -1162,14 +1176,14 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       await connect(provider)
 
       const connected = (await provider.request({ method: 'eth_accounts' }))[0]!
-      const { keyId } = await provider.request({
+      const { keyAuthorization } = await provider.request({
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry: Expiry.days(1) }],
       })
 
       await provider.request({
         method: 'wallet_revokeAccessKey',
-        params: [{ address: connected, accessKeyAddress: keyId }],
+        params: [{ address: connected, accessKeyAddress: keyAuthorization.address }],
       })
 
       // After revoking, sendTransactionSync should use root key (still works)
@@ -1344,8 +1358,8 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         method: 'wallet_authorizeAccessKey',
         params: [{ ...accessKeyAccount, expiry: Expiry.days(1) }],
       })
-      expect(result.keyId).toBe(accessKeyAccount.address)
-      expect(result.keyType).toBe('p256')
+      expect(result.keyAuthorization.keyId).toBe(accessKeyAccount.address)
+      expect(result.keyAuthorization.keyType).toBe('p256')
     })
 
     test('behavior: external key authorization can be used to send a transaction', async () => {
@@ -1365,7 +1379,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const receipt = await sendTransactionSync(client, {
         account: TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress }),
         calls: [transferCall],
-        keyAuthorization: KeyAuthorization.fromRpc(result),
+        keyAuthorization: KeyAuthorization.fromRpc(result.keyAuthorization),
       })
       expect(receipt.status).toBe('success')
     })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -440,7 +440,6 @@ export function create(options: create.Options = {}): create.ReturnType {
                     return
 
                   case 'wallet_authorizeAccessKey': {
-                    assertConnected()
                     if (!actions.authorizeAccessKey)
                       throw new ox_Provider.UnsupportedMethodError({
                         message: '`authorizeAccessKey` not supported by adapter.',
@@ -448,8 +447,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const decoded = request._decoded.params[0]
                     const result = await actions.authorizeAccessKey(decoded, request)
                     return {
-                      ...result,
-                      address: result.keyId,
+                      keyAuthorization: {
+                        ...result.keyAuthorization,
+                        address: result.keyAuthorization.keyId,
+                      },
+                      rootAddress: result.rootAddress,
                     } satisfies Rpc.wallet_authorizeAccessKey.Encoded['returns']
                   }
 

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -106,18 +106,11 @@ describe('Encoded', () => {
   })
 
   test('wallet_authorizeAccessKey', () => {
-    expectTypeOf<Rpc.wallet_authorizeAccessKey.Encoded>().toMatchTypeOf<{
-      method: 'wallet_authorizeAccessKey'
-      params: readonly [
-        {
-          address?: Hex | undefined
-          expiry: number
-          keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
-          limits?: readonly { token: Hex; limit: Hex }[] | undefined
-          publicKey?: Hex | undefined
-        },
-      ]
-    }>()
+    expectTypeOf<Rpc.wallet_authorizeAccessKey.Encoded>().toHaveProperty('method')
+    expectTypeOf<Rpc.wallet_authorizeAccessKey.Encoded['returns']>().toHaveProperty('rootAddress')
+    expectTypeOf<Rpc.wallet_authorizeAccessKey.Encoded['returns']>().toHaveProperty(
+      'keyAuthorization',
+    )
   })
 
   test('wallet_disconnect', () => {

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -361,7 +361,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
           if (accessKey) {
             const account = getAccount({ accessKey: false, signable: false })
-            saveAccessKey(account.address, result, accessKey.keyPair)
+            saveAccessKey(account.address, result.keyAuthorization, accessKey.keyPair)
           }
 
           return result

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -73,7 +73,7 @@ export function local(options: local.Options): Adapter.Adapter {
       options: {
         signature?: Hex.Hex | undefined
       } = {},
-    ): Promise<Adapter.authorizeAccessKey.ReturnType> {
+    ) {
       const { keyPair } = prepared
 
       const keyAuthorization = await (async () => {
@@ -140,7 +140,10 @@ export function local(options: local.Options): Adapter.Adapter {
         async authorizeAccessKey(parameters) {
           const prepared = await prepareKeyAuthorization(parameters)
           const account = getAccount({ accessKey: false, signable: true })
-          return await signKeyAuthorization(account, prepared, { signature: parameters.signature })
+          const keyAuthorization = await signKeyAuthorization(account, prepared, {
+            signature: parameters.signature,
+          })
+          return { keyAuthorization, rootAddress: account.address }
         },
         async loadAccounts(parameters) {
           const { authorizeAccessKey, ...rest } =

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -259,10 +259,15 @@ export namespace wallet_authorizeAccessKey {
     publicKey: z.optional(u.hex()),
   })
 
+  const returns = z.object({
+    keyAuthorization,
+    rootAddress: u.address(),
+  })
+
   export const schema = Schema.defineItem({
     method: z.literal('wallet_authorizeAccessKey'),
     params: z.readonly(z.tuple([parameters])),
-    returns: keyAuthorization,
+    returns,
   })
   export type Encoded = Schema.Encoded<typeof schema>
   export type Decoded = Schema.Decoded<typeof schema>

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -27,6 +27,7 @@ export const keyAuthorization = z.object({
 /** Request body for `POST /auth/pkce/code`. */
 export const createRequest = z.object({
   account: z.optional(u.address()),
+  chainId: z.optional(u.bigint()),
   codeChallenge: z.string(),
   expiry: z.optional(z.number()),
   keyType: z.optional(keyType),
@@ -345,7 +346,6 @@ export async function createDeviceCode(
   options: createDeviceCode.Options,
 ): Promise<createDeviceCode.ReturnType> {
   const {
-    chainId = BigInt(tempo.id),
     now = Date.now,
     policy = Policy.allow(),
     random = randomBytes,
@@ -353,6 +353,7 @@ export async function createDeviceCode(
     store = Store.memory(),
     ttlMs = 10 * 60 * 1_000,
   } = options
+  const chainId = request.chainId ?? options.chainId ?? BigInt(tempo.id)
   const { account, codeChallenge, pubKey } = request
   const keyType = request.keyType ?? 'secp256k1'
   const approved = await policy.validate({


### PR DESCRIPTION
### Summary

- Added `wallet_authorizeAccessKey` action to CLI adapter for authorizing access keys independently from `wallet_connect`
- Wrapped `wallet_authorizeAccessKey` return type in `{ keyAuthorization, rootAddress }` envelope across all adapters
- Pass `chainId` from provider store to device-code creation
- Support `account` parameter in CLI device-code flow for connected accounts
- Updated all tests and type tests to match new return shape