### PR TITLE
fix: add *.tempo.xyz to trusted hosts

### DIFF
--- a/.changeset/trusted-tempo-subdomains.md
+++ b/.changeset/trusted-tempo-subdomains.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `*.tempo.xyz` to trusted hosts.

--- a/src/core/TrustedHosts.ts
+++ b/src/core/TrustedHosts.ts
@@ -8,6 +8,7 @@
 export const hosts = {
   'tempo.xyz': [
     'localhost',
+    '*.tempo.xyz',
     'promptgolf.sh',
     'app.polyhedge.capital',
     'tempodex.vercel.app',


### PR DESCRIPTION
Added `*.tempo.xyz` to trusted hosts so all Tempo subdomains bypass IO v2 occlusion detection.