### PR TITLE
fix: run build before dev scripts that depend on dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "dev:hosts": "./scripts/dev:hosts.sh",
     "dev:dialog": "pnpm --filter tempo-app dev:ssl",
     "dev:dialog-ref": "pnpm --filter dialog-ref dev",
-    "dev:playground": "pnpm --filter playground dev",
-    "example:wagmi": "pnpm --filter wagmi dev & pnpm dev:dialog",
-    "example:cli": "pnpm --filter cli-auth dev & pnpm --filter cli connect",
+    "dev:playground": "pnpm build && pnpm --filter playground dev",
+    "example:wagmi": "pnpm build && pnpm --filter wagmi dev & pnpm dev:dialog",
+    "example:cli": "pnpm build && pnpm --filter cli-auth dev & pnpm --filter cli connect",
     "preconstruct": "zile dev",
     "test": "vp test",
     "vp": "vp"


### PR DESCRIPTION
Dev scripts (`dev:playground`, `example:wagmi`, `example:cli`) import from `accounts/server`, `accounts/cli`, and `accounts/wagmi` which resolve to `dist/`. Without a prior build, these fail with `Cannot find module`.

This adds `pnpm build &&` before each so they just work from a clean checkout.