### PR TITLE
feat: rename `feePayerUrl` to `feePayer` with precedence support

### DIFF
--- a/.changeset/rename-fee-payer-option.md
+++ b/.changeset/rename-fee-payer-option.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+**Breaking:** Renamed `feePayerUrl` to `feePayer`.

--- a/examples/cli/cli.ts
+++ b/examples/cli/cli.ts
@@ -8,7 +8,7 @@ import { Actions } from 'viem/tempo'
 import { Provider } from '../../src/cli/index.js'
 
 const provider = Provider.create({
-  feePayerUrl: 'https://sponsor.moderato.tempo.xyz',
+  feePayer: 'https://sponsor.moderato.tempo.xyz',
   mpp: true,
   testnet: true,
 })

--- a/examples/with-fee-payer-and-webauthn/src/config.ts
+++ b/examples/with-fee-payer-and-webauthn/src/config.ts
@@ -4,7 +4,7 @@ import { tempo, tempoModerato } from 'wagmi/chains'
 
 export const config = createConfig({
   chains: [tempo, tempoModerato],
-  connectors: [webAuthn({ testnet: true, authUrl: '/auth', feePayerUrl: '/fee-payer' })],
+  connectors: [webAuthn({ testnet: true, authUrl: '/auth', feePayer: '/fee-payer' })],
   multiInjectedProviderDiscovery: false,
   transports: {
     [tempo.id]: http(),

--- a/examples/with-fee-payer/README.md
+++ b/examples/with-fee-payer/README.md
@@ -16,4 +16,4 @@ local fee-payer endpoint (required due to Chrome's
 [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) policy).
 
 > [!NOTE]
-> In production, set `feePayerUrl` to your deployed worker URL — no tunnel needed.
+> In production, set `feePayer` to your deployed worker URL — no tunnel needed.

--- a/examples/with-fee-payer/src/config.ts
+++ b/examples/with-fee-payer/src/config.ts
@@ -12,7 +12,7 @@ const feePayerUrl = await (async () => {
 
 export const config = createConfig({
   chains: [tempo, tempoModerato],
-  connectors: [tempoWallet({ testnet: true, feePayerUrl })],
+  connectors: [tempoWallet({ testnet: true, feePayer: feePayerUrl })],
   multiInjectedProviderDiscovery: false,
   transports: {
     [tempo.id]: http(),

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -19,15 +19,17 @@ export function fromChainId(
   chainId: number | undefined,
   options: fromChainId.Options,
 ): Client<Transport, typeof tempo> {
-  const { chains, feePayer, provider, store } = options
+  const { chains, feePayer: feePayerOption, provider, store } = options
+  const feePayerUrl = typeof feePayerOption === 'string' ? feePayerOption : feePayerOption?.url
+  const precedence = (typeof feePayerOption === 'object' ? feePayerOption?.precedence : undefined) ?? 'fee-payer-first'
   const id = chainId ?? store.getState().chainId
-  const key = `${id}:${provider ? 'p' : ''}:${feePayer ?? ''}`
+  const key = `${id}:${provider ? 'p' : ''}:${feePayerUrl ?? ''}:${precedence}`
   let client = clients.get(key)
   if (!client) {
     const chain = chains.find((c) => c.id === id) ?? chains[0]!
     const base = http()
     const transport_base = provider ? providerTransport(provider, base) : base
-    const transport = feePayer ? feePayerTransport(transport_base, feePayer) : transport_base
+    const transport = feePayerUrl ? feePayerTransport(transport_base, feePayerUrl, precedence) : transport_base
     client = createClient({ chain, transport, pollingInterval: 1000 })
     clients.set(key, client)
   }
@@ -38,8 +40,13 @@ export declare namespace fromChainId {
   type Options = {
     /** Supported chains. */
     chains: readonly [Chain, ...Chain[]]
-    /** Sponsor service URL. When set, the transport routes sponsored RPC calls to this URL. */
-    feePayer?: string | undefined
+    /** Fee payer configuration. A URL string or config object with `url` and `precedence`. */
+    feePayer?: string | {
+      /** Fee payer service URL. */
+      url: string
+      /** Signing precedence. @default 'fee-payer-first' */
+      precedence?: 'fee-payer-first' | 'user-first' | undefined
+    } | undefined
     /** Provider instance. When set, the transport routes requests through the provider first, falling back to HTTP for unknown methods. */
     provider?: ox_Provider.Provider | undefined
     /** Reactive state store. */
@@ -66,7 +73,7 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
   }
 }
 
-function feePayerTransport(base: Transport, url: string): Transport {
+function feePayerTransport(base: Transport, url: string, precedence: 'fee-payer-first' | 'user-first'): Transport {
   return (params) => {
     const baseTransport = base(params)
     const sponsor = http(url)(params)
@@ -76,7 +83,7 @@ function feePayerTransport(base: Transport, url: string): Transport {
       async request({ method, params: rpcParams }: { method: string; params?: unknown }) {
         const args = rpcParams as readonly unknown[] | undefined
 
-        if (method === 'eth_fillTransaction') {
+        if (precedence === 'fee-payer-first' && method === 'eth_fillTransaction') {
           const request = args?.[0]
           if (
             request &&

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1660,7 +1660,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const provider = Provider.create({
         adapter: adapter(),
         chains: [chain],
-        feePayerUrl: server.url,
+        feePayer: server.url,
       })
 
       const connected = await connect(provider)
@@ -1682,7 +1682,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const provider = Provider.create({
         adapter: adapter(),
         chains: [chain],
-        feePayerUrl: server.url,
+        feePayer: server.url,
       })
 
       const connected = await connect(provider)

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -50,11 +50,20 @@ export function create(options: create.Options = {}): create.ReturnType {
   const {
     adapter = dialog(),
     chains = [tempo, tempoModerato],
-    feePayerUrl,
     persistCredentials,
     testnet,
     storage = typeof window !== 'undefined' ? Storage.idb() : Storage.memory(),
   } = options
+
+  const feePayerConfig = (() => {
+    if (!options.feePayer) return undefined
+    if (typeof options.feePayer === 'string')
+      return { precedence: 'fee-payer-first' as const, url: options.feePayer }
+    return {
+      precedence: options.feePayer.precedence ?? ('fee-payer-first' as const),
+      url: options.feePayer.url,
+    }
+  })()
 
   const defaultChain = testnet
     ? (chains.find((c) => c.testnet) ?? chains[chains.length - 1]!)
@@ -76,7 +85,11 @@ export function create(options: create.Options = {}): create.ReturnType {
     options: { chainId?: number | undefined; feePayer?: string | undefined } = {},
   ) {
     const { chainId, feePayer } = options
-    return Client.fromChainId(chainId, { chains, feePayer, store })
+    return Client.fromChainId(chainId, {
+      chains,
+      feePayer: feePayer ? { url: feePayer, precedence: feePayerConfig?.precedence } : undefined,
+      store,
+    })
   }
 
   const instance = adapter({ getAccount, getClient, storage, store })
@@ -125,7 +138,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     const url = (() => {
       if (typeof feePayer === 'string') return feePayer
       if (feePayer === false) return undefined
-      return feePayerUrl
+      return feePayerConfig?.url
     })()
     if (!url) return undefined
     if (url.startsWith('http://') || url.startsWith('https://')) return url
@@ -340,7 +353,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const decoded = request._decoded.params?.[0]
                     const { calls = [], capabilities, chainId, from } = decoded ?? {}
                     const sync = capabilities?.sync
-                    const feePayer = resolveFeePayer(feePayerUrl ? true : undefined)
+                    const feePayer = resolveFeePayer(feePayerConfig ? true : undefined)
                     const txRequest = {
                       calls,
                       chainId,
@@ -663,11 +676,8 @@ export declare namespace create {
      * @default [tempo, tempoModerato]
      */
     chains?: readonly [Chain, ...Chain[]] | undefined
-    /**
-     * Fee payer URL for interacting with a service running `Handler.feePayer`
-     * from `accounts/server`.
-     */
-    feePayerUrl?: string | undefined
+    /** Fee payer configuration. @see {@link Client.fromChainId.Options.feePayer} */
+    feePayer?: Client.fromChainId.Options['feePayer']
     /** Enable Machine Payment Protocol (mppx) support. @default false */
     mpp?: boolean | undefined
     /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */


### PR DESCRIPTION
## Summary

Renames `feePayerUrl` to `feePayer` on `Provider.create` and `Client.fromChainId`.

`feePayer` now accepts a URL string or a config object with `url` and `precedence`:

- `'fee-payer-first'` (default): `eth_fillTransaction` is routed to the fee payer URL so the fee payer can estimate and sign first.
- `'user-first'`: the user signs first; `eth_fillTransaction` is not routed to the fee payer.

### Examples

```ts
// String (same as before, just renamed)
Provider.create({ feePayer: 'https://sponsor.example.com' })

// Config object with precedence
Provider.create({
  feePayer: {
    url: 'https://sponsor.example.com',
    precedence: 'user-first',
  },
})
```

### Breaking Changes

- `feePayerUrl` option renamed to `feePayer` on `Provider.create` and `Client.fromChainId`
