### PR TITLE
feat: deploy playground to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Playground
+    name: Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -34,13 +34,12 @@ jobs:
         run: pnpm build
 
       - name: Deploy to Cloudflare Workers
-        id: deploy
+        if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: playground
-          command: ${{ github.event_name == 'pull_request' && format('deploy --name accounts-playground-pr-{0}', github.event.pull_request.number) || 'deploy' }}
           secrets: |
             ORIGIN
             RP_ID
@@ -51,6 +50,16 @@ jobs:
           RP_ID: tempo.xyz
           MPP_SECRET_KEY: ${{ secrets.MPP_SECRET_KEY }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Upload preview version
+        id: deploy
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: playground
+          command: versions upload
 
       - name: Preview URL
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -1,0 +1,63 @@
+name: Deploy Workers
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-playground-${{ github.event.pull_request.number || 'production' }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Playground
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Build playground
+        working-directory: playground
+        env:
+          VITE_WALLET_DIALOG_HOST: https://wallet.tempo.xyz/embed
+          VITE_ENV: mainnet
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Workers
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: playground
+          command: ${{ github.event_name == 'pull_request' && format('deploy --name accounts-playground-pr-{0}', github.event.pull_request.number) || 'deploy' }}
+          secrets: |
+            ORIGIN
+            RP_ID
+            MPP_SECRET_KEY
+            PRIVATE_KEY
+        env:
+          ORIGIN: https://playground.accounts.tempo.xyz
+          RP_ID: tempo.xyz
+          MPP_SECRET_KEY: ${{ secrets.MPP_SECRET_KEY }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Preview URL
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: deploy-workers
+          message: |
+            | Worker | Preview |
+            |--------|---------|
+            | Playground | ${{ steps.deploy.outputs.deployment-url }} |

--- a/playground/wrangler.jsonc
+++ b/playground/wrangler.jsonc
@@ -4,6 +4,7 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
+  "routes": [{ "pattern": "playground.accounts.tempo.xyz", "custom_domain": true }],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/fee-payer", "/fortune"],


### PR DESCRIPTION
Adds a `Deploy Workers` GitHub Action that:

- Deploys the playground to Cloudflare Workers on push to `main`
- Deploys preview workers on PRs (`accounts-playground-pr-{number}`)
- Posts a sticky PR comment with a preview URL table
- Sets `VITE_WALLET_DIALOG_HOST` to `https://wallet.tempo.xyz/embed`
- Configures custom domain `playground.accounts.tempo.xyz` via wrangler

### Required GitHub secrets
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`
- `MPP_SECRET_KEY`
- `PRIVATE_KEY`