### PR TITLE
feat: add vercel preview to trusted hosts

### DIFF
--- a/.changeset/add-vercel-trusted-host.md
+++ b/.changeset/add-vercel-trusted-host.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `tempo-docs-git-jxom-accounts-sdk-docs-tempoxyz.vercel.app` to trusted hosts.

--- a/src/trusted-hosts.json
+++ b/src/trusted-hosts.json
@@ -11,6 +11,7 @@
     "print-a-tshirt.com",
     "*.porto.workers.dev",
     "benedict.dev",
-    "papercut.lol"
+    "papercut.lol",
+    "tempo-docs-git-jxom-accounts-sdk-docs-tempoxyz.vercel.app"
   ]
 }


### PR DESCRIPTION
Adds `tempo-docs-git-jxom-accounts-sdk-docs-tempoxyz.vercel.app` to the trusted hosts list.