### PR TITLE
fix: add *.localhost and benedict.dev to trusted hosts

### DIFF
--- a/.changeset/trusted-hosts-localhost.md
+++ b/.changeset/trusted-hosts-localhost.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `*.localhost` and `benedict.dev` to trusted hosts.

--- a/src/core/TrustedHosts.ts
+++ b/src/core/TrustedHosts.ts
@@ -8,6 +8,7 @@
 export const hosts = {
   'tempo.xyz': [
     'localhost',
+    '*.localhost',
     '*.tempo.xyz',
     'promptgolf.sh',
     'app.polyhedge.capital',
@@ -16,6 +17,7 @@ export const hosts = {
     'tempai.town',
     'print-a-tshirt.com',
     '*.porto.workers.dev',
+    'benedict.dev',
   ],
 } as const satisfies Record<string, readonly string[]>
 


### PR DESCRIPTION
Adds `*.localhost` wildcard so prefixed localhosts (e.g. `testnet.localhost:5173`) work with the trusted host model. Also adds `benedict.dev`.