### PR TITLE
fix(wagmi): forward `authUrl` to webauthn adapter

### DIFF
--- a/.changeset/dull-frogs-poke.md
+++ b/.changeset/dull-frogs-poke.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed the wagmi WebAuthn connector to forward authUrl so server-backed WebAuthn flows correctly called /auth/\* instead of falling back to local-only mode.

--- a/src/wagmi/Connector.ts
+++ b/src/wagmi/Connector.ts
@@ -255,10 +255,14 @@ export declare namespace setup {
  * ```
  */
 export function webAuthn(options: webAuthn.Options = {}) {
-  const { ceremony, icon, name, rdns, ...rest } = options
+  const { authUrl, ceremony, icon, name, rdns, ...rest } = options
+  const adapter = ceremony
+    ? webAuthn_adapter({ ceremony, icon, name, rdns })
+    : webAuthn_adapter({ authUrl, icon, name, rdns })
+
   return setup({
     ...rest,
-    adapter: webAuthn_adapter({ ceremony, icon, name, rdns }),
+    adapter,
   })
 }
 


### PR DESCRIPTION
Fixes a wagmi WebAuthn bug where `webAuthn({ authUrl })` silently dropped `authUrl` and fell back to the local-only WebAuthn path.

cause: in `src/wagmi/Connector.ts`, the wagmi `webAuthn(...)` helper forwarded `ceremony`, `icon`, `name`, and `rdns` into the core adapter, but did not forward `authUrl`. As a result, server-backed WebAuthn flows never called `/auth/*`.

fix: update `src/wagmi/Connector.ts` so the wagmi connector forwards `authUrl` into the core WebAuthn adapter, while still preserving the existing `ceremony/authUrl OneOf` behavior.

<details>
<summary>
repro
</summary>

repro script [wagmi-webauthn-bug-repro.ts](https://gists.sh/o-az/7871ca7c8172d025dd4c7fa7e73a220d) to show the broken code never touched the configured auth endpoint, while the fix correctly routes the login flow through /auth/login/options.

before:

```sh
pnpm exec tsx wagmi-webauthn-bug-repro.ts

error: Failed to request credential.

Details: window is not defined
fetch calls: []
```

after:

```sh
pnpm exec tsx wagmi-webauthn-bug-repro.ts

error: FETCH_CALLED
fetch calls: [
  "https://wallet.test/auth/login/options"
]
```

</details>