### PR TITLE
fix: account email label on sign in

### DIFF
--- a/apps/connect/src/routes/_remote/rpc/wallet_connect.tsx
+++ b/apps/connect/src/routes/_remote/rpc/wallet_connect.tsx
@@ -75,11 +75,13 @@ function WelcomeBack(props: { onSignUp: () => void; submit: Submit }) {
     queryKey: ['auth', 'me'],
     queryFn: async () => {
       const res = await api.api.auth.me.$get()
-      return (await res.json()) as { email: string | null }
+      return (await res.json()) as { email: string | null; username: string | null }
     },
   })
   const label =
-    me.data?.email ?? (address ? `${address.slice(0, 8)}…${address.slice(-6)}` : undefined)
+    me.data?.email ??
+    me.data?.username ??
+    (address ? `${address.slice(0, 8)}…${address.slice(-6)}` : undefined)
 
   return (
     <Frames.WelcomeBack

--- a/apps/connect/worker/auth.ts
+++ b/apps/connect/worker/auth.ts
@@ -1,9 +1,23 @@
 import { Hono } from 'hono'
+import { type Address } from 'ox'
 
+import * as Account from './lib/db/account.js'
+import * as Db from './lib/db/index.js'
+import * as Wallet from './lib/db/wallet.js'
 import * as Middleware from './lib/middleware.js'
 
 export const auth = new Hono<{ Bindings: Env }>()
-  /** `GET /me` — return the current session's address. */
-  .get('/me', Middleware.requireSession(), (c) => {
-    return c.json({ address: c.var.session.address })
+  /** `GET /me` — return the current session's address, email, and username. */
+  .get('/me', Middleware.requireSession(), async (c) => {
+    const { address } = c.var.session
+    const db = Db.get(c.env.HYPERDRIVE)
+    const [account, wallet] = await Promise.all([
+      Account.getByAddress(db, address as Address.Address),
+      Wallet.getByAddress(db, address as Address.Address),
+    ])
+    return c.json({
+      address,
+      email: account?.email ?? null,
+      username: wallet?.username ?? null,
+    })
   })

--- a/apps/connect/worker/webauthn.ts
+++ b/apps/connect/worker/webauthn.ts
@@ -36,7 +36,7 @@ export const webauthn = new Hono<{ Bindings: Env }>().all('/*', (c) => {
     path: '/api/webauthn',
     rpId: hostname.split('.').slice(-2).join('.'),
 
-    async onRegister({ credentialId, publicKey }) {
+    async onRegister({ credentialId, name, publicKey }) {
       const address = Address.fromPublicKey(PublicKey.fromHex(publicKey as Hex.Hex))
       const db = Db.get(c.env.HYPERDRIVE)
 
@@ -47,7 +47,7 @@ export const webauthn = new Hono<{ Bindings: Env }>().all('/*', (c) => {
         credentialId,
         label: 'Passkey',
         publicKey,
-        username: address,
+        username: name,
       })
 
       return res(hostname, address, {

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -57,7 +57,7 @@ export function webAuthn(options: webAuthn.Options): Handler {
         ...(userId ? { user: { id: new TextEncoder().encode(userId), name } } : undefined),
       })
 
-      await kv.set(`challenge:${challenge}`, Date.now())
+      await kv.set(`challenge:${challenge}`, { created: Date.now(), name })
 
       return Response.json({ options })
     } catch (error) {
@@ -74,8 +74,8 @@ export function webAuthn(options: webAuthn.Options): Handler {
         Bytes.toString(new Uint8Array(deserialized.clientDataJSON)),
       ) as { challenge: string }
       const challenge = Hex.fromBytes(Base64.toBytes(clientData.challenge))
-      const stored = await kv.get<number>(`challenge:${challenge}`)
-      if (!stored || Date.now() - stored > challengeTtl * 1_000)
+      const stored = await kv.get<{ created: number; name: string }>(`challenge:${challenge}`)
+      if (!stored || Date.now() - stored.created > challengeTtl * 1_000)
         throw new Error('Missing or expired challenge')
       await kv.delete(`challenge:${challenge}`)
 
@@ -91,7 +91,12 @@ export function webAuthn(options: webAuthn.Options): Handler {
       await kv.set(`credential:${credentialId}`, { publicKey })
 
       const json = { credentialId, publicKey }
-      const hook = await onRegister?.({ credentialId, publicKey, request: c.req.raw })
+      const hook = await onRegister?.({
+        credentialId,
+        name: stored.name,
+        publicKey,
+        request: c.req.raw,
+      })
       return mergeResponse(json, hook)
     } catch (error) {
       return Response.json({ error: (error as Error).message }, { status: 400 })
@@ -179,6 +184,8 @@ export declare namespace webAuthn {
     /** Called after a successful registration. The returned response is merged onto the default JSON response. */
     onRegister?: (parameters: {
       credentialId: string
+      /** The name provided during `/register/options` (e.g. user email). */
+      name: string
       publicKey: string
       request: Request
     }) => Response | Promise<Response> | void | Promise<void>


### PR DESCRIPTION
Passes the email that will be set as the passkey username through so it's persisted on `wallets`.

Updates me endpoint to return this label.