### PR TITLE
fix: tolerate KeyNotFound when revoking pending-only access keys

### DIFF
--- a/.changeset/tolerate-key-not-found.md
+++ b/.changeset/tolerate-key-not-found.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `wallet_revokeAccessKey` in the local adapter crashing with `KeyNotFound` when the access key was only authorized locally and never registered on-chain via a transaction.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -650,9 +650,17 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       await expect(
         provider.request({
           method: 'wallet_send',
-          params: [{ to: '0x0000000000000000000000000000000000000001', token: Addresses.pathUsd, value: '1' }],
+          params: [
+            {
+              to: '0x0000000000000000000000000000000000000001',
+              token: Addresses.pathUsd,
+              value: '1',
+            },
+          ],
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`[Provider.UnsupportedMethodError: \`send\` not supported by adapter.]`)
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Provider.UnsupportedMethodError: \`send\` not supported by adapter.]`,
+      )
     })
   })
 
@@ -1376,6 +1384,12 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         params: [{ expiry: Expiry.days(1) }],
       })
       expect(provider.store.getState().accessKeys).toHaveLength(1)
+
+      // Send a tx to register the key on-chain via keyAuthorization.
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
 
       // Revoke the access key on-chain so the node will reject it.
       const { accessKeys } = provider.store.getState()

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,5 +1,6 @@
 import { Address as ox_Address, Hex, Provider as ox_Provider, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { BaseError } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 
@@ -192,7 +193,12 @@ export function local(options: local.Options): Adapter.Adapter {
               accessKey: parameters.accessKeyAddress,
             } as never)
           } catch (error) {
-            if (!(error instanceof Error) || !error.message.includes('KeyNotFound')) throw error
+            const isKeyNotFound =
+              error instanceof BaseError &&
+              !!error.walk(
+                (e) => (e as { data?: { errorName?: string } }).data?.errorName === 'KeyNotFound',
+              )
+            if (!isKeyNotFound) throw error
           }
           store.setState((state) => ({
             accessKeys: state.accessKeys.filter(

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -186,10 +186,14 @@ export function local(options: local.Options): Adapter.Adapter {
         async revokeAccessKey(parameters) {
           const account = getAccount({ accessKey: false, signable: true })
           const client = getClient()
-          await Actions.accessKey.revoke(client, {
-            account,
-            accessKey: parameters.accessKeyAddress,
-          } as never)
+          try {
+            await Actions.accessKey.revoke(client, {
+              account,
+              accessKey: parameters.accessKeyAddress,
+            } as never)
+          } catch (error) {
+            if (!(error instanceof Error) || !error.message.includes('KeyNotFound')) throw error
+          }
           store.setState((state) => ({
             accessKeys: state.accessKeys.filter(
               (a) => a.address?.toLowerCase() !== parameters.accessKeyAddress.toLowerCase(),


### PR DESCRIPTION
When `revokeAccessKey` is called on a key that was only authorized locally (never registered on-chain via a transaction), the on-chain `revokeKey` call reverts with `KeyNotFound`. This was introduced in #275 which added on-chain revocation without accounting for pending-only keys.

**Changes:**

- **Production**: catch `KeyNotFound` reverts in the local adapter's `revokeAccessKey` using `BaseError.walk()` to structurally match the error. Other errors are still re-thrown. Local state cleanup always runs regardless.
- **Test**: the stale-key retry test now sends `eth_sendTransactionSync` to register the key on-chain before revoking, matching the setup of the other `wallet_revokeAccessKey` tests.