### PR TITLE
feat: add wallet_send RPC action

### DIFF
--- a/.changeset/feat-wallet-send.md
+++ b/.changeset/feat-wallet-send.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `wallet_send` RPC action.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -80,6 +80,7 @@ export function App() {
       <WalletGetBalances />
       <Faucet />
       <WalletDeposit />
+      <WalletSend />
 
       <h2>Transactions</h2>
       <Transactions />
@@ -173,6 +174,50 @@ function WalletDeposit() {
         }
       >
         Deposit (displayName: DoorDash)
+      </button>
+    </Method>
+  )
+}
+
+function WalletSend() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="wallet_send" result={result} error={error}>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_send',
+              params: [{}],
+            }),
+          )
+        }
+      >
+        Send
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_send',
+              params: [{ token: tokens.pathUSD }],
+            }),
+          )
+        }
+      >
+        Send (PathUSD)
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_send',
+              params: [{ to: '0x0000000000000000000000000000000000000001', token: tokens.pathUSD, value: '1' }],
+            }),
+          )
+        }
+      >
+        Send ($1 PathUSD)
       </button>
     </Method>
   )

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -67,6 +67,13 @@ export type Instance = {
           request: EncodedRequest<Rpc.wallet_revokeAccessKey.Encoded>,
         ) => Promise<void>)
       | undefined
+    /** Open the send-token flow. */
+    send?:
+      | ((
+          params: send.Parameters,
+          request: EncodedRequest<Rpc.wallet_send.Encoded>,
+        ) => Promise<send.ReturnType>)
+      | undefined
     /** Send a transaction. */
     sendTransaction: (
       params: sendTransaction.Parameters,
@@ -249,6 +256,11 @@ export declare namespace revokeAccessKey {
     /** Address of the access key to revoke. */
     accessKeyAddress: Address
   }
+}
+
+export declare namespace send {
+  type Parameters = ActionRequest<typeof Rpc.wallet_send.schema>
+  type ReturnType = Rpc.wallet_send.Encoded['returns']
 }
 
 export declare namespace sendTransaction {

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -642,6 +642,20 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
     })
   })
 
+  describe('wallet_send', () => {
+    test('error: throws UnsupportedMethodError when adapter has no send action', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      await connect(provider)
+
+      await expect(
+        provider.request({
+          method: 'wallet_send',
+          params: [{ to: '0x0000000000000000000000000000000000000001', token: Addresses.pathUsd, value: '1' }],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`[Provider.UnsupportedMethodError: \`send\` not supported by adapter.]`)
+    })
+  })
+
   describe('wallet_getCapabilities', () => {
     test('default: returns atomic supported for all chains', async () => {
       const provider = Provider.create({ adapter: adapter() })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -619,6 +619,18 @@ export function create(options: create.Options = {}): create.ReturnType {
                     )) satisfies Rpc.wallet_deposit.Encoded['returns']
                   }
 
+                  case 'wallet_send': {
+                    assertConnected()
+                    if (!actions.send)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`send` not supported by adapter.',
+                      })
+                    return (await actions.send(
+                      (request._decoded.params?.[0] ?? {}) as Adapter.send.Parameters,
+                      request,
+                    )) satisfies Rpc.wallet_send.Encoded['returns']
+                  }
+
                   case 'wallet_switchEthereumChain': {
                     const { chainId } = request._decoded.params[0]
                     if (!chains.some((c) => c.id === chainId))

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -121,6 +121,22 @@ describe('Encoded', () => {
     }>()
   })
 
+  test('wallet_send', () => {
+    expectTypeOf<Rpc.wallet_send.Encoded>().toMatchTypeOf<{
+      method: 'wallet_send'
+      params:
+        | readonly [
+            {
+              to?: Hex | undefined
+              token?: Hex | undefined
+              value?: string | undefined
+            },
+          ]
+        | undefined
+      returns: { transactionHash: Hex }
+    }>()
+  })
+
   test('wallet_switchEthereumChain', () => {
     expectTypeOf<Rpc.wallet_switchEthereumChain.Encoded>().toEqualTypeOf<{
       method: 'wallet_switchEthereumChain'
@@ -159,7 +175,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[18]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[19]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -186,6 +202,7 @@ describe('Request', () => {
       | 'wallet_deposit'
       | 'wallet_getBalances'
       | 'wallet_revokeAccessKey'
+      | 'wallet_send'
     >()
   })
 

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -93,6 +93,7 @@ export const schema = from([
   Rpc.wallet_getCallsStatus.schema,
   Rpc.wallet_getCapabilities.schema,
   Rpc.wallet_revokeAccessKey.schema,
+  Rpc.wallet_send.schema,
   Rpc.wallet_sendCalls.schema,
   Rpc.wallet_switchEthereumChain.schema,
 ])

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -395,6 +395,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           return await provider.request(request)
         },
 
+        async send(_params, request) {
+          return await provider.request(request)
+        },
+
         async disconnect() {
           store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
         },

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -531,6 +531,32 @@ export namespace wallet_getCallsStatus {
   export type Decoded = Schema.Decoded<typeof schema>
 }
 
+export namespace wallet_send {
+  export const schema = Schema.defineItem({
+    method: z.literal('wallet_send'),
+    params: z.optional(
+      z.readonly(
+        z.tuple([
+          z.object({
+            /** Recipient address to pre-fill. */
+            to: z.optional(u.address()),
+            /** Token contract address to pre-fill. Omit to let the user choose. */
+            token: z.optional(u.address()),
+            /** Human-readable amount to pre-fill (e.g. "1.5"). */
+            value: z.optional(z.string()),
+          }),
+        ]),
+      ),
+    ),
+    returns: z.object({
+      /** Transaction hash of the submitted send. */
+      transactionHash: u.hex(),
+    }),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
 export namespace wallet_switchEthereumChain {
   export const schema = Schema.defineItem({
     method: z.literal('wallet_switchEthereumChain'),


### PR DESCRIPTION
Add wallet_send RPC method with optional to, token, and value parameters for dapps to open a send-token flow in the wallet UI.

- Schema: optional params (to, token, value), returns transactionHash
- Provider: assertConnected + delegates to actions.send
- Adapter: optional send action, dialog adapter forwards to embedded wallet
- Tests: UnsupportedMethodError test, type tests, Schema.test-d.ts
- Playground: 3 buttons (bare, with token, with token+value+to)