### PR TITLE
fix(dialog): singleton iframe instance keyed by host

### DIFF
--- a/.changeset/singleton-iframe-dialog.md
+++ b/.changeset/singleton-iframe-dialog.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `Dialog.iframe()` injecting duplicate iframes when `tempoWallet()` was instantiated multiple times (React StrictMode, HMR, multiple configs). The iframe instance is now cached as a singleton keyed by host URL — subsequent setup calls swap the store and fallback refs and return the cached instance.

--- a/.changeset/singleton-iframe-dialog.md
+++ b/.changeset/singleton-iframe-dialog.md
@@ -1,5 +1,5 @@
 ---
-"accounts": patch
+'accounts': patch
 ---
 
-Fixed `Dialog.iframe()` injecting duplicate iframes when `tempoWallet()` was instantiated multiple times (React StrictMode, HMR, multiple configs). The iframe instance is now cached as a singleton keyed by host URL — subsequent setup calls swap the store and fallback refs and return the cached instance.
+Fixed `Dialog.iframe()` injecting duplicate iframes by caching the instance as a singleton keyed by host.

--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -13,10 +13,15 @@ function setup() {
   })
   const dialog = Dialog.iframe()
   const handle = dialog({ host, store })
+  lastHandle = handle
   return { handle, store }
 }
 
+let lastHandle: Dialog.Instance | undefined
+
 afterEach(() => {
+  lastHandle?.destroy()
+  lastHandle = undefined
   document.querySelectorAll('dialog[data-tempo-wallet]').forEach((el) => el.remove())
   document.body.style.overflow = ''
 })
@@ -28,6 +33,16 @@ describe('Dialog.iframe', () => {
     expect(dialog).not.toBeNull()
     const iframe = dialog!.querySelector('iframe')
     expect(iframe).not.toBeNull()
+  })
+
+  test('behavior: singleton — multiple calls reuse same iframe', () => {
+    const { handle: a } = setup()
+    const { handle: b } = setup()
+    const { handle: c } = setup()
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    const dialogs = document.querySelectorAll('dialog[data-tempo-wallet]')
+    expect(dialogs.length).toBe(1)
   })
 
   test('behavior: iframe has correct sandbox attributes', () => {

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -59,6 +59,13 @@ export function isSafari(): boolean {
   return ua.includes('safari') && !ua.includes('chrome')
 }
 
+/** Cached iframe singleton — keyed by host, reused across setup calls. */
+let _cached: { host: string; instance: Instance } | undefined
+
+/** Mutable refs swapped on re-entry so the singleton always uses the latest caller's state. */
+let _store: Store.Store | undefined
+let _fallback: Instance | undefined
+
 /** Creates an iframe dialog that embeds the auth app in a `<dialog>` element. */
 export function iframe(): Dialog {
   if (typeof window === 'undefined') return noop()
@@ -66,7 +73,19 @@ export function iframe(): Dialog {
   return define({ name: 'iframe' }, (parameters) => {
     const { host, store } = parameters
 
-    const fallback = popup()(parameters)
+    // Reuse existing iframe if the host matches — just swap the store/fallback refs.
+    if (_cached && _cached.host === host) {
+      _store = store
+      _fallback?.destroy()
+      _fallback = popup()(parameters)
+      return _cached.instance
+    }
+
+    // Different host — tear down old iframe and create fresh.
+    _cached?.instance.destroy()
+
+    _store = store
+    _fallback = popup()(parameters)
 
     let open = false
 
@@ -144,7 +163,7 @@ export function iframe(): Dialog {
         }),
         waitForReady: true,
       })
-      m.on('rpc-response', (response) => handleResponse(store, response))
+      m.on('rpc-response', (response) => handleResponse(_store!, response))
       return m
     }
 
@@ -168,7 +187,7 @@ export function iframe(): Dialog {
     let savedOverflow = ''
     let opener: HTMLElement | null = null
 
-    const onBlur = () => handleBlur(store)
+    const onBlur = () => handleBlur(_store!)
 
     // 1Password extension adds `inert` attribute to `dialog` rendering it unusable.
     const inertObserver = new MutationObserver((mutations) => {
@@ -244,33 +263,38 @@ export function iframe(): Dialog {
       activatePage()
       open = false
 
-      const pending = store
+      const pending = _store!
         .getState()
         .requestQueue.filter(
           (x): x is Store.QueuedRequest & { status: 'pending' } => x.status === 'pending',
         )
-      if (pending.length > 0) fallback.syncRequests(pending)
+      if (pending.length > 0) _fallback!.syncRequests(pending)
     })
 
-    return {
+    const instance: Instance = {
       close() {
-        fallback.close()
+        _fallback!.close()
         open = false
 
         hideDialog()
         activatePage()
       },
       destroy() {
-        fallback.close()
+        if (_cached?.instance === instance) _cached = undefined
+
+        _fallback?.close()
         open = false
 
         activatePage()
         hideDialog()
 
-        fallback.destroy()
+        _fallback?.destroy()
         messenger.destroy()
         root.remove()
         inertObserver.disconnect()
+
+        _store = undefined
+        _fallback = undefined
       },
       open() {
         if (open) return
@@ -287,7 +311,7 @@ export function iframe(): Dialog {
           isSafari() &&
           requests.some((x) => ['wallet_connect', 'eth_requestAccounts'].includes(x.request.method))
         ) {
-          fallback.syncRequests(requests)
+          _fallback!.syncRequests(requests)
           return
         }
 
@@ -305,18 +329,21 @@ export function iframe(): Dialog {
               'To enable the iframe dialog, add your hostname to the trusted hosts list.',
             ].join('\n'),
           )
-          fallback.syncRequests(requests)
+          _fallback!.syncRequests(requests)
         } else {
           const requiresConfirm = requests.some((x) => x.status === 'pending')
           if (!open && requiresConfirm) this.open()
           messenger.send('rpc-requests', {
-            account: getAccount(store),
-            chainId: store.getState().chainId,
+            account: getAccount(_store!),
+            chainId: _store!.getState().chainId,
             requests,
           })
         }
       },
     }
+
+    _cached = { host, instance }
+    return instance
   })
 }
 

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -60,32 +60,32 @@ export function isSafari(): boolean {
 }
 
 /** Cached iframe singleton — keyed by host, reused across setup calls. */
-let _cached: { host: string; instance: Instance } | undefined
+let cached: { host: string; instance: Instance } | undefined
 
 /** Mutable refs swapped on re-entry so the singleton always uses the latest caller's state. */
-let _store: Store.Store | undefined
-let _fallback: Instance | undefined
+let store: Store.Store | undefined
+let fallback: Instance | undefined
 
 /** Creates an iframe dialog that embeds the auth app in a `<dialog>` element. */
 export function iframe(): Dialog {
   if (typeof window === 'undefined') return noop()
 
   return define({ name: 'iframe' }, (parameters) => {
-    const { host, store } = parameters
+    const { host } = parameters
 
     // Reuse existing iframe if the host matches — just swap the store/fallback refs.
-    if (_cached && _cached.host === host) {
-      _store = store
-      _fallback?.destroy()
-      _fallback = popup()(parameters)
-      return _cached.instance
+    if (cached && cached.host === host) {
+      store = parameters.store
+      fallback?.destroy()
+      fallback = popup()(parameters)
+      return cached.instance
     }
 
     // Different host — tear down old iframe and create fresh.
-    _cached?.instance.destroy()
+    cached?.instance.destroy()
 
-    _store = store
-    _fallback = popup()(parameters)
+    store = parameters.store
+    fallback = popup()(parameters)
 
     let open = false
 
@@ -163,7 +163,7 @@ export function iframe(): Dialog {
         }),
         waitForReady: true,
       })
-      m.on('rpc-response', (response) => handleResponse(_store!, response))
+      m.on('rpc-response', (response) => handleResponse(store!, response))
       return m
     }
 
@@ -187,7 +187,7 @@ export function iframe(): Dialog {
     let savedOverflow = ''
     let opener: HTMLElement | null = null
 
-    const onBlur = () => handleBlur(_store!)
+    const onBlur = () => handleBlur(store!)
 
     // 1Password extension adds `inert` attribute to `dialog` rendering it unusable.
     const inertObserver = new MutationObserver((mutations) => {
@@ -263,38 +263,38 @@ export function iframe(): Dialog {
       activatePage()
       open = false
 
-      const pending = _store!
+      const pending = store!
         .getState()
         .requestQueue.filter(
           (x): x is Store.QueuedRequest & { status: 'pending' } => x.status === 'pending',
         )
-      if (pending.length > 0) _fallback!.syncRequests(pending)
+      if (pending.length > 0) fallback!.syncRequests(pending)
     })
 
     const instance: Instance = {
       close() {
-        _fallback!.close()
+        fallback!.close()
         open = false
 
         hideDialog()
         activatePage()
       },
       destroy() {
-        if (_cached?.instance === instance) _cached = undefined
+        if (cached?.instance === instance) cached = undefined
 
-        _fallback?.close()
+        fallback?.close()
         open = false
 
         activatePage()
         hideDialog()
 
-        _fallback?.destroy()
+        fallback?.destroy()
         messenger.destroy()
         root.remove()
         inertObserver.disconnect()
 
-        _store = undefined
-        _fallback = undefined
+        store = undefined
+        fallback = undefined
       },
       open() {
         if (open) return
@@ -311,7 +311,7 @@ export function iframe(): Dialog {
           isSafari() &&
           requests.some((x) => ['wallet_connect', 'eth_requestAccounts'].includes(x.request.method))
         ) {
-          _fallback!.syncRequests(requests)
+          fallback!.syncRequests(requests)
           return
         }
 
@@ -329,20 +329,20 @@ export function iframe(): Dialog {
               'To enable the iframe dialog, add your hostname to the trusted hosts list.',
             ].join('\n'),
           )
-          _fallback!.syncRequests(requests)
+          fallback!.syncRequests(requests)
         } else {
           const requiresConfirm = requests.some((x) => x.status === 'pending')
           if (!open && requiresConfirm) this.open()
           messenger.send('rpc-requests', {
-            account: getAccount(_store!),
-            chainId: _store!.getState().chainId,
+            account: getAccount(store!),
+            chainId: store!.getState().chainId,
             requests,
           })
         }
       },
     }
 
-    _cached = { host, instance }
+    cached = { host, instance }
     return instance
   })
 }


### PR DESCRIPTION
## Summary

`Dialog.iframe()` now caches a single iframe instance per host URL. Subsequent setup calls with the same host swap the mutable store/fallback refs and return the cached instance — no new DOM elements, messengers, or MutationObservers are created.

## Motivation

`tempoWallet()` injecting duplicate iframes when instantiated multiple times (React StrictMode, HMR, multiple configs on docs site). Confirmed 2,700+ `dialog[data-tempo-wallet]` elements in a [minimal repro](https://github.com/tempoxyz/accounts-sdk-duplicate-iframe-repro).

## Changes

- Add module-level `_cached`, `_store`, `_fallback` refs in `Dialog.ts`
- On re-entry with same host: swap `_store`/`_fallback`, return cached instance
- On re-entry with different host: destroy old, create fresh
- All store-dependent reads (`handleResponse`, `handleBlur`, `getAccount`, `syncRequests`) go through `_store` ref
- `destroy()` clears cache and refs
- Add browser test: `singleton — multiple calls reuse same iframe`

## Testing

- `tsc -b` passes
- Patched the [repro app](https://github.com/tempoxyz/accounts-sdk-duplicate-iframe-repro) node_modules with this fix — verified via agent-browser: stays at 1 iframe after multiple config re-creations and "Add page" clicks

Prompted by: tony