### PR TITLE
feat: add MPP auth demo to playground

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -94,7 +94,7 @@ export function App() {
 
       <h2>MPP</h2>
       <Fortune />
-      <MppZeroDollarAuth />
+      <MppIdentity />
 
       <h2>RPC Proxy (fallthrough)</h2>
       <EthBlockNumber />
@@ -900,45 +900,12 @@ function Fortune() {
   )
 }
 
-function MppZeroDollarAuth() {
+function MppIdentity() {
   const [result, error, execute] = useRequest()
   return (
-    <Method method="auth" result={result} error={error}>
-      <button
-        onClick={() =>
-          execute(async () => {
-            const accounts = await provider.request({ method: 'eth_accounts' })
-            if (accounts.length === 0) return 'No accounts connected'
-            const chainId = await provider.request({ method: 'eth_chainId' })
-            return provider.request({
-              method: 'eth_signTypedData_v4',
-              params: [
-                accounts[0],
-                Json.stringify({
-                  types: {
-                    EIP712Domain: [
-                      { name: 'name', type: 'string' },
-                      { name: 'version', type: 'string' },
-                      { name: 'chainId', type: 'uint256' },
-                    ],
-                    Proof: [{ name: 'challengeId', type: 'string' }],
-                  },
-                  primaryType: 'Proof',
-                  domain: {
-                    name: 'MPP',
-                    version: '1',
-                    chainId: Number(chainId),
-                  },
-                  message: {
-                    challengeId: crypto.randomUUID(),
-                  },
-                }),
-              ],
-            })
-          })
-        }
-      >
-        Sign MPP Proof
+    <Method method="fetch /zero-dollar-auth" result={result} error={error}>
+      <button onClick={() => execute(() => fetch('/zero-dollar-auth').then((r) => r.json()))}>
+        Zero-Dollar Auth
       </button>
     </Method>
   )

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -94,6 +94,7 @@ export function App() {
 
       <h2>MPP</h2>
       <Fortune />
+      <MppZeroDollarAuth />
 
       <h2>RPC Proxy (fallthrough)</h2>
       <EthBlockNumber />
@@ -894,6 +895,50 @@ function Fortune() {
     <Method method="fetch /fortune" result={result} error={error}>
       <button onClick={() => execute(() => fetch('/fortune').then((r) => r.json()))}>
         Get Fortune (0.01 pathUSD)
+      </button>
+    </Method>
+  )
+}
+
+function MppZeroDollarAuth() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="auth" result={result} error={error}>
+      <button
+        onClick={() =>
+          execute(async () => {
+            const accounts = await provider.request({ method: 'eth_accounts' })
+            if (accounts.length === 0) return 'No accounts connected'
+            const chainId = await provider.request({ method: 'eth_chainId' })
+            return provider.request({
+              method: 'eth_signTypedData_v4',
+              params: [
+                accounts[0],
+                Json.stringify({
+                  types: {
+                    EIP712Domain: [
+                      { name: 'name', type: 'string' },
+                      { name: 'version', type: 'string' },
+                      { name: 'chainId', type: 'uint256' },
+                    ],
+                    Proof: [{ name: 'challengeId', type: 'string' }],
+                  },
+                  primaryType: 'Proof',
+                  domain: {
+                    name: 'MPP',
+                    version: '1',
+                    chainId: Number(chainId),
+                  },
+                  message: {
+                    challengeId: crypto.randomUUID(),
+                  },
+                }),
+              ],
+            })
+          })
+        }
+      >
+        Sign MPP Proof
       </button>
     </Method>
   )

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -94,7 +94,7 @@ export function App() {
 
       <h2>MPP</h2>
       <Fortune />
-      <MppIdentity />
+      <MppZeroDollarAuth />
 
       <h2>RPC Proxy (fallthrough)</h2>
       <EthBlockNumber />
@@ -900,7 +900,7 @@ function Fortune() {
   )
 }
 
-function MppIdentity() {
+function MppZeroDollarAuth() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="fetch /zero-dollar-auth" result={result} error={error}>

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -33,6 +33,16 @@ export default {
   async fetch(request) {
     const url = new URL(request.url)
 
+    if (url.pathname === '/zero-dollar-auth') {
+      const result = await payment.charge({
+        amount: '0',
+      })(request)
+
+      if (result.status === 402) return result.challenge
+
+      return result.withReceipt(Response.json({ authenticated: true }))
+    }
+
     if (url.pathname === '/fortune') {
       const result = await payment.charge({
         amount: '0.01',

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -6,6 +6,6 @@
   "main": "./worker/index.ts",
   "assets": {
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/fee-payer", "/fortune"],
+    "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/fee-payer", "/fortune", "/zero-dollar-auth"],
   },
 }


### PR DESCRIPTION
- Add zero-dollar auth demo (`/zero-dollar-auth` endpoint) in the playground MPP section
- Update dialog submodule (MPP zero-dollar auth UX, Apple Pay embed, Coinflow purchase UI, layout fixes)