### PR TITLE
fix: use accounts-pg.tempo.xyz for playground domain

### DIFF
--- a/playground/wrangler.jsonc
+++ b/playground/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
-  "routes": [{ "pattern": "playground.accounts.tempo.xyz", "custom_domain": true }],
+  "routes": [{ "pattern": "accounts-pg.tempo.xyz", "custom_domain": true }],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/fee-payer", "/fortune"],


### PR DESCRIPTION
Changes playground custom domain from `playground.accounts.tempo.xyz` to `accounts-pg.tempo.xyz` to avoid multi-level subdomain SSL issues.