### PR TITLE
fix: dialog insecure context detection & fee payer default behavior

### DIFF
--- a/.changeset/fix-dialog-insecure-context.md
+++ b/.changeset/fix-dialog-insecure-context.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed `Dialog.isInsecureContext()` to return `true` for `http:` protocol — `http://localhost` is a secure context but WebAuthn still requires HTTPS, so the dialog now correctly defaults to popup.

--- a/.changeset/fix-feepayer-default.md
+++ b/.changeset/fix-feepayer-default.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed `feePayerUrl` to be used by default when configured — previously required `feePayer: true` on each transaction, now auto-applies unless explicitly opted out with `feePayer: false`.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -47,6 +47,8 @@ export function define(meta: Meta, fn: SetupFn): Dialog {
 /** Detects an insecure context (e.g. HTTP) where iframes lack WebAuthn support. */
 export function isInsecureContext(): boolean {
   if (typeof window === 'undefined') return false
+  // `http://localhost` is a secure context but WebAuthn still requires HTTPS.
+  if (window.location.protocol === 'http:') return true
   return !window.isSecureContext
 }
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -122,8 +122,11 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   /** Resolves the `feePayer` field from a transaction request into an absolute URL string or `undefined`. */
   function resolveFeePayer(feePayer: string | boolean | undefined): string | undefined {
-    const url =
-      typeof feePayer === 'string' ? feePayer : feePayer === true ? feePayerUrl : undefined
+    const url = (() => {
+      if (typeof feePayer === 'string') return feePayer
+      if (feePayer === false) return undefined
+      return feePayerUrl
+    })()
     if (!url) return undefined
     if (url.startsWith('http://') || url.startsWith('https://')) return url
     if (typeof window !== 'undefined') return new URL(url, window.location.origin).href


### PR DESCRIPTION
## SDK Fixes

- **Dialog**: `isInsecureContext()` now returns `true` for `http:` protocol — `http://localhost` is a secure context but WebAuthn requires HTTPS, so the dialog correctly defaults to popup
- **Fee Payer**: `feePayerUrl` auto-applies when configured — previously required `feePayer: true` on each transaction, now uses the configured URL unless explicitly opted out with `feePayer: false`