### PR TITLE
fix: align iframe color-scheme with embedded dialog app

### DIFF
--- a/.changeset/fix-dialog-backdrop.md
+++ b/.changeset/fix-dialog-backdrop.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed dialog backdrop appearing black on macOS Light mode.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -235,6 +235,10 @@ export function iframe(): Dialog {
       }
     }
 
+    messenger.waitForReady().then(({ colorScheme }) => {
+      if (colorScheme) frame.style.colorScheme = colorScheme
+    })
+
     messenger.on('switch-mode', () => {
       hideDialog()
       activatePage()

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -22,6 +22,8 @@ export type Messenger = {
 
 /** Options sent with the `ready` signal from the remote frame. */
 export type ReadyOptions = {
+  /** CSS `color-scheme` used by the remote embed (e.g. `'dark'`). */
+  colorScheme?: string | undefined
   /** Hostnames trusted by the remote embed to render in an iframe. */
   trustedHosts?: readonly string[] | undefined
 }

--- a/src/core/Remote.ts
+++ b/src/core/Remote.ts
@@ -70,7 +70,7 @@ export type Remote = {
    * Signals readiness to the host and begins accepting requests.
    * Call this after the remote context is fully initialized.
    */
-  ready: () => void
+  ready: (options?: Messenger.ReadyOptions | undefined) => void
   /**
    * Reject an RPC request.
    */
@@ -182,8 +182,8 @@ export function create(options: create.Options): Remote {
       })
     },
 
-    ready() {
-      messenger.ready({ trustedHosts })
+    ready(options) {
+      messenger.ready({ ...options, trustedHosts })
 
       if (typeof window !== 'undefined') {
         const params = new URLSearchParams(window.location.search)


### PR DESCRIPTION
Fixes dialog backdrop appearing fully black on macOS Light mode.

**Root cause:** The iframe element set `colorScheme: 'light dark'`, but the embedded dialog app forces `color-scheme: dark`. On Light-mode Macs, Chromium resolves the iframe to `light`, which conflicts with the embed's `dark` scheme — causing the browser to add a solid backdrop instead of preserving transparency.

**Fix:** Set the iframe's `colorScheme` to `'dark'` to match the embedded app.