### PR TITLE
feat: update urls to wallet-next.tempo.xyz

### DIFF
--- a/ref-impls/cli-auth/cli.ts
+++ b/ref-impls/cli-auth/cli.ts
@@ -6,7 +6,7 @@ import { Hex } from 'ox'
 import { tempoMainnet, tempoTestnet, tempoDevnet } from 'viem/chains'
 import { connect } from 'viem/experimental/erc7846'
 
-const defaultHost = 'https://wallet.tempo.xyz/cli-auth' as const
+const defaultHost = 'https://wallet-next.tempo.xyz/api/auth/cli' as const
 const defaultToken = '0x20c0000000000000000000000000000000000000' as const
 
 const options = z.object({

--- a/src/cli/Provider.ts
+++ b/src/cli/Provider.ts
@@ -8,7 +8,7 @@ import { cli } from './adapter.js'
 export function create(options: create.Options): create.ReturnType {
   const {
     // TODO: use the new host
-    // host = 'https://wallet-next.tempo.xyz/remote/auth/cli',
+    // host = 'https://wallet-next.tempo.xyz/api/auth/cli',
     host = 'https://wallet.tempo.xyz/cli-auth',
     keysPath,
     open,

--- a/src/react-native/Provider.test.ts
+++ b/src/react-native/Provider.test.ts
@@ -91,7 +91,7 @@ describe('create', () => {
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
+      host: 'https://wallet-next.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
       secureStorage,


### PR DESCRIPTION
Update default host URLs to point to `wallet-next.tempo.xyz`:\n\n- CLI auth ref-impl: `wallet-next.tempo.xyz/api/auth/cli`\n- CLI Provider comment: updated TODO comment URL\n- React Native Provider test: `wallet-next.tempo.xyz`