### PR TITLE
feat: add dangerous_secp256k1 wagmi connector

### DIFF
--- a/.changeset/dangerous-secp256k1-wagmi.md
+++ b/.changeset/dangerous-secp256k1-wagmi.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `dangerous_secp256k1` wagmi connector.

--- a/src/wagmi/Connector.ts
+++ b/src/wagmi/Connector.ts
@@ -8,6 +8,7 @@ import {
 } from 'viem'
 import * as z from 'zod/mini'
 
+import { dangerous_secp256k1 as dangerous_secp256k1_adapter } from '../core/adapters/dangerous_secp256k1.js'
 import { dialog as core_dialog } from '../core/adapters/dialog.js'
 import { webAuthn as webAuthn_adapter } from '../core/adapters/webAuthn.js'
 import * as Provider from '../core/Provider.js'
@@ -291,4 +292,35 @@ export function dialog(options: dialog.Options = {}) {
 
 export declare namespace dialog {
   type Options = core_dialog.Options & Omit<setup.Parameters, 'adapter'>
+}
+
+/**
+ * Creates a wagmi connector backed by a secp256k1 adapter.
+ *
+ * @deprecated Private keys are stored in plaintext via the provider's storage adapter.
+ * Use only for development, testing, or when the threat model allows it.
+ *
+ * @example
+ * ```ts
+ * import { createConfig, http } from 'wagmi'
+ * import { tempoModerato } from 'wagmi/chains'
+ * import { dangerous_secp256k1 } from 'accounts/wagmi'
+ *
+ * const config = createConfig({
+ *   chains: [tempoModerato],
+ *   connectors: [dangerous_secp256k1()],
+ *   transports: { [tempoModerato.id]: http() },
+ * })
+ * ```
+ */
+export function dangerous_secp256k1(options: dangerous_secp256k1.Options = {}) {
+  const { icon, name, rdns, ...rest } = options
+  return setup({
+    ...rest,
+    adapter: dangerous_secp256k1_adapter({ icon, name, rdns }),
+  })
+}
+
+export declare namespace dangerous_secp256k1 {
+  type Options = dangerous_secp256k1_adapter.Options & Omit<setup.Parameters, 'adapter'>
 }

--- a/src/wagmi/index.ts
+++ b/src/wagmi/index.ts
@@ -1,2 +1,2 @@
 export * as Connector from './Connector.js'
-export { dialog, dialog as tempoWallet, webAuthn } from './Connector.js'
+export { dangerous_secp256k1, dialog, dialog as tempoWallet, webAuthn } from './Connector.js'


### PR DESCRIPTION
Added `dangerous_secp256k1` wagmi connector that wraps the existing `dangerous_secp256k1` adapter, following the same pattern as `webAuthn` and `dialog`.