### PR TITLE
chore: add pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,3 +39,5 @@ onlyBuiltDependencies:
 
 overrides:
   accounts: workspace:*
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
Adds `minimumReleaseAge: 1440` (1 day) to pnpm config as a supply-chain attack mitigation. This prevents pnpm from installing packages published less than 24 hours ago.

See: https://pnpm.io/settings#minimumreleaseage

Prompted by: horsefacts