### PR TITLE
Support external access key authorisation in dialog adapter

### DIFF
--- a/src/core/Provider.connect.browser.test.ts
+++ b/src/core/Provider.connect.browser.test.ts
@@ -1,7 +1,7 @@
-import { Hex } from 'ox'
+import { Hex, WebCryptoP256 } from 'ox'
 import { type Address, createClient, defineChain, parseUnits } from 'viem'
 import { tempoLocalnet, tempoModerato } from 'viem/chains'
-import { Actions, Addresses } from 'viem/tempo'
+import { Account as TempoAccount, Actions, Addresses } from 'viem/tempo'
 import { afterEach, beforeAll, describe, expect, test } from 'vp/test'
 
 import { accounts, http } from '../../test/config.js'
@@ -310,6 +310,27 @@ describe('wallet_authorizeAccessKey', () => {
       },
     )
     expect(result.keyAuthorization.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+
+  test('behavior: authorizes an external p256 access key via iframe confirm', async () => {
+    provider = getProvider()
+    await connectViaIframe(provider)
+
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKeyAccount = TempoAccount.fromWebCryptoP256(keyPair)
+
+    const result = await interact(
+      provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ ...accessKeyAccount, expiry: Expiry.days(1) }],
+      }),
+      async (iframe) => {
+        await iframe.getByTestId('confirm').click()
+      },
+    )
+
+    expect(result.keyAuthorization.keyId).toBe(accessKeyAccount.address)
+    expect(result.keyAuthorization.keyType).toMatchInlineSnapshot(`"p256"`)
   })
 })
 

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -368,7 +368,12 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
           const result = await provider.request({
             ...request,
-            params: [z.encode(Rpc.wallet_connect.authorizeAccessKey, accessKey!.request)!],
+            params: [
+              z.encode(
+                Rpc.wallet_connect.authorizeAccessKey,
+                accessKey ? accessKey.request : parameters,
+              )!,
+            ],
           })
 
           if (accessKey) {


### PR DESCRIPTION
## Summary
- fix `wallet_authorizeAccessKey` in the Tempo dialog adapter when the caller provides an external access key (`publicKey`/`address`)
- send the original authorisation parameters for external keys instead of dereferencing `accessKey.request` when no local keypair was generated
- add a browser regression test covering external `p256` access-key authorisation through the dialog flow
## Problem
External session key authorisation was broken in the dialog adapter. When callers invoked `wallet_authorizeAccessKey` with an externally managed key, `generateAccessKey(...)` correctly returned `undefined`, but the adapter still tried to read `accessKey.request`. That caused a runtime crash:
`Cannot read properties of undefined (reading 'request')`

## Fix
- `accessKey.request` for managed/generated keys
- the original `parameters` for externally supplied keys

This preserves the existing generated-key flow while allowing external `p256` session keys to be authorized correctly.