### PR TITLE
feat: support feePayer: false opt-out and feePayer capabilities

### DIFF
--- a/.changeset/fee-payer-capabilities.md
+++ b/.changeset/fee-payer-capabilities.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `feePayer` to `wallet_sendCalls` capabilities and `wallet_getCapabilities` response.

--- a/.changeset/fee-payer-opt-out.md
+++ b/.changeset/fee-payer-opt-out.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Support `feePayer: false` to opt out of fee payers on a per-transaction basis when a provider-level fee payer is configured.

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -133,8 +133,8 @@ export declare namespace getClient {
   type Options = {
     /** Chain ID. Defaults to the active chain. */
     chainId?: number | undefined
-    /** Fee payer service URL. */
-    feePayer?: string | undefined
+    /** Fee payer service URL, or `false` to opt out of fee payers for this transaction if set globally. */
+    feePayer?: string | false | undefined
   }
 }
 

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -20,12 +20,18 @@ export function fromChainId(
   options: fromChainId.Options,
 ): Client<Transport, typeof tempo> {
   const { chains, feePayer: feePayerOption, provider, store } = options
-  const feePayerUrl = typeof feePayerOption === 'string' ? feePayerOption : feePayerOption?.url
-  const precedence =
-    (typeof feePayerOption === 'object' ? feePayerOption?.precedence : undefined) ??
-    'fee-payer-first'
+  const feePayerUrl = (() => {
+    if (feePayerOption === false) return undefined
+    if (typeof feePayerOption === 'string') return feePayerOption
+    return feePayerOption?.url
+  })()
+  const precedence = (() => {
+    if (typeof feePayerOption === 'object' && feePayerOption !== null)
+      return feePayerOption.precedence ?? 'fee-payer-first'
+    return 'fee-payer-first'
+  })()
   const id = chainId ?? store.getState().chainId
-  const key = `${id}:${provider ? 'p' : ''}:${feePayerUrl ?? ''}:${precedence}`
+  const key = `${id}:${provider ? 'p' : ''}:${feePayerOption === false ? 'no-fp' : feePayerUrl ?? ''}:${precedence}`
   let client = clients.get(key)
   if (!client) {
     const chain = chains.find((c) => c.id === id) ?? chains[0]!
@@ -44,9 +50,10 @@ export declare namespace fromChainId {
   type Options = {
     /** Supported chains. */
     chains: readonly [Chain, ...Chain[]]
-    /** Fee payer configuration. A URL string or config object with `url` and `precedence`. */
+    /** Fee payer configuration. A URL string, config object, or `false` to opt out. */
     feePayer?:
       | string
+      | false
       | {
           /** Fee payer service URL. */
           url: string

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -727,6 +727,27 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(Object.keys(result).length).toMatchInlineSnapshot(`2`)
       expect(result[Hex.fromNumber(tempo.id)]!.atomic.status).toMatchInlineSnapshot(`"supported"`)
     })
+
+    test('behavior: includes feePayer when configured', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        feePayer: 'https://fee-payer.example.com',
+      })
+
+      const result = await provider.request({ method: 'wallet_getCapabilities' })
+      expect(result[Hex.fromNumber(tempo.id)]!.feePayer).toMatchInlineSnapshot(`
+        {
+          "status": "supported",
+        }
+      `)
+    })
+
+    test('behavior: excludes feePayer when not configured', async () => {
+      const provider = Provider.create({ adapter: adapter() })
+
+      const result = await provider.request({ method: 'wallet_getCapabilities' })
+      expect(result[Hex.fromNumber(tempo.id)]!.feePayer).toBeUndefined()
+    })
   })
 
   describe('wallet_getBalances', () => {
@@ -1717,6 +1738,279 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const client = provider.getClient()
       const receipt = await waitForTransactionReceipt(client, { hash })
       expect(receipt.feePayer).not.toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: precedence fee-payer-first (default) on eth_sendTransaction', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const hash = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [{ calls: [transferCall], feePayer: true }],
+      })
+
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: precedence fee-payer-first (default) on eth_sendTransactionSync', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+      const syncTransferCall = Actions.token.transfer.call({
+        to: '0x0000000000000000000000000000000000000001',
+        token: Addresses.pathUsd,
+        amount: parseUnits('5', 6),
+      })
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [syncTransferCall], feePayer: true }],
+      })
+
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: precedence user-first on eth_sendTransaction', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: { url: server.url, precedence: 'user-first' },
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const hash = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [{ calls: [transferCall], feePayer: true }],
+      })
+
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: precedence user-first on eth_sendTransactionSync', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: { url: server.url, precedence: 'user-first' },
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+      const syncTransferCall = Actions.token.transfer.call({
+        to: '0x0000000000000000000000000000000000000001',
+        token: Addresses.pathUsd,
+        amount: parseUnits('6', 6),
+      })
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [syncTransferCall], feePayer: true }],
+      })
+
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: precedence user-first on eth_signTransaction', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: { url: server.url, precedence: 'user-first' },
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const signed = await provider.request({
+        method: 'eth_signTransaction',
+        params: [{ calls: [transferCall], feePayer: true }],
+      })
+
+      expect(signed).toMatch(/^0x78/)
+    })
+
+    test('behavior: feePayer: false opts out on eth_sendTransaction', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const hash = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [{ calls: [transferCall], feePayer: false }],
+      })
+
+      expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).not.toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: feePayer: false opts out on eth_sendTransactionSync', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+      const syncTransferCall = Actions.token.transfer.call({
+        to: '0x0000000000000000000000000000000000000001',
+        token: Addresses.pathUsd,
+        amount: parseUnits('4', 6),
+      })
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [syncTransferCall], feePayer: false }],
+      })
+
+      expect(receipt.feePayer).not.toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: feePayer: false opts out on eth_signTransaction', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const signed = await provider.request({
+        method: 'eth_signTransaction',
+        params: [{ calls: [transferCall], feePayer: false }],
+      })
+
+      expect(signed).toMatch(/^0x76/)
+    })
+
+    test('behavior: wallet_sendCalls with feePayer capability', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [transferCall],
+            capabilities: { feePayer: server.url },
+          },
+        ],
+      })
+
+      expect(result.id).toMatch(/^0x[0-9a-f]+$/)
+
+      const hash = result.id.slice(0, 66) as `0x${string}`
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: wallet_sendCalls with feePayer: true uses provider default', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [transferCall],
+            capabilities: { feePayer: true },
+          },
+        ],
+      })
+
+      expect(result.id).toMatch(/^0x[0-9a-f]+$/)
+
+      const hash = result.id.slice(0, 66) as `0x${string}`
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: wallet_sendCalls with feePayer: false opts out', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        feePayer: server.url,
+      })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [transferCall],
+            capabilities: { feePayer: false },
+          },
+        ],
+      })
+
+      expect(result.id).toMatch(/^0x[0-9a-f]+$/)
+
+      const hash = result.id.slice(0, 66) as `0x${string}`
+      const client = provider.getClient()
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt.feePayer).not.toBe(feePayerAccount.address.toLowerCase())
+    })
+
+    test('behavior: wallet_sendCalls with sync and feePayer capability', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+
+      const connected = await connect(provider)
+      await fund(connected)
+      const syncTransferCall = Actions.token.transfer.call({
+        to: '0x0000000000000000000000000000000000000001',
+        token: Addresses.pathUsd,
+        amount: parseUnits('7', 6),
+      })
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [syncTransferCall],
+            capabilities: { feePayer: server.url, sync: true },
+          },
+        ],
+      })
+
+      expect(result.receipts?.[0]?.feePayer).toBe(
+        feePayerAccount.address.toLowerCase(),
+      )
     })
   })
 })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -82,12 +82,16 @@ export function create(options: create.Options = {}): create.ReturnType {
   let providerRef: ox_Provider.Provider | undefined
 
   function getClient(
-    options: { chainId?: number | undefined; feePayer?: string | undefined } = {},
+    options: { chainId?: number | undefined; feePayer?: string | false | undefined } = {},
   ) {
     const { chainId, feePayer } = options
     return Client.fromChainId(chainId, {
       chains,
-      feePayer: feePayer ? { url: feePayer, precedence: feePayerConfig?.precedence } : undefined,
+      feePayer: (() => {
+        if (feePayer === false) return false
+        if (feePayer) return { url: feePayer, precedence: feePayerConfig?.precedence }
+        return undefined
+      })(),
       store,
     })
   }
@@ -353,7 +357,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const decoded = request._decoded.params?.[0]
                     const { calls = [], capabilities, chainId, from } = decoded ?? {}
                     const sync = capabilities?.sync
-                    const feePayer = resolveFeePayer(feePayerConfig ? true : undefined)
+                    const feePayer = resolveFeePayer(
+                      capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
+                    )
                     const txRequest = {
                       calls,
                       chainId,
@@ -473,12 +479,14 @@ export function create(options: create.Options = {}): create.ReturnType {
                       {
                         accessKeys: { status: 'supported' }
                         atomic: { status: 'supported' }
+                        feePayer?: { status: 'supported' } | undefined
                       }
                     > = {}
                     for (const chain of filtered)
                       result[Hex.fromNumber(chain.id)] = {
                         accessKeys: { status: 'supported' },
                         atomic: { status: 'supported' },
+                        ...(feePayerConfig ? { feePayer: { status: 'supported' } } : {}),
                       }
                     return result as Rpc.wallet_getCapabilities.Encoded['returns']
                   }

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -277,7 +277,11 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
-              feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+              feePayer: (() => {
+                if (feePayer === false) return false
+                if (typeof feePayer === 'string') return feePayer
+                return undefined
+              })(),
             })
             const prepared = await prepareTransactionRequest(client, {
               account,
@@ -303,7 +307,11 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
-              feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+              feePayer: (() => {
+                if (feePayer === false) return false
+                if (typeof feePayer === 'string') return feePayer
+                return undefined
+              })(),
             })
             const prepared = await prepareTransactionRequest(client, {
               account,
@@ -329,7 +337,11 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
-              feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+              feePayer: (() => {
+                if (feePayer === false) return false
+                if (typeof feePayer === 'string') return feePayer
+                return undefined
+              })(),
             })
             const prepared = await prepareTransactionRequest(client, {
               account,

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -194,7 +194,11 @@ export function local(options: local.Options): Adapter.Adapter {
         async signTransaction(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
-            feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+            feePayer: (() => {
+              if (feePayer === false) return false
+              if (typeof feePayer === 'string') return feePayer
+              return undefined
+            })(),
           })
           const { account, prepared } = await withAccessKey(async (account, keyAuthorization) => ({
             account,
@@ -221,7 +225,11 @@ export function local(options: local.Options): Adapter.Adapter {
         async sendTransaction(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
-            feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+            feePayer: (() => {
+              if (feePayer === false) return false
+              if (typeof feePayer === 'string') return feePayer
+              return undefined
+            })(),
           })
           const { account, prepared } = await withAccessKey(async (account, keyAuthorization) => ({
             account,
@@ -242,7 +250,11 @@ export function local(options: local.Options): Adapter.Adapter {
         async sendTransactionSync(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
-            feePayer: typeof feePayer === 'string' ? feePayer : undefined,
+            feePayer: (() => {
+              if (feePayer === false) return false
+              if (typeof feePayer === 'string') return feePayer
+              return undefined
+            })(),
           })
           const { account, prepared } = await withAccessKey(async (account, keyAuthorization) => ({
             account,

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -173,7 +173,12 @@ export namespace personal_sign {
   export type Decoded = Schema.Decoded<typeof schema>
 }
 
-const sendCallsCapabilities = z.optional(z.object({ sync: z.optional(z.boolean()) }))
+const sendCallsCapabilities = z.optional(
+  z.object({
+    feePayer: z.optional(z.union([z.boolean(), z.string()])),
+    sync: z.optional(z.boolean()),
+  }),
+)
 
 export namespace wallet_sendCalls {
   export const schema = Schema.defineItem({
@@ -256,6 +261,11 @@ export namespace wallet_getCapabilities {
         atomic: z.object({
           status: z.union([z.literal('supported'), z.literal('ready'), z.literal('unsupported')]),
         }),
+        feePayer: z.optional(
+          z.object({
+            status: z.union([z.literal('supported'), z.literal('unsupported')]),
+          }),
+        ),
       }),
     ),
   })


### PR DESCRIPTION
## Changes

### `feePayer: false` per-transaction opt-out
When a provider-level fee payer is configured, individual transactions can now pass `feePayer: false` to opt out. Works across `eth_sendTransaction`, `eth_sendTransactionSync`, and `eth_signTransaction`.

### `feePayer` on `wallet_sendCalls` capabilities
`wallet_sendCalls` now accepts `capabilities: { feePayer: true | false | '<url>' }` to control fee payer per-call, with the provider-level config as default.

### `feePayer` on `wallet_getCapabilities`
When a provider-level fee payer is configured, `wallet_getCapabilities` now includes `feePayer: { status: 'supported' }` in the response.

### Tests
- `feePayer: false` opt-out on `eth_sendTransaction`, `eth_sendTransactionSync`, `eth_signTransaction`
- Precedence tests for `fee-payer-first` and `user-first` flows
- `wallet_sendCalls` with `feePayer` capability (URL, true, false, sync+feePayer)
- `wallet_getCapabilities` includes/excludes `feePayer`