### PR TITLE
feat: `wallet_send` tweaks

### DIFF
--- a/.changeset/better-loops-marry.md
+++ b/.changeset/better-loops-marry.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Modified `wallet_send` to return `{ receipt }` instead of `{ transactionHash }`

--- a/.changeset/client-fee-payer-url-normalize.md
+++ b/.changeset/client-fee-payer-url-normalize.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Resolved relative `feePayer` URLs in `Client.fromChainId` against `window.location.origin` in the browser.

--- a/.changeset/relay-merge-request-into-fill-result.md
+++ b/.changeset/relay-merge-request-into-fill-result.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Merged original `eth_fillTransaction` request fields (calls, chainId, validBefore, key data, feePayer) into the chain's filled tx so sponsorship envelope serialization no longer throws `CallsEmptyError`.

--- a/.changeset/relay-upstream-fee-payer-fill.md
+++ b/.changeset/relay-upstream-fee-payer-fill.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Forwarded upstream relay `capabilities.autoSwap` and `InsufficientBalance` errors through the wallet relay so external fee-payer fills surface autoSwap metadata and trigger the local autoSwap fallback.

--- a/.changeset/wallet-send-fee-payer-param.md
+++ b/.changeset/wallet-send-fee-payer-param.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `feePayer` parameter to `wallet_send` for per-call fee payer override.

--- a/.changeset/wallet-send-parameters-schema.md
+++ b/.changeset/wallet-send-parameters-schema.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Exported `Rpc.wallet_send.parameters` zod schema for the `wallet_send` parameters object.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -80,10 +80,10 @@ export function App() {
       <WalletGetBalances />
       <Faucet />
       <WalletDeposit />
-      <WalletSend />
 
       <h2>Transactions</h2>
       <Transactions />
+      <WalletSend />
 
       <h2>Receipts &amp; Status</h2>
       <EthGetTransactionReceipt />
@@ -181,14 +181,37 @@ function WalletDeposit() {
 
 function WalletSend() {
   const [result, error, execute] = useRequest()
+  const [feePayerMode, setFeePayerMode] = useState<'wallet' | 'playground' | 'disabled'>('wallet')
+
+  const feePayerParam = (() => {
+    if (feePayerMode === 'disabled') return { feePayer: false as const }
+    if (feePayerMode === 'playground') return { feePayer: '/relay' }
+    return {}
+  })()
+
   return (
     <Method method="wallet_send" result={result} error={error}>
+      <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
+        <legend>Fee Payer</legend>
+        {(['wallet', 'playground', 'disabled'] as const).map((mode) => (
+          <label key={mode} style={{ marginRight: 12 }}>
+            <input
+              type="radio"
+              name="walletSendFeePayerMode"
+              value={mode}
+              checked={feePayerMode === mode}
+              onChange={() => setFeePayerMode(mode)}
+            />{' '}
+            {mode[0]!.toUpperCase() + mode.slice(1)}
+          </label>
+        ))}
+      </fieldset>
       <button
         onClick={() =>
           execute(() =>
             provider.request({
               method: 'wallet_send',
-              params: [{}],
+              params: [{ ...feePayerParam }],
             }),
           )
         }
@@ -200,7 +223,7 @@ function WalletSend() {
           execute(() =>
             provider.request({
               method: 'wallet_send',
-              params: [{ token: tokens.pathUSD }],
+              params: [{ token: tokens.pathUSD, ...feePayerParam }],
             }),
           )
         }
@@ -212,7 +235,14 @@ function WalletSend() {
           execute(() =>
             provider.request({
               method: 'wallet_send',
-              params: [{ to: '0x0000000000000000000000000000000000000001', token: tokens.pathUSD, value: '1' }],
+              params: [
+                {
+                  to: '0x0000000000000000000000000000000000000001',
+                  token: tokens.pathUSD,
+                  value: '1',
+                  ...feePayerParam,
+                },
+              ],
             }),
           )
         }
@@ -478,7 +508,7 @@ function Transactions() {
 
   return (
     <div>
-      <h3>Calls</h3>
+      <h3>Send</h3>
       <table style={{ borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>
         <colgroup>
           <col style={{ width: '15%' }} />
@@ -547,7 +577,6 @@ function Transactions() {
         + Add Call
       </button>
 
-      <h3>Send</h3>
       <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
         <legend>Fee Payer</legend>
         {(['wallet', 'playground', 'disabled'] as const).map((mode) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ overrides:
   react: ^19.2.5
   react-dom: ^19.2.5
   accounts: workspace:*
-  viem: ^2.48.1
+  viem: ^2.48.4
   wrangler: ^4.84.1
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
@@ -77,7 +77,7 @@ importers:
         version: 0.0.7(typescript@5.9.3)
       mppx:
         specifier: 0.5.11
-        version: 0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       ox:
         specifier: ~0.14.18
         version: 0.14.18(typescript@5.9.3)(zod@4.3.6)
@@ -126,7 +126,7 @@ importers:
         version: 5.2.0(vite@8.0.9)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 3.4.4(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.4.4(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       elysia:
         specifier: ^1.4.28
         version: 1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -167,14 +167,14 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       vp:
         specifier: npm:vite-plus@~0.1.18
         version: vite-plus@0.1.18(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitejs/devtools@0.1.11)(bufferutil@4.0.9)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(publint@0.3.18)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(vite@8.0.9)(yaml@2.8.3)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       zile:
         specifier: ^0.0.25
         version: 0.0.25(@typescript/native-preview@7.0.0-dev.20260416.2)(typescript@5.9.3)
@@ -194,11 +194,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -231,8 +231,8 @@ importers:
         specifier: ~0.14.18
         version: 0.14.18(typescript@5.9.3)(zod@4.3.6)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: latest
@@ -259,11 +259,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -308,11 +308,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -348,11 +348,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -397,11 +397,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -446,11 +446,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -519,8 +519,8 @@ importers:
         specifier: ~4.23.0
         version: 4.23.0(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -544,11 +544,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: latest
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -582,7 +582,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 0.5.11
-        version: 0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.14)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.14)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -590,8 +590,8 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.48.1
-        version: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
@@ -683,7 +683,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
     devDependencies:
       '@tanstack/router-plugin':
         specifier: ^1.167.20
@@ -3224,7 +3224,7 @@ packages:
       accounts: workspace:*
       porto: ~0.2.35
       typescript: '>=5.7.3'
-      viem: ^2.48.1
+      viem: ^2.48.4
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -3252,7 +3252,7 @@ packages:
       accounts: workspace:*
       ox: ~0.14.18
       typescript: '>=5.7.3'
-      viem: ^2.48.1
+      viem: ^2.48.4
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -3270,7 +3270,7 @@ packages:
       accounts: workspace:*
       ox: ~0.14.18
       typescript: '>=5.7.3'
-      viem: ^2.48.1
+      viem: ^2.48.4
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -5222,7 +5222,7 @@ packages:
       elysia: '>=1'
       express: '>=5'
       hono: '>=4.12.12'
-      viem: ^2.48.1
+      viem: ^2.48.4
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -6556,8 +6556,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.48.1:
-    resolution: {integrity: sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==}
+  viem@2.48.4:
+    resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -6650,7 +6650,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.5
       typescript: '>=5.7.3'
-      viem: ^2.48.1
+      viem: ^2.48.4
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9631,19 +9631,19 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
-  '@wagmi/connectors@8.0.2(@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.2(@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       accounts: 'link:'
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.99.2
@@ -9656,11 +9656,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.4(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.4(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.99.2
@@ -11965,11 +11965,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.18(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -11979,11 +11979,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.14)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.5.11(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@21.1.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.14)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.18(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -13282,7 +13282,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -13399,14 +13399,14 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
-  wagmi@3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.6.2(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.99.2(react@19.2.5)
-      '@wagmi/connectors': 8.0.2(@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 8.0.2(@wagmi/core@3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.3(@tanstack/query-core@5.99.2)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(ox@0.14.18(typescript@5.9.3)(zod@4.3.6))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   tsx: ^4.21.0
   typed-query-selector: ^2.12.1
   typescript: ^5.9.3
-  viem: ^2.48.1
+  viem: ^2.48.4
   vite: ^8.0.5
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -22,8 +22,9 @@ export function fromChainId(
   const { chains, feePayer: feePayerOption, provider, store } = options
   const feePayerUrl = (() => {
     if (feePayerOption === false) return undefined
-    if (typeof feePayerOption === 'string') return feePayerOption
-    return feePayerOption?.url
+    if (typeof feePayerOption === 'string') return normalizeFeePayerUrl(feePayerOption)
+    if (feePayerOption?.url) return normalizeFeePayerUrl(feePayerOption.url)
+    return undefined
   })()
   const precedence = (() => {
     if (typeof feePayerOption === 'object' && feePayerOption !== null)
@@ -85,6 +86,17 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
       },
     } as ReturnType<Transport>
   }
+}
+
+/**
+ * Resolves a fee payer URL to an absolute URL string. Relative paths (e.g.
+ * `/relay`) are resolved against `window.location.origin` when running in a
+ * browser; on the server, relative paths are returned as-is.
+ */
+function normalizeFeePayerUrl(url: string): string {
+  if (url.startsWith('http://') || url.startsWith('https://')) return url
+  if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
+  return url
 }
 
 function feePayerTransport(

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -625,8 +625,15 @@ export function create(options: create.Options = {}): create.ReturnType {
                       throw new ox_Provider.UnsupportedMethodError({
                         message: '`send` not supported by adapter.',
                       })
+                    const decoded = request._decoded.params?.[0] ?? {}
+                    const parameters = {
+                      ...decoded,
+                      ...(typeof decoded.feePayer !== 'undefined'
+                        ? { feePayer: resolveFeePayer(decoded.feePayer) }
+                        : {}),
+                    } as Adapter.send.Parameters
                     return (await actions.send(
-                      (request._decoded.params?.[0] ?? {}) as Adapter.send.Parameters,
+                      parameters,
                       request,
                     )) satisfies Rpc.wallet_send.Encoded['returns']
                   }

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -133,7 +133,7 @@ describe('Encoded', () => {
             },
           ]
         | undefined
-      returns: { transactionHash: Hex }
+      returns: { receipt: { transactionHash: Hex } }
     }>()
   })
 

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -396,8 +396,11 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           return await provider.request(request)
         },
 
-        async send(_params, request) {
-          return await provider.request(request)
+        async send(params, request) {
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.wallet_send.parameters, params)] as const,
+          })
         },
 
         async disconnect() {

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -532,22 +532,24 @@ export namespace wallet_getCallsStatus {
 }
 
 export namespace wallet_send {
+  /** Parameters object for `wallet_send`. */
+  export const parameters = z.object({
+    /**
+     * Fee payer override. `false` to disable the wallet's default fee
+     * payer, a URL string to use a custom fee payer service.
+     */
+    feePayer: z.optional(z.union([z.boolean(), z.string()])),
+    /** Recipient address to pre-fill. */
+    to: z.optional(u.address()),
+    /** Token contract address to pre-fill. Omit to let the user choose. */
+    token: z.optional(u.address()),
+    /** Human-readable amount to pre-fill (e.g. "1.5"). */
+    value: z.optional(z.string()),
+  })
+
   export const schema = Schema.defineItem({
     method: z.literal('wallet_send'),
-    params: z.optional(
-      z.readonly(
-        z.tuple([
-          z.object({
-            /** Recipient address to pre-fill. */
-            to: z.optional(u.address()),
-            /** Token contract address to pre-fill. Omit to let the user choose. */
-            token: z.optional(u.address()),
-            /** Human-readable amount to pre-fill (e.g. "1.5"). */
-            value: z.optional(z.string()),
-          }),
-        ]),
-      ),
-    ),
+    params: z.optional(z.readonly(z.tuple([parameters]))),
     returns: z.object({
       /** Receipt of the submitted send. */
       receipt,

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -549,8 +549,8 @@ export namespace wallet_send {
       ),
     ),
     returns: z.object({
-      /** Transaction hash of the submitted send. */
-      transactionHash: u.hex(),
+      /** Receipt of the submitted send. */
+      receipt,
     }),
   })
   export type Encoded = Schema.Encoded<typeof schema>

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -281,6 +281,127 @@ describe('behavior: with app-provided feePayer URL', () => {
   })
 })
 
+describe('behavior: with app-provided feePayer URL + autoSwap', () => {
+  let appServer: Server
+  let walletServer: Server
+  let client: ReturnType<typeof getClient<typeof chain>>
+
+  beforeAll(async () => {
+    // App relay sponsors fees AND has `features: 'all'` so it can recover
+    // from InsufficientBalance via autoSwap.
+    appServer = await createServer(
+      relay({
+        chains: [chain],
+        features: 'all',
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          name: 'App Sponsor',
+          url: 'https://app.example.com',
+        },
+      }).listener,
+    )
+
+    // Wallet relay forwards to the app relay; also has features:'all' so its
+    // own fill() can detect upstream `capabilities.error` as InsufficientBalance.
+    walletServer = await createServer(
+      relay({
+        chains: [chain],
+        features: 'all',
+        transports: { [chain.id]: http() },
+      }).listener,
+    )
+
+    client = getClient({ transport: http(walletServer.url) })
+  })
+
+  afterAll(() => {
+    appServer.close()
+    walletServer.close()
+  })
+
+  test('behavior: autoSwap recovers when external feePayer surfaces InsufficientBalance', async () => {
+    const sender = accounts[6]!
+
+    // Token pair + DEX liquidity. Use alphaUsd as the quote token so the
+    // relay can swap alphaUsd → base to cover the deficit.
+    const rpc = getClient({ account: accounts[0]! })
+    const { token: base } = await Actions.token.createSync(rpc, {
+      name: 'External Swap Base',
+      symbol: 'EXTBASE',
+      currency: 'USD',
+      quoteToken: addresses.alphaUsd,
+    })
+    await sendTransactionSync(rpc, {
+      calls: [
+        Actions.token.grantRoles.call({ token: base, role: 'issuer', to: rpc.account!.address }),
+        Actions.token.mint.call({
+          token: base,
+          to: rpc.account!.address,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.mint.call({
+          token: addresses.alphaUsd,
+          to: rpc.account!.address,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.approve.call({
+          token: base,
+          spender: Addresses.stablecoinDex,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.approve.call({
+          token: addresses.alphaUsd,
+          spender: Addresses.stablecoinDex,
+          amount: parseUnits('10000', 6),
+        }),
+      ],
+    })
+    await Actions.dex.createPairSync(rpc, { base })
+    await Actions.dex.placeSync(rpc, {
+      token: base,
+      amount: parseUnits('500', 6),
+      type: 'sell',
+      tick: Tick.fromPrice('1.001'),
+    })
+
+    // Give sender alphaUsd (fee + swap source) but NO base tokens.
+    await Actions.token.mintSync(rpc, {
+      token: addresses.alphaUsd,
+      amount: parseUnits('1000', 6),
+      to: sender.address,
+    })
+    await Actions.fee.setUserToken(getClient({ account: sender }), { token: addresses.alphaUsd })
+
+    // Sender attempts to transfer base via the wallet relay, which forwards
+    // to the app relay. The app relay returns 200 with capabilities.error =
+    // InsufficientBalance and a stub tx; the wallet relay must convert that
+    // into a synthetic throw so its own fill() autoSwap branch can recover.
+    const transferAmount = parseUnits('5', 6)
+    const result = await fillTransaction(client, {
+      account: sender.address,
+      ...Actions.token.transfer.call({
+        token: base,
+        to: accounts[7]!.address,
+        amount: transferAmount,
+      }),
+      feePayer: appServer.url as never,
+    })
+
+    const { transaction, capabilities } = result
+
+    // Tx is filled with the swap calls prepended (approve + buy + transfer).
+    expect(transaction.calls).toHaveLength(3)
+    expect(transaction.feePayerSignature).toBeDefined()
+
+    // autoSwap metadata is surfaced.
+    expect(capabilities?.autoSwap?.slippage).toBe(0.05)
+    expect(capabilities?.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
+    expect(capabilities?.autoSwap?.minOut.symbol).toBe('EXTBASE')
+    expect(capabilities?.autoSwap?.minOut.formatted).toBe('5')
+  })
+})
+
 describe('behavior: chainId path parameter', () => {
   let server: Server
   let client: ReturnType<typeof getClient<typeof chain>>

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -573,10 +573,37 @@ async function fill(
     // @ts-expect-error
     if (result.tx.gas && request.feePayer && !result.tx.feePayerSignature)
       result.tx.gas = Hex.fromNumber(BigInt(result.tx.gas) + 20_000n)
-    const sponsor = (result as Record<string, any>).capabilities?.sponsor as
+    const upstreamCapabilities = (result as { capabilities?: Record<string, unknown> })
+      .capabilities
+    const sponsor = upstreamCapabilities?.sponsor as
       | { address: Address; name?: string; url?: string }
       | undefined
-    return { transaction: Utils.normalizeTempoTransaction(result.tx), sponsor }
+    // External fee-payer relays surface chain reverts (e.g. InsufficientBalance)
+    // inside `capabilities.error` with a stub `tx` instead of throwing. Detect
+    // that here and re-throw so the autoSwap branch below can recover the same
+    // way it does for the direct-chain path.
+    const upstreamError = upstreamCapabilities?.error as
+      | { errorName?: string; message?: string; data?: `0x${string}` }
+      | undefined
+    if (upstreamError?.errorName === 'InsufficientBalance') {
+      const synthetic = new Error(upstreamError.message ?? 'InsufficientBalance')
+      synthetic.name = 'UpstreamRevertError'
+      ;(synthetic as { data?: `0x${string}` | undefined }).data = upstreamError.data
+      throw synthetic
+    }
+    // Reconstruct a `swap` shape from upstream's `capabilities.autoSwap` so the
+    // wallet relay's outer code can re-resolve autoSwap metadata locally —
+    // otherwise upstream-driven swaps are silently dropped from the response.
+    const swap = extractSwapFromCapabilities(upstreamCapabilities?.autoSwap)
+    // The chain's `eth_fillTransaction` doesn't echo back `calls`, so merge
+    // them in from the original request before normalizing — otherwise the
+    // typed envelope built for sponsorship signing throws CallsEmptyError.
+    const mergedTx = mergeCallsFromRequest(result.tx as Record<string, unknown>, request)
+    return {
+      transaction: Utils.normalizeTempoTransaction(mergedTx),
+      sponsor,
+      ...(swap ? { swap } : {}),
+    }
   } catch (error) {
     if (!(error instanceof Error)) throw error
     if (!autoSwap) throw error
@@ -613,8 +640,12 @@ async function fill(
     const sponsor = (result as Record<string, any>).capabilities?.sponsor as
       | { address: Address; name?: string; url?: string }
       | undefined
+    const mergedTx = mergeCallsFromRequest(result.tx as Record<string, unknown>, {
+      ...request,
+      calls: [...swapCalls, ...originalCalls],
+    })
     return {
-      transaction: Utils.normalizeTempoTransaction(result.tx),
+      transaction: Utils.normalizeTempoTransaction(mergedTx),
       sponsor,
       swap: {
         calls: swapCalls,
@@ -1014,4 +1045,76 @@ function buildSwapCalls(
     { to: approve.to, data: approve.data, value: 0n },
     { to: buy.to, data: buy.data, value: 0n },
   ] as const
+}
+
+/**
+ * Merges the original fill request into the result tx. The chain's
+ * `eth_fillTransaction` returns only the "filled" gas/nonce/fee fields and
+ * omits envelope inputs like `calls`, `chainId`, `validBefore`, `nonceKey`,
+ * `keyData`, `keyType`, `feePayer`. Without these the typed Tempo envelope
+ * built for sponsorship signing throws `CallsEmptyError` or
+ * `Cannot convert undefined to a BigInt` when serializing.
+ *
+ * Result fields take precedence (they are the chain's authoritative filled
+ * values); request fields fill in everything else. Calls are normalized
+ * separately so legacy `to`/`data`/`value` requests are also supported.
+ */
+function mergeCallsFromRequest(
+  resultTx: Record<string, unknown>,
+  request: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...request, ...resultTx }
+  const resultCalls = resultTx.calls
+  if (Array.isArray(resultCalls) && resultCalls.length > 0) return merged
+
+  const reqCalls = request.calls
+  if (Array.isArray(reqCalls) && reqCalls.length > 0) {
+    merged.calls = reqCalls
+    return merged
+  }
+
+  const { to, data, value } = request
+  if (typeof to === 'undefined' && typeof data === 'undefined' && typeof value === 'undefined')
+    return merged
+
+  merged.calls = [
+    {
+      ...(typeof to !== 'undefined' ? { to } : {}),
+      ...(typeof data !== 'undefined' ? { data } : {}),
+      ...(typeof value !== 'undefined' ? { value } : {}),
+    },
+  ]
+  return merged
+}
+
+/**
+ * Reconstructs a `swap` shape (matching the inner autoSwap branch's return
+ * value) from an upstream relay's `capabilities.autoSwap`. Used so a wallet
+ * relay forwarding to an external feePayer URL can re-emit autoSwap metadata
+ * locally without losing track of the upstream's swap.
+ */
+function extractSwapFromCapabilities(autoSwap: unknown):
+  | {
+      calls: readonly { to: Address; data: `0x${string}` }[]
+      tokenIn: Address
+      tokenOut: Address
+      amountOut: bigint
+      maxAmountIn: bigint
+    }
+  | undefined {
+  if (!autoSwap || typeof autoSwap !== 'object') return undefined
+  const a = autoSwap as {
+    calls?: readonly { to: Address; data: `0x${string}` }[]
+    maxIn?: { token?: Address; value?: `0x${string}` }
+    minOut?: { token?: Address; value?: `0x${string}` }
+  }
+  if (!a.calls || !a.maxIn?.token || !a.maxIn.value || !a.minOut?.token || !a.minOut.value)
+    return undefined
+  return {
+    calls: a.calls,
+    tokenIn: a.maxIn.token,
+    tokenOut: a.minOut.token,
+    amountOut: BigInt(a.minOut.value),
+    maxAmountIn: BigInt(a.maxIn.value),
+  }
 }


### PR DESCRIPTION
## Summary

- Added `feePayer` parameter to `wallet_send` (`boolean | string`) for per-call fee payer override.
- Exported `Rpc.wallet_send.parameters` zod schema.
- Resolved relative `feePayer` URLs in `Client.fromChainId` against `window.location.origin`.
- Forwarded upstream relay `capabilities.autoSwap` and `InsufficientBalance` errors through the wallet relay so external fee-payer fills surface autoSwap metadata and trigger the local autoSwap fallback.
- Merged original `eth_fillTransaction` request fields (calls, chainId, validBefore, key data, feePayer) into the chain's filled tx so sponsorship envelope serialization no longer throws `CallsEmptyError`.
