### PR TITLE
feat: update dialog popup default width to 504px

### DIFF
--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -34,7 +34,7 @@ export declare namespace SetupFn {
   }
 }
 
-export const defaultSize = { height: 440, width: 360 }
+export const defaultSize = { height: 440, width: 504 }
 
 /** Creates a dialog from metadata and a setup function. */
 export function define(meta: Meta, fn: SetupFn): Dialog {


### PR DESCRIPTION
Update the default popup width from 360px to 504px to match the redesigned embed dialog.