### PR TITLE
feat: scope TrustedHosts `.local` bypass to same registrable domain

### DIFF
--- a/.changeset/trusted-hosts-same-registrable-domain.md
+++ b/.changeset/trusted-hosts-same-registrable-domain.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Replaced the `.local` shortcut in `TrustedHosts.match` with an opt-in `source` parameter that treats hostnames sharing the same registrable domain ("eTLD+1") as `source` as trusted.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -371,7 +371,9 @@ export function iframe(): Dialog {
 
         const ioSupported = IO.supported()
         const hostname = window.location.hostname.replace(/^www\./, '')
-        const trusted = Boolean(trustedHosts && TrustedHosts.match(trustedHosts, hostname))
+        const trusted = Boolean(
+          trustedHosts && TrustedHosts.match(trustedHosts, hostname, hostUrl.hostname),
+        )
         const secure = ioSupported || trusted
 
         if (!secure) {

--- a/src/core/TrustedHosts.ts
+++ b/src/core/TrustedHosts.ts
@@ -10,15 +10,31 @@ import _hosts from '../trusted-hosts.json' with { type: 'json' }
 export const hosts: Record<string, readonly string[]> = _hosts
 
 /**
- * Returns `true` if `hostname` matches any pattern in `trustedHosts`.
+ * Returns `true` if `hostname` matches any pattern in `trustedHosts`,
+ * or (when `source` is provided) if `hostname` shares the same
+ * registrable domain ("eTLD+1") as `source`.
+ *
  * Patterns starting with `*.` match any subdomain suffix
  * (e.g. `*.workers.dev` matches `foo.workers.dev`).
  */
-export function match(trustedHosts: readonly string[], hostname: string) {
-  if (hostname.endsWith('.local')) return true
+export function match(trustedHosts: readonly string[], hostname: string, source?: string) {
+  if (source && sameRegistrableDomain(hostname, source)) return true
   return trustedHosts.some((pattern) => {
     if (pattern.startsWith('*.'))
       return hostname.endsWith(pattern.slice(1)) && hostname.length > pattern.length - 1
     return pattern === hostname
   })
+}
+
+/** Returns `true` if `a` and `b` share the same registrable domain ("eTLD+1"). */
+export function sameRegistrableDomain(a: string, b: string) {
+  return registrableDomain(a) === registrableDomain(b)
+}
+
+/** Returns the registrable domain ("eTLD+1") for a hostname. */
+function registrableDomain(host: string) {
+  const hostname = host.split(':')[0]!.toLowerCase()
+  const labels = hostname.split('.')
+  if (labels.length <= 2) return hostname
+  return labels.slice(-2).join('.')
 }

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -18,7 +18,7 @@ export function useEnsureVisibility(
     if (!origin) return false
     try {
       const hostname = new URL(origin).hostname.replace(/^www\./, '')
-      return TrustedHosts.match(remote.trustedHosts, hostname)
+      return TrustedHosts.match(remote.trustedHosts, hostname, window.location.hostname)
     } catch {
       return false
     }


### PR DESCRIPTION
Replaced the `.local` shortcut in `TrustedHosts.match` with an opt-in `source` parameter that treats hostnames sharing the same registrable domain ("eTLD+1") as `source` as trusted.