### PR TITLE
refactor: match `Handler.codeAuth` to `Handler.feePayer` interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,6 @@
 - **Workspace examples may need source imports** — when an example must reflect unpublished local SDK changes immediately, import the local `src/*` modules instead of the package entrypoint so it does not silently use stale `dist/*` output.
 - **`dialog` is a git submodule** — points to `git@github.com:tempoxyz/app.git`. Initialize with `git submodule update --init --recursive`.
 - **`VITE_NODE_TAG`** — accepts a Docker image tag (e.g. `latest`, `sha-abc123`) or an HTTP RPC URL (e.g. `https://rpc.moderato.tempo.xyz`) that resolves to a `sha-<hash>` tag via `web3_clientVersion`.
+- **Deduplicate `vp` in Vitest config** — in this workspace, mixed peer resolution (for example different `@types/node` versions across packages) can load two `vp` instances and break suite initialization; set `resolve.dedupe` to include `vp`.
+- **CLI auth example URL inputs** — the example CLI flow is expected to support both `--url` and `AUTH_URL`-based defaults, and should avoid hardcoded personal hostnames in source.
+- **Test RPC port selection should auto-fallback** — localnet test setup should start from `VITE_RPC_PORT` (or `8545`) and select the next available port to avoid `EADDRINUSE` collisions.

--- a/playgrounds/web/worker/cli-auth.ts
+++ b/playgrounds/web/worker/cli-auth.ts
@@ -134,8 +134,7 @@ page.post(`${path}/approve`, async ({ request }) => {
 export const handler = Handler.compose([
   page,
   Handler.codeAuth({
-    chainId: tempoTestnet.id,
-    client,
+    chains: [tempoTestnet],
     path,
     store,
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,19 +192,19 @@ importers:
         specifier: ^10.42.0
         version: 10.47.0(react@19.2.4)
       '@tanstack/query-sync-storage-persister':
-        specifier: ^5.95.2
+        specifier: ^5.90.22
         version: 5.96.1
       '@tanstack/react-query':
-        specifier: ^5.95.2
-        version: 5.96.1(react@19.2.4)
+        specifier: ^5.90.20
+        version: 5.96.2(react@19.2.4)
       '@tanstack/react-query-persist-client':
-        specifier: ^5.95.2
-        version: 5.96.1(@tanstack/react-query@5.96.1(react@19.2.4))(react@19.2.4)
+        specifier: ^5.90.22
+        version: 5.96.1(@tanstack/react-query@5.96.2(react@19.2.4))(react@19.2.4)
       '@tanstack/react-router':
-        specifier: ^1.168.10
+        specifier: ^1.167.4
         version: 1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start':
-        specifier: ^1.167.16
+        specifier: ^1.166.16
         version: 1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.27.4))
       '@wagmi/core':
         specifier: 3.4.0
@@ -268,7 +268,7 @@ importers:
         version: 2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 3.5.0
-        version: 3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       webauthx:
         specifier: ~0.1.0
         version: 0.1.0(typescript@5.9.3)(zod@4.3.6)
@@ -307,7 +307,7 @@ importers:
         specifier: ^4.2.1
         version: 4.2.2(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/router-plugin':
-        specifier: ^1.167.12
+        specifier: ^1.166.13
         version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.27.4))
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
@@ -3614,11 +3614,6 @@ packages:
 
   '@tanstack/react-query@5.90.5':
     resolution: {integrity: sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q==}
-    peerDependencies:
-      react: ^19.2.4
-
-  '@tanstack/react-query@5.96.1':
-    resolution: {integrity: sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==}
     peerDependencies:
       react: ^19.2.4
 
@@ -7323,11 +7318,6 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  srvx@0.11.14:
-    resolution: {integrity: sha512-mx+pKrWJCzo5m6uXqyB7n4VA81mpdFRroSWsVTQTYqCZE65hFJ+jtVIeyhtL2/kvtDMrHdbA0hWEUh/vu0+Viw==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
   srvx@0.11.15:
     resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
     engines: {node: '>=20.16.0'}
@@ -10526,20 +10516,15 @@ snapshots:
       '@tanstack/query-core': 5.96.1
       '@tanstack/query-persist-client-core': 5.96.1
 
-  '@tanstack/react-query-persist-client@5.96.1(@tanstack/react-query@5.96.1(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-query-persist-client@5.96.1(@tanstack/react-query@5.96.2(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/query-persist-client-core': 5.96.1
-      '@tanstack/react-query': 5.96.1(react@19.2.4)
+      '@tanstack/react-query': 5.96.2(react@19.2.4)
       react: 19.2.4
 
   '@tanstack/react-query@5.90.5(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.5
-      react: 19.2.4
-
-  '@tanstack/react-query@5.96.1(react@19.2.4)':
-    dependencies:
-      '@tanstack/query-core': 5.96.1
       react: 19.2.4
 
   '@tanstack/react-query@5.96.2(react@19.2.4)':
@@ -10746,9 +10731,9 @@ snapshots:
       cheerio: 1.2.0
       exsolve: 1.0.8
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       source-map: 0.7.6
-      srvx: 0.11.14
+      srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
       vite: rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -14521,8 +14506,6 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  srvx@0.11.14: {}
-
   srvx@0.11.15: {}
 
   ssh-remote-port-forward@1.0.4:
@@ -15286,9 +15269,9 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
-  wagmi@3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
-      '@tanstack/react-query': 5.96.1(react@19.2.4)
+      '@tanstack/react-query': 5.96.2(react@19.2.4)
       '@wagmi/connectors': 7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@wagmi/core': 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.10(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.4

--- a/ref-impls/cli-auth/src/App.tsx
+++ b/ref-impls/cli-auth/src/App.tsx
@@ -167,19 +167,20 @@ export function App() {
       {pending.status === 'idle' && <p>Paste a device code to load the pending request.</p>}
       {pending.status === 'loading' && <p>Loading request...</p>}
       {pending.status === 'error' && <p>{pending.error}</p>}
-      {approveState.status === 'approved' && (
+      {pending.status === 'ready' && (
         <>
-          <h2>Approved</h2>
-          <p>
-            Device code <strong>{approveState.code}</strong> was authorized by{' '}
-            <code>{approveState.approved.accountAddress}</code>.
-          </p>
-          <p>You can return to the CLI.</p>
-        </>
-      )}
-      {approveState.status !== 'approved' && pending.status === 'ready' && (
-        <>
-          <h2>Pending request</h2>
+          {approveState.status === 'approved' ? (
+            <>
+              <h2>Approved</h2>
+              <p>
+                Device code <strong>{approveState.code}</strong> was authorized by{' '}
+                <code>{approveState.approved.accountAddress}</code>.
+              </p>
+              <p>You can return to the CLI.</p>
+            </>
+          ) : (
+            <h2>Pending request</h2>
+          )}
           <dl>
             <dt>Device code</dt>
             <dd>{pending.pending.code}</dd>
@@ -212,11 +213,15 @@ export function App() {
               </>
             )}
           </dl>
-          {approveState.status === 'error' && <p>{approveState.error}</p>}
-          <form action={approve}>
-            <input name="code" type="hidden" value={pending.pending.code} />
-            <button type="submit">{approving ? 'Approving...' : 'Approve'}</button>
-          </form>
+          {approveState.status !== 'approved' && (
+            <>
+              {approveState.status === 'error' && <p>{approveState.error}</p>}
+              <form action={approve}>
+                <input name="code" type="hidden" value={pending.pending.code} />
+                <button type="submit">{approving ? 'Approving...' : 'Approve'}</button>
+              </form>
+            </>
+          )}
         </>
       )}
     </main>

--- a/ref-impls/cli-auth/worker/approve.ts
+++ b/ref-impls/cli-auth/worker/approve.ts
@@ -1,0 +1,64 @@
+import { CliAuth } from 'accounts/server'
+import { Address, type Hex, PublicKey } from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
+import { Account } from 'viem/tempo'
+import * as z from 'zod/mini'
+
+import { client, store } from './deps.js'
+
+function parseCode(value: string) {
+  const code = value.replaceAll('-', '').toUpperCase()
+  if (/^[A-Z0-9]{8}$/.test(code)) return code
+
+  throw new Error('Expected an 8-character device code.')
+}
+
+function getRoot(env: { PRIVATE_KEY: Hex.Hex }) {
+  if (!env.PRIVATE_KEY)
+    throw new Error('Missing PRIVATE_KEY. Copy .env.example to .env and set a root wallet key.')
+
+  return Account.fromSecp256k1(env.PRIVATE_KEY)
+}
+
+/**
+ * Signs the pending key authorization with the root wallet and completes CLI device-code authorization.
+ */
+export async function approve(request: Request, env: { PRIVATE_KEY: Hex.Hex }) {
+  const body = z.decode(z.object({ code: z.string() }), await request.json())
+  const code = parseCode(body.code)
+  const pending = await CliAuth.pending({
+    code,
+    store,
+  })
+  const root = getRoot(env)
+  const signed = await root.signKeyAuthorization(
+    {
+      accessKeyAddress: Address.fromPublicKey(PublicKey.from(pending.pubKey)),
+      keyType: pending.keyType,
+    },
+    {
+      chainId: pending.chainId,
+      expiry: pending.expiry,
+      ...(pending.limits ? { limits: pending.limits } : {}),
+    },
+  )
+  const keyAuthorization = KeyAuthorization.toRpc(signed)
+  const result = await CliAuth.authorize({
+    chainId: pending.chainId,
+    client,
+    request: {
+      accountAddress: root.address,
+      code,
+      keyAuthorization: z.decode(CliAuth.keyAuthorization, {
+        ...keyAuthorization,
+        address: keyAuthorization.keyId,
+      }),
+    },
+    store,
+  })
+
+  return Response.json({
+    accountAddress: root.address,
+    status: result.status,
+  })
+}

--- a/ref-impls/cli-auth/worker/deps.ts
+++ b/ref-impls/cli-auth/worker/deps.ts
@@ -2,7 +2,7 @@ import { CliAuth } from 'accounts/server'
 import { createClient, http } from 'viem'
 import { tempoModerato } from 'viem/chains'
 
-/** Viem client for Tempo Moderato RPC used by `Handler.codeAuth` and `approve`. */
+/** Viem client for Tempo Moderato RPC used by `approve`. */
 export const client = createClient({
   chain: tempoModerato,
   transport: http(tempoModerato.rpcUrls.default.http[0]),

--- a/ref-impls/cli-auth/worker/deps.ts
+++ b/ref-impls/cli-auth/worker/deps.ts
@@ -1,0 +1,12 @@
+import { CliAuth } from 'accounts/server'
+import { createClient, http } from 'viem'
+import { tempoModerato } from 'viem/chains'
+
+/** Viem client for Tempo Moderato RPC used by `Handler.codeAuth` and `approve`. */
+export const client = createClient({
+  chain: tempoModerato,
+  transport: http(tempoModerato.rpcUrls.default.http[0]),
+})
+
+/** In-memory pending device-code store shared by the worker handler and approve route. */
+export const store = CliAuth.Store.memory()

--- a/ref-impls/cli-auth/worker/index.ts
+++ b/ref-impls/cli-auth/worker/index.ts
@@ -3,7 +3,7 @@ import { type Hex } from 'ox'
 import { tempoModerato } from 'viem/chains'
 
 import { approve } from './approve.js'
-import { client, store } from './deps.js'
+import { store } from './deps.js'
 
 const path = '/cli-auth'
 
@@ -17,8 +17,7 @@ type Bindings = CloudflareBindings & {
 }
 
 const cliAuth = Handler.codeAuth({
-  chainId: tempoModerato.id,
-  client,
+  chains: [tempoModerato],
   path,
   store,
 })

--- a/ref-impls/cli-auth/worker/index.ts
+++ b/ref-impls/cli-auth/worker/index.ts
@@ -1,10 +1,9 @@
 import { CliAuth, Handler } from 'accounts/server'
-import { Address, type Hex, PublicKey } from 'ox'
-import { KeyAuthorization } from 'ox/tempo'
-import { createClient, http } from 'viem'
+import { type Hex } from 'ox'
 import { tempoModerato } from 'viem/chains'
-import { Account } from 'viem/tempo'
-import * as z from 'zod/mini'
+
+import { approve } from './approve.js'
+import { client, store } from './deps.js'
 
 const path = '/cli-auth'
 
@@ -17,73 +16,12 @@ type Bindings = CloudflareBindings & {
   PRIVATE_KEY: Hex.Hex
 }
 
-const client = createClient({
-  chain: tempoModerato,
-  transport: http(tempoModerato.rpcUrls.default.http[0]),
-})
-
-const store = CliAuth.Store.memory()
-
 const cliAuth = Handler.codeAuth({
   chainId: tempoModerato.id,
   client,
   path,
   store,
 })
-
-function parseCode(value: string) {
-  const code = value.replaceAll('-', '').toUpperCase()
-  if (/^[A-Z0-9]{8}$/.test(code)) return code
-
-  throw new Error('Expected an 8-character device code.')
-}
-
-function getRoot(env: Bindings) {
-  if (!env.PRIVATE_KEY)
-    throw new Error('Missing PRIVATE_KEY. Copy .env.example to .env and set a root wallet key.')
-
-  return Account.fromSecp256k1(env.PRIVATE_KEY)
-}
-
-async function approve(request: Request, env: Bindings) {
-  const body = z.decode(z.object({ code: z.string() }), await request.json())
-  const code = parseCode(body.code)
-  const pending = await CliAuth.pending({
-    code,
-    store,
-  })
-  const root = getRoot(env)
-  const signed = await root.signKeyAuthorization(
-    {
-      accessKeyAddress: Address.fromPublicKey(PublicKey.from(pending.pubKey)),
-      keyType: pending.keyType,
-    },
-    {
-      chainId: pending.chainId,
-      expiry: pending.expiry,
-      ...(pending.limits ? { limits: pending.limits } : {}),
-    },
-  )
-  const keyAuthorization = KeyAuthorization.toRpc(signed)
-  const result = await CliAuth.authorize({
-    chainId: pending.chainId,
-    client,
-    request: {
-      accountAddress: root.address,
-      code,
-      keyAuthorization: z.decode(CliAuth.keyAuthorization, {
-        ...keyAuthorization,
-        address: keyAuthorization.keyId,
-      }),
-    },
-    store,
-  })
-
-  return Response.json({
-    accountAddress: root.address,
-    status: result.status,
-  })
-}
 
 /** Minimal Cloudflare Worker reference for CLI device-code approval. */
 export default {

--- a/src/cli/Provider.test.ts
+++ b/src/cli/Provider.test.ts
@@ -81,8 +81,7 @@ function createHandler() {
 
   return Handler.codeAuth({
     path: '/cli-auth',
-    chainId: chain.id,
-    client: getClient({ chain }),
+    chains: [chain],
     policy: {
       validate({ expiry: requestedExpiry, limits }) {
         return {

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -159,7 +159,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[16]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[18]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -167,23 +167,25 @@ describe('Request', () => {
   test('is a discriminated union of all methods', () => {
     type Methods = Schema.Request['method']
     expectTypeOf<Methods>().toEqualTypeOf<
-      | 'eth_accounts'
       | 'eth_chainId'
+      | 'eth_fillTransaction'
+      | 'eth_accounts'
       | 'eth_requestAccounts'
       | 'eth_sendTransaction'
       | 'eth_signTransaction'
-      | 'eth_sendTransactionSync'
       | 'eth_signTypedData_v4'
       | 'personal_sign'
-      | 'wallet_sendCalls'
-      | 'wallet_getBalances'
-      | 'wallet_getCallsStatus'
-      | 'wallet_getCapabilities'
       | 'wallet_connect'
       | 'wallet_disconnect'
-      | 'wallet_authorizeAccessKey'
-      | 'wallet_revokeAccessKey'
+      | 'wallet_getCallsStatus'
+      | 'wallet_getCapabilities'
+      | 'wallet_sendCalls'
       | 'wallet_switchEthereumChain'
+      | 'wallet_authorizeAccessKey'
+      | 'eth_sendTransactionSync'
+      | 'wallet_deposit'
+      | 'wallet_getBalances'
+      | 'wallet_revokeAccessKey'
     >()
   })
 

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -356,7 +356,7 @@ describe('pending', () => {
   test('behavior: handler returns 400 for a completed code', async () => {
     const store = CliAuth.Store.memory()
     const handler = Handler.codeAuth({
-      chainId: chain.id,
+      chains: [chain],
       store,
     })
     const { codeVerifier, request } = await createRequest()
@@ -397,7 +397,7 @@ describe('pending', () => {
   test('behavior: handler accepts a hyphenated code', async () => {
     const store = CliAuth.Store.memory()
     const handler = Handler.codeAuth({
-      chainId: chain.id,
+      chains: [chain],
       store,
     })
     const { request } = await createRequest()
@@ -463,7 +463,7 @@ describe('poll', () => {
 
   test('behavior: rejects a PKCE mismatch', async () => {
     const handler = Handler.codeAuth({
-      chainId: chain.id,
+      chains: [chain],
       store: CliAuth.Store.memory(),
     })
     const { request } = await createRequest()

--- a/src/server/Handler.test-d.ts
+++ b/src/server/Handler.test-d.ts
@@ -1,0 +1,30 @@
+import { createClient, http, type Chain, type Transport } from 'viem'
+import { tempo, tempoModerato } from 'viem/chains'
+import { describe, expectTypeOf, test } from 'vp/test'
+
+import * as Handler from './Handler.js'
+
+describe('codeAuth options', () => {
+  test('supports chain-agnostic chains/transports configuration', () => {
+    expectTypeOf<Handler.codeAuth.Options>().toMatchTypeOf<{
+      chains?: readonly [Chain, ...Chain[]] | undefined
+      transports?: Record<number, Transport> | undefined
+    }>()
+  })
+
+  test('accepts derived clients from chains/transports', () => {
+    void Handler.codeAuth({
+      chains: [tempo, tempoModerato],
+      transports: {
+        [tempo.id]: http('https://rpc.tempo.xyz'),
+        [tempoModerato.id]: http('https://rpc.moderato.tempo.xyz'),
+      },
+    })
+  })
+
+  test('keeps explicit client option support', () => {
+    void Handler.codeAuth({
+      client: createClient({ chain: tempo, transport: http('https://rpc.tempo.xyz') }),
+    })
+  })
+})

--- a/src/server/Handler.test-d.ts
+++ b/src/server/Handler.test-d.ts
@@ -1,4 +1,4 @@
-import { createClient, http, type Chain, type Transport } from 'viem'
+import { http, type Chain, type Transport } from 'viem'
 import { tempo, tempoModerato } from 'viem/chains'
 import { describe, expectTypeOf, test } from 'vp/test'
 
@@ -19,12 +19,6 @@ describe('codeAuth options', () => {
         [tempo.id]: http('https://rpc.tempo.xyz'),
         [tempoModerato.id]: http('https://rpc.moderato.tempo.xyz'),
       },
-    })
-  })
-
-  test('keeps explicit client option support', () => {
-    void Handler.codeAuth({
-      client: createClient({ chain: tempo, transport: http('https://rpc.tempo.xyz') }),
     })
   })
 })

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -391,17 +391,16 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
 
   const defaultChainId = chainId ?? client?.chain?.id ?? chains.at(0)?.id
 
-  function assertConfiguredChain(chainId: bigint | number | undefined) {
-    if (client || !chainId) return
-    if (!clients.has(Number(chainId))) throw new Error(`Chain ${chainId} not configured`)
-  }
-
   function resolveClient(chainId: bigint | number | undefined): Client {
     if (client) return client
     const id = Number(chainId ?? defaultChainId)
-    if (typeof id === 'undefined') throw new Error('No chain configured')
+    if (!Number.isFinite(id)) throw new Error('No chain configured')
     const resolved = clients.get(id)
-    if (!resolved) throw new Error(`Chain ${id} not configured`)
+    if (!resolved)
+      return createClient({
+        chain: { ...tempo, id },
+        transport: http(),
+      })
     return resolved
   }
 
@@ -426,7 +425,6 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   router.post(`${path}/code`, async ({ request: req }) => {
     try {
       const request = z.decode(CliAuth.createRequest, await req.json())
-      assertConfiguredChain(request.chainId ?? defaultChainId)
       const result = await CliAuth.createDeviceCode({
         chainId: defaultChainId,
         ...(now ? { now } : {}),

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -370,9 +370,7 @@ export declare namespace feePayer {
  */
 export function codeAuth(options: codeAuth.Options = {}): Handler {
   const {
-    chainId,
     chains = [tempo, tempoModerato],
-    client,
     now,
     path = '/auth/pkce',
     policy,
@@ -389,19 +387,14 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     clients.set(chain.id, createClient({ chain, transport }))
   }
 
-  const defaultChainId = chainId ?? client?.chain?.id ?? chains.at(0)?.id
-
-  function resolveClient(chainId: bigint | number | undefined): Client {
-    if (client) return client
-    const id = Number(chainId ?? defaultChainId)
-    if (!Number.isFinite(id)) throw new Error('No chain configured')
-    const resolved = clients.get(id)
-    if (!resolved)
-      return createClient({
-        chain: { ...tempo, id },
-        transport: http(),
-      })
-    return resolved
+  function getClient(chainId?: bigint | number): Client {
+    if (typeof chainId !== 'undefined') {
+      const id = Number(chainId)
+      const client = clients.get(id)
+      if (!client) throw new Error(`Chain ${id} not configured`)
+      return client
+    }
+    return clients.get(chains[0]!.id)!
   }
 
   const router = from(rest)
@@ -425,8 +418,10 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   router.post(`${path}/code`, async ({ request: req }) => {
     try {
       const request = z.decode(CliAuth.createRequest, await req.json())
+      const chainId = request.chainId ?? chains[0]!.id
+      getClient(chainId)
       const result = await CliAuth.createDeviceCode({
-        chainId: defaultChainId,
+        chainId,
         ...(now ? { now } : {}),
         ...(policy ? { policy } : {}),
         ...(random ? { random } : {}),
@@ -462,8 +457,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     try {
       const request = z.decode(CliAuth.authorizeRequest, await req.json())
       const result = await CliAuth.authorize({
-        chainId: defaultChainId,
-        client: resolveClient(request.keyAuthorization.chainId),
+        client: getClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
         request,
         store,
@@ -480,18 +474,12 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
 
 export declare namespace codeAuth {
   export type Options = from.Options & {
-    /** Chain ID embedded into authorized access keys. Defaults to the client chain or first configured chain. */
-    chainId?: bigint | number | undefined
     /**
-     * Supported chains. Used to derive verification clients when `client` is omitted.
+     * Supported chains. The handler resolves the client based on chain IDs carried
+     * by device-code requests and key authorizations.
      * @default [tempo, tempoModerato]
      */
     chains?: readonly [Chain, ...Chain[]] | undefined
-    /**
-     * Client used to verify signed key authorizations.
-     * When omitted, the handler derives per-chain clients from `chains` and `transports`.
-     */
-    client?: Client<Transport, Chain | undefined> | undefined
     /** Time source used for TTL evaluation. */
     now?: (() => number) | undefined
     /** Path prefix for the code auth endpoints. @default "/auth/pkce" */

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -371,15 +371,39 @@ export declare namespace feePayer {
 export function codeAuth(options: codeAuth.Options = {}): Handler {
   const {
     chainId,
+    chains = [tempo, tempoModerato],
     client,
     now,
     path = '/auth/pkce',
     policy,
     random,
     store = CliAuth.Store.memory(),
+    transports = {},
     ttlMs,
     ...rest
   } = options
+
+  const clients = new Map<number, Client>()
+  for (const chain of chains) {
+    const transport = transports[chain.id] ?? http()
+    clients.set(chain.id, createClient({ chain, transport }))
+  }
+
+  const defaultChainId = chainId ?? client?.chain?.id ?? chains.at(0)?.id
+
+  function assertConfiguredChain(chainId: bigint | number | undefined) {
+    if (client || !chainId) return
+    if (!clients.has(Number(chainId))) throw new Error(`Chain ${chainId} not configured`)
+  }
+
+  function resolveClient(chainId: bigint | number | undefined): Client {
+    if (client) return client
+    const id = Number(chainId ?? defaultChainId)
+    if (typeof id === 'undefined') throw new Error('No chain configured')
+    const resolved = clients.get(id)
+    if (!resolved) throw new Error(`Chain ${id} not configured`)
+    return resolved
+  }
 
   const router = from(rest)
 
@@ -402,8 +426,9 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   router.post(`${path}/code`, async ({ request: req }) => {
     try {
       const request = z.decode(CliAuth.createRequest, await req.json())
+      assertConfiguredChain(request.chainId ?? defaultChainId)
       const result = await CliAuth.createDeviceCode({
-        ...(typeof chainId !== 'undefined' ? { chainId } : {}),
+        chainId: defaultChainId,
         ...(now ? { now } : {}),
         ...(policy ? { policy } : {}),
         ...(random ? { random } : {}),
@@ -439,8 +464,8 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     try {
       const request = z.decode(CliAuth.authorizeRequest, await req.json())
       const result = await CliAuth.authorize({
-        ...(typeof chainId !== 'undefined' ? { chainId } : {}),
-        ...(client ? { client } : {}),
+        chainId: defaultChainId,
+        client: resolveClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
         request,
         store,
@@ -457,9 +482,17 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
 
 export declare namespace codeAuth {
   export type Options = from.Options & {
-    /** Chain ID embedded into authorized access keys. Defaults to the client chain or tempo.id. */
+    /** Chain ID embedded into authorized access keys. Defaults to the client chain or first configured chain. */
     chainId?: bigint | number | undefined
-    /** Client used to verify signed key authorizations. */
+    /**
+     * Supported chains. Used to derive verification clients when `client` is omitted.
+     * @default [tempo, tempoModerato]
+     */
+    chains?: readonly [Chain, ...Chain[]] | undefined
+    /**
+     * Client used to verify signed key authorizations.
+     * When omitted, the handler derives per-chain clients from `chains` and `transports`.
+     */
     client?: Client<Transport, Chain | undefined> | undefined
     /** Time source used for TTL evaluation. */
     now?: (() => number) | undefined
@@ -471,6 +504,8 @@ export declare namespace codeAuth {
     random?: ((size: number) => Uint8Array) | undefined
     /** Device-code store. */
     store?: CliAuth.Store | undefined
+    /** Transports keyed by chain ID. Defaults to `http()` for each chain. */
+    transports?: Record<number, Transport> | undefined
     /** Pending entry TTL in milliseconds. @default 600000 */
     ttlMs?: number | undefined
   }

--- a/test/config.ts
+++ b/test/config.ts
@@ -26,9 +26,10 @@ export const id =
 export const nodeEnv = import.meta.env.VITE_NODE_ENV || 'localnet'
 
 export const rpcUrl = (() => {
+  const rpcPort = process.env.VITE_RPC_PORT ?? import.meta.env.VITE_RPC_PORT ?? '8545'
   if (nodeEnv === 'testnet') return tempoModerato.rpcUrls.default.http[0]
   if (nodeEnv === 'devnet') return tempoDevnet.rpcUrls.default.http[0]
-  return `http://localhost:${import.meta.env.VITE_RPC_PORT ?? '8545'}/${id}`
+  return `http://localhost:${rpcPort}/${id}`
 })()
 
 const accountsMnemonic = (() => {

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,7 +1,35 @@
+import * as net from 'node:net'
+
 import { nodeEnv } from './config.js'
 import { setupServer } from './prool.js'
 
+async function isPortAvailable(port: number) {
+  return await new Promise<boolean>((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE') {
+        resolve(false)
+        return
+      }
+      reject(error)
+    })
+    server.once('listening', () => {
+      server.close(() => resolve(true))
+    })
+    server.listen(port)
+  })
+}
+
 export default async function () {
   if (nodeEnv !== 'localnet') return undefined
-  return await setupServer({ port: 8545 })
+  const startPort = Number(process.env.VITE_RPC_PORT ?? '8545')
+
+  for (let i = 0; i < 20; i++) {
+    const port = startPort + i
+    if (!(await isPortAvailable(port))) continue
+    process.env.VITE_RPC_PORT = String(port)
+    return await setupServer({ port })
+  }
+
+  throw new Error(`Unable to find an available RPC port starting at ${startPort}.`)
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,35 +5,79 @@ import { afterAll, beforeAll } from 'vp/test'
 import { accounts, getClient, nodeEnv, rpcUrl, webAuthnAccounts } from './config.js'
 
 const client = getClient()
+const localnetSetupKey = '__accounts_localnet_setup__'
+
+type SetupState = {
+  promise?: Promise<void> | undefined
+}
+
+function getSetupState() {
+  const globalState = globalThis as typeof globalThis & {
+    [localnetSetupKey]?: SetupState | undefined
+  }
+  globalState[localnetSetupKey] ??= {}
+  return globalState[localnetSetupKey]!
+}
 
 beforeAll(async () => {
   if (nodeEnv === 'localnet') {
-    async function getValidBefore() {
-      return Math.floor(Date.now() / 1000) + 25
+    const state = getSetupState()
+    if (state.promise) {
+      await state.promise
+      return
     }
 
-    // Mint liquidity for fee tokens.
-    for (const id of [1n, 2n, 3n])
-      await Actions.amm.mintSync(client, {
-        account: accounts[0],
-        feeToken: Addresses.pathUsd,
-        nonceKey: 'expiring',
-        validBefore: await getValidBefore(),
-        userTokenAddress: id,
-        validatorTokenAddress: Addresses.pathUsd,
-        validatorTokenAmount: parseUnits('1000', 6),
-        to: accounts[0].address,
-      })
+    async function wait(ms: number) {
+      await new Promise((resolve) => setTimeout(resolve, ms))
+    }
 
-    // Fund first webAuthn account for provider tests.
-    await Actions.token.transferSync(client, {
-      account: accounts[0],
-      feeToken: Addresses.pathUsd,
-      validBefore: await getValidBefore(),
-      to: webAuthnAccounts[0].address,
-      token: Addresses.pathUsd,
-      amount: parseUnits('100', 6),
-    })
+    async function withRetry(fn: () => Promise<void>) {
+      let error: unknown
+      for (let i = 0; i < 12; i++) {
+        try {
+          await fn()
+          return
+        } catch (e) {
+          error = e
+          const message = e instanceof Error ? e.message : String(e)
+          const isTransientRpcError =
+            message.includes('HTTP request failed') ||
+            message.includes('request timed out') ||
+            message.includes('eth_getBlockByNumber') ||
+            message.includes('Bad Request')
+          if (!isTransientRpcError) throw e
+          await wait(200 * (i + 1))
+        }
+      }
+      throw error
+    }
+
+    state.promise = (async () => {
+      // Mint liquidity for fee tokens.
+      for (const id of [1n, 2n, 3n])
+        await withRetry(async () => {
+          await Actions.amm.mintSync(client, {
+            account: accounts[0],
+            feeToken: Addresses.pathUsd,
+            userTokenAddress: id,
+            validatorTokenAddress: Addresses.pathUsd,
+            validatorTokenAmount: parseUnits('1000', 6),
+            to: accounts[0].address,
+          })
+        })
+
+      // Fund first webAuthn account for provider tests.
+      await withRetry(async () => {
+        await Actions.token.transferSync(client, {
+          account: accounts[0],
+          feeToken: Addresses.pathUsd,
+          to: webAuthnAccounts[0].address,
+          token: Addresses.pathUsd,
+          amount: parseUnits('100', 6),
+        })
+      })
+    })()
+    await state.promise
 
     return
   }


### PR DESCRIPTION
- match `Handler.codeAuth` to `Handler.feePayer` interface
- **Worker layout:** Move shared viem client and `CliAuth.Store.memory()` into `ref-impls/cli-auth/worker/deps.ts`, and move the POST `/cli-auth/approve` handler into `approve.ts`, so `worker/index.ts` is mostly routing and asset fallbacks.
- **Approval UI:** After a successful approve, the page still shows the full pending-request block (device code, access key, account, chain, key type, absolute expiry, live **time left**, and **max spend** limits). Only the Approve form is hidden; the one-second timer keeps updating time remaining until expiry.