### PR TITLE
feat: support JSON-RPC batch requests in Handler.relay

### DIFF
--- a/.changeset/relay-batch-support.md
+++ b/.changeset/relay-batch-support.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added JSON-RPC batch request support to `Handler.relay`. The handler now accepts arrays of JSON-RPC request objects and returns an array of responses, matching the [JSON-RPC 2.0 batch spec](https://www.jsonrpc.org/specification#batch).

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -73,6 +73,26 @@ describe('behavior: without feePayer', () => {
     const chainId = await client.request({ method: 'eth_chainId' })
     expect(Number(chainId)).toMatchInlineSnapshot(`${chain.id}`)
   })
+
+  test('behavior: handles JSON-RPC batch requests', async () => {
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([
+        { jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] },
+        { jsonrpc: '2.0', id: 2, method: 'eth_chainId', params: [] },
+      ]),
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { id: number; result: string }[]
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toHaveLength(2)
+    expect(body[0]!.id).toBe(1)
+    expect(body[1]!.id).toBe(2)
+    expect(Number(body[0]!.result)).toBe(chain.id)
+    expect(Number(body[1]!.result)).toBe(chain.id)
+  })
 })
 
 describe('behavior: capabilities', () => {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -99,11 +99,7 @@ export function relay(options: relay.Options = {}): Handler {
     return clients.get(chains[0]!.id)!
   }
 
-  const router = from(rest)
-
-  router.post(path, async (c) => {
-    const request = RpcRequest.from(await c.req.raw.json()) as RpcRequest.RpcRequest<Schema.Ox>
-
+  async function handleRequest(request: RpcRequest.RpcRequest<Schema.Ox>) {
     await onRequest?.(request)
 
     // Resolve chainId + client from the first param object (if present).
@@ -216,33 +212,50 @@ export function relay(options: relay.Options = {}): Handler {
             }
           })()
 
-          return Response.json(
-            RpcResponse.from(
-              {
-                result: {
-                  tx: core_Transaction.toRpc(transaction_final as core_Transaction.Transaction),
-                  capabilities: {
-                    balanceDiffs,
-                    fee,
-                    sponsored: !!sponsor,
-                    ...(sponsor ? { sponsor } : {}),
-                    ...(autoSwap_ ? { autoSwap: autoSwap_ } : {}),
-                  },
+          return RpcResponse.from(
+            {
+              result: {
+                tx: core_Transaction.toRpc(transaction_final as core_Transaction.Transaction),
+                capabilities: {
+                  balanceDiffs,
+                  fee,
+                  sponsored: !!sponsor,
+                  ...(sponsor ? { sponsor } : {}),
+                  ...(autoSwap_ ? { autoSwap: autoSwap_ } : {}),
                 },
               },
-              { request },
-            ),
+            },
+            { request },
           )
         } catch (error) {
-          return Utils.rpcError(request, error)
+          return Utils.rpcErrorJson(request, error)
         }
       }
 
       default: {
         const result = await client.request(request as never)
-        return Response.json(RpcResponse.from({ result }, { request }))
+        return RpcResponse.from({ result }, { request })
       }
     }
+  }
+
+  const router = from(rest)
+
+  router.post(path, async (c) => {
+    const body = await c.req.raw.json()
+    const isBatch = Array.isArray(body)
+
+    if (!isBatch) {
+      const request = RpcRequest.from(body) as RpcRequest.RpcRequest<Schema.Ox>
+      return Response.json(await handleRequest(request))
+    }
+
+    const responses = await Promise.all(
+      (body as unknown[]).map((item) =>
+        handleRequest(RpcRequest.from(item as never) as RpcRequest.RpcRequest<Schema.Ox>),
+      ),
+    )
+    return Response.json(responses)
   })
 
   return router

--- a/src/server/internal/handlers/utils.ts
+++ b/src/server/internal/handlers/utils.ts
@@ -39,37 +39,38 @@ export function normalizeTempoTransaction(value: Record<string, unknown> | undef
   return core_Transaction.fromRpc({ type: '0x76', ...value } as core_Transaction.Rpc)!
 }
 
-export function rpcError(request: RpcRequest.RpcRequest, error: unknown) {
+/** Returns a raw JSON-RPC error response object (not wrapped in a `Response`). */
+export function rpcErrorJson(request: RpcRequest.RpcRequest, error: unknown) {
   if (error instanceof RpcResponse.InvalidParamsError)
-    return Response.json(RpcResponse.from({ error }, { request }))
+    return RpcResponse.from({ error }, { request })
 
   if (error instanceof RpcResponse.MethodNotSupportedError)
-    return Response.json(RpcResponse.from({ error }, { request }))
+    return RpcResponse.from({ error }, { request })
 
   if ((error as { name?: string | undefined }).name === 'ZodError')
-    return Response.json(
-      RpcResponse.from(
-        {
-          error: new RpcResponse.InvalidParamsError({
-            message: (error as Error).message,
-          }),
-        },
-        { request },
-      ),
+    return RpcResponse.from(
+      {
+        error: new RpcResponse.InvalidParamsError({
+          message: (error as Error).message,
+        }),
+      },
+      { request },
     )
 
   const inner = resolveError(error)
   const message = inner.message ?? (error as Error).message
   const code = inner.code ?? -32603
   const data = inner.data
-  return Response.json(
-    RpcResponse.from(
-      {
-        error: { code, message, ...(data ? { data } : {}) },
-      },
-      { request },
-    ),
+  return RpcResponse.from(
+    {
+      error: { code, message, ...(data ? { data } : {}) },
+    },
+    { request },
   )
+}
+
+export function rpcError(request: RpcRequest.RpcRequest, error: unknown) {
+  return Response.json(rpcErrorJson(request, error))
 }
 
 export function rpcResult(request: RpcRequest.RpcRequest, result: unknown) {


### PR DESCRIPTION
## Summary

`Handler.relay` previously parsed the request body as a single JSON-RPC object via `RpcRequest.from()`. When viem's `http()` transport has `batch: true`, it sends an array of JSON-RPC requests which caused the handler to fail.

## Changes

- **`relay.ts`**: Extracted the single-request processing logic into a `handleRequest()` function that returns raw `RpcResponse` objects. The route handler now checks if the body is an array (batch) or object (single), processes each request via `handleRequest()`, and returns an array of responses for batches per the [JSON-RPC 2.0 batch spec](https://www.jsonrpc.org/specification#batch).
- **`utils.ts`**: Added `rpcResultJson()` and `rpcErrorJson()` that return raw `RpcResponse` objects (without wrapping in `Response.json()`), so batch responses can be collected into a single `Response.json(array)`. The existing `rpcResult`/`rpcError` now delegate to these.
- **`relay.test.ts`**: Added a test that sends a batch of two `eth_chainId` requests and asserts both responses are returned in an array with correct IDs.