### PR TITLE
fix: accept decimal string for wallet_swap amount

### DIFF
--- a/.changeset/wallet-swap-amount-string.md
+++ b/.changeset/wallet-swap-amount-string.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Changed `wallet_swap` `amount` parameter from raw hex to a human-readable decimal string (e.g. `"1.5"`), matching `wallet_send`'s `value`.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -290,9 +290,7 @@ function WalletSwap() {
           execute(() =>
             provider.request({
               method: 'wallet_swap',
-              params: [
-                { amount: '0xde0b6b3a7640000', pairToken, slippage: 0.01, token, type: 'sell' },
-              ],
+              params: [{ amount: '1', pairToken, slippage: 0.01, token, type: 'sell' }],
             }),
           )
         }
@@ -304,7 +302,7 @@ function WalletSwap() {
           execute(() =>
             provider.request({
               method: 'wallet_swap',
-              params: [{ amount: '0xde0b6b3a7640000', pairToken, token, type: 'buy' }],
+              params: [{ amount: '1', pairToken, token, type: 'buy' }],
             }),
           )
         }

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -672,7 +672,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       await expect(
         provider.request({
           method: 'wallet_swap',
-          params: [{ amount: '0x1', token: Addresses.pathUsd, type: 'sell' }],
+          params: [{ amount: '1', token: Addresses.pathUsd, type: 'sell' }],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `[Provider.UnsupportedMethodError: \`swap\` not supported by adapter.]`,

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -143,7 +143,7 @@ describe('Encoded', () => {
       params:
         | readonly [
             {
-              amount?: Hex | undefined
+              amount?: string | undefined
               pairToken?: Hex | undefined
               slippage?: number | undefined
               token?: Hex | undefined

--- a/src/core/zod/request.test.ts
+++ b/src/core/zod/request.test.ts
@@ -89,7 +89,7 @@ describe('validate', () => {
       method: 'wallet_swap',
       params: [
         {
-          amount: '0x64',
+          amount: '1.5',
           pairToken: '0x0000000000000000000000000000000000000002',
           slippage: 0.01,
           token: '0x0000000000000000000000000000000000000001',
@@ -102,7 +102,7 @@ describe('validate', () => {
         "method": "wallet_swap",
         "params": [
           {
-            "amount": "0x64",
+            "amount": "1.5",
             "pairToken": "0x0000000000000000000000000000000000000002",
             "slippage": 0.01,
             "token": "0x0000000000000000000000000000000000000001",

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -560,8 +560,8 @@ export namespace wallet_send {
 }
 
 const swapParameters = z.object({
-  /** Raw token amount to pre-fill. Omit to let the user choose. */
-  amount: z.optional(u.hex()),
+  /** Human-readable amount to pre-fill (e.g. "1.5"). */
+  amount: z.optional(z.string()),
   /** Other side of the swap pair. For buys, this is the token to sell. For sells, this is the token to buy. */
   pairToken: z.optional(u.address()),
   /** Maximum allowed slippage as a decimal fraction (for example `0.05` for 5%). */


### PR DESCRIPTION
## Summary
`wallet_swap`'s `amount` parameter now takes a human-readable decimal string (e.g. `"1.5"`), matching `wallet_send`'s `value`.

## Motivation
The original schema accepted a raw hex amount (`u.hex()`), which forces callers to know the target token's decimals and parse to wei before calling. That couples the integrator to chain-specific decimal handling and made it easy to mis-scale (e.g. passing `parseEther("1")` for a 6-decimal token displayed "1T pathUSD" in the wallet dialog).

## Changes
- `src/core/zod/rpc.ts`: `amount: u.hex()` → `amount: z.string()`
- `src/core/Schema.test-d.ts`: update encoded type expectation
- Tests + playground updated to use decimal strings

## Testing
`pnpm test src/core/zod/request.test.ts src/core/Provider.test.ts` — 224 passed.
`pnpm exec tsc -b --noEmit` — clean.