### PR TITLE
fix: remove fee payer raw transaction test flake

### DIFF
--- a/src/server/internal/handlers/feePayer.test.ts
+++ b/src/server/internal/handlers/feePayer.test.ts
@@ -1,7 +1,7 @@
 import type { RpcRequest } from 'ox'
 import { SignatureEnvelope, Transaction as core_Transaction, TxEnvelopeTempo } from 'ox/tempo'
 import { parseUnits } from 'viem'
-import { sendTransactionSync } from 'viem/actions'
+import { sendTransaction, sendTransactionSync, waitForTransactionReceipt } from 'viem/actions'
 import { Actions, Transaction, withFeePayer } from 'viem/tempo'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
 
@@ -150,16 +150,17 @@ describe('POST /', () => {
       }),
     })
 
-    const receipt = await sendTransactionSync(client, {
+    const hash = await sendTransaction(client, {
       feePayer: true,
-      to: '0x0000000000000000000000000000000000000000',
+      to: '0x0000000000000000000000000000000000000001',
     })
+    const receipt = await waitForTransactionReceipt(getClient(), { hash })
 
     expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
 
     expect(requests.map(({ method }) => method)).toMatchInlineSnapshot(`
       [
-        "eth_sendRawTransactionSync",
+        "eth_sendRawTransaction",
       ]
     `)
   })
@@ -174,7 +175,7 @@ describe('POST /', () => {
 
     const receipt = await sendTransactionSync(client, {
       feePayer: true,
-      to: '0x0000000000000000000000000000000000000000',
+      to: '0x0000000000000000000000000000000000000002',
     })
 
     expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())


### PR DESCRIPTION
## Summary
- make the `eth_sendRawTransaction` test exercise the async raw-transaction path instead of the sync path
- use distinct recipient addresses for the raw transaction broadcast tests so they do not re-submit the same deterministic Tempo transaction
- fix the request snapshot to match the actual RPC method under test

## Verification
- `pnpm vp test src/server/internal/handlers/feePayer.test.ts --retry 0`
- repeated the same test file locally multiple times to confirm the replay flake no longer reproduces

## Context
- fixes the flaky CI failure from https://github.com/tempoxyz/accounts/actions/runs/24375820562/job/71200962580