### PR TITLE
feat(dialog): add payment permission to embed iframe

### DIFF
--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -105,6 +105,7 @@ export function iframe(): Dialog {
         `publickey-credentials-get ${hostUrl.origin}`,
         `publickey-credentials-create ${hostUrl.origin}`,
         'clipboard-write',
+        'payment',
       ].join('; '),
     )
     frame.setAttribute('allowtransparency', 'true')


### PR DESCRIPTION
## Summary

Add `payment` to the embed iframe's `allow` attribute so the Coinbase Apple Pay iframe can access the Payment Request API.

## Motivation

The embed iframe only permitted `publickey-credentials-get`, `publickey-credentials-create`, and `clipboard-write`. When the Apple Pay onramp flow runs inside the embed (dApp → embed iframe → Coinbase iframe), the nested Coinbase iframe couldn't create an Apple Pay session — the browser silently blocks the Payment Request API without the `payment` permission on the parent iframe.

## Changes

- `src/core/Dialog.ts` — added `'payment'` to the iframe `allow` attribute list

## Testing

- `pnpm check` and `pnpm check:types` pass
- Companion PR: [tempoxyz/app#1195](https://github.com/tempoxyz/app/pull/1195)
- Test by running `pnpm example:wagmi`, connecting, sending a tx with insufficient funds, and selecting Apple Pay

Prompted by: alex