### PR TITLE
feat: support wildcard patterns in trusted hosts

### DIFF
--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -1,6 +1,7 @@
 import * as IO from './IntersectionObserver.js'
 import * as Messenger from './Messenger.js'
 import type * as Store from './Store.js'
+import * as TrustedHosts from './TrustedHosts.js'
 
 /** Dialog interface — manages the iframe/popup lifecycle for cross-origin auth. */
 export type Dialog = SetupFn & Meta
@@ -282,7 +283,7 @@ export function iframe(): Dialog {
           const { trustedHosts } = await messenger.waitForReady()
           const ioSupported = IO.supported()
           const hostname = window.location.hostname.replace(/^www\./, '')
-          const trusted = Boolean(trustedHosts?.includes(hostname))
+          const trusted = Boolean(trustedHosts && TrustedHosts.match(trustedHosts, hostname))
           return ioSupported || trusted
         })()
 

--- a/src/core/TrustedHosts.ts
+++ b/src/core/TrustedHosts.ts
@@ -3,6 +3,7 @@
  *
  * Each key is a dialog host (e.g. `tempo.xyz`), and its value is the
  * list of third-party origins that the dialog trusts to embed it.
+ * Supports wildcard patterns (e.g. `*.workers.dev`).
  */
 export const hosts = {
   'tempo.xyz': [
@@ -13,5 +14,19 @@ export const hosts = {
     'currencycompetition.com',
     'tempai.town',
     'print-a-tshirt.com',
+    '*.porto.workers.dev',
   ],
 } as const satisfies Record<string, readonly string[]>
+
+/**
+ * Returns `true` if `hostname` matches any pattern in `trustedHosts`.
+ * Patterns starting with `*.` match any subdomain suffix
+ * (e.g. `*.workers.dev` matches `foo.workers.dev`).
+ */
+export function match(trustedHosts: readonly string[], hostname: string) {
+  return trustedHosts.some((pattern) => {
+    if (pattern.startsWith('*.'))
+      return hostname.endsWith(pattern.slice(1)) && hostname.length > pattern.length - 1
+    return pattern === hostname
+  })
+}

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -3,6 +3,7 @@ import { useStore } from 'zustand'
 
 import * as IO from '../core/IntersectionObserver.js'
 import type * as CoreRemote from '../core/Remote.js'
+import * as TrustedHosts from '../core/TrustedHosts.js'
 
 /** Monitors element visibility using IntersectionObserver v2. */
 export function useEnsureVisibility(
@@ -17,7 +18,7 @@ export function useEnsureVisibility(
     if (!origin) return false
     try {
       const hostname = new URL(origin).hostname.replace(/^www\./, '')
-      return remote.trustedHosts.includes(hostname)
+      return TrustedHosts.match(remote.trustedHosts, hostname)
     } catch {
       return false
     }


### PR DESCRIPTION
Adds `TrustedHosts.match()` utility that supports `*.` wildcard patterns (e.g. `*.porto.workers.dev`).

- Adds `*.porto.workers.dev` to the trusted hosts list
- Updates `Dialog.ts` and `Remote.ts` to use `TrustedHosts.match()` instead of `.includes()`

The dialog submodule (`embed.tsx` + `security-headers.ts`) has matching changes ready — will open a separate PR there after this lands.