### PR TITLE
refactor: rename meta to capabilities in eth_fillTransaction RPC schema

### DIFF
--- a/.changeset/open-states-wave.md
+++ b/.changeset/open-states-wave.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Updated RPC types.

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -148,7 +148,7 @@ export namespace eth_fillTransaction {
     method: z.literal('eth_fillTransaction'),
     params: z.readonly(z.tuple([transactionRequest])),
     returns: z.object({
-      meta: z.object({
+      capabilities: z.object({
         balanceDiffs: z.optional(z.record(u.address(), z.readonly(z.array(balanceDiff)))),
         fee: z.nullable(
           z.object({


### PR DESCRIPTION
Renames `meta` to `capabilities` in the `eth_fillTransaction` return type RPC schema.