### PR TITLE
fix: regenerate lockfile for viem catalog resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ catalogs:
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
-    viem:
-      specifier: ^2.47.18
-      version: 2.47.18
     vp:
       specifier: npm:vite-plus@~0.1.14
       version: 0.1.15
@@ -171,7 +168,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       vp:
         specifier: 'catalog:'
@@ -276,7 +273,7 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(typescript@5.9.3)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 3.5.0
@@ -427,7 +424,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -464,7 +461,7 @@ importers:
         specifier: ~0.14.15
         version: 0.14.15(typescript@5.9.3)(zod@4.3.6)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@types/node':
@@ -492,7 +489,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -541,7 +538,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -581,7 +578,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -630,7 +627,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -679,7 +676,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -725,7 +722,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
@@ -774,7 +771,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       viem:
-        specifier: 'catalog:'
+        specifier: ^2.47.18
         version: 2.47.18(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@bomb.sh/args':
@@ -16027,7 +16024,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -648,24 +648,32 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const result = await provider.request({ method: 'wallet_getCapabilities' })
       expect(result).toMatchInlineSnapshot(`
-        {
-          "0x1079": {
-            "accessKeys": {
-              "status": "supported",
-            },
-            "atomic": {
-              "status": "supported",
-            },
-          },
-          "0xa5bf": {
-            "accessKeys": {
-              "status": "supported",
-            },
-            "atomic": {
-              "status": "supported",
-            },
-          },
-        }
+      	{
+      	  "0x1079": {
+      	    "accessKeys": {
+      	      "status": "supported",
+      	    },
+      	    "atomic": {
+      	      "status": "supported",
+      	    },
+      	  },
+      	  "0x7a56": {
+      	    "accessKeys": {
+      	      "status": "supported",
+      	    },
+      	    "atomic": {
+      	      "status": "supported",
+      	    },
+      	  },
+      	  "0xa5bf": {
+      	    "accessKeys": {
+      	      "status": "supported",
+      	    },
+      	    "atomic": {
+      	      "status": "supported",
+      	    },
+      	  },
+      	}
       `)
     })
 
@@ -724,7 +732,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         method: 'wallet_getCapabilities',
         params: [connected],
       })
-      expect(Object.keys(result).length).toMatchInlineSnapshot(`2`)
+      expect(Object.keys(result).length).toMatchInlineSnapshot(`3`)
       expect(result[Hex.fromNumber(tempo.id)]!.atomic.status).toMatchInlineSnapshot(`"supported"`)
     })
 


### PR DESCRIPTION
The lockfile had `catalog:` specifiers for viem but `minimumReleaseAgeExclude` causes pnpm to resolve the actual version specifier, breaking `--frozen-lockfile` in CI.