### PR TITLE
feat: add temporium.xyz to trusted hosts

### DIFF
--- a/src/trusted-hosts.json
+++ b/src/trusted-hosts.json
@@ -12,6 +12,8 @@
     "*.porto.workers.dev",
     "benedict.dev",
     "papercut.lol",
-    "tempo-docs-git-jxom-accounts-sdk-docs-tempoxyz.vercel.app"
+    "tempo-docs-git-jxom-accounts-sdk-docs-tempoxyz.vercel.app",
+    "temporium.xyz",
+    "*.temporium.xyz"
   ]
 }


### PR DESCRIPTION
Adds `temporium.xyz` and `*.temporium.xyz` to the trusted hosts list.

Temporium is a payments and token management gateway built on Tempo.