### PR TITLE
chore: harden supply chain config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 shell-emulator=true
 node-options='--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'
-trust-policy-exclude=chokidar@4.0.3,semver@6.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,8 +41,15 @@ minimumReleaseAgeExclude:
   - viem
 
 onlyBuiltDependencies:
+  - bufferutil
+  - cloudflared
+  - cpu-features
   - esbuild
+  - protobufjs
+  - sharp
   - simple-git-hooks
+  - ssh2
+  - utf-8-validate
   - workerd
 
 overrides:
@@ -50,4 +57,8 @@ overrides:
   ox: ~0.14.15
   react: catalog:default
   react-dom: catalog:default
-trustPolicy: permissive
+strictDepBuilds: true
+trustPolicy: no-downgrade
+trustPolicyExclude:
+  - chokidar@4.0.3
+  - semver@6.3.1


### PR DESCRIPTION
- `trustPolicy: permissive` → `no-downgrade` — blocks packages with trust downgrades (possible takeover signal)
- Added `strictDepBuilds: true` — fails on unreviewed postinstall scripts instead of warning
- Moved `trust-policy-exclude` from `.npmrc` to `pnpm-workspace.yaml` `trustPolicyExclude` (required for no-downgrade to honor excludes)
- Expanded `onlyBuiltDependencies` allowlist (bufferutil, cloudflared, cpu-features, protobufjs, sharp, ssh2, utf-8-validate)

Dep updates split out to a follow-up PR.

Prompted by: georgen