### PR TITLE
fix: use iframe dialog on safari for non-WebAuthn requests

### DIFF
--- a/.changeset/safari-iframe-dialog.md
+++ b/.changeset/safari-iframe-dialog.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed Safari using popup instead of iframe for non-WebAuthn requests (e.g. `sendTransaction`).

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -26,7 +26,7 @@ import * as Rpc from '../zod/rpc.js'
  */
 export function dialog(options: dialog.Options = {}): Adapter.Adapter {
   const {
-    dialog = Dialog.isSafari() || Dialog.isInsecureContext() ? Dialog.popup() : Dialog.iframe(),
+    dialog = Dialog.isInsecureContext() ? Dialog.popup() : Dialog.iframe(),
     host = 'https://wallet.tempo.xyz/embed',
     icon = 'data:image/svg+xml,<svg width="269" height="269" viewBox="0 0 269 269" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="269" height="269" fill="black"/><path d="M123.273 190.794H93.445L121.09 105.318H85.7334L93.445 80.2642H191.95L184.238 105.318H150.773L123.273 190.794Z" fill="white"/></svg>',
     name = 'Tempo Wallet',


### PR DESCRIPTION
Safari was unconditionally forced to use a popup dialog due to `isSafari()` in the default dialog option. This meant that after login, non-WebAuthn requests like `sendTransaction` opened in a popup instead of an iframe.

The narrower check in `Dialog.iframe().syncRequests` already handles falling back to popup only for WebAuthn methods (`wallet_connect`, `eth_requestAccounts`). Removing the top-level `isSafari()` check lets Safari use the iframe for everything else.