### PR TITLE
chore: add changesets for recent fixes

### DIFF
--- a/.changeset/popup-insecure-contexts.md
+++ b/.changeset/popup-insecure-contexts.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Defaulted to popup dialog on insecure (HTTP) contexts where iframes cannot use WebAuthn.

--- a/.changeset/strip-www-trusted-hosts.md
+++ b/.changeset/strip-www-trusted-hosts.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Stripped `www.` prefix when checking trusted hosts for dialog origin validation.


### PR DESCRIPTION
Adds changesets for:
- `popup-insecure-contexts`: Defaulted to popup dialog on insecure (HTTP) contexts
- `strip-www-trusted-hosts`: Stripped `www.` prefix when checking trusted hosts