### PR TITLE
fix: log silent-sign error in dialog adapter's withAccessKey

### DIFF
--- a/.changeset/log-silent-sign-error.md
+++ b/.changeset/log-silent-sign-error.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Log the underlying error when silent signing with an access key fails in the `dialog` adapter. The `withAccessKey` catch block now logs the thrown error via `console.warn` before removing the stale key, so consumers get a signal for why a silent sign fell back to the approval dialog.

--- a/.changeset/log-silent-sign-error.md
+++ b/.changeset/log-silent-sign-error.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Log the underlying error when silent signing with an access key fails in the `dialog` adapter. The `withAccessKey` catch block now logs the thrown error via `console.warn` before removing the stale key, so consumers get a signal for why a silent sign fell back to the approval dialog.
+Logged access key sign errors in the `dialog` adapter's `withAccessKey` catch block via `console.warn` before removing the stale key.

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -166,7 +166,8 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         const result = await fn(account, keyAuthorization ?? undefined)
         AccessKey.removePending(account, { store })
         return result
-      } catch {
+      } catch (err) {
+        console.warn('[accounts] silent sign with access key failed, removing key:', err)
         AccessKey.remove(account, { store })
         return undefined
       }


### PR DESCRIPTION
Closes #260.

`withAccessKey` in the dialog adapter was catching every error from the silent-sign path with a bare `catch` block and removing the access key before falling through. Consumers got no signal about why silent signing failed — I hit this debugging why my playground kept falling back to the approval dialog on payment pages.

This captures the error and logs it via `console.warn` before the remove. No behavior change beyond the log.

Transient-vs-permanent error handling and an opt-out flag are bigger decisions, happy to follow up if there's a direction you'd like.

```diff
-      } catch {
+      } catch (err) {
+        console.warn('[accounts] silent sign with access key failed, removing key:', err)
         AccessKey.remove(account, { store })
         return undefined
       }
```