### PR TITLE
fix: search previous stores for in-flight responses on iframe re-entry

### DIFF
--- a/.changeset/fix-iframe-store-swap.md
+++ b/.changeset/fix-iframe-store-swap.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed iframe dialog getting stuck on "Check prompt" when the store is swapped during React re-renders.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -65,6 +65,8 @@ let cached: { host: string; instance: Instance } | undefined
 /** Mutable refs swapped on re-entry so the singleton always uses the latest caller's state. */
 let store: Store.Store | undefined
 let fallback: Instance | undefined
+/** Previous stores kept alive so in-flight responses find their matching request. */
+let previousStores: Store.Store[] = []
 
 /** Creates an iframe dialog that embeds the auth app in a `<dialog>` element. */
 export function iframe(): Dialog {
@@ -75,7 +77,13 @@ export function iframe(): Dialog {
 
     // Reuse existing iframe if the host matches — just swap the store/fallback refs.
     if (cached && cached.host === host) {
+      const oldStore = store
       store = parameters.store
+
+      // Keep the old store so in-flight responses can find their matching request.
+      if (oldStore && oldStore !== store && !previousStores.includes(oldStore))
+        previousStores.push(oldStore)
+
       fallback?.destroy()
       fallback = popup()(parameters)
       return cached.instance
@@ -168,7 +176,10 @@ export function iframe(): Dialog {
         }),
         waitForReady: true,
       })
-      m.on('rpc-response', (response) => handleResponse(store!, response))
+      m.on('rpc-response', (response) => {
+        const targetStore = findStoreForResponse(store!, previousStores, response.id)
+        handleResponse(targetStore, response)
+      })
       m.waitForReady().then((result) => {
         readyResult = result
         if (result.colorScheme) frame.style.colorScheme = result.colorScheme
@@ -300,6 +311,7 @@ export function iframe(): Dialog {
 
         store = undefined
         fallback = undefined
+        previousStores = []
       },
       open() {
         if (open) return
@@ -492,6 +504,21 @@ export function noop(): Dialog {
     destroy() {},
     async syncRequests() {},
   }))
+}
+
+/** Finds the store that owns the request matching the given response id. */
+function findStoreForResponse(
+  current: Store.Store,
+  previous: Store.Store[],
+  id: number,
+): Store.Store {
+  if (current.getState().requestQueue.some((q) => q.request.id === id))
+    return current
+  for (const s of previous) {
+    if (s.getState().requestQueue.some((q) => q.request.id === id))
+      return s
+  }
+  return current
 }
 
 /** Updates the store with an RPC response from the remote auth app. */


### PR DESCRIPTION
Supersedes #175.

## Problem

When the iframe singleton is reused during React re-renders, the module-level `store` ref is swapped to the new caller's store. The request queue is **empty at swap time** (the request gets queued into the old store *after* the swap), so migrating pending requests at re-entry doesn't work — there's nothing to migrate yet.

When the `rpc-response` arrives, the handler looks in the new store, finds no matching request, and silently drops the response — leaving the dialog stuck.

## Fix

Track previous stores and search them when handling `rpc-response`. The `findStoreForResponse` helper checks the current store first, then falls back to previous stores to find the one that owns the matching request.