### PR TITLE
fix: revoke access key on-chain in local adapter

### DIFF
--- a/.changeset/revoke-access-key-on-chain.md
+++ b/.changeset/revoke-access-key-on-chain.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Made `wallet_revokeAccessKey` on the local adapter send a `revokeKey` transaction to the AccountKeychain precompile via `Actions.accessKey.revoke` before removing the key from the local store.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1214,24 +1214,95 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
   })
 
   describe('wallet_revokeAccessKey', () => {
-    test('default: revokes a granted access key', async () => {
+    test('default: revokes a granted access key on-chain', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       await connect(provider)
 
       const connected = (await provider.request({ method: 'eth_accounts' }))[0]!
+      await fund(connected)
+
       const { keyAuthorization } = await provider.request({
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry: Expiry.days(1) }],
       })
+
+      // Send a tx to register the key on-chain via keyAuthorization.
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      // Key should exist on-chain before revocation.
+      const client = getClient()
+      const before = await Actions.accessKey.getMetadata(client, {
+        account: connected,
+        accessKey: keyAuthorization.address,
+      })
+      expect(before.isRevoked).toBe(false)
 
       await provider.request({
         method: 'wallet_revokeAccessKey',
         params: [{ address: connected, accessKeyAddress: keyAuthorization.address }],
       })
 
-      // After revoking, sendTransactionSync should use root key (still works)
-      const address = (await provider.request({ method: 'eth_accounts' }))[0]!
-      await fund(address)
+      // Key should be revoked on-chain.
+      const after = await Actions.accessKey.getMetadata(client, {
+        account: connected,
+        accessKey: keyAuthorization.address,
+      })
+      expect(after.isRevoked).toBe(true)
+    })
+
+    test('behavior: removes key from local store', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      await connect(provider)
+
+      const connected = (await provider.request({ method: 'eth_accounts' }))[0]!
+      await fund(connected)
+
+      const { keyAuthorization } = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      // Register the key on-chain.
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      expect(provider.store.getState().accessKeys).toHaveLength(1)
+
+      await provider.request({
+        method: 'wallet_revokeAccessKey',
+        params: [{ address: connected, accessKeyAddress: keyAuthorization.address }],
+      })
+
+      expect(provider.store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
+    })
+
+    test('behavior: root key still works after revoking access key', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      await connect(provider)
+
+      const connected = (await provider.request({ method: 'eth_accounts' }))[0]!
+      await fund(connected)
+
+      const { keyAuthorization } = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      // Register the key on-chain, then revoke it.
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      await provider.request({
+        method: 'wallet_revokeAccessKey',
+        params: [{ address: connected, accessKeyAddress: keyAuthorization.address }],
+      })
 
       const receipt = await provider.request({
         method: 'eth_sendTransactionSync',

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,7 +1,7 @@
 import { Address as ox_Address, Hex, Provider as ox_Provider, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Account as TempoAccount } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Account from '../Account.js'
@@ -184,10 +184,17 @@ export function local(options: local.Options): Adapter.Adapter {
           return { accounts, email, keyAuthorization, signature: signature_, username }
         },
         async revokeAccessKey(parameters) {
-          AccessKey.revoke({
-            address: parameters.address,
-            store,
-          })
+          const account = getAccount({ accessKey: false, signable: true })
+          const client = getClient()
+          await Actions.accessKey.revoke(client, {
+            account,
+            accessKey: parameters.accessKeyAddress,
+          } as never)
+          store.setState((state) => ({
+            accessKeys: state.accessKeys.filter(
+              (a) => a.address?.toLowerCase() !== parameters.accessKeyAddress.toLowerCase(),
+            ),
+          }))
         },
         async signPersonalMessage({ data, address }) {
           const account = getAccount({ address, signable: true })


### PR DESCRIPTION
## Summary

`wallet_revokeAccessKey` on the local adapter now sends a `revokeKey` transaction to the AccountKeychain precompile via `Actions.accessKey.revoke` from `viem/tempo`, instead of only removing the key from the local store.

### Changes

- **`src/core/adapters/local.ts`** — `revokeAccessKey` calls `Actions.accessKey.revoke()` using the root account, then removes the key from the store by its address
- **`src/core/Provider.test.ts`** — Three new tests:
  - Verifies on-chain revocation (`getMetadata` confirms `isRevoked: true`)
  - Verifies local store cleanup (`accessKeys` is empty after revoke)
  - Verifies root key still works after revoking an access key

### Changeset

`accounts`: patch