### PR TITLE
feat: add calls to capabilities.autoSwap

### DIFF
--- a/.changeset/relay-autoswap-calls.md
+++ b/.changeset/relay-autoswap-calls.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `calls` to `capabilities.autoSwap` containing the injected swap calls (approve + buy).

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -202,6 +202,7 @@ export function relay(options: relay.Options = {}): Handler {
         ])
         if (!inMeta || !outMeta) return undefined
         return {
+          calls: swap.calls.map((c) => ({ to: c.to, data: c.data })),
           slippage: autoSwap!.slippage,
           maxIn: {
             token: swap.tokenIn,
@@ -296,6 +297,7 @@ async function fill(
     return {
       transaction: Utils.normalizeTempoTransaction(result.tx),
       swap: {
+        calls: swapCalls,
         tokenIn: feeToken,
         tokenOut: parsed.token,
         amountOut: deficit,


### PR DESCRIPTION
Adds a `calls` field to `capabilities.autoSwap` containing the injected swap calls (approve + buy) so consumers can inspect the exact calldata.