### PR TITLE
fix: export Encoded, Decoded, Item from internal/schema

### DIFF
--- a/src/core/internal/schema.ts
+++ b/src/core/internal/schema.ts
@@ -1,5 +1,7 @@
 import type * as Schema from '../Schema.js'
 
+export type { Encoded, Decoded, Item } from '../Schema.js'
+
 /** Defines a JSON-RPC method schema item. */
 export function defineItem<const item extends Schema.Item>(item: item): item {
   return item


### PR DESCRIPTION
Follow-up to #61 — `rpc.ts` uses `Schema.Encoded` and `Schema.Decoded` types which weren't re-exported from `internal/schema.ts`.