### PR TITLE
fix: remove custom domain from playground

### DIFF
--- a/playground/wrangler.jsonc
+++ b/playground/wrangler.jsonc
@@ -4,7 +4,6 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
-  "routes": [{ "pattern": "accounts-pg.tempo.xyz", "custom_domain": true }],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/fee-payer", "/fortune"],


### PR DESCRIPTION
Removes custom domain route — deploy to default `.workers.dev` URL until API token permissions are sorted.