### PR TITLE
fix: fall back to 'latest' tag when VITE_NODE_TAG is empty

### DIFF
--- a/test/prool.ts
+++ b/test/prool.ts
@@ -7,7 +7,7 @@ import { fetchOptions, getClient } from './config.js'
 export async function setupServer({ port }: { port: number }) {
   const tag = await (async () => {
     if (!import.meta.env.VITE_NODE_TAG?.startsWith('http'))
-      return import.meta.env.VITE_NODE_TAG ?? 'latest'
+      return import.meta.env.VITE_NODE_TAG || 'latest'
 
     const client = getClient({
       transport: http(import.meta.env.VITE_NODE_TAG, {


### PR DESCRIPTION
When `VITE_NODE_TAG` is set to an empty string in `.env`, the nullish coalescing operator (`??`) doesn't catch it, producing the Docker image ref `ghcr.io/tempoxyz/tempo:` (no tag). Docker rejects this with `invalid reference format`, which surfaces as an opaque HTTP 400 from the prool server during test setup.

Switches `??` → `||` so empty string also falls back to `'latest'`.