### PR TITLE
fix: deduplicate EIP-6963 announcements, add default icon and rename to Tempo Wallet

### DIFF
--- a/.changeset/dedupe-eip6963-announce.md
+++ b/.changeset/dedupe-eip6963-announce.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed duplicate EIP-6963 provider announcements for the same wallet rdns.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -32,6 +32,8 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
     store: Store.Store
   }
 
+const announced = new Set<string>()
+
 /**
  * Creates an EIP-1193 provider with a pluggable adapter.
  *
@@ -499,17 +501,21 @@ export function create(options: create.Options = {}): create.ReturnType {
   )
 
   if (typeof window !== 'undefined') {
-    announceProvider({
-      info: {
-        icon: adapter.icon ?? defaultIcon,
-        name: adapter.name ?? 'Injected Wallet',
-        rdns:
-          adapter.rdns ??
-          `com.${(adapter.name ?? 'Injected Wallet').toLowerCase().replace(/\s+/g, '')}`,
-        uuid: crypto.randomUUID(),
-      },
-      provider,
-    } as never)
+    const rdns =
+      adapter.rdns ?? `com.${(adapter.name ?? 'Injected Wallet').toLowerCase().replace(/\s+/g, '')}`
+
+    if (!announced.has(rdns)) {
+      announced.add(rdns)
+      announceProvider({
+        info: {
+          icon: adapter.icon ?? defaultIcon,
+          name: adapter.name ?? 'Injected Wallet',
+          rdns,
+          uuid: crypto.randomUUID(),
+        },
+        provider,
+      } as never)
+    }
   }
 
   if (options.mpp)

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -28,8 +28,8 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
   const {
     dialog = Dialog.isSafari() || Dialog.isInsecureContext() ? Dialog.popup() : Dialog.iframe(),
     host = 'https://wallet.tempo.xyz/embed',
-    icon,
-    name = 'Tempo',
+    icon = 'data:image/svg+xml,<svg width="269" height="269" viewBox="0 0 269 269" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="269" height="269" fill="black"/><path d="M123.273 190.794H93.445L121.09 105.318H85.7334L93.445 80.2642H191.95L184.238 105.318H150.773L123.273 190.794Z" fill="white"/></svg>',
+    name = 'Tempo Wallet',
     rdns = 'xyz.tempo',
   } = options
 


### PR DESCRIPTION
- Deduplicate EIP-6963 `announceProvider` calls by tracking announced `rdns` values, preventing the same wallet from appearing multiple times in wallet selection UIs
- Default `icon` to the Tempo favicon-dark SVG (inline data URI, EIP-6963 compliant)
- Rename default connector name from `Tempo` to `Tempo Wallet`