### PR TITLE
fix: remove secrets from deploy workflow

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -40,16 +40,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: playground
-          secrets: |
-            ORIGIN
-            RP_ID
-            MPP_SECRET_KEY
-            PRIVATE_KEY
-        env:
-          ORIGIN: https://playground.accounts.tempo.xyz
-          RP_ID: tempo.xyz
-          MPP_SECRET_KEY: ${{ secrets.MPP_SECRET_KEY }}
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
 
       - name: Upload preview version
         id: deploy


### PR DESCRIPTION
Removes worker secrets (`ORIGIN`, `RP_ID`, `MPP_SECRET_KEY`, `PRIVATE_KEY`) from the GitHub Action — manage them directly in the Cloudflare dashboard instead.

Fixes the `secret bulk` ordering issue where Cloudflare rejects setting secrets before a version is deployed.