### PR TITLE
feat(connect): add fee-payer budget validation to relay

### DIFF
--- a/apps/connect/.env.example
+++ b/apps/connect/.env.example
@@ -14,8 +14,8 @@ RELAY_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2
 FEE_PAYER_DAILY_LIMIT_USD=0.20
 FEE_PAYER_GLOBAL_DAILY_LIMIT_USD=50
 # tidx indexer API keys (per network)
-TEMPO_INDEXER_API_KEY=
-TEMPO_MODERATO_INDEXER_API_KEY=
+TIDX_MAINNET_API_KEY=
+TIDX_TESTNET_API_KEY=
 # (required) Ed25519 private key for signing session tokens (note: test key pair)
 SESSION_PRIVATE_KEY={"key_ops":["sign"],"ext":true,"alg":"Ed25519","crv":"Ed25519","d":"X4r_1njmh53RSO6lQSqJAWOsrUMwoPZdzOEIY5JDJVE","x":"isqJogp6bz4xx5aIxG6sR7YiPMNm2qKFZL7LiWJfh68","kty":"OKP"}
 # (required) Ed25519 public key for verifying session tokens

--- a/apps/connect/.env.example
+++ b/apps/connect/.env.example
@@ -10,6 +10,12 @@ MAILGUN_DOMAIN=
 RELAY_API_KEY=
 # (required) Private key for the relay fee payer (note: anvil account[0] — "test test test ... junk" mnemonic)
 RELAY_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+# Fee payer budget limits
+FEE_PAYER_DAILY_LIMIT_USD=0.20
+FEE_PAYER_GLOBAL_DAILY_LIMIT_USD=50
+# tidx indexer API keys (per network)
+TEMPO_INDEXER_API_KEY=
+TEMPO_MODERATO_INDEXER_API_KEY=
 # (required) Ed25519 private key for signing session tokens (note: test key pair)
 SESSION_PRIVATE_KEY={"key_ops":["sign"],"ext":true,"alg":"Ed25519","crv":"Ed25519","d":"X4r_1njmh53RSO6lQSqJAWOsrUMwoPZdzOEIY5JDJVE","x":"isqJogp6bz4xx5aIxG6sR7YiPMNm2qKFZL7LiWJfh68","kty":"OKP"}
 # (required) Ed25519 public key for verifying session tokens

--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -38,6 +38,7 @@
     "posthog-js": "1.360.2",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "tidx.ts": "0.1.0",
     "viem": "catalog:",
     "wagmi": "catalog:"
   },

--- a/apps/connect/test/cloudflare-workers.ts
+++ b/apps/connect/test/cloudflare-workers.ts
@@ -1,0 +1,2 @@
+/** Test shim for `cloudflare:workers`. */
+export function waitUntil(_promise: Promise<unknown>) {}

--- a/apps/connect/tsconfig.worker.json
+++ b/apps/connect/tsconfig.worker.json
@@ -16,5 +16,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["worker", "worker-configuration.d.ts"]
+  "include": ["worker", "worker-configuration.d.ts"],
+  "exclude": ["worker/**/*.test.ts", "worker/**/*.test-d.ts"]
 }

--- a/apps/connect/tsconfig.worker.json
+++ b/apps/connect/tsconfig.worker.json
@@ -16,6 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["worker", "worker-configuration.d.ts"],
-  "exclude": ["worker/**/*.test.ts", "worker/**/*.test-d.ts"]
+  "include": ["worker", "worker-configuration.d.ts"]
 }

--- a/apps/connect/worker/lib/chain.ts
+++ b/apps/connect/worker/lib/chain.ts
@@ -1,0 +1,11 @@
+import { tempo, tempoModerato } from 'viem/chains'
+
+/** Supported Tempo network. */
+export type TempoChain = 'mainnet' | 'testnet'
+
+/** Resolves a numeric chain ID to a `TempoChain`. Throws if the chain is not supported. */
+export function fromId(chainId: number): TempoChain {
+  if (chainId === tempo.id) return 'mainnet'
+  if (chainId === tempoModerato.id) return 'testnet'
+  throw new Error(`Unsupported chain ID: ${chainId}`)
+}

--- a/apps/connect/worker/lib/fee-payer.test.ts
+++ b/apps/connect/worker/lib/fee-payer.test.ts
@@ -1,0 +1,146 @@
+import { encodeAbiParameters, parseUnits } from 'viem'
+import type { Transaction } from 'viem/tempo'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as FeePayer from './fee-payer.js'
+
+function parseAttodollar(value: string) {
+  return parseUnits(value, 18)
+}
+
+function encodeBalance(value: bigint) {
+  return encodeAbiParameters([{ type: 'uint256' }], [value])
+}
+
+const FEE_PAYER = '0x1111111111111111111111111111111111111111' as const
+const REQUESTER = '0x2222222222222222222222222222222222222222' as const
+
+function createKv() {
+  const store = new Map<string, string>()
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+  } as unknown as KVNamespace
+}
+
+function createMocks(
+  state: {
+    requesterRows?: { gas_used: string; effective_gas_price: string }[]
+    globalRows?: { gas_used: string; effective_gas_price: string }[]
+    balance?: bigint
+  } = {},
+) {
+  const { requesterRows = [], globalRows = [], balance = 2_000_000n } = state
+  return {
+    client: {
+      chain: { id: 4217 },
+      request: vi.fn(async () => encodeBalance(balance)),
+    } as never,
+    queryBuilder: {
+      selectFrom: () => {
+        let requesterFilter: string | undefined
+        return {
+          select() {
+            return this
+          },
+          where(column: string, _op: string, value: unknown) {
+            if (column === 'from') requesterFilter = value as string
+            return this
+          },
+          execute: vi.fn(async () => (requesterFilter ? requesterRows : globalRows)),
+        }
+      },
+    } as never,
+  }
+}
+
+function request(from?: string) {
+  return {
+    from: from ?? REQUESTER,
+    gas: 1n,
+    maxFeePerGas: parseAttodollar('0.02'),
+    chainId: 4217,
+  } as Transaction.TransactionRequest
+}
+
+/** Call once to populate KV via background refresh, then validate again. */
+async function warmAndValidate(
+  validate: FeePayer.create.ReturnType,
+  req: Transaction.TransactionRequest,
+) {
+  await validate(req)
+  await new Promise((r) => setTimeout(r, 10))
+  return validate(req)
+}
+
+describe('create', () => {
+  test('approves on cold KV (first call)', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    expect(await validate(request())).toMatchInlineSnapshot(`true`)
+  })
+
+  test('approves when under budget (warm KV)', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`true`)
+  })
+
+  test('blocks when requester daily budget is exceeded', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(
+      FEE_PAYER,
+      kv,
+      createMocks({
+        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+      }),
+    )
+    expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
+  })
+
+  test('blocks when global daily budget is exceeded', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(
+      FEE_PAYER,
+      kv,
+      createMocks({
+        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.01').toString() }],
+        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('49.99').toString() }],
+      }),
+    )
+    expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
+  })
+
+  test('blocks when fee payer has insufficient balance', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(FEE_PAYER, kv, createMocks({ balance: 0n }))
+    expect(await validate(request())).toMatchInlineSnapshot(`false`)
+  })
+
+  test('approves when both limits are disabled', async () => {
+    process.env.FEE_PAYER_DAILY_LIMIT_USD = '0'
+    process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD = '0'
+    try {
+      const kv = createKv()
+      const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+      expect(await validate(request())).toMatchInlineSnapshot(`true`)
+    } finally {
+      delete process.env.FEE_PAYER_DAILY_LIMIT_USD
+      delete process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD
+    }
+  })
+
+  test('approves when gas/maxFeePerGas missing', async () => {
+    const kv = createKv()
+    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    expect(
+      await validate({ from: REQUESTER } as Transaction.TransactionRequest),
+    ).toMatchInlineSnapshot(`true`)
+  })
+})

--- a/apps/connect/worker/lib/fee-payer.test.ts
+++ b/apps/connect/worker/lib/fee-payer.test.ts
@@ -1,6 +1,15 @@
 import { encodeAbiParameters, parseUnits } from 'viem'
 import type { Transaction } from 'viem/tempo'
-import { describe, expect, test, vi } from 'vp/test'
+import { vi } from 'vitest'
+import { describe, expect, test } from 'vp/test'
+
+vi.mock('./viem.js', () => ({
+  getClient: () => mockClient,
+}))
+
+vi.mock('./tidx.js', () => ({
+  getQueryBuilder: () => mockQueryBuilder,
+}))
 
 import * as FeePayer from './fee-payer.js'
 
@@ -15,6 +24,9 @@ function encodeBalance(value: bigint) {
 const FEE_PAYER = '0x1111111111111111111111111111111111111111' as const
 const REQUESTER = '0x2222222222222222222222222222222222222222' as const
 
+let mockClient: unknown
+let mockQueryBuilder: unknown
+
 function createKv() {
   const store = new Map<string, string>()
   return {
@@ -28,7 +40,7 @@ function createKv() {
   } as unknown as KVNamespace
 }
 
-function createMocks(
+function setupMocks(
   state: {
     requesterRows?: { gas_used: string; effective_gas_price: string }[]
     globalRows?: { gas_used: string; effective_gas_price: string }[]
@@ -36,26 +48,24 @@ function createMocks(
   } = {},
 ) {
   const { requesterRows = [], globalRows = [], balance = 2_000_000n } = state
-  return {
-    client: {
-      chain: { id: 4217 },
-      request: vi.fn(async () => encodeBalance(balance)),
-    } as never,
-    queryBuilder: {
-      selectFrom: () => {
-        let requesterFilter: string | undefined
-        return {
-          select() {
-            return this
-          },
-          where(column: string, _op: string, value: unknown) {
-            if (column === 'from') requesterFilter = value as string
-            return this
-          },
-          execute: vi.fn(async () => (requesterFilter ? requesterRows : globalRows)),
-        }
-      },
-    } as never,
+  mockClient = {
+    chain: { id: 4217 },
+    request: vi.fn(async () => encodeBalance(balance)),
+  }
+  mockQueryBuilder = {
+    selectFrom: () => {
+      let requesterFilter: string | undefined
+      return {
+        select() {
+          return this
+        },
+        where(column: string, _op: string, value: unknown) {
+          if (column === 'from') requesterFilter = value as string
+          return this
+        },
+        execute: vi.fn(async () => (requesterFilter ? requesterRows : globalRows)),
+      }
+    },
   }
 }
 
@@ -80,65 +90,60 @@ async function warmAndValidate(
 
 describe('create', () => {
   test('approves on cold KV (first call)', async () => {
+    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(await validate(request())).toMatchInlineSnapshot(`true`)
   })
 
   test('approves when under budget (warm KV)', async () => {
+    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`true`)
   })
 
   test('blocks when requester daily budget is exceeded', async () => {
+    setupMocks({
+      requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+      globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+    })
     const kv = createKv()
-    const validate = FeePayer.create(
-      FEE_PAYER,
-      kv,
-      createMocks({
-        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
-        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
-      }),
-    )
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
   })
 
   test('blocks when global daily budget is exceeded', async () => {
+    setupMocks({
+      requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.01').toString() }],
+      globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('49.99').toString() }],
+    })
     const kv = createKv()
-    const validate = FeePayer.create(
-      FEE_PAYER,
-      kv,
-      createMocks({
-        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.01').toString() }],
-        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('49.99').toString() }],
-      }),
-    )
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
   })
 
   test('blocks when fee payer has insufficient balance', async () => {
+    setupMocks({ balance: 0n })
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv, createMocks({ balance: 0n }))
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(await validate(request())).toMatchInlineSnapshot(`false`)
   })
 
   test('approves when both limits are disabled', async () => {
-    process.env.FEE_PAYER_DAILY_LIMIT_USD = '0'
-    process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD = '0'
-    try {
-      const kv = createKv()
-      const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
-      expect(await validate(request())).toMatchInlineSnapshot(`true`)
-    } finally {
-      delete process.env.FEE_PAYER_DAILY_LIMIT_USD
-      delete process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD
-    }
+    setupMocks()
+    const kv = createKv()
+    const validate = FeePayer.create(FEE_PAYER, kv, {
+      dailyLimitUsd: '0',
+      globalDailyLimitUsd: '0',
+    })
+    expect(await validate(request())).toMatchInlineSnapshot(`true`)
   })
 
   test('approves when gas/maxFeePerGas missing', async () => {
+    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv, createMocks())
+    const validate = FeePayer.create(FEE_PAYER, kv)
     expect(
       await validate({ from: REQUESTER } as Transaction.TransactionRequest),
     ).toMatchInlineSnapshot(`true`)

--- a/apps/connect/worker/lib/fee-payer.test.ts
+++ b/apps/connect/worker/lib/fee-payer.test.ts
@@ -2,14 +2,6 @@ import { encodeAbiParameters, parseUnits } from 'viem'
 import type { Transaction } from 'viem/tempo'
 import { describe, expect, test, vi } from 'vp/test'
 
-vi.mock('./viem.js', () => ({
-  getClient: () => mockClient,
-}))
-
-vi.mock('./tidx.js', () => ({
-  getQueryBuilder: () => mockQueryBuilder,
-}))
-
 import * as FeePayer from './fee-payer.js'
 
 function parseAttodollar(value: string) {
@@ -22,9 +14,6 @@ function encodeBalance(value: bigint) {
 
 const FEE_PAYER = '0x1111111111111111111111111111111111111111' as const
 const REQUESTER = '0x2222222222222222222222222222222222222222' as const
-
-let mockClient: unknown
-let mockQueryBuilder: unknown
 
 function createKv() {
   const store = new Map<string, string>()
@@ -39,32 +28,34 @@ function createKv() {
   } as unknown as KVNamespace
 }
 
-function setupMocks(
+function createMocks(
   state: {
     requesterRows?: { gas_used: string; effective_gas_price: string }[]
     globalRows?: { gas_used: string; effective_gas_price: string }[]
     balance?: bigint
   } = {},
-) {
+): FeePayer.create.Internal {
   const { requesterRows = [], globalRows = [], balance = 2_000_000n } = state
-  mockClient = {
-    chain: { id: 4217 },
-    request: vi.fn(async () => encodeBalance(balance)),
-  }
-  mockQueryBuilder = {
-    selectFrom: () => {
-      let requesterFilter: string | undefined
-      return {
-        select() {
-          return this
-        },
-        where(column: string, _op: string, value: unknown) {
-          if (column === 'from') requesterFilter = value as string
-          return this
-        },
-        execute: vi.fn(async () => (requesterFilter ? requesterRows : globalRows)),
-      }
-    },
+  return {
+    client: {
+      chain: { id: 4217 },
+      request: vi.fn(async () => encodeBalance(balance)),
+    } as never,
+    queryBuilder: {
+      selectFrom: () => {
+        let requesterFilter: string | undefined
+        return {
+          select() {
+            return this
+          },
+          where(column: string, _op: string, value: unknown) {
+            if (column === 'from') requesterFilter = value as string
+            return this
+          },
+          execute: vi.fn(async () => (requesterFilter ? requesterRows : globalRows)),
+        }
+      },
+    } as never,
   }
 }
 
@@ -89,60 +80,65 @@ async function warmAndValidate(
 
 describe('create', () => {
   test('approves on cold KV (first call)', async () => {
-    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(FEE_PAYER, kv, {}, createMocks())
     expect(await validate(request())).toMatchInlineSnapshot(`true`)
   })
 
   test('approves when under budget (warm KV)', async () => {
-    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(FEE_PAYER, kv, {}, createMocks())
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`true`)
   })
 
   test('blocks when requester daily budget is exceeded', async () => {
-    setupMocks({
-      requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
-      globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
-    })
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(
+      FEE_PAYER,
+      kv,
+      {},
+      createMocks({
+        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.19').toString() }],
+      }),
+    )
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
   })
 
   test('blocks when global daily budget is exceeded', async () => {
-    setupMocks({
-      requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.01').toString() }],
-      globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('49.99').toString() }],
-    })
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(
+      FEE_PAYER,
+      kv,
+      {},
+      createMocks({
+        requesterRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('0.01').toString() }],
+        globalRows: [{ gas_used: '1', effective_gas_price: parseAttodollar('49.99').toString() }],
+      }),
+    )
     expect(await warmAndValidate(validate, request())).toMatchInlineSnapshot(`false`)
   })
 
   test('blocks when fee payer has insufficient balance', async () => {
-    setupMocks({ balance: 0n })
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(FEE_PAYER, kv, {}, createMocks({ balance: 0n }))
     expect(await validate(request())).toMatchInlineSnapshot(`false`)
   })
 
   test('approves when both limits are disabled', async () => {
-    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv, {
-      dailyLimitUsd: '0',
-      globalDailyLimitUsd: '0',
-    })
+    const validate = FeePayer.create(
+      FEE_PAYER,
+      kv,
+      { dailyLimitUsd: '0', globalDailyLimitUsd: '0' },
+      createMocks(),
+    )
     expect(await validate(request())).toMatchInlineSnapshot(`true`)
   })
 
   test('approves when gas/maxFeePerGas missing', async () => {
-    setupMocks()
     const kv = createKv()
-    const validate = FeePayer.create(FEE_PAYER, kv)
+    const validate = FeePayer.create(FEE_PAYER, kv, {}, createMocks())
     expect(
       await validate({ from: REQUESTER } as Transaction.TransactionRequest),
     ).toMatchInlineSnapshot(`true`)

--- a/apps/connect/worker/lib/fee-payer.test.ts
+++ b/apps/connect/worker/lib/fee-payer.test.ts
@@ -1,7 +1,6 @@
 import { encodeAbiParameters, parseUnits } from 'viem'
 import type { Transaction } from 'viem/tempo'
-import { vi } from 'vitest'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 vi.mock('./viem.js', () => ({
   getClient: () => mockClient,

--- a/apps/connect/worker/lib/fee-payer.ts
+++ b/apps/connect/worker/lib/fee-payer.ts
@@ -1,8 +1,10 @@
 import { waitUntil } from 'cloudflare:workers'
-import { QueryBuilder, Tidx } from 'tidx.ts'
-import { type Address, type Client, createClient, formatUnits, http, parseUnits } from 'viem'
-import { tempo, tempoModerato } from 'viem/chains'
+import { type Address, formatUnits, parseUnits } from 'viem'
 import { Actions, Transaction } from 'viem/tempo'
+
+import { type TempoChain, fromId } from './chain.js'
+import * as Tidx from './tidx.js'
+import * as Viem from './viem.js'
 
 const ATTODOLLARS_PER_MICRODOLLAR = 10n ** 12n
 const MIN_BALANCE_UNITS = 1_000_000n
@@ -28,14 +30,6 @@ function parseUsdLimit(value: string | undefined, defaultValue: string): bigint 
   }
 }
 
-function createQueryBuilder(chainId: number) {
-  const tidxAuth =
-    chainId === tempoModerato.id
-      ? process.env.TEMPO_MODERATO_INDEXER_API_KEY
-      : process.env.TEMPO_INDEXER_API_KEY
-  return QueryBuilder.from(Tidx.create({ basicAuth: tidxAuth, chainId }))
-}
-
 /**
  * Prevent abuse while being blazing fast:
  *   - Always read from KV within request / response cycle, it's ok to be stale
@@ -44,27 +38,23 @@ function createQueryBuilder(chainId: number) {
 export function create(
   feePayerAddress: Address,
   kv: KVNamespace,
-  /** @internal — test overrides. */
-  internal: {
-    client?: Client | undefined
-    queryBuilder?: QueryBuilder.QueryBuilder | undefined
-  } = {},
+  options: create.Options = {},
 ): create.ReturnType {
-  const dailyLimitMicroUsd = parseUsdLimit(process.env.FEE_PAYER_DAILY_LIMIT_USD, '0.20')
-  const globalDailyLimitMicroUsd = parseUsdLimit(process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD, '50')
+  const dailyLimitMicroUsd = parseUsdLimit(options.dailyLimitUsd, '0.20')
+  const globalDailyLimitMicroUsd = parseUsdLimit(options.globalDailyLimitUsd, '50')
 
-  function kvKey(chainId: number, scope: string) {
-    return `fee-payer:${chainId}:${scope}`
+  function kvKey(chain: TempoChain, scope: string) {
+    return `fee-payer:${chain}:${scope}`
   }
 
   /** Read cached spend from KV. Returns `0n` on miss and refreshes in background. */
-  async function getSpend(chainId: number, requester?: string | undefined) {
+  async function getSpend(chain: TempoChain, requester?: string | undefined) {
     const scope = requester ? requester.toLowerCase() : 'global'
-    const key = kvKey(chainId, scope)
+    const key = kvKey(chain, scope)
     const raw = await kv.get(key)
 
     // Always refresh in background.
-    const qb = internal.queryBuilder ?? createQueryBuilder(chainId)
+    const qb = Tidx.getQueryBuilder(chain)
     const since = new Date(Date.now() - 86_400_000)
 
     let query = qb
@@ -92,20 +82,13 @@ export function create(
   }
 
   /** Read cached balance from KV. First read fetches on-chain; subsequent reads use cache. Always refreshes in background. */
-  async function getHasFunds(chainId: number) {
-    const key = kvKey(chainId, 'balance')
+  async function getHasFunds(chain: TempoChain) {
+    const key = kvKey(chain, 'balance')
     const raw = await kv.get(key)
-
-    const client =
-      internal.client ??
-      createClient({
-        chain: chainId === tempoModerato.id ? tempoModerato : tempo,
-        transport: http(),
-      })
 
     const fetchAndCache = () =>
       Actions.token
-        .getBalance(client, { account: feePayerAddress, token: FEE_TOKEN })
+        .getBalance(Viem.getClient(chain), { account: feePayerAddress, token: FEE_TOKEN })
         .then(async (balance) => {
           await kv.put(key, String(balance >= MIN_BALANCE_UNITS), { expirationTtl: 86_400 })
         })
@@ -132,16 +115,16 @@ export function create(
       const maxFeePerGas = request.maxFeePerGas as bigint | undefined
       if (!gas || !maxFeePerGas) return true
 
-      const chainId = (request as { chainId?: number }).chainId ?? tempo.id
+      const chain = fromId((request as { chainId?: number }).chainId ?? 4217)
 
-      if (!(await getHasFunds(chainId))) {
+      if (!(await getHasFunds(chain))) {
         console.warn('[fee-payer] insufficient balance')
         return false
       }
 
       const txFee = attodollarToMicrodollar(gas * maxFeePerGas)
 
-      const globalSpend = await getSpend(chainId)
+      const globalSpend = await getSpend(chain)
       if (globalDailyLimitMicroUsd !== null && globalSpend + txFee > globalDailyLimitMicroUsd) {
         console.info('[fee-payer] global budget exceeded', {
           globalSpentUsd: formatMicrodollar(globalSpend),
@@ -152,7 +135,7 @@ export function create(
       }
 
       if (dailyLimitMicroUsd !== null && from) {
-        const requesterSpend = await getSpend(chainId, from)
+        const requesterSpend = await getSpend(chain, from)
         if (requesterSpend + txFee > dailyLimitMicroUsd) {
           console.info('[fee-payer] address budget exceeded', {
             requester: from,
@@ -173,5 +156,12 @@ export function create(
 }
 
 export declare namespace create {
+  type Options = {
+    /** Per-address daily spend limit in USD (e.g. `"0.20"`). Defaults to `"0.20"`. */
+    dailyLimitUsd?: string | undefined
+    /** Global daily spend limit in USD (e.g. `"50"`). Defaults to `"50"`. */
+    globalDailyLimitUsd?: string | undefined
+  }
+
   type ReturnType = (request: Transaction.TransactionRequest) => boolean | Promise<boolean>
 }

--- a/apps/connect/worker/lib/fee-payer.ts
+++ b/apps/connect/worker/lib/fee-payer.ts
@@ -1,0 +1,177 @@
+import { waitUntil } from 'cloudflare:workers'
+import { QueryBuilder, Tidx } from 'tidx.ts'
+import { type Address, type Client, createClient, formatUnits, http, parseUnits } from 'viem'
+import { tempo, tempoModerato } from 'viem/chains'
+import { Actions, Transaction } from 'viem/tempo'
+
+const ATTODOLLARS_PER_MICRODOLLAR = 10n ** 12n
+const MIN_BALANCE_UNITS = 1_000_000n
+
+/** pathUSD — same address on all Tempo chains. */
+const FEE_TOKEN: Address = '0x20c0000000000000000000000000000000000000'
+
+function attodollarToMicrodollar(attodollars: bigint) {
+  return (attodollars + ATTODOLLARS_PER_MICRODOLLAR - 1n) / ATTODOLLARS_PER_MICRODOLLAR
+}
+
+function formatMicrodollar(value: bigint) {
+  return Number(formatUnits(value, 6))
+}
+
+function parseUsdLimit(value: string | undefined, defaultValue: string): bigint | null {
+  try {
+    const parsed = parseUnits(value || defaultValue, 6)
+    if (parsed <= 0n) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function createQueryBuilder(chainId: number) {
+  const tidxAuth =
+    chainId === tempoModerato.id
+      ? process.env.TEMPO_MODERATO_INDEXER_API_KEY
+      : process.env.TEMPO_INDEXER_API_KEY
+  return QueryBuilder.from(Tidx.create({ basicAuth: tidxAuth, chainId }))
+}
+
+/**
+ * Prevent abuse while being blazing fast:
+ *   - Always read from KV within request / response cycle, it's ok to be stale
+ *   - Apply per-address and global (soft) limits
+ */
+export function create(
+  feePayerAddress: Address,
+  kv: KVNamespace,
+  /** @internal — test overrides. */
+  internal: {
+    client?: Client | undefined
+    queryBuilder?: QueryBuilder.QueryBuilder | undefined
+  } = {},
+): create.ReturnType {
+  const dailyLimitMicroUsd = parseUsdLimit(process.env.FEE_PAYER_DAILY_LIMIT_USD, '0.20')
+  const globalDailyLimitMicroUsd = parseUsdLimit(process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD, '50')
+
+  function kvKey(chainId: number, scope: string) {
+    return `fee-payer:${chainId}:${scope}`
+  }
+
+  /** Read cached spend from KV. Returns `0n` on miss and refreshes in background. */
+  async function getSpend(chainId: number, requester?: string | undefined) {
+    const scope = requester ? requester.toLowerCase() : 'global'
+    const key = kvKey(chainId, scope)
+    const raw = await kv.get(key)
+
+    // Always refresh in background.
+    const qb = internal.queryBuilder ?? createQueryBuilder(chainId)
+    const since = new Date(Date.now() - 86_400_000)
+
+    let query = qb
+      .selectFrom('receipts')
+      .select(['gas_used', 'effective_gas_price'])
+      .where('fee_payer', '=', feePayerAddress.toLowerCase() as `0x${string}`)
+
+    if (scope !== 'global') query = query.where('from', '=', scope as `0x${string}`)
+
+    waitUntil(
+      query
+        .where('block_timestamp', '>=', since.toISOString() as never)
+        .execute()
+        .then(async (rows) => {
+          let total = 0n
+          for (const row of rows)
+            total += attodollarToMicrodollar(BigInt(row.gas_used) * BigInt(row.effective_gas_price))
+          await kv.put(key, total.toString(), { expirationTtl: 86_400 })
+        })
+        .catch((err) => console.error('[fee-payer] tidx fetch failed', err)),
+    )
+
+    if (!raw) return 0n
+    return BigInt(raw)
+  }
+
+  /** Read cached balance from KV. First read fetches on-chain; subsequent reads use cache. Always refreshes in background. */
+  async function getHasFunds(chainId: number) {
+    const key = kvKey(chainId, 'balance')
+    const raw = await kv.get(key)
+
+    const client =
+      internal.client ??
+      createClient({
+        chain: chainId === tempoModerato.id ? tempoModerato : tempo,
+        transport: http(),
+      })
+
+    const fetchAndCache = () =>
+      Actions.token
+        .getBalance(client, { account: feePayerAddress, token: FEE_TOKEN })
+        .then(async (balance) => {
+          await kv.put(key, String(balance >= MIN_BALANCE_UNITS), { expirationTtl: 86_400 })
+        })
+        .catch((err) => console.error('[fee-payer] balance check failed', err))
+
+    // Cache hit — return cached value, refresh in background.
+    if (raw !== null) {
+      waitUntil(fetchAndCache())
+      return raw === 'true'
+    }
+
+    // Cold start — fetch synchronously, then cache.
+    await fetchAndCache()
+    const fresh = await kv.get(key)
+    return fresh === 'true'
+  }
+
+  return async (request) => {
+    try {
+      if (dailyLimitMicroUsd === null && globalDailyLimitMicroUsd === null) return true
+
+      const from = request.from as Address | undefined
+      const gas = request.gas as bigint | undefined
+      const maxFeePerGas = request.maxFeePerGas as bigint | undefined
+      if (!gas || !maxFeePerGas) return true
+
+      const chainId = (request as { chainId?: number }).chainId ?? tempo.id
+
+      if (!(await getHasFunds(chainId))) {
+        console.warn('[fee-payer] insufficient balance')
+        return false
+      }
+
+      const txFee = attodollarToMicrodollar(gas * maxFeePerGas)
+
+      const globalSpend = await getSpend(chainId)
+      if (globalDailyLimitMicroUsd !== null && globalSpend + txFee > globalDailyLimitMicroUsd) {
+        console.info('[fee-payer] global budget exceeded', {
+          globalSpentUsd: formatMicrodollar(globalSpend),
+          txFeeUsd: formatMicrodollar(txFee),
+          globalDailyLimitUsd: formatMicrodollar(globalDailyLimitMicroUsd),
+        })
+        return false
+      }
+
+      if (dailyLimitMicroUsd !== null && from) {
+        const requesterSpend = await getSpend(chainId, from)
+        if (requesterSpend + txFee > dailyLimitMicroUsd) {
+          console.info('[fee-payer] address budget exceeded', {
+            requester: from,
+            requesterSpentUsd: formatMicrodollar(requesterSpend),
+            txFeeUsd: formatMicrodollar(txFee),
+            dailyLimitUsd: formatMicrodollar(dailyLimitMicroUsd),
+          })
+          return false
+        }
+      }
+
+      return true
+    } catch (error) {
+      console.error('[fee-payer] validation failed', error)
+      return false
+    }
+  }
+}
+
+export declare namespace create {
+  type ReturnType = (request: Transaction.TransactionRequest) => boolean | Promise<boolean>
+}

--- a/apps/connect/worker/lib/fee-payer.ts
+++ b/apps/connect/worker/lib/fee-payer.ts
@@ -1,5 +1,6 @@
 import { waitUntil } from 'cloudflare:workers'
-import { type Address, formatUnits, parseUnits } from 'viem'
+import { QueryBuilder } from 'tidx.ts'
+import { type Address, type Client, formatUnits, parseUnits } from 'viem'
 import { Actions, Transaction } from 'viem/tempo'
 
 import { type TempoChain, fromId } from './chain.js'
@@ -39,6 +40,8 @@ export function create(
   feePayerAddress: Address,
   kv: KVNamespace,
   options: create.Options = {},
+  /** @internal — test overrides. */
+  internal: create.Internal = {},
 ): create.ReturnType {
   const dailyLimitMicroUsd = parseUsdLimit(options.dailyLimitUsd, '0.20')
   const globalDailyLimitMicroUsd = parseUsdLimit(options.globalDailyLimitUsd, '50')
@@ -54,7 +57,7 @@ export function create(
     const raw = await kv.get(key)
 
     // Always refresh in background.
-    const qb = Tidx.getQueryBuilder(chain)
+    const qb = internal.queryBuilder ?? Tidx.getQueryBuilder(chain)
     const since = new Date(Date.now() - 86_400_000)
 
     let query = qb
@@ -88,7 +91,7 @@ export function create(
 
     const fetchAndCache = () =>
       Actions.token
-        .getBalance(Viem.getClient(chain), { account: feePayerAddress, token: FEE_TOKEN })
+        .getBalance(internal.client ?? Viem.getClient(chain), { account: feePayerAddress, token: FEE_TOKEN })
         .then(async (balance) => {
           await kv.put(key, String(balance >= MIN_BALANCE_UNITS), { expirationTtl: 86_400 })
         })
@@ -161,6 +164,12 @@ export declare namespace create {
     dailyLimitUsd?: string | undefined
     /** Global daily spend limit in USD (e.g. `"50"`). Defaults to `"50"`. */
     globalDailyLimitUsd?: string | undefined
+  }
+
+  /** @internal — test-only dependency overrides. */
+  type Internal = {
+    client?: Client | undefined
+    queryBuilder?: QueryBuilder.QueryBuilder | undefined
   }
 
   type ReturnType = (request: Transaction.TransactionRequest) => boolean | Promise<boolean>

--- a/apps/connect/worker/lib/fee-payer.ts
+++ b/apps/connect/worker/lib/fee-payer.ts
@@ -91,7 +91,10 @@ export function create(
 
     const fetchAndCache = () =>
       Actions.token
-        .getBalance(internal.client ?? Viem.getClient(chain), { account: feePayerAddress, token: FEE_TOKEN })
+        .getBalance(internal.client ?? Viem.getClient(chain), {
+          account: feePayerAddress,
+          token: FEE_TOKEN,
+        })
         .then(async (balance) => {
           await kv.put(key, String(balance >= MIN_BALANCE_UNITS), { expirationTtl: 86_400 })
         })

--- a/apps/connect/worker/lib/tidx.ts
+++ b/apps/connect/worker/lib/tidx.ts
@@ -1,0 +1,14 @@
+import { QueryBuilder, Tidx } from 'tidx.ts'
+import { tempo, tempoModerato } from 'viem/chains'
+
+import type { TempoChain } from './chain.js'
+
+/** Returns a Tidx query builder for the given chain. */
+export function getQueryBuilder(chain: TempoChain) {
+  const tidxAuth =
+    chain === 'testnet'
+      ? process.env.TEMPO_MODERATO_INDEXER_API_KEY
+      : process.env.TEMPO_INDEXER_API_KEY
+  const chainId = chain === 'testnet' ? tempoModerato.id : tempo.id
+  return QueryBuilder.from(Tidx.create({ basicAuth: tidxAuth, chainId }))
+}

--- a/apps/connect/worker/lib/tidx.ts
+++ b/apps/connect/worker/lib/tidx.ts
@@ -7,8 +7,8 @@ import type { TempoChain } from './chain.js'
 export function getQueryBuilder(chain: TempoChain) {
   const tidxAuth =
     chain === 'testnet'
-      ? process.env.TEMPO_MODERATO_INDEXER_API_KEY
-      : process.env.TEMPO_INDEXER_API_KEY
+      ? process.env.TIDX_TESTNET_API_KEY
+      : process.env.TIDX_MAINNET_API_KEY
   const chainId = chain === 'testnet' ? tempoModerato.id : tempo.id
   return QueryBuilder.from(Tidx.create({ basicAuth: tidxAuth, chainId }))
 }

--- a/apps/connect/worker/lib/tidx.ts
+++ b/apps/connect/worker/lib/tidx.ts
@@ -6,9 +6,7 @@ import type { TempoChain } from './chain.js'
 /** Returns a Tidx query builder for the given chain. */
 export function getQueryBuilder(chain: TempoChain) {
   const tidxAuth =
-    chain === 'testnet'
-      ? process.env.TIDX_TESTNET_API_KEY
-      : process.env.TIDX_MAINNET_API_KEY
+    chain === 'testnet' ? process.env.TIDX_TESTNET_API_KEY : process.env.TIDX_MAINNET_API_KEY
   const chainId = chain === 'testnet' ? tempoModerato.id : tempo.id
   return QueryBuilder.from(Tidx.create({ basicAuth: tidxAuth, chainId }))
 }

--- a/apps/connect/worker/lib/viem.ts
+++ b/apps/connect/worker/lib/viem.ts
@@ -1,0 +1,28 @@
+import { type Client, createClient, http } from 'viem'
+import { tempo, tempoModerato } from 'viem/chains'
+
+import type { TempoChain } from './chain.js'
+
+function getRpcUrl(chain: TempoChain) {
+  const chainId = chain === 'testnet' ? tempoModerato.id : tempo.id
+  const url = new URL(`https://proxy.tempo.xyz/rpc/${chainId}`)
+  if (process.env.TEMPO_RPC_KEY) url.searchParams.set('key', process.env.TEMPO_RPC_KEY)
+  return url.toString()
+}
+
+function getFetchOptions(chain: TempoChain): RequestInit | undefined {
+  if (chain === 'testnet' || !process.env.PRESTO_RPC_AUTH) return undefined
+  return {
+    headers: {
+      Authorization: `Basic ${btoa(process.env.PRESTO_RPC_AUTH)}`,
+    },
+  }
+}
+
+/** Returns a viem client for the given chain. */
+export function getClient(chain: TempoChain): Client {
+  return createClient({
+    chain: chain === 'testnet' ? tempoModerato : tempo,
+    transport: http(getRpcUrl(chain), { fetchOptions: getFetchOptions(chain) }),
+  })
+}

--- a/apps/connect/worker/relay.ts
+++ b/apps/connect/worker/relay.ts
@@ -13,7 +13,10 @@ export const relay = new Hono<{ Bindings: Env }>().all('/*', async (c) => {
     const key = process.env.RELAY_PRIVATE_KEY
     if (!key) return undefined
     const account = privateKeyToAccount(key as `0x${string}`)
-    const budgetValidate = FeePayer.create(account.address, c.env.KV)
+    const budgetValidate = FeePayer.create(account.address, c.env.KV, {
+      dailyLimitUsd: process.env.FEE_PAYER_DAILY_LIMIT_USD,
+      globalDailyLimitUsd: process.env.FEE_PAYER_GLOBAL_DAILY_LIMIT_USD,
+    })
     return {
       account,
       validate: (request: { from?: Address | undefined }) => {

--- a/apps/connect/worker/relay.ts
+++ b/apps/connect/worker/relay.ts
@@ -1,14 +1,33 @@
 import { Handler } from 'accounts/server'
 import { Hono } from 'hono'
+import { type Address, isAddressEqual } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
-export const relay = new Hono<{ Bindings: Env }>().all('/*', (c) =>
-  Handler.relay({
+import * as FeePayer from './lib/fee-payer.js'
+import * as Session from './lib/session.js'
+
+export const relay = new Hono<{ Bindings: Env }>().all('/*', async (c) => {
+  const session = await Session.fromRequest(c, process.env.SESSION_PUBLIC_KEY!)
+
+  const feePayer = (() => {
+    const key = process.env.RELAY_PRIVATE_KEY
+    if (!key) return undefined
+    const account = privateKeyToAccount(key as `0x${string}`)
+    const budgetValidate = FeePayer.create(account.address, c.env.KV)
+    return {
+      account,
+      validate: (request: { from?: Address | undefined }) => {
+        if (!session || !request.from) return false
+        if (!isAddressEqual(session.address as Address, request.from as Address)) return false
+        return budgetValidate(request)
+      },
+    }
+  })()
+
+  return Handler.relay({
     cors: false,
-    feePayer: {
-      account: privateKeyToAccount(process.env.RELAY_PRIVATE_KEY as `0x${string}`),
-    },
+    feePayer,
     features: 'all',
     path: '/api/relay',
-  }).fetch(c.req.raw),
-)
+  }).fetch(c.req.raw)
+})

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,8 @@ services:
     environment:
       BYPASS_EMAIL_OTP: 'true'
       DATABASE_URL: postgres://tempo:tempo@host.docker.internal:5432/connect
+      TEMPO_INDEXER_API_KEY: ${TEMPO_INDEXER_API_KEY:-}
+      TEMPO_MODERATO_INDEXER_API_KEY: ${TEMPO_MODERATO_INDEXER_API_KEY:-}
       # workerd needs CA certs for outbound HTTPS fetch in local dev.
       # https://github.com/cloudflare/workers-sdk/issues/9356
       SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      tidx.ts:
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.9.3)
       viem:
         specifier: ^2.48.1
         version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -12108,7 +12111,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.0(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12164,7 +12167,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.83.4
       debug: 4.4.3
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.0(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -15098,7 +15101,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.0(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -16172,7 +16175,7 @@ snapshots:
 
   expo-keep-awake@55.0.6(expo@55.0.12)(react@19.2.5):
     dependencies:
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.0(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 19.2.5
 
   expo-linking@55.0.13(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3):
@@ -16210,7 +16213,7 @@ snapshots:
 
   expo-secure-store@55.0.13(expo@55.0.12):
     dependencies:
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.0.9)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.0(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
   expo-server@55.0.7: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,11 @@ export default defineConfig({
       },
       {
         extends: true,
+        resolve: {
+          alias: {
+            'cloudflare:workers': join(import.meta.dirname, './apps/connect/test/cloudflare-workers.ts'),
+          },
+        },
         test: {
           include: ['./apps/connect/worker/**/*.test.ts'],
           name: 'connect/worker',


### PR DESCRIPTION
Ports fee-payer budget logic from the app repo into `Handler.relay` in connect.

Prevent abuse while being blazing fast:
  - Always read from KV within request / response cycle, it's ok to be stale
  - Apply per-address and global (soft) limits

## What

- Per-address ($0.20/day) and global ($50/day) spend limits enforced via tidx indexer queries
- On-chain balance check (pathUSD ≥ $1) on cold start, cached in KV
- Spend data cached in KV with 1-day TTL, refreshed in background via `waitUntil` on every read
- Rolling 24h window for spend calculations
- Skips fee payer entirely when `RELAY_PRIVATE_KEY` is unset

## Design

- **KV as shared cache** across CF Worker isolates — no in-memory state
- **Stale-while-revalidate**: reads cached spend from KV, fires background tidx refresh, uses cached value for the current decision
- **Cold start**: balance fetched synchronously, spend approved optimistically (0n) until first tidx refresh lands
- **`waitUntil`** keeps the isolate alive for background fetches

## Env vars

| Var | Default | Description |
|-----|---------|-------------|
| `TEMPO_INDEXER_API_KEY` | — | tidx auth for mainnet |
| `TEMPO_MODERATO_INDEXER_API_KEY` | — | tidx auth for moderato |
| `FEE_PAYER_DAILY_LIMIT_USD` | `0.20` | Per-address daily limit |
| `FEE_PAYER_GLOBAL_DAILY_LIMIT_USD` | `50` | Global daily limit |
