### PR TITLE
feat: add with-fee-estimate example

### DIFF
--- a/examples/with-fee-estimate/.gitignore
+++ b/examples/with-fee-estimate/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.local

--- a/examples/with-fee-estimate/README.md
+++ b/examples/with-fee-estimate/README.md
@@ -1,0 +1,5 @@
+```
+npx gitpick tempoxyz/accounts/examples/with-fee-estimate
+npm i
+npm dev
+```

--- a/examples/with-fee-estimate/index.html
+++ b/examples/with-fee-estimate/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fee Estimate Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/with-fee-estimate/package.json
+++ b/examples/with-fee-estimate/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "with-fee-estimate-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "latest",
+    "accounts": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "viem": "latest",
+    "wagmi": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "latest",
+    "typescript": "~5.9.3",
+    "vite": "latest",
+    "vite-plugin-mkcert": "^1.17.10"
+  }
+}

--- a/examples/with-fee-estimate/src/App.tsx
+++ b/examples/with-fee-estimate/src/App.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react'
+import { formatUnits, parseUnits, stringify, type Hex } from 'viem'
+import { fillTransaction } from 'viem/actions'
+import { Actions } from 'viem/tempo'
+import {
+  useChains,
+  useConnect,
+  useConnectorClient,
+  useConnection,
+  useConnectors,
+  useDisconnect,
+  useSendTransactionSync,
+  useSwitchChain,
+} from 'wagmi'
+import { Hooks } from 'wagmi/tempo'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+
+export default function App() {
+  const { address, chainId, status } = useConnection()
+  return (
+    <div>
+      <h1>Fee Estimate Example</h1>
+
+      <h2>Connection</h2>
+      <pre>
+        {stringify({ address: address ?? null, chainId: chainId ?? null, status }, null, 2)}
+      </pre>
+
+      <h2>Connect</h2>
+      <Connect />
+
+      {status === 'connected' && (
+        <>
+          <h2>Switch Chain</h2>
+          <SwitchChain />
+
+          <h2>Balance</h2>
+          <Balance />
+
+          <h2>Send Transaction (with fee estimate)</h2>
+          <SendTransaction />
+        </>
+      )}
+    </div>
+  )
+}
+
+function Connect() {
+  const { mutate: connect, status, error } = useConnect()
+  const { mutate: disconnect } = useDisconnect()
+  const { address } = useConnection()
+  const connectors = useConnectors()
+  const connector = connectors[0]
+
+  if (!connector) return null
+
+  return (
+    <div>
+      {address ? (
+        <button type="button" onClick={() => disconnect()}>
+          Disconnect
+        </button>
+      ) : (
+        <button type="button" onClick={() => connect({ connector })}>
+          Login
+        </button>
+      )}
+      <div>{status}</div>
+      {error && <pre style={{ color: 'red' }}>{error.message}</pre>}
+    </div>
+  )
+}
+
+function SwitchChain() {
+  const { chainId } = useConnection()
+  const chains = useChains()
+  const { mutate: switchChain } = useSwitchChain()
+  return (
+    <div style={{ display: 'flex', gap: 8 }}>
+      {chains.map((chain) => (
+        <button
+          key={chain.id}
+          type="button"
+          disabled={chain.id === chainId}
+          onClick={() => switchChain({ chainId: chain.id })}
+        >
+          {chain.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function Balance() {
+  const { address } = useConnection()
+  const { data, isLoading } = Hooks.token.useGetBalance({
+    account: address,
+    token: pathUsd,
+    query: { refetchInterval: 1_000 },
+  })
+  return (
+    <div>{isLoading ? 'Loading...' : data !== undefined ? formatUnits(data, 6) : '—'} pathUsd</div>
+  )
+}
+
+function SendTransaction() {
+  const { data: client } = useConnectorClient()
+  const {
+    mutate: sendTransactionSync,
+    data: receipt,
+    error: sendError,
+    isPending: isSending,
+  } = useSendTransactionSync()
+
+  const [prepared, setPrepared] = useState<{
+    calls: readonly { to?: Hex | undefined; data?: Hex | undefined; value?: bigint | undefined }[]
+    fee: { amount: string; decimals: number; formatted: string; symbol: string } | null
+    sponsored: boolean
+  } | null>(null)
+  const [isPreparing, setIsPreparing] = useState(false)
+  const [prepareError, setPrepareError] = useState<Error | null>(null)
+
+  async function prepare(form: FormData) {
+    if (!client) return
+    setPrepared(null)
+    setPrepareError(null)
+    setIsPreparing(true)
+
+    const calls = [
+      Actions.token.transfer.call({
+        to: form.get('to') as string as Hex,
+        token: pathUsd,
+        amount: parseUnits((form.get('amount') as string) || '0', 6),
+      }),
+    ]
+
+    try {
+      const result = await fillTransaction(client, {
+        account: client.account!.address,
+        calls,
+      })
+      setPrepared({
+        calls,
+        fee: result.capabilities?.fee ?? null,
+        sponsored: result.capabilities?.sponsored ?? false,
+      })
+    } catch (e) {
+      setPrepareError(e instanceof Error ? e : new Error(String(e)))
+    } finally {
+      setIsPreparing(false)
+    }
+  }
+
+  function confirm() {
+    if (!prepared) return
+    sendTransactionSync({ calls: prepared.calls } as never)
+    setPrepared(null)
+  }
+
+  function cancel() {
+    setPrepared(null)
+    setPrepareError(null)
+  }
+
+  const hasPrepared = !!prepared
+  const error = prepareError ?? sendError
+
+  return (
+    <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          prepare(new FormData(e.currentTarget))
+        }}
+        style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <input
+          name="to"
+          defaultValue="0x0000000000000000000000000000000000000001"
+          placeholder="To (0x...)"
+          disabled={hasPrepared}
+          style={{ flex: 1, fontFamily: 'monospace' }}
+        />
+        <input
+          name="amount"
+          defaultValue="1"
+          placeholder="Amount"
+          disabled={hasPrepared}
+          style={{ width: 80 }}
+        />
+        <button type="submit" disabled={isPreparing || hasPrepared}>
+          {isPreparing ? 'Estimating...' : 'Estimate Fee'}
+        </button>
+      </form>
+
+      {prepared && (
+        <div style={{ marginTop: 8 }}>
+          {prepared.fee ? (
+            <p>
+              Estimated fee: <strong>{prepared.fee.formatted} {prepared.fee.symbol}</strong>
+            </p>
+          ) : prepared.sponsored ? (
+            <p>Transaction is sponsored (no fee)</p>
+          ) : (
+            <p>Fee estimate unavailable</p>
+          )}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={confirm} disabled={isSending}>
+              {isSending ? 'Sending...' : 'Confirm & Send'}
+            </button>
+            <button type="button" onClick={cancel} disabled={isSending}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
+      {receipt !== undefined && <pre>{stringify(receipt, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/examples/with-fee-estimate/src/config.ts
+++ b/examples/with-fee-estimate/src/config.ts
@@ -1,0 +1,19 @@
+import { tempoWallet } from 'accounts/wagmi'
+import { createConfig, http } from 'wagmi'
+import { tempo, tempoModerato } from 'wagmi/chains'
+
+export const config = createConfig({
+  chains: [tempo, tempoModerato],
+  connectors: [tempoWallet({ testnet: true })],
+  multiInjectedProviderDiscovery: false,
+  transports: {
+    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
+  },
+})
+
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}

--- a/examples/with-fee-estimate/src/main.tsx
+++ b/examples/with-fee-estimate/src/main.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { WagmiProvider } from 'wagmi'
+
+import App from './App.js'
+import { config } from './config.js'
+
+const queryClient = new QueryClient()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </WagmiProvider>
+  </StrictMode>,
+)

--- a/examples/with-fee-estimate/tsconfig.app.json
+++ b/examples/with-fee-estimate/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "customConditions": ["src"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/with-fee-estimate/tsconfig.json
+++ b/examples/with-fee-estimate/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/examples/with-fee-estimate/tsconfig.node.json
+++ b/examples/with-fee-estimate/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/with-fee-estimate/vite.config.ts
+++ b/examples/with-fee-estimate/vite.config.ts
@@ -1,0 +1,7 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import mkcert from 'vite-plugin-mkcert'
+
+export default defineConfig({
+  plugins: [react(), mkcert()],
+})


### PR DESCRIPTION
Adds a `with-fee-estimate` example that demonstrates preparing a transaction request and sending it in two distinct steps so fee estimates can be shown to the user before confirming.

## Flow

1. User fills in transfer details and clicks **Estimate Fee**
2. `fillTransaction` (via `eth_fillTransaction`) returns the fee estimate and capabilities
3. UI displays the estimated fee (amount + symbol), or shows sponsored/unavailable states
4. User clicks **Confirm & Send** to broadcast via `sendTransactionSync`, or **Cancel** to go back

Inputs are disabled while a prepared estimate is pending to prevent drift between what's shown and what gets sent.

Prompted by: Tony