### PR TITLE
fix: migrate pending requests on iframe singleton re-entry

### DIFF
--- a/.changeset/fix-iframe-store-swap.md
+++ b/.changeset/fix-iframe-store-swap.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed iframe dialog getting stuck on "Check prompt" when the store is swapped during React re-renders.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -75,7 +75,21 @@ export function iframe(): Dialog {
 
     // Reuse existing iframe if the host matches — just swap the store/fallback refs.
     if (cached && cached.host === host) {
+      const oldStore = store
       store = parameters.store
+
+      // Migrate in-flight requests so responses land in the current store.
+      if (oldStore && oldStore !== store) {
+        const pending = oldStore
+          .getState()
+          .requestQueue.filter((q) => q.status === 'pending')
+        if (pending.length > 0)
+          store.setState((x) => ({
+            ...x,
+            requestQueue: [...x.requestQueue, ...pending],
+          }))
+      }
+
       fallback?.destroy()
       fallback = popup()(parameters)
       return cached.instance


### PR DESCRIPTION
## Problem

When the iframe singleton is reused (e.g. during React re-renders), the module-level `store` ref is swapped to the new caller's store. If a request was queued in the old store, the `rpc-response` handler looks in the new (empty) store and silently drops the response — leaving the dialog stuck on "Check prompt".

## Fix

On re-entry, migrate any pending requests from the old store into the new store so the response handler always finds matching requests. Single localized change, no new state or helpers needed.