### PR TITLE
fix: break Schema ↔ rpc circular dependency

### DIFF
--- a/.changeset/fix-schema-circular-dep.md
+++ b/.changeset/fix-schema-circular-dep.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Broke circular dependency between `Schema` and `rpc` modules that caused runtime errors when bundled with esbuild.

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -4,26 +4,8 @@ import * as z from 'zod/mini'
 
 import * as Rpc from './zod/rpc.js'
 
-/** All provider-handled RPC method definitions. */
-export const schema = from([
-  Rpc.eth_accounts.schema,
-  Rpc.eth_chainId.schema,
-  Rpc.eth_requestAccounts.schema,
-  Rpc.eth_sendTransaction.schema,
-  Rpc.eth_signTransaction.schema,
-  Rpc.eth_sendTransactionSync.schema,
-  Rpc.eth_signTypedData_v4.schema,
-  Rpc.personal_sign.schema,
-  Rpc.wallet_sendCalls.schema,
-  Rpc.wallet_getBalances.schema,
-  Rpc.wallet_getCallsStatus.schema,
-  Rpc.wallet_getCapabilities.schema,
-  Rpc.wallet_connect.schema,
-  Rpc.wallet_disconnect.schema,
-  Rpc.wallet_authorizeAccessKey.schema,
-  Rpc.wallet_revokeAccessKey.schema,
-  Rpc.wallet_switchEthereumChain.schema,
-])
+export { defineItem, from } from './internal/schema.js'
+import { from } from './internal/schema.js'
 
 /**
  * A single JSON-RPC method definition with Zod schemas for
@@ -92,6 +74,27 @@ export type ToViem<schema extends Schema> = {
   }
 }
 
+/** All provider-handled RPC method definitions. */
+export const schema = from([
+  Rpc.eth_accounts.schema,
+  Rpc.eth_chainId.schema,
+  Rpc.eth_requestAccounts.schema,
+  Rpc.eth_sendTransaction.schema,
+  Rpc.eth_signTransaction.schema,
+  Rpc.eth_sendTransactionSync.schema,
+  Rpc.eth_signTypedData_v4.schema,
+  Rpc.personal_sign.schema,
+  Rpc.wallet_sendCalls.schema,
+  Rpc.wallet_getBalances.schema,
+  Rpc.wallet_getCallsStatus.schema,
+  Rpc.wallet_getCapabilities.schema,
+  Rpc.wallet_connect.schema,
+  Rpc.wallet_disconnect.schema,
+  Rpc.wallet_authorizeAccessKey.schema,
+  Rpc.wallet_revokeAccessKey.schema,
+  Rpc.wallet_switchEthereumChain.schema,
+])
+
 /** Ox-compatible RPC schema union for the provider. */
 export type Ox = RpcSchema.Eth | ToOx<typeof schema>
 export const ox = RpcSchema.from<Ox>()
@@ -131,13 +134,3 @@ export const Request: z.ZodMiniType<
   ToRequestInput<typeof schema>
 > = z.discriminatedUnion('method', schema.map(toRequestSchema) as never)
 export type Request = ToRequestOutput<typeof schema>
-
-/** Defines a JSON-RPC method schema item. */
-export function defineItem<const item extends Item>(item: item): item {
-  return item
-}
-
-/** Creates a {@link Schema}. */
-export function from<const schema extends Schema>(schema: schema): schema {
-  return schema
-}

--- a/src/core/internal/schema.ts
+++ b/src/core/internal/schema.ts
@@ -1,0 +1,11 @@
+import type * as Schema from '../Schema.js'
+
+/** Defines a JSON-RPC method schema item. */
+export function defineItem<const item extends Schema.Item>(item: item): item {
+  return item
+}
+
+/** Creates a {@link Schema}. */
+export function from<const schema extends Schema.Schema>(schema: schema): schema {
+  return schema
+}

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -1,7 +1,7 @@
 import type { SignatureEnvelope } from 'ox/tempo'
 import * as z from 'zod/mini'
 
-import * as Schema from '../Schema.js'
+import * as Schema from '../internal/schema.js'
 import * as u from './utils.js'
 
 export const log = z.object({


### PR DESCRIPTION
## Problem

`Schema.ts` and `zod/rpc.ts` have a circular import — `Schema` imports `Rpc` to build the schema array, and `rpc` imports `Schema` for `defineItem`/`from`. This works in native ESM (function declarations hoist), but when esbuild flattens both modules into a single chunk it reorders statements so that `Rpc.eth_accounts.schema` is read before the namespace IIFE that populates `eth_accounts` has run:

```
Cannot read properties of undefined (reading 'schema')
```

## Fix

Moved `defineItem` and `from` to `core/internal/schema.ts`. Now `rpc.ts` imports from `internal/schema.ts` (a leaf node) instead of `Schema.ts`, eliminating the cycle.

```
internal/schema.ts  →  (nothing)
zod/rpc.ts          →  internal/schema.ts
Schema.ts           →  internal/schema.ts + zod/rpc.ts
```

esbuild can now topologically sort: `internal/schema → rpc → Schema` ✅