### PR TITLE
fix(ci): use --frozen-lockfile in install-dependencies action

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Get Playwright version
       if: inputs.playwright == 'true'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm zile publish:prepare


### PR DESCRIPTION
Adds `--frozen-lockfile` to all `pnpm install` calls in CI to prevent accidental dependency upgrades. Without this flag, `pnpm install` can resolve newer versions of transitive dependencies (e.g. axios) that match caret ranges in the dependency tree.

Changes:
- `.github/actions/install-dependencies/action.yml`: `pnpm install` → `pnpm install --frozen-lockfile`
- `.github/workflows/prerelease.yml`: `pnpm install` → `pnpm install --frozen-lockfile`

Prompted by: jxom