### PR TITLE
fix: check request.feePayer for relay gas bump

### DIFF
--- a/.changeset/fix-relay-gas-bump.md
+++ b/.changeset/fix-relay-gas-bump.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed relay handler gas bump not applying when `feePayer` is present. The condition checked `result.tx.feePayer` (node response) which is not set; now checks `request.feePayer` (the input).

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -569,7 +569,9 @@ async function fill(
     // FIXME: node estimates gas with secp256k1 dummy sig + null feePayerSignature.
     // Actual tx has larger keychain/webAuthn sigs + real fee payer sig, costing
     // more intrinsic gas. Mirror the bump from viem's tempo chainConfig.
-    if (result.tx.gas && request.feePayer)
+    // Skip if another relay already bumped (indicated by feePayerSignature).
+    // @ts-expect-error
+    if (result.tx.gas && request.feePayer && !result.tx.feePayerSignature)
       result.tx.gas = Hex.fromNumber(BigInt(result.tx.gas) + 20_000n)
     const sponsor = (result as Record<string, any>).capabilities?.sponsor as
       | { address: Address; name?: string; url?: string }

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -569,8 +569,7 @@ async function fill(
     // FIXME: node estimates gas with secp256k1 dummy sig + null feePayerSignature.
     // Actual tx has larger keychain/webAuthn sigs + real fee payer sig, costing
     // more intrinsic gas. Mirror the bump from viem's tempo chainConfig.
-    // @ts-expect-error
-    if (result.tx.gas && result.tx.feePayer)
+    if (result.tx.gas && request.feePayer)
       result.tx.gas = Hex.fromNumber(BigInt(result.tx.gas) + 20_000n)
     const sponsor = (result as Record<string, any>).capabilities?.sponsor as
       | { address: Address; name?: string; url?: string }


### PR DESCRIPTION
The relay handler's `fill` function bumps gas by 20k when a fee payer is present to account for larger WebAuthn/Keychain signatures. However, the condition checked `result.tx.feePayer` (the node response), which doesn't include that field. This meant the bump was never applied.

Now checks `request.feePayer` (the input) instead.