### PR TITLE
fix: strip www. prefix when checking trusted hosts

### DIFF
--- a/.changeset/fix-schema-circular-dep.md
+++ b/.changeset/fix-schema-circular-dep.md
@@ -1,5 +1,5 @@
 ---
-"accounts": patch
+'accounts': patch
 ---
 
 Broke circular dependency between `Schema` and `rpc` modules that caused runtime errors when bundled with esbuild.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -275,7 +275,8 @@ export function iframe(): Dialog {
         const secure = await (async () => {
           const { trustedHosts } = await messenger.waitForReady()
           const ioSupported = IO.supported()
-          const trusted = Boolean(trustedHosts?.includes(window.location.hostname))
+          const hostname = window.location.hostname.replace(/^www\./, '')
+          const trusted = Boolean(trustedHosts?.includes(hostname))
           return ioSupported || trusted
         })()
 

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -16,7 +16,7 @@ export function useEnsureVisibility(
   const trusted = useMemo(() => {
     if (!origin) return false
     try {
-      const hostname = new URL(origin).hostname
+      const hostname = new URL(origin).hostname.replace(/^www\./, '')
       return remote.trustedHosts.includes(hostname)
     } catch {
       return false


### PR DESCRIPTION
Trusted host checks used strict `.includes(hostname)` — if a host like `promptgolf.sh` is in the list, `www.promptgolf.sh` would fail the check and fall back to popup or get rejected.

Strips the `www.` prefix from hostnames before comparing against `trustedHosts` in:
- `src/core/Dialog.ts` — iframe security check
- `src/react/Remote.ts` — `useEnsureVisibility` visibility hook

The CSP `frame-ancestors` in the dialog submodule already handles this via `https://*.${host}` wildcards.

Prompted by: jxom