### PR TITLE
chore: up changeset

### DIFF
--- a/.changeset/social-keys-travel.md
+++ b/.changeset/social-keys-travel.md
@@ -2,5 +2,5 @@
 "accounts": minor
 ---
 
-Removed `Handler.feePayer`.
+**Breaking:** Removed `Handler.feePayer`.
 Updated `Handler.relay` to be backwards compatible with `Handler.feePayer`. 


### PR DESCRIPTION
Updated `Handler.relay` for backwards compatibility after removing `Handler.feePayer`. This change is breaking.