### PR TITLE
feat: support chainId in wallet_connect

### DIFF
--- a/.changeset/wallet-connect-chain-id.md
+++ b/.changeset/wallet-connect-chain-id.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Support `chainId` in `wallet_connect` to set the active chain before the dialog opens.
+Added `chainId` in `wallet_connect` to set the active chain before the dialog opens.

--- a/.changeset/wallet-connect-chain-id.md
+++ b/.changeset/wallet-connect-chain-id.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Support `chainId` in `wallet_connect` to set the active chain before the dialog opens.

--- a/examples/wagmi/src/App.tsx
+++ b/examples/wagmi/src/App.tsx
@@ -11,6 +11,7 @@ import {
   useSignMessage,
   useSignTypedData,
 } from 'wagmi'
+import { tempoModerato, tempo } from 'wagmi/chains'
 import { Hooks } from 'wagmi/tempo'
 
 import { testnet, tokens } from './config.js'
@@ -71,6 +72,7 @@ function Connect() {
             onClick={() =>
               connect({
                 connector,
+                chainId: testnet ? tempoModerato.id : tempo.id,
                 ...(accessKey
                   ? {
                       capabilities: {

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -3,6 +3,7 @@ import { Hex, Json, P256 } from 'ox'
 import { useCallback, useEffect, useSyncExternalStore, useState } from 'react'
 import { parseUnits } from 'viem'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
+import { tempo, tempoModerato } from 'viem/chains'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 
 import { CliAuth } from './CliAuth.js'
@@ -180,7 +181,7 @@ function WalletConnect() {
     execute(() =>
       provider.request({
         method: 'wallet_connect',
-        params: [{ capabilities }],
+        params: [{ capabilities, chainId: testnet ? tempoModerato.id : tempo.id }],
       }),
     )
   }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -386,6 +386,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                   }
 
                   case 'wallet_connect': {
+                    const chainId = request._decoded.params?.[0]?.chainId
+                    if (chainId) store.setState((x) => ({ ...x, chainId }))
+
                     const capabilities = request._decoded.params?.[0]?.capabilities
                     const authorizeAccessKey =
                       capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.()

--- a/src/wagmi/Connector.ts
+++ b/src/wagmi/Connector.ts
@@ -47,7 +47,7 @@ export function setup(parameters: setup.Parameters = {} as setup.Parameters) {
 
     return {
       async connect(params: Parameters<Properties['connect']>[0] = {}) {
-        const { isReconnecting, withCapabilities } = params
+        const { chainId, isReconnecting, withCapabilities } = params
         const capabilities = 'capabilities' in params ? params.capabilities : undefined
 
         let accounts: readonly { address: Address; capabilities: Record<string, unknown> }[] = []
@@ -65,11 +65,17 @@ export function setup(parameters: setup.Parameters = {} as setup.Parameters) {
             const res = await provider.request({
               method: 'wallet_connect',
               params: [
-                capabilities
-                  ? {
-                      capabilities: z.encode(Rpc.wallet_connect.capabilities.request, capabilities),
-                    }
-                  : {},
+                {
+                  ...(chainId ? { chainId } : {}),
+                  ...(capabilities
+                    ? {
+                        capabilities: z.encode(
+                          Rpc.wallet_connect.capabilities.request,
+                          capabilities,
+                        ),
+                      }
+                    : {}),
+                },
               ] as never,
             })
             accounts = res.accounts


### PR DESCRIPTION
Use `chainId` from `wallet_connect` params to update the store before the dialog opens, ensuring the correct chain is sent to the embed app.

### Changes

- **Provider.ts** — `wallet_connect` handler reads `chainId` from params and updates the store before connecting
- **Connector.ts** — wagmi connector extracts `chainId` from connect params and forwards it in `wallet_connect` RPC
- **wagmi example** — passes `chainId` based on `?testnet` flag
- **playground** — passes `chainId` based on `testnet` flag