### PR TITLE
feat: pass CLI auth chain to policy

### DIFF
--- a/.changeset/cli-auth-policy-chain.md
+++ b/.changeset/cli-auth-policy-chain.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Pass the resolved CLI auth chain ID to `CliAuth.Policy.validate`.

--- a/.changeset/cli-auth-policy-chain.md
+++ b/.changeset/cli-auth-policy-chain.md
@@ -2,4 +2,4 @@
 'accounts': patch
 ---
 
-Pass the resolved CLI auth chain ID to `CliAuth.Policy.validate`.
+Passed the resolved CLI auth chain ID to `CliAuth.Policy.validate`.

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -343,6 +343,7 @@ describe('createDeviceCode', () => {
     const store = CliAuth.Store.memory()
     const now = () => 1_000
     const defaultExpiry = 4_600
+    let validatedChainId: bigint | undefined
     const { request } = await createRequest('device-code-verifier', {
       accessKey: secpAccessKey,
       expiry: undefined,
@@ -354,7 +355,8 @@ describe('createDeviceCode', () => {
       chainId: chain.id,
       now,
       policy: {
-        validate({ expiry, limits }) {
+        validate({ chainId, expiry, limits }) {
+          validatedChainId = chainId
           return {
             expiry: expiry ?? defaultExpiry,
             ...(limits ? { limits } : {}),
@@ -368,17 +370,20 @@ describe('createDeviceCode', () => {
     })
     const entry = await store.get(result.code)
 
-    expect(entry).toMatchInlineSnapshot(`
+    expect({ entry, validatedChainId }).toMatchInlineSnapshot(`
       {
-        "chainId": 1337n,
-        "code": "ABCDEFGH",
-        "codeChallenge": "NUwjc1h8PuXcsvSOG44Rp4bMayBXnOkriHEJ19CaSQM",
-        "createdAt": 1000,
-        "expiresAt": 31000,
-        "expiry": 4600,
-        "keyType": "secp256k1",
-        "pubKey": "${secpAccessKey.publicKey}",
-        "status": "pending",
+        "entry": {
+          "chainId": 1337n,
+          "code": "ABCDEFGH",
+          "codeChallenge": "NUwjc1h8PuXcsvSOG44Rp4bMayBXnOkriHEJ19CaSQM",
+          "createdAt": 1000,
+          "expiresAt": 31000,
+          "expiry": 4600,
+          "keyType": "secp256k1",
+          "pubKey": "${secpAccessKey.publicKey}",
+          "status": "pending",
+        },
+        "validatedChainId": 1337n,
       }
     `)
   })

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -208,6 +208,8 @@ export declare namespace Policy {
     export type Options = {
       /** Requested root account restriction. */
       account?: Address.Address | undefined
+      /** Requested chain ID. */
+      chainId: bigint
       /** Requested access-key expiry timestamp. Omit to let the server choose one. */
       expiry?: number | undefined
       /** Requested key type. */
@@ -446,6 +448,7 @@ export function from(options: from.Options = {}): CliAuth {
       const keyType = options.request.keyType ?? 'secp256k1'
       const approved = await policy.validate({
         ...(account ? { account } : {}),
+        chainId: typeof nextChainId === 'bigint' ? nextChainId : BigInt(nextChainId),
         expiry: options.request.expiry,
         keyType,
         ...(options.request.limits ? { limits: options.request.limits } : {}),


### PR DESCRIPTION
## Summary
Pass the resolved CLI auth chain ID into the device-code policy hook.

## Motivation
Wallet approval needs chain-aware server defaults so CLI auth can choose the right default USD token for mainnet vs testnets.

## Changes
- Add `chainId` to `CliAuth.Policy.validate.Options` in `src/server/CliAuth.ts`
- Pass the resolved device-code chain into `policy.validate`
- Cover the policy chain value in `src/server/CliAuth.test.ts`
- Add a patch changeset for `accounts`

## Testing
- `pnpm --dir ref/sdk vp check --fix src/server/CliAuth.ts src/server/CliAuth.test.ts`
- `pnpm --dir ref/sdk test src/server/CliAuth.test.ts`

Note: the changeset-only follow-up commit was made from an isolated git worktree without `node_modules`, so the final push did not rerun package scripts there.