### PR TITLE
chore: add changeset for mpp cli example

### DIFF
--- a/.changeset/enable-mpp-cli.md
+++ b/.changeset/enable-mpp-cli.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Enabled MPP on provider with pull mode by default.


### PR DESCRIPTION
Adds patch changeset for enabling MPP on provider with pull mode by default.