### PR TITLE
ci: improve CI runtime with caching and pinned image

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -17,6 +17,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: '24'
+        cache: 'pnpm'
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,10 +28,12 @@ jobs:
     name: 'Test Runtime (env: localnet, tag: ${{ matrix.tag }})'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
     strategy:
       matrix:
         tag:
-          - latest
+          - sha-a5ea176
           - https://rpc.moderato.tempo.xyz
 
     steps:
@@ -45,6 +47,24 @@ jobs:
 
       - name: Setup Docker
         uses: docker/setup-docker-action@v4
+
+      - name: Cache Tempo Docker image
+        if: "!startsWith(matrix.tag, 'http')"
+        uses: actions/cache@v4
+        id: docker-cache
+        with:
+          path: /tmp/tempo-image.tar
+          key: tempo-image-${{ matrix.tag }}
+
+      - name: Load cached Tempo image
+        if: "!startsWith(matrix.tag, 'http') && steps.docker-cache.outputs.cache-hit == 'true'"
+        run: docker load -i /tmp/tempo-image.tar
+
+      - name: Pull and cache Tempo image
+        if: "!startsWith(matrix.tag, 'http') && steps.docker-cache.outputs.cache-hit != 'true'"
+        run: |
+          docker pull ghcr.io/tempoxyz/tempo:${{ matrix.tag }}
+          docker save ghcr.io/tempoxyz/tempo:${{ matrix.tag }} -o /tmp/tempo-image.tar
 
       - name: Run tests
         run: pnpm test --bail=1


### PR DESCRIPTION
## Changes

Several CI perf improvements -- inspired by what we do in mppx

### 1. Enable pnpm store cache (~40s savings per job)
Added `cache: 'pnpm'` to `setup-node` in the install-dependencies action. Previously every job cold-downloaded all 838 packages.

### 2. Pin Tempo Docker image to `sha-a5ea176`
Replaced `latest` (uncacheable — changes every push) with a pinned SHA tag, matching how mppx pins `sha-20aecec`. This makes the Docker image deterministic and cacheable.

### 3. Cache Tempo Docker image
Added Docker image caching (pull → save → cache → load) for the pinned SHA tag, skipped for the RPC URL matrix entry. Avoids re-pulling on every run.

### 4. Disable testcontainers Ryuk sidecar
Set `TESTCONTAINERS_RYUK_DISABLED: true` on the test jobs. GitHub-hosted runners are ephemeral so Ryuk cleanup is unnecessary, and skipping it avoids a Docker Hub pull + sidecar overhead. 

### Expected savings
~1.5–2 minutes off the critical path (current: ~5 min → target: ~3–3.5 min).