### PR TITLE
feat: default to popup dialog on insecure (HTTP) contexts

### DIFF
--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -43,6 +43,12 @@ export function define(meta: Meta, fn: SetupFn): Dialog {
   return Object.assign(fn, rest) as Dialog
 }
 
+/** Detects an insecure context (e.g. HTTP) where iframes lack WebAuthn support. */
+export function isInsecureContext(): boolean {
+  if (typeof window === 'undefined') return false
+  return !window.isSecureContext
+}
+
 /** Detects Safari (which does not support WebAuthn in cross-origin iframes). */
 export function isSafari(): boolean {
   if (typeof navigator === 'undefined') return false

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -26,14 +26,19 @@ import * as Rpc from '../zod/rpc.js'
  */
 export function dialog(options: dialog.Options = {}): Adapter.Adapter {
   const {
-    dialog = Dialog.isSafari() || Dialog.isInsecureContext()
-      ? Dialog.popup()
-      : Dialog.iframe(),
+    dialog = Dialog.isSafari() || Dialog.isInsecureContext() ? Dialog.popup() : Dialog.iframe(),
     host = 'https://wallet.tempo.xyz/embed',
     icon,
     name = 'Tempo',
     rdns = 'xyz.tempo',
   } = options
+
+  if (typeof window !== 'undefined' && !window.isSecureContext)
+    console.warn(
+      '[accounts] Detected insecure context (HTTP).',
+      `\n\nThe Tempo Wallet iframe dialog is not supported on HTTP origins (${window.location.origin})`,
+      'due to lack of WebAuthn passkey support in non-secure contexts.',
+    )
 
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -26,19 +26,14 @@ import * as Rpc from '../zod/rpc.js'
  */
 export function dialog(options: dialog.Options = {}): Adapter.Adapter {
   const {
-    dialog = Dialog.isSafari() ? Dialog.popup() : Dialog.iframe(),
+    dialog = Dialog.isSafari() || Dialog.isInsecureContext()
+      ? Dialog.popup()
+      : Dialog.iframe(),
     host = 'https://wallet.tempo.xyz/embed',
     icon,
     name = 'Tempo',
     rdns = 'xyz.tempo',
   } = options
-
-  if (typeof window !== 'undefined' && !window.isSecureContext)
-    console.warn(
-      '[accounts] Detected insecure context (HTTP).',
-      `\n\nThe Tempo Wallet iframe dialog is not supported on HTTP origins (${window.location.origin})`,
-      'due to lack of WebAuthn passkey support in non-secure contexts.',
-    )
 
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()
@@ -381,7 +376,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
 export declare namespace dialog {
   type Options = {
-    /** Dialog to use for the embed app. @default `Dialog.iframe()` (or `Dialog.popup()` in Safari) */
+    /** Dialog to use for the embed app. @default `Dialog.iframe()` (or `Dialog.popup()` in Safari/insecure contexts) */
     dialog?: Dialog.Dialog | undefined
     /** URL of the embed app. @default `'https://wallet.tempo.xyz/embed'` */
     host?: string | undefined


### PR DESCRIPTION
When the host page is on an insecure protocol (e.g. `http://`), iframes can't use WebAuthn passkeys. This adds `Dialog.isInsecureContext()` and uses it alongside the existing Safari check to default to popup mode automatically.

- Added `Dialog.isInsecureContext()` helper (`!window.isSecureContext`)
- Default dialog selection now uses popup for both Safari and insecure contexts
- Removed the console.warn that previously just warned without fixing the problem

Prompted by: jxom