### PR TITLE
refactor: rename Handler.webauthn to Handler.webAuthn

### DIFF
--- a/.changeset/rename-webauthn-handler.md
+++ b/.changeset/rename-webauthn-handler.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Renamed `Handler.webauthn` to `Handler.webAuthn`.

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -17,7 +17,7 @@ const payment = Mppx.create({
 
 const handler = Handler.compose([
   cliAuth,
-  Handler.webauthn({
+  Handler.webAuthn({
     kv: Kv.memory(),
     origin: process.env.ORIGIN,
     path: '/webauthn',

--- a/src/core/WebAuthnCeremony.ts
+++ b/src/core/WebAuthnCeremony.ts
@@ -148,7 +148,7 @@ export declare namespace local {
 }
 
 /**
- * Creates a server-backed ceremony that delegates to a remote {@link Handler.webauthn} endpoint.
+ * Creates a server-backed ceremony that delegates to a remote {@link Handler.webAuthn} endpoint.
  *
  * All challenge generation, verification, and credential storage happen server-side.
  * The client uses `fetch()` to communicate with 4 POST endpoints derived from the base URL.

--- a/src/server/Handler.test.ts
+++ b/src/server/Handler.test.ts
@@ -853,7 +853,7 @@ describe('webauthn', () => {
 
   beforeAll(async () => {
     server = await createServer(
-      Handler.webauthn({
+      Handler.webAuthn({
         kv: Kv.memory(),
         origin: 'http://localhost',
         rpId: 'localhost',
@@ -953,7 +953,7 @@ describe('webauthn', () => {
     test('behavior: onRegister error does not call hook', async () => {
       let called = false
       const hookServer = await createServer(
-        Handler.webauthn({
+        Handler.webAuthn({
           kv: Kv.memory(),
           origin: 'http://localhost',
           rpId: 'localhost',
@@ -978,7 +978,7 @@ describe('webauthn', () => {
     test('behavior: onAuthenticate error does not call hook', async () => {
       let called = false
       const hookServer = await createServer(
-        Handler.webauthn({
+        Handler.webAuthn({
           kv: Kv.memory(),
           origin: 'http://localhost',
           rpId: 'localhost',

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -490,7 +490,7 @@ export declare namespace codeAuth {
  * ```ts
  * import { Handler, Kv } from 'accounts/server'
  *
- * const handler = Handler.webauthn({
+ * const handler = Handler.webAuthn({
  *   kv: Kv.memory(),
  *   origin: 'https://example.com',
  *   rpId: 'example.com',
@@ -502,7 +502,7 @@ export declare namespace codeAuth {
  * @param options - Options.
  * @returns Request handler.
  */
-export function webauthn(options: webauthn.Options): Handler {
+export function webAuthn(options: webAuthn.Options): Handler {
   const { challengeTtl = 300, kv, onAuthenticate, onRegister, path = '', rpId, ...rest } = options
   const origin = options.origin as string | string[]
 
@@ -637,7 +637,7 @@ export function webauthn(options: webauthn.Options): Handler {
   return router
 }
 
-export declare namespace webauthn {
+export declare namespace webAuthn {
   type Options = from.Options & {
     /** Maximum age of a challenge in seconds before it expires. @default 300 */
     challengeTtl?: number | undefined

--- a/test/setup.global.browser.ts
+++ b/test/setup.global.browser.ts
@@ -17,11 +17,11 @@ export default async function () {
   }
 
   const server = await createServer(
-    Handler.webauthn({ kv: Kv.memory(), origin: 'http://localhost', rpId: 'localhost' }).listener,
+    Handler.webAuthn({ kv: Kv.memory(), origin: 'http://localhost', rpId: 'localhost' }).listener,
     { port },
   )
   const hooksServer = await createServer(
-    Handler.webauthn({
+    Handler.webAuthn({
       cors: { exposeHeaders: 'x-custom' },
       kv: Kv.memory(),
       origin: 'http://localhost',

--- a/test/webauthn.setup.global.ts
+++ b/test/webauthn.setup.global.ts
@@ -9,13 +9,13 @@ export default async function () {
   const server = Http.createServer((req, res) => {
     // Origin varies per Playwright run; extract from request header.
     const origin = req.headers.origin ?? 'http://localhost'
-    Handler.webauthn({ kv, origin, rpId: 'localhost' }).listener(req, res)
+    Handler.webAuthn({ kv, origin, rpId: 'localhost' }).listener(req, res)
   })
 
   const hooksKv = Kv.memory()
   const hooksServer = Http.createServer((req, res) => {
     const origin = req.headers.origin ?? 'http://localhost'
-    Handler.webauthn({
+    Handler.webAuthn({
       cors: { exposeHeaders: 'x-custom' },
       kv: hooksKv,
       origin,


### PR DESCRIPTION
Renames `Handler.webauthn` to `Handler.webAuthn` for consistent camelCase.