### PR TITLE
feat: enable mpp on cli example with paid fetch

### DIFF
--- a/examples/cli/cli.ts
+++ b/examples/cli/cli.ts
@@ -7,9 +7,13 @@ import { Actions } from 'viem/tempo'
 
 import { Provider } from '../../src/cli/index.js'
 
-const provider = Provider.create({ testnet: true })
+const provider = Provider.create({
+  feePayerUrl: 'https://sponsor.moderato.tempo.xyz',
+  mpp: true,
+  testnet: true,
+})
 
-const token = '0x20c0000000000000000000000000000000000001' as const
+const token = '0x20c0000000000000000000000000000000000000' as const
 
 Cli.create('example', {
   async run() {
@@ -39,8 +43,13 @@ Cli.create('example', {
       token,
     })
 
+    // 3. Fetch a paid API endpoint via MPP.
+    const response = await fetch('https://mpp.dev/api/ping/paid')
+    const data = await response.text()
+
     return {
       hash: receipt.transactionHash,
+      ping: data,
     }
   },
 }).serve()

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -559,6 +559,7 @@ export function create(options: create.Options = {}): create.ReturnType {
             const account = Account.find({ store, signable: true })
             return Object.assign(client, { account })
           },
+          mode: 'pull',
         }),
       ],
     })


### PR DESCRIPTION
- Enable `mpp: true` on CLI example provider
- Add `fetch('https://mpp.dev/api/ping/paid')` call with receipt extraction
- Default provider mpp to pull mode