### PR TITLE
fix: install git in docker containers for postinstall hooks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     labels:
       dev.orbstack.domains: playground.tempo.local
     command: >
-      sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm --filter playground dev -- --host"
+      sh -c "apt-get update -qq && apt-get install -yqq git > /dev/null 2>&1; corepack enable && pnpm install --frozen-lockfile && pnpm --filter playground dev -- --host"
     depends_on:
       install:
         condition: service_completed_successfully
@@ -58,7 +58,7 @@ services:
     labels:
       dev.orbstack.domains: connect.tempo.local
     command: >
-      sh -c "apt-get update -qq && apt-get install -yqq ca-certificates > /dev/null 2>&1; corepack enable && pnpm install --frozen-lockfile && pnpm --filter connect dev -- --host"
+      sh -c "apt-get update -qq && apt-get install -yqq ca-certificates git > /dev/null 2>&1; corepack enable && pnpm install --frozen-lockfile && pnpm --filter connect dev -- --host"
     depends_on:
       install:
         condition: service_completed_successfully
@@ -77,7 +77,7 @@ services:
     labels:
       dev.orbstack.domains: dialog-ref.tempo.local
     command: >
-      sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm --filter dialog-ref dev -- --host"
+      sh -c "apt-get update -qq && apt-get install -yqq git > /dev/null 2>&1; corepack enable && pnpm install --frozen-lockfile && pnpm --filter dialog-ref dev -- --host"
     depends_on:
       install:
         condition: service_completed_successfully
@@ -120,7 +120,7 @@ services:
     labels:
       dev.orbstack.domains: wagmi.tempo.local
     command: >
-      sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm --filter wagmi dev -- --host --port 5175"
+      sh -c "apt-get update -qq && apt-get install -yqq git > /dev/null 2>&1; corepack enable && pnpm install --frozen-lockfile && pnpm --filter wagmi dev -- --host --port 5175"
     depends_on:
       install:
         condition: service_completed_successfully

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:cli": "pnpm --filter './playgrounds/cli' connect",
     "dev:logs": "docker compose logs -f",
     "examples": "node --import tsx scripts/examples.ts",
-    "postinstall": "pnpm preconstruct && git submodule update --init --recursive",
+    "postinstall": "pnpm preconstruct && [ -n \"$CI\" ] || git submodule update --init --recursive",
     "preconstruct": "zile dev",
     "test": "vp test",
     "vp": "vp"


### PR DESCRIPTION
The root `postinstall` script runs `git submodule update --init --recursive`, so any container that runs `pnpm install` needs `git` installed. Added `git` to the `apt-get install` step in `playground`, `connect`, `dialog-ref`, and `wagmi` services.

Re-creation of #217 after base branch reset.