### PR TITLE
refactor: rename meta to capabilities in eth_fillTransaction response

### DIFF
--- a/.changeset/relay-capabilities-rename.md
+++ b/.changeset/relay-capabilities-rename.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Renamed `meta` to `capabilities` in `eth_fillTransaction` response.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ overrides:
   react: ^19.2.4
   react-dom: ^19.2.4
   accounts: workspace:*
-  viem: ^2.47.14
+  viem: ^2.47.15
   wrangler: ^4.80.0
 
 importers:
@@ -78,7 +78,7 @@ importers:
         version: 0.0.7(typescript@5.9.3)
       mppx:
         specifier: ^0.5.10
-        version: 0.5.10(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.5.10(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       ox:
         specifier: ~0.14.15
         version: 0.14.15(typescript@5.9.3)(zod@4.3.6)
@@ -127,7 +127,7 @@ importers:
         version: 5.1.4(vite@8.0.3)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       elysia:
         specifier: ^1.4.27
         version: 1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -168,8 +168,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       vp:
         specifier: 'catalog:'
         version: vite-plus@0.1.15(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitejs/devtools@0.1.11)(bufferutil@4.0.9)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(publint@0.3.18)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(vite@8.0.3)(yaml@2.8.2)
@@ -217,7 +217,7 @@ importers:
         version: 1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rolldown-vite@7.3.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.8.1)(@types/node@25.4.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.4(esbuild@0.27.7))
       '@wagmi/core':
         specifier: 3.4.0
-        version: 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       accounts:
         specifier: workspace:*
         version: link:..
@@ -273,11 +273,11 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(typescript@5.9.3)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 3.5.0
-        version: 3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       webauthx:
         specifier: ~0.1.1
         version: 0.1.1(typescript@5.9.3)(zod@4.3.6)
@@ -424,11 +424,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -461,8 +461,8 @@ importers:
         specifier: ~0.14.15
         version: 0.14.15(typescript@5.9.3)(zod@4.3.6)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: latest
@@ -489,11 +489,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -538,11 +538,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -578,11 +578,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -627,11 +627,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -676,11 +676,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -716,8 +716,8 @@ importers:
         specifier: ~0.14.15
         version: 0.14.15(typescript@5.9.3)(zod@4.3.6)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -744,11 +744,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -785,7 +785,7 @@ importers:
         version: link:../..
       mppx:
         specifier: ^0.5.5
-        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -793,8 +793,8 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.47.15
+        version: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@bomb.sh/args':
         specifier: ^0.3.1
@@ -895,7 +895,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.90.5(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.90.5(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@tanstack/router-plugin':
         specifier: ^1.166.7
@@ -5127,7 +5127,7 @@ packages:
       '@walletconnect/ethereum-provider': ^2.21.1
       porto: ~0.2.35
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -5158,7 +5158,7 @@ packages:
       '@walletconnect/ethereum-provider': ^2.21.1
       porto: ~0.2.35
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -5183,7 +5183,7 @@ packages:
       '@tanstack/query-core': '>=5.0.0'
       ox: ~0.14.15
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -5198,7 +5198,7 @@ packages:
       '@tanstack/query-core': '>=5.0.0'
       ox: ~0.14.15
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -7643,7 +7643,7 @@ packages:
       elysia: '>=1'
       express: '>=5'
       hono: '>=4'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -7662,7 +7662,7 @@ packages:
       elysia: '>=1'
       express: '>=5'
       hono: '>=4'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -9467,8 +9467,8 @@ packages:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
     engines: {node: '>=4'}
 
-  viem@2.47.14:
-    resolution: {integrity: sha512-PHmJF1dfa9HEfrVshFXFkixzh/22Z3VFXN1omeFfjMoOFDGQkghsRdDW+KcE29gzM7KZ+MC04L+xpbm2G/kOkw==}
+  viem@2.47.15:
+    resolution: {integrity: sha512-7XmWSEqiUo9fymSXfAg9bL1erVJslKLabv7Q2ZktxejoAvAdoVjyZqSU5PYgBy/ZuvTM7CXGDRAFQGCg57reHw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9647,7 +9647,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.4
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9658,7 +9658,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.4
       typescript: '>=5.7.3'
-      viem: ^2.47.14
+      viem: ^2.47.15
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -14051,25 +14051,25 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
-  '@wagmi/connectors@7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/connectors@7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/connectors@8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
@@ -14081,11 +14081,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
@@ -14097,11 +14097,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
@@ -16862,11 +16862,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.5.10(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.5.10(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.15(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -16876,13 +16876,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.27(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
       incur: 0.3.13(@cfworker/json-schema@4.1.1)(openapi-types@12.1.3)
       ox: 0.14.15(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -18625,7 +18625,7 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -18916,14 +18916,14 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
-  wagmi@3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.5.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.1(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.96.1(react@19.2.4)
-      '@wagmi/connectors': 7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.0(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18939,14 +18939,14 @@ snapshots:
       - ox
       - porto
 
-  wagmi@3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.90.5(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.90.5(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.90.5(react@19.2.4)
-      '@wagmi/connectors': 8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18962,14 +18962,14 @@ snapshots:
       - ox
       - porto
 
-  wagmi@3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.6.0(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.4))(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.4)
-      '@wagmi/connectors': 8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 8.0.0(@wagmi/core@3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.1(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.15(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
-      viem: 2.47.14(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.15(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   tsx: ^4.21.0
   typed-query-selector: ^2.12.1
   typescript: ^5.9.3
-  viem: ^2.47.14
+  viem: ^2.47.15
   vite: ^8.0.5
   vp: npm:vite-plus@~0.1.14
   wagmi: ^3.5.0

--- a/register.ts
+++ b/register.ts
@@ -1,0 +1,7 @@
+import type { Capabilities } from 'viem/tempo'
+
+declare module 'viem' {
+  interface Register {
+    CapabilitiesSchema: Capabilities.Schema
+  }
+}

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -2,7 +2,7 @@ import type { RpcRequest } from 'ox'
 import { SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
 import { parseUnits } from 'viem'
 import { fillTransaction, sendTransactionSync } from 'viem/actions'
-import { Actions, Addresses, Tick, Transaction } from 'viem/tempo'
+import { Actions, Addresses, Capabilities, Tick, Transaction } from 'viem/tempo'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
 
 import { accounts, addresses, chain, getClient, http } from '../../../../test/config.js'
@@ -14,7 +14,10 @@ const feePayerAccount = accounts[0]!
 const recipient = accounts[7]!
 
 /** Case-insensitive lookup into balanceDiffs keyed by address. */
-function findDiffs(balanceDiffs: relay.Meta['balanceDiffs'], address: string) {
+function findDiffs(
+  balanceDiffs: Capabilities.FillTransactionCapabilities['balanceDiffs'],
+  address: string,
+) {
   return Object.entries(balanceDiffs ?? {}).find(
     ([addr]) => addr.toLowerCase() === address.toLowerCase(),
   )?.[1]
@@ -56,7 +59,7 @@ describe('behavior: without feePayer', () => {
     server.close()
   })
 
-  test('default: returns filled transaction with meta', async () => {
+  test('default: returns filled transaction with capabilities', async () => {
     const { transaction } = await fillTransaction(client, {
       account: userAccount.address,
       calls: [transferCall()],
@@ -72,7 +75,7 @@ describe('behavior: without feePayer', () => {
   })
 })
 
-describe('behavior: meta', () => {
+describe('behavior: capabilities', () => {
   let server: Server
   let client: ReturnType<typeof getClient<typeof chain>>
 
@@ -95,12 +98,12 @@ describe('behavior: meta', () => {
       account: userAccount.address,
       calls: [transferCall()],
     })
-    const meta = result.meta as relay.Meta
+    const meta = result.capabilities
 
-    expect(meta.fee).toBeDefined()
-    expect(meta.fee!.decimals).toBe(6)
-    expect(meta.fee!.symbol).toBe('AlphaUSD')
-    expect(meta.sponsored).toBe(false)
+    expect(meta?.fee).toBeDefined()
+    expect(meta?.fee?.decimals).toBe(6)
+    expect(meta?.fee?.symbol).toBe('AlphaUSD')
+    expect(meta?.sponsored).toBe(false)
   })
 
   test('behavior: token transfer produces balance diffs', async () => {
@@ -130,8 +133,8 @@ describe('behavior: meta', () => {
       data,
     })
 
-    const meta = result.meta as relay.Meta
-    const senderDiffs = findDiffs(meta.balanceDiffs, sender.address)!
+    const meta = result.capabilities
+    const senderDiffs = findDiffs(meta?.balanceDiffs, sender.address)!
     const tokenDiff = senderDiffs.find((d) => d.address.toLowerCase() === token.toLowerCase())!
     expect(tokenDiff.decimals).toBe(6)
     expect(tokenDiff.direction).toBe('outgoing')
@@ -226,9 +229,9 @@ describe('behavior: meta', () => {
         }),
       ],
     })
-    const meta = result.meta as relay.Meta
+    const meta = result.capabilities
 
-    const diffs = findDiffs(meta.balanceDiffs, sender.address)!
+    const diffs = findDiffs(meta?.balanceDiffs, sender.address)!
     expect(diffs).toHaveLength(1)
 
     const quoteDiff = diffs[0]!
@@ -262,9 +265,9 @@ describe('behavior: meta', () => {
         }),
       ],
     })
-    const meta = result.meta as relay.Meta
+    const meta = result.capabilities
 
-    const diffs = findDiffs(meta.balanceDiffs, sender.address)!
+    const diffs = findDiffs(meta?.balanceDiffs, sender.address)!
     const tokenDiff = diffs.find((d) => d.address.toLowerCase() === token.toLowerCase())!
     // Only the transfer shows — approval is fully covered.
     expect(tokenDiff.value).toBe('0x64')
@@ -292,9 +295,9 @@ describe('behavior: meta', () => {
         }),
       ],
     })
-    const meta = result.meta as relay.Meta
+    const meta = result.capabilities
 
-    const diffs = findDiffs(meta.balanceDiffs, sender.address)!
+    const diffs = findDiffs(meta?.balanceDiffs, sender.address)!
     const tokenDiff = diffs.find((d) => d.address.toLowerCase() === token.toLowerCase())!
     // transfer(50) + uncovered approval(150) = 200 outgoing.
     expect(tokenDiff.value).toBe('0xc8')
@@ -386,19 +389,19 @@ describe('behavior: AMM resolution', () => {
     })
 
     // Should succeed — relay auto-swapped quote → base.
-    const { transaction, meta } = result
+    const { transaction, capabilities } = result
     expect(transaction.gas).toBeDefined()
     expect(transaction.nonce).toBeDefined()
     expect(transaction.feeToken).toBe(addresses.alphaUsd)
     expect(transaction.calls).toHaveLength(3) // approve + swap + transfer
 
-    const m = meta as relay.Meta
-    expect(m.sponsored).toBe(false)
-    expect(m.fee?.decimals).toBe(6)
-    expect(m.fee?.symbol).toBe('AlphaUSD')
+    const m = capabilities
+    expect(m?.sponsored).toBe(false)
+    expect(m?.fee?.decimals).toBe(6)
+    expect(m?.fee?.symbol).toBe('AlphaUSD')
 
     // Balance diffs exclude swap tokens — only the user's transfer shows.
-    const diffs = findDiffs(m.balanceDiffs, sender.address)!
+    const diffs = findDiffs(m?.balanceDiffs, sender.address)!
     expect(diffs).toHaveLength(1)
     expect(diffs[0]!.direction).toBe('outgoing')
     expect(diffs[0]!.formatted).toBe('5')
@@ -406,13 +409,13 @@ describe('behavior: AMM resolution', () => {
     expect(diffs[0]!.address.toLowerCase()).toBe(base.toLowerCase())
 
     // autoSwap reports the injected AMM swap.
-    expect(m.autoSwap?.slippage).toBe(0.05)
-    expect(m.autoSwap?.maxIn.formatted).toBe('5.25')
-    expect(m.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
-    expect(m.autoSwap?.maxIn.token.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())
-    expect(m.autoSwap?.minOut.formatted).toBe('5')
-    expect(m.autoSwap?.minOut.symbol).toBe('SWBASE')
-    expect(m.autoSwap?.minOut.token.toLowerCase()).toBe(base.toLowerCase())
+    expect(m?.autoSwap?.slippage).toBe(0.05)
+    expect(m?.autoSwap?.maxIn.formatted).toBe('5.25')
+    expect(m?.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
+    expect(m?.autoSwap?.maxIn.token.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())
+    expect(m?.autoSwap?.minOut.formatted).toBe('5')
+    expect(m?.autoSwap?.minOut.symbol).toBe('SWBASE')
+    expect(m?.autoSwap?.minOut.token.toLowerCase()).toBe(base.toLowerCase())
   })
 
   test('behavior: custom slippage is applied to autoSwap', async () => {
@@ -487,11 +490,11 @@ describe('behavior: AMM resolution', () => {
     })
     customServer.close()
 
-    const m = result.meta as relay.Meta
-    expect(m.autoSwap?.slippage).toBe(0.02)
+    const m = result.capabilities
+    expect(m?.autoSwap?.slippage).toBe(0.02)
     // 10 + 2% = 10.2
-    expect(m.autoSwap?.maxIn.formatted).toBe('10.2')
-    expect(m.autoSwap?.minOut.formatted).toBe('10')
+    expect(m?.autoSwap?.maxIn.formatted).toBe('10.2')
+    expect(m?.autoSwap?.minOut.formatted).toBe('10')
   })
 
   test('behavior: autoSwap disabled throws InsufficientBalance instead of swapping', async () => {
@@ -606,15 +609,15 @@ describe('behavior: with feePayer', () => {
     `)
   })
 
-  test('behavior: returns sponsor metadata', async () => {
+  test('behavior: returns sponsor capabilities', async () => {
     const result = await fillTransaction(client, {
       account: userAccount.address,
       calls: [transferCall()],
     })
-    const meta = result.meta as relay.Meta
+    const meta = result.capabilities
 
-    expect(meta.sponsored).toBe(true)
-    expect(meta.sponsor).toMatchInlineSnapshot(`
+    expect(meta?.sponsored).toBe(true)
+    expect(meta?.sponsor).toMatchInlineSnapshot(`
       {
         "address": "${feePayerAccount.address}",
         "name": "Test Sponsor",
@@ -714,9 +717,9 @@ describe('behavior: conditional sponsoring', () => {
     })
     expect(result.transaction.feePayerSignature).toBeUndefined()
 
-    const meta = result.meta as relay.Meta
-    expect(meta.sponsored).toBe(false)
-    expect(meta.sponsor).toBeUndefined()
+    const meta = result.capabilities
+    expect(meta?.sponsored).toBe(false)
+    expect(meta?.sponsor).toBeUndefined()
 
     const serialized = (await Transaction.serialize(result.transaction as never)) as `0x76${string}`
     const envelope = TxEnvelopeTempo.deserialize(serialized)

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -16,7 +16,7 @@ import {
 } from 'viem'
 import { simulateCalls } from 'viem/actions'
 import { tempo, tempoLocalnet, tempoMainnet, tempoModerato } from 'viem/chains'
-import { Abis, Actions, Addresses, Transaction } from 'viem/tempo'
+import { Abis, Actions, Addresses, Capabilities, Transaction } from 'viem/tempo'
 
 import { type Handler, from } from '../../Handler.js'
 import * as FeePayer from './feePayer.js'
@@ -194,7 +194,7 @@ export function relay(options: relay.Options = {}): Handler {
         : undefined
 
       // 6. Resolve autoSwap metadata (when AMM path was taken).
-      const autoSwapMeta = await (async (): Promise<relay.Meta['autoSwap']> => {
+      const autoSwap_ = await (async () => {
         if (!swap) return undefined
         const [inMeta, outMeta] = await Promise.all([
           resolveTokenMetadata(client, swap.tokenIn).catch(() => undefined),
@@ -224,12 +224,12 @@ export function relay(options: relay.Options = {}): Handler {
 
       return Utils.rpcResult(request, {
         tx: core_Transaction.toRpc(tx as core_Transaction.Transaction),
-        meta: {
+        capabilities: {
           balanceDiffs,
           fee,
           sponsored: !!sponsor,
           ...(sponsor ? { sponsor } : {}),
-          ...(autoSwapMeta ? { autoSwap: autoSwapMeta } : {}),
+          ...(autoSwap_ ? { autoSwap: autoSwap_ } : {}),
         },
       })
     } catch (error) {
@@ -376,65 +376,6 @@ export namespace relay {
     path?: string | undefined
     /** Transports keyed by chain ID. Defaults to `http()` for each chain. */
     transports?: Record<number, Transport> | undefined
-  }
-
-  /** Metadata returned alongside the filled transaction. */
-  export type Meta = {
-    /** Per-account balance diffs keyed by address. */
-    balanceDiffs?: Record<Address, readonly BalanceDiff[]> | undefined
-    /** Fee estimate for the transaction. */
-    fee: { amount: Hex.Hex; decimals: number; formatted: string; symbol: string } | null
-    /** Whether the transaction is sponsored by a fee payer. */
-    sponsored: boolean
-    /** Sponsor details (when sponsored). */
-    sponsor?: { address: Address; name: string; url: string } | undefined
-    /** AMM swap injected by the relay to cover an InsufficientBalance. */
-    autoSwap?:
-      | {
-          /** Max input amount with slippage. */
-          maxIn: SwapAmount
-          /** Deficit amount that triggered the swap. */
-          minOut: SwapAmount
-          /** Slippage tolerance (e.g. 0.1 = 10%). */
-          slippage: number
-        }
-      | undefined
-  }
-
-  /** Token amount in a fee swap. */
-  export type SwapAmount = {
-    /** Token address. */
-    token: Address
-    /** Amount (hex-encoded). */
-    value: Hex.Hex
-    /** Human-readable formatted amount. */
-    formatted: string
-    /** Token decimals. */
-    decimals: number
-    /** Token symbol (e.g. "USDC.e"). */
-    symbol: string
-    /** Token name (e.g. "USDC.e"). */
-    name: string
-  }
-
-  /** Balance diff for a single token relative to the user account. */
-  export type BalanceDiff = {
-    /** Token address. */
-    address: Address
-    /** Token decimals (e.g. 6). */
-    decimals: number
-    /** Direction relative to the user. */
-    direction: 'incoming' | 'outgoing'
-    /** Human-readable formatted currency value (e.g. "100.00"). */
-    formatted: string
-    /** Token name (e.g. "USDC.e"). */
-    name: string
-    /** Addresses receiving this asset. */
-    recipients: readonly Address[]
-    /** Token symbol (e.g. "USDC.e"). */
-    symbol: string
-    /** Token amount (hex-encoded). */
-    value: Hex.Hex
   }
 }
 
@@ -627,7 +568,7 @@ async function buildBalanceDiffs(
     const fromLower = log.args.from.toLowerCase()
     const toLower = log.args.to.toLowerCase()
 
-    // Skip swap-related transfers (reported in meta.feeSwap instead).
+    // Skip swap-related transfers (reported in capabilities.autoSwap instead).
     if (swap) {
       if (token === swapTokenIn && fromLower === accountLower && toLower === dexLower) continue
       if (token === swapTokenOut && fromLower === dexLower && toLower === accountLower) continue
@@ -654,7 +595,7 @@ async function buildBalanceDiffs(
     if (log.args.owner.toLowerCase() !== accountLower) continue
     const token = log.address.toLowerCase()
 
-    // Skip swap-related approvals (reported in meta.feeSwap instead).
+    // Skip swap-related approvals (reported in capabilities.autoSwap instead).
     if (swap && token === swapTokenIn && log.args.spender.toLowerCase() === dexLower) continue
 
     const spenderKey = `${token}:${log.args.spender.toLowerCase()}`
@@ -691,7 +632,7 @@ async function buildBalanceDiffs(
   )
 
   // Build the diff array for this account.
-  const diffs: relay.BalanceDiff[] = []
+  const diffs: Capabilities.BalanceDiff[] = []
   for (const entry of entries) {
     const net =
       entry.outgoing > entry.incoming


### PR DESCRIPTION
Renames `meta` to `capabilities` in the `eth_fillTransaction` response to align with the viem `Capabilities` types from `viem/tempo`.

- Replaces local `relay.Meta`, `relay.BalanceDiff`, `relay.SwapAmount` types with `Capabilities.FillTransactionCapabilities` and `Capabilities.BalanceDiff` from `viem/tempo`
- Updates all tests to use `result.capabilities` instead of `result.meta`
- Bumps viem to `^2.47.15`