### PR TITLE
fix: enforce cli auth policy on authorization

### DIFF
--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -371,31 +371,48 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         badServer.close()
       })
 
-      test(
-        'default: auth as string shorthand fetches challenge, signs once, posts verify',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('default: auth as string shorthand fetches challenge, signs once, posts verify', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          const result = await provider.request({
-            method: 'wallet_connect',
-            params: [{ capabilities: { method: 'register', auth: authBase } }],
-          })
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { method: 'register', auth: authBase } }],
+        })
 
-          const capabilities = result.accounts[0]!.capabilities
-          expect(capabilities.auth).toEqual({ token: expect.any(String) })
-          expect(capabilities.personalSign).toEqual({
-            message: expect.stringContaining('wants you to sign in'),
-          })
-          expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
-        },
-      )
+        const capabilities = result.accounts[0]!.capabilities
+        expect(capabilities.auth).toEqual({ token: expect.any(String) })
+        expect(capabilities.personalSign).toEqual({
+          message: expect.stringContaining('wants you to sign in'),
+        })
+        expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+      })
 
-      test(
-        'default: object-form auth with explicit endpoints uses the override URLs',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('default: object-form auth with explicit endpoints uses the override URLs', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          const result = await provider.request({
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [
+            {
+              capabilities: {
+                method: 'register',
+                auth: {
+                  challenge: `${authBase}/challenge`,
+                  verify: authBase,
+                },
+              },
+            },
+          ],
+        })
+
+        expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+      })
+
+      test('error: verify endpoint returns 401 → InternalError; user already signed', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        await expect(
+          provider.request({
             method: 'wallet_connect',
             params: [
               {
@@ -403,42 +420,16 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
                   method: 'register',
                   auth: {
                     challenge: `${authBase}/challenge`,
-                    verify: authBase,
+                    verify: `${server.url}/bad/verify-401`,
                   },
                 },
               },
             ],
-          })
-
-          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
-        },
-      )
-
-      test(
-        'error: verify endpoint returns 401 → InternalError; user already signed',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
-
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${authBase}/challenge`,
-                      verify: `${server.url}/bad/verify-401`,
-                    },
-                  },
-                },
-              ],
-            }),
-          ).rejects.toThrow(
-            /Server Authentication verify endpoint `http:\/\/localhost:\d+\/bad\/verify-401` returned 401\./,
-          )
-        },
-      )
+          }),
+        ).rejects.toThrow(
+          /Server Authentication verify endpoint `http:\/\/localhost:\d+\/bad\/verify-401` returned 401\./,
+        )
+      })
 
       test('error: auth + personalSign throws InvalidParamsError synchronously', async () => {
         const provider = Provider.create({ adapter: adapter() })
@@ -461,164 +452,146 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         )
       })
 
-      test(
-        'default: auth + authorizeAccessKey surfaces both capabilities (two ceremonies)',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('default: auth + authorizeAccessKey surfaces both capabilities (two ceremonies)', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          const result = await provider.request({
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [
+            {
+              capabilities: {
+                method: 'register',
+                auth: authBase,
+                authorizeAccessKey: { expiry: 0 },
+              },
+            },
+          ],
+        })
+
+        expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+        expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
+        expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+          message: expect.any(String),
+        })
+        expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+      })
+
+      test('error: challenge endpoint returns 500 → InvalidParamsError; no verify', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        await expect(
+          provider.request({
             method: 'wallet_connect',
             params: [
               {
                 capabilities: {
                   method: 'register',
-                  auth: authBase,
-                  authorizeAccessKey: { expiry: 0 },
+                  auth: {
+                    challenge: `${server.url}/bad/challenge-500`,
+                    verify: authBase,
+                  },
                 },
               },
             ],
-          })
+          }),
+        ).rejects.toThrow(
+          /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-500` returned 500\./,
+        )
+      })
 
-          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
-          expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
-          expect(result.accounts[0]!.capabilities.personalSign).toEqual({
-            message: expect.any(String),
-          })
-          expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
-        },
-      )
+      test('error: challenge response missing `message` → InvalidParamsError', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-      test(
-        'error: challenge endpoint returns 500 → InvalidParamsError; no verify',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
-
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${server.url}/bad/challenge-500`,
-                      verify: authBase,
-                    },
+        await expect(
+          provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: {
+                    challenge: `${server.url}/bad/challenge-empty`,
+                    verify: authBase,
                   },
                 },
-              ],
-            }),
-          ).rejects.toThrow(
-            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-500` returned 500\./,
-          )
-        },
-      )
+              },
+            ],
+          }),
+        ).rejects.toThrow(
+          /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-empty` response missing `message`\./,
+        )
+      })
 
-      test(
-        'error: challenge response missing `message` → InvalidParamsError',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('error: challenge bound to a different domain → InvalidParamsError; never signs', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${server.url}/bad/challenge-empty`,
-                      verify: authBase,
-                    },
+        await expect(
+          provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: {
+                    challenge: `${server.url}/bad/challenge-evil-domain`,
+                    verify: authBase,
                   },
                 },
-              ],
-            }),
-          ).rejects.toThrow(
-            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-empty` response missing `message`\./,
-          )
-        },
-      )
+              },
+            ],
+          }),
+        ).rejects.toThrow(/returned a message bound to `evil\.example`/)
+      })
 
-      test(
-        'error: challenge bound to a different domain → InvalidParamsError; never signs',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('error: `challenge` and `verify` on different origins → InvalidParamsError', async () => {
+        // Phishing guard: a malicious dapp must not be able to point
+        // `challenge` at the victim and `verify` at attacker.com to
+        // harvest a valid signed payload.
+        const provider = Provider.create({ adapter: adapter() })
 
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${server.url}/bad/challenge-evil-domain`,
-                      verify: authBase,
-                    },
+        await expect(
+          provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: {
+                    challenge: `${authBase}/challenge`,
+                    verify: `${badServer.url}/collect`,
                   },
                 },
-              ],
-            }),
-          ).rejects.toThrow(/returned a message bound to `evil\.example`/)
-        },
-      )
+              },
+            ],
+          }),
+        ).rejects.toThrow(
+          /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
+        )
+      })
 
-      test(
-        'error: `challenge` and `verify` on different origins → InvalidParamsError',
-        async () => {
-          // Phishing guard: a malicious dapp must not be able to point
-          // `challenge` at the victim and `verify` at attacker.com to
-          // harvest a valid signed payload.
-          const provider = Provider.create({ adapter: adapter() })
+      test('error: `logout` on a different origin → InvalidParamsError', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${authBase}/challenge`,
-                      verify: `${badServer.url}/collect`,
-                    },
+        await expect(
+          provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: {
+                    challenge: `${authBase}/challenge`,
+                    verify: authBase,
+                    logout: `${badServer.url}/logout`,
                   },
                 },
-              ],
-            }),
-          ).rejects.toThrow(
-            /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
-          )
-        },
-      )
-
-      test(
-        'error: `logout` on a different origin → InvalidParamsError',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
-
-          await expect(
-            provider.request({
-              method: 'wallet_connect',
-              params: [
-                {
-                  capabilities: {
-                    method: 'register',
-                    auth: {
-                      challenge: `${authBase}/challenge`,
-                      verify: authBase,
-                      logout: `${badServer.url}/logout`,
-                    },
-                  },
-                },
-              ],
-            }),
-          ).rejects.toThrow(
-            /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
-          )
-        },
-      )
+              },
+            ],
+          }),
+        ).rejects.toThrow(
+          /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
+        )
+      })
 
       test('default: no auth capability → no auth/personalSign on result', async () => {
         const provider = Provider.create({ adapter: adapter() })
@@ -632,69 +605,61 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         expect(result.accounts[0]!.capabilities.personalSign).toBeUndefined()
       })
 
-      test(
-        'default: login (post-register) + auth populates capabilities.auth',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('default: login (post-register) + auth populates capabilities.auth', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          // Register first so login has an account to load.
-          await provider.request({
-            method: 'wallet_connect',
-            params: [{ capabilities: { method: 'register' } }],
-          })
+        // Register first so login has an account to load.
+        await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { method: 'register' } }],
+        })
 
-          const result = await provider.request({
-            method: 'wallet_connect',
-            params: [{ capabilities: { auth: authBase } }],
-          })
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { auth: authBase } }],
+        })
 
-          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
-          expect(result.accounts[0]!.capabilities.personalSign).toEqual({
-            message: expect.stringContaining(
-              'wants you to sign in',
-            ),
-          })
-          expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
-        },
-      )
+        expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+        expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+          message: expect.stringContaining('wants you to sign in'),
+        })
+        expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+      })
 
-      test(
-        'end-to-end: connect → call protected /me with bearer token',
-        async () => {
-          const provider = Provider.create({ adapter: adapter() })
+      test('end-to-end: connect → call protected /me with bearer token', async () => {
+        const provider = Provider.create({ adapter: adapter() })
 
-          // Token mode: the server returns the session token in the body
-          // (no cookie) and the SDK surfaces it on `capabilities.auth.token`.
-          const result = await provider.request({
-            method: 'wallet_connect',
-            params: [
-              {
-                capabilities: {
-                  method: 'register',
-                  auth: { url: authBase, returnToken: true },
-                },
+        // Token mode: the server returns the session token in the body
+        // (no cookie) and the SDK surfaces it on `capabilities.auth.token`.
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [
+            {
+              capabilities: {
+                method: 'register',
+                auth: { url: authBase, returnToken: true },
               },
-            ],
-          })
+            },
+          ],
+        })
 
-          const token = result.accounts[0]!.capabilities.auth?.token
-          expect(token).toMatch(/^[a-z0-9]+$/)
+        const token = result.accounts[0]!.capabilities.auth?.token
+        expect(token).toMatch(/^[a-z0-9]+$/)
 
-          // Authenticated request resolves the connected address.
-          const me = await fetch(`${server.url}/me`, {
-            headers: { authorization: `Bearer ${token}` },
-          })
-          expect(me.status).toBe(200)
-          expect(await me.json()).toEqual({
-            address: result.accounts[0]!.address,
-            chainId: expect.any(Number),
-          })
+        // Authenticated request resolves the connected address.
+        const me = await fetch(`${server.url}/me`, {
+          headers: { authorization: `Bearer ${token}` },
+        })
+        expect(me.status).toBe(200)
+        expect(await me.json()).toEqual({
+          address: result.accounts[0]!.address,
+          chainId: expect.any(Number),
+        })
 
-          // Unauthenticated request is rejected.
-          const anon = await fetch(`${server.url}/me`)
-          expect(anon.status).toBe(401)
-        },
-      )
+        // Unauthenticated request is rejected.
+        const anon = await fetch(`${server.url}/me`)
+        expect(anon.status).toBe(401)
+      })
     })
   })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -596,9 +596,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             digest: capabilities?.digest,
                             authorizeAccessKey,
                             selectAccount: capabilities?.selectAccount,
-                            ...(personalSign_request
-                              ? { personalSign: personalSign_request }
-                              : {}),
+                            ...(personalSign_request ? { personalSign: personalSign_request } : {}),
                           },
                           request,
                         )

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -613,9 +613,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                       // disconnect could POST to a logout URL the
                       // current page never opted into.
                       auth:
-                        auth_request && typeof auth_request === 'object'
-                          ? auth_request
-                          : undefined,
+                        auth_request && typeof auth_request === 'object' ? auth_request : undefined,
                     })
 
                     const accountAddress = accounts[0]?.address
@@ -1015,9 +1013,7 @@ function absolutizeAuth(
   return resolved
 }
 
-function assertSameAuthOrigin(
-  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
-): void {
+function assertSameAuthOrigin(auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>): void {
   if (typeof auth !== 'object') return
   const urls = [auth.challenge, auth.verify, auth.logout].filter(
     (u): u is string => typeof u === 'string',
@@ -1035,8 +1031,7 @@ function assertSameAuthOrigin(
   const first = origins[0]!
   if (origins.some((origin) => origin !== first))
     throw new RpcResponse.InvalidParamsError({
-      message:
-        '`auth` endpoints (`challenge`, `verify`, `logout`) must share the same origin.',
+      message: '`auth` endpoints (`challenge`, `verify`, `logout`) must share the same origin.',
     })
 }
 

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -193,7 +193,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[20]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[21]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -218,10 +218,12 @@ describe('Request', () => {
       | 'wallet_authorizeAccessKey'
       | 'eth_sendTransactionSync'
       | 'wallet_deposit'
+      | 'wallet_depositZone'
       | 'wallet_getBalances'
       | 'wallet_revokeAccessKey'
       | 'wallet_send'
       | 'wallet_swap'
+      | 'wallet_withdrawZone'
     >()
   })
 

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -10,9 +10,9 @@ import {
   webAuthnAccounts,
 } from '../../../test/config.js'
 import * as Account from '../Account.js'
+import type * as Adapter from '../Adapter.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
-import type * as Adapter from '../Adapter.js'
 import { local } from './local.js'
 
 describe('local', () => {
@@ -238,9 +238,7 @@ describe('local', () => {
 function makeLoadAccounts(
   index: number,
   captured: { digest: Hex | undefined }[],
-): (
-  params?: Adapter.loadAccounts.Parameters,
-) => Promise<Adapter.loadAccounts.ReturnType> {
+): (params?: Adapter.loadAccounts.Parameters) => Promise<Adapter.loadAccounts.ReturnType> {
   return async (params) => {
     captured.push({ digest: params?.digest })
     return {

--- a/src/core/zod/request.test.ts
+++ b/src/core/zod/request.test.ts
@@ -189,9 +189,7 @@ describe('validate', () => {
   test('default: validates wallet_connect with personalSign capability (register branch)', () => {
     const result = RpcRequest.validate(Schema.Request, {
       method: 'wallet_connect',
-      params: [
-        { capabilities: { method: 'register', personalSign: { message: 'hello' } } },
-      ],
+      params: [{ capabilities: { method: 'register', personalSign: { message: 'hello' } } }],
     })
     expect(result._decoded).toMatchInlineSnapshot(`
       {

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -498,6 +498,12 @@ export namespace wallet_connect {
     result: z.object({
       email: z.optional(z.nullable(z.string())),
       keyAuthorization: z.optional(keyAuthorization),
+      /**
+       * Echo of the `personalSign` request, present iff the caller set
+       * `capabilities.personalSign` (or `capabilities.auth` folded a SIWE
+       * message into the same slot). The signature itself lives on the
+       * top-level `capabilities.signature` field.
+       */
       personalSign: z.optional(
         z.object({
           message: z.string(),

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -498,6 +498,11 @@ export namespace wallet_connect {
     result: z.object({
       email: z.optional(z.nullable(z.string())),
       keyAuthorization: z.optional(keyAuthorization),
+      personalSign: z.optional(
+        z.object({
+          message: z.string(),
+        }),
+      ),
       signature: z.optional(u.hex()),
       username: z.optional(z.nullable(z.string())),
       /**
@@ -508,17 +513,6 @@ export namespace wallet_connect {
       auth: z.optional(
         z.object({
           token: z.optional(z.string()),
-        }),
-      ),
-      /**
-       * Echo of the `personalSign` request, present iff the caller set
-       * `capabilities.personalSign` (or `capabilities.auth` folded a SIWE
-       * message into the same slot). The signature itself lives on the
-       * top-level `capabilities.signature` field.
-       */
-      personalSign: z.optional(
-        z.object({
-          message: z.string(),
         }),
       ),
     }),

--- a/src/core/zod/utils.ts
+++ b/src/core/zod/utils.ts
@@ -4,8 +4,9 @@ import type * as zc from 'zod/v4/core'
 
 import type { OneOf } from '../../internal/types.js'
 
-/** EVM address (`0x...`). */
-export const address = () => z.templateLiteral(['0x', z.string()], 'Expected address')
+/** EVM address (`0x...` followed by 20 bytes). */
+export const address = () =>
+  z.templateLiteral(['0x', z.string().check(z.regex(/^[0-9a-fA-F]{40}$/))], 'Expected address')
 
 /** Hex-encoded bigint. Decodes from `0x...` hex or raw `bigint` to `bigint`. */
 export const bigint = () =>

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -360,6 +360,96 @@ describe('createDeviceCode', () => {
     expect(response.status).toMatchInlineSnapshot(`400`)
   })
 
+  test('behavior: handler rejects oversized JSON request bodies', async () => {
+    const { request } = await createRequest()
+    const handler = Handler.codeAuth({ maxBodyBytes: 16 })
+    const response = await handler.fetch(
+      new Request('http://localhost/auth/pkce/code', {
+        body: JSON.stringify(z.encode(CliAuth.createRequest, request)),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }),
+    )
+    const body = await response.json()
+
+    expect({ body, status: response.status }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "Request body is too large.",
+        },
+        "status": 400,
+      }
+    `)
+  })
+
+  test('behavior: rejects invalid public keys at creation time', async () => {
+    const { request } = await createRequest()
+
+    await expect(
+      CliAuth.createDeviceCode({
+        chainId: chain.id,
+        request: { ...request, pubKey: '0x1234' },
+        store: CliAuth.Store.memory(),
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid access-key public key.]`)
+  })
+
+  test('behavior: rejects too many limits', async () => {
+    const { request } = await createRequest()
+    const result = await z.safeDecodeAsync(CliAuth.createRequest, {
+      ...z.encode(CliAuth.createRequest, request),
+      limits: Array.from({ length: 11 }, () => ({
+        limit: '0x1',
+        token: '0x20c0000000000000000000000000000000000001',
+      })),
+    } as never)
+
+    expect(result).toMatchInlineSnapshot(`
+    	{
+    	  "error": [$ZodError: [
+    	  {
+    	    "origin": "array",
+    	    "code": "too_big",
+    	    "maximum": 10,
+    	    "inclusive": true,
+    	    "path": [
+    	      "limits"
+    	    ],
+    	    "message": "Invalid input"
+    	  }
+    	]],
+    	  "success": false,
+    	}
+    `)
+  })
+
+  test('behavior: rejects malformed limit tokens', async () => {
+    const { request } = await createRequest()
+    const result = await z.safeDecodeAsync(CliAuth.createRequest, {
+      ...z.encode(CliAuth.createRequest, request),
+      limits: [{ limit: '0x1', token: '0x1234' }],
+    } as never)
+
+    expect(result).toMatchInlineSnapshot(`
+    	{
+    	  "error": [$ZodError: [
+    	  {
+    	    "code": "invalid_format",
+    	    "format": "template_literal",
+    	    "pattern": "^0x[0-9a-fA-F]{40}$",
+    	    "path": [
+    	      "limits",
+    	      0,
+    	      "token"
+    	    ],
+    	    "message": "Expected address"
+    	  }
+    	]],
+    	  "success": false,
+    	}
+    `)
+  })
+
   test('behavior: handler rejects requests for unconfigured chains', async () => {
     const handler = Handler.codeAuth({
       chains: [chain],

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -13,10 +13,12 @@ const webAuthnRoot = webAuthnAccounts[0]!
 const accessKey = TempoAccount.fromP256(privateKeys[1]!)
 const secpAccessKey = accounts[1]!
 const expiry = Math.floor(Date.now() / 1000) + 3_600
+const token = '0x20c0000000000000000000000000000000000001' as const
+const limit = 1_000n
 const limits = [
   {
-    limit: 1_000n,
-    token: '0x20c0000000000000000000000000000000000001' as const,
+    limit,
+    token,
   },
 ] as const
 
@@ -391,18 +393,23 @@ describe('createDeviceCode', () => {
         request: { ...request, pubKey: '0x1234' },
         store: CliAuth.Store.memory(),
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid access-key public key.]`)
+    ).rejects
+      .toThrowErrorMatchingInlineSnapshot(`[PublicKey.InvalidSerializedSizeError: Value \`0x1234\` is an invalid public key size.
+
+Expected: 33 bytes (compressed + prefix), 64 bytes (uncompressed) or 65 bytes (uncompressed + prefix).
+Received 2 bytes.]`)
   })
 
   test('behavior: rejects too many limits', async () => {
     const { request } = await createRequest()
+    const item = {
+      limit: '0x1' as const,
+      token: '0x20c0000000000000000000000000000000000001' as const,
+    }
     const result = await z.safeDecodeAsync(CliAuth.createRequest, {
       ...z.encode(CliAuth.createRequest, request),
-      limits: Array.from({ length: 11 }, () => ({
-        limit: '0x1',
-        token: '0x20c0000000000000000000000000000000000001',
-      })),
-    } as never)
+      limits: Array.from({ length: 11 }, () => item),
+    })
 
     expect(result).toMatchInlineSnapshot(`
     	{
@@ -428,7 +435,7 @@ describe('createDeviceCode', () => {
     const result = await z.safeDecodeAsync(CliAuth.createRequest, {
       ...z.encode(CliAuth.createRequest, request),
       limits: [{ limit: '0x1', token: '0x1234' }],
-    } as never)
+    })
 
     expect(result).toMatchInlineSnapshot(`
     	{
@@ -886,7 +893,7 @@ describe('authorize', () => {
     const approvedLimits = [
       {
         limit: 2_000n,
-        token: limits[0]!.token,
+        token,
       },
     ] as const
 
@@ -951,7 +958,7 @@ describe('authorize', () => {
         chainId: chain.id,
         policy,
         request: await authorize(code, {
-          limits: [{ limit: 2_000n, token: limits[0]!.token }],
+          limits: [{ limit: 2_000n, token }],
         }),
         store,
       }),
@@ -989,7 +996,7 @@ describe('authorize', () => {
           ...authorized,
           keyAuthorization: {
             ...authorized.keyAuthorization,
-            limits: [{ limit: limits[0]!.limit + 1n, token: limits[0]!.token }],
+            limits: [{ limit: limit + 1n, token }],
           },
         },
         store,
@@ -1126,8 +1133,8 @@ describe('Store.kv', () => {
   test('default: persists encoded entries through KV', async () => {
     const store = CliAuth.Store.kv({
       async delete() {},
-      async get<_value = unknown>(_key: string) {
-        return undefined as never
+      async get<_value = unknown>(_key: string): Promise<_value> {
+        throw new Error('Not implemented.')
       },
       async set() {},
     })

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -344,6 +344,82 @@ describe('createDeviceCode', () => {
     `)
   })
 
+  test('behavior: handler ignores untrusted forwarding headers for rate-limit keys', async () => {
+    const calls: { key: string }[] = []
+    const handler = Handler.codeAuth({
+      rateLimit: {
+        limit(options) {
+          calls.push({ key: options.key })
+          return { success: true }
+        },
+      },
+    })
+
+    await get(handler, {
+      url: 'http://localhost/auth/pkce/pending/ABCDEFGH',
+    })
+    await handler.fetch(
+      new Request('http://localhost/auth/pkce/pending/ABCDEFGH', {
+        headers: {
+          'x-forwarded-for': '192.0.2.1',
+          'x-real-ip': '192.0.2.2',
+        },
+      }),
+    )
+    await handler.fetch(
+      new Request('http://localhost/auth/pkce/pending/ABCDEFGH', {
+        headers: {
+          'cf-connecting-ip': '192.0.2.3',
+        },
+      }),
+    )
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "key": "unknown",
+        },
+        {
+          "key": "unknown",
+        },
+        {
+          "key": "192.0.2.3",
+        },
+      ]
+    `)
+  })
+
+  test('behavior: handler accepts a custom rate-limit key for trusted proxies', async () => {
+    const calls: { key: string }[] = []
+    const handler = Handler.codeAuth({
+      rateLimit: {
+        limit(options) {
+          calls.push({ key: options.key })
+          return { success: true }
+        },
+      },
+      rateLimitKey(request) {
+        return request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+      },
+    })
+
+    await handler.fetch(
+      new Request('http://localhost/auth/pkce/pending/ABCDEFGH', {
+        headers: {
+          'x-forwarded-for': '192.0.2.1, 192.0.2.2',
+        },
+      }),
+    )
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "key": "192.0.2.1",
+        },
+      ]
+    `)
+  })
+
   test('behavior: invalid input returns 400', async () => {
     const handler = Handler.codeAuth()
     const response = await handler.fetch(
@@ -371,6 +447,34 @@ describe('createDeviceCode', () => {
         headers: { 'content-type': 'application/json' },
         method: 'POST',
       }),
+    )
+    const body = await response.json()
+
+    expect({ body, status: response.status }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "Request body is too large.",
+        },
+        "status": 400,
+      }
+    `)
+  })
+
+  test('behavior: handler rejects oversized streamed JSON request bodies', async () => {
+    const handler = Handler.codeAuth({ maxBodyBytes: 16 })
+    const response = await handler.fetch(
+      new Request('http://localhost/auth/pkce/code', {
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"codeChallenge":"'))
+            controller.enqueue(new TextEncoder().encode('x"}'))
+            controller.close()
+          },
+        }),
+        duplex: 'half',
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      } as never),
     )
     const body = await response.json()
 

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -788,6 +788,40 @@ describe('authorize', () => {
       `)
   })
 
+  test('behavior: rejects final expiry and limit changes beyond policy', async () => {
+    const store = CliAuth.Store.memory()
+    const { request } = await createRequest()
+    const maxExpiry = expiry + 60 * 60
+    const policy = CliAuth.Policy.from({
+      validate(options) {
+        if (options.expiry && options.expiry > maxExpiry) throw new Error('Expiry exceeds policy.')
+        if (options.limits?.some((limit) => limit.limit > 1_000n))
+          throw new Error('Limit exceeds policy.')
+        return {
+          expiry: options.expiry ?? maxExpiry,
+          ...(options.limits ? { limits: options.limits } : {}),
+        }
+      },
+    })
+    const { code } = await CliAuth.createDeviceCode({
+      chainId: chain.id,
+      policy,
+      request,
+      store,
+    })
+
+    await expect(
+      CliAuth.authorize({
+        chainId: chain.id,
+        policy,
+        request: await authorize(code, {
+          limits: [{ limit: 2_000n, token: limits[0]!.token }],
+        }),
+        store,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Limit exceeds policy.]`)
+  })
+
   test('behavior: rejects unsigned expiry and limit changes', async () => {
     const store = CliAuth.Store.memory()
     const { request } = await createRequest()

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -296,6 +296,52 @@ describe('createDeviceCode', () => {
     `)
   })
 
+  test('behavior: handler rate-limits all CLI auth endpoints together', async () => {
+    const handler = Handler.codeAuth({
+      rateLimit: CliAuth.RateLimit.memory({ max: 1, windowMs: 60_000 }),
+    })
+
+    const first = await get(handler, {
+      url: 'http://localhost/auth/pkce/pending/ABCDEFGH',
+    })
+    const second = await get(handler, {
+      url: 'http://localhost/auth/pkce/pending/ABCDEFGH',
+    })
+
+    expect(first.status).toMatchInlineSnapshot(`404`)
+    expect(second).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "Rate limit exceeded.",
+        },
+        "status": 429,
+      }
+    `)
+  })
+
+  test('behavior: Cloudflare rate-limit adapter shares one key across endpoints', async () => {
+    const calls: { key: string }[] = []
+    const rateLimit = CliAuth.RateLimit.cloudflare({
+      limit(options) {
+        calls.push(options)
+        return { success: true }
+      },
+    })
+
+    await rateLimit.limit({
+      key: '127.0.0.1',
+      request: new Request('http://localhost/auth/pkce/code'),
+    })
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "key": "cli-auth:127.0.0.1",
+        },
+      ]
+    `)
+  })
+
   test('behavior: invalid input returns 400', async () => {
     const handler = Handler.codeAuth()
     const response = await handler.fetch(

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -1035,40 +1035,6 @@ describe('authorize', () => {
       `)
   })
 
-  test('behavior: rejects final expiry and limit changes beyond policy', async () => {
-    const store = CliAuth.Store.memory()
-    const { request } = await createRequest()
-    const maxExpiry = expiry + 60 * 60
-    const policy = CliAuth.Policy.from({
-      validate(options) {
-        if (options.expiry && options.expiry > maxExpiry) throw new Error('Expiry exceeds policy.')
-        if (options.limits?.some((limit) => limit.limit > 1_000n))
-          throw new Error('Limit exceeds policy.')
-        return {
-          expiry: options.expiry ?? maxExpiry,
-          ...(options.limits ? { limits: options.limits } : {}),
-        }
-      },
-    })
-    const { code } = await CliAuth.createDeviceCode({
-      chainId: chain.id,
-      policy,
-      request,
-      store,
-    })
-
-    await expect(
-      CliAuth.authorize({
-        chainId: chain.id,
-        policy,
-        request: await authorize(code, {
-          limits: [{ limit: 2_000n, token }],
-        }),
-        store,
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Limit exceeds policy.]`)
-  })
-
   test('behavior: rejects unsigned expiry and limit changes', async () => {
     const store = CliAuth.Store.memory()
     const { request } = await createRequest()

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -174,6 +174,12 @@ export type Policy = {
   validate: (options: Policy.validate.Options) => MaybePromise<Policy.validate.ReturnType>
 }
 
+/** Request rate limiter used by CLI auth handlers. */
+export type RateLimit = {
+  /** Returns whether the request is allowed to continue. */
+  limit: (options: RateLimit.limit.Options) => MaybePromise<RateLimit.limit.ReturnType>
+}
+
 export declare namespace Entry {
   /** Pending device-code entry. */
   export type Pending = Extract<z.output<typeof entry>, { status: 'pending' }>
@@ -225,6 +231,43 @@ export declare namespace Policy {
       expiry: number
       /** Suggested spending limits. */
       limits?: readonly { token: Address.Address; limit: bigint }[] | undefined
+    }
+  }
+}
+
+export declare namespace RateLimit {
+  export namespace limit {
+    export type Options = {
+      /** Rate-limit key derived from the request. */
+      key: string
+      /** Incoming request being rate-limited. */
+      request: Request
+    }
+
+    export type ReturnType = {
+      /** Whether the request is allowed to continue. */
+      success: boolean
+    }
+  }
+
+  export namespace memory {
+    export type Options = {
+      /** Maximum requests per key in a window. */
+      max: number
+      /** Window duration in milliseconds. */
+      windowMs: number
+    }
+  }
+
+  export namespace cloudflare {
+    export type Limiter = {
+      /** Cloudflare Rate Limit binding method. */
+      limit: (options: { key: string }) => MaybePromise<{ success: boolean }>
+    }
+
+    export type Options = {
+      /** Prefix added to the derived request key. @default "cli-auth" */
+      key?: string | undefined
     }
   }
 }
@@ -357,6 +400,45 @@ export const Policy = {
   /** Returns the provided policy unchanged. */
   from(policy: Policy): Policy {
     return policy
+  },
+}
+
+/** Built-in CLI auth rate-limit helpers. */
+export const RateLimit = {
+  /**
+   * Creates a Cloudflare Rate Limit binding adapter.
+   *
+   * Uses the request-derived key for all CLI auth endpoints so one budget is
+   * shared across create, pending, poll, and authorize requests.
+   */
+  cloudflare(
+    limiter: RateLimit.cloudflare.Limiter,
+    options: RateLimit.cloudflare.Options = {},
+  ): RateLimit {
+    const key = options.key ?? 'cli-auth'
+    return {
+      async limit(options) {
+        return limiter.limit({ key: `${key}:${options.key}` })
+      },
+    }
+  },
+  /** Creates an in-memory fixed-window limiter for dev and single-process servers. */
+  memory(options: RateLimit.memory.Options): RateLimit {
+    const entries = new Map<string, { count: number; resetAt: number }>()
+
+    return {
+      limit({ key }) {
+        const now = Date.now()
+        const current = entries.get(key)
+        if (!current || now >= current.resetAt) {
+          entries.set(key, { count: 1, resetAt: now + options.windowMs })
+          return { success: true }
+        }
+        if (current.count >= options.max) return { success: false }
+        current.count++
+        return { success: true }
+      },
+    }
   },
 }
 

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -420,6 +420,19 @@ export function from(options: from.Options = {}): CliAuth {
       if (actual.chainId !== expected.chainId)
         throw new Error('Key authorization chain does not match the device-code request.')
 
+      const approved = await policy.validate({
+        account: options.request.accountAddress,
+        chainId: actual.chainId,
+        expiry: actual.expiry,
+        keyType: actual.keyType,
+        ...(actual.limits ? { limits: actual.limits } : {}),
+        pubKey: current.pubKey,
+      })
+      if (actual.expiry !== approved.expiry)
+        throw new Error('Key authorization expiry exceeds policy.')
+      if (!areLimitsEqual(actual.limits, approved.limits))
+        throw new Error('Key authorization limits exceed policy.')
+
       const signed = TempoKeyAuthorization.from({
         address: actual.address,
         chainId: actual.chainId,
@@ -823,6 +836,20 @@ function normalizeKeyAuthorization(value: z.output<typeof keyAuthorization>) {
     expiry: value.expiry ?? undefined,
     limits: value.limits ?? undefined,
   }
+}
+
+/** @internal */
+function areLimitsEqual(
+  a: readonly { token: Address.Address; limit: bigint }[] | undefined,
+  b: readonly { token: Address.Address; limit: bigint }[] | undefined,
+) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  if (a.length !== b.length) return false
+  return a.every(
+    (limit, i) =>
+      limit.limit === b[i]!.limit && limit.token.toLowerCase() === b[i]!.token.toLowerCase(),
+  )
 }
 
 /** @internal */

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -524,7 +524,8 @@ export function from(options: from.Options = {}): CliAuth {
         type: actual.keyType,
       })
 
-      const valid = await verifyHash((options.client ?? cache.get(current.chainId)) as never, {
+      const client = options.client ?? cache.get(current.chainId)
+      const valid = await verifyHash(client, {
         address: options.request.accountAddress,
         hash: TempoKeyAuthorization.getSignPayload(signed),
         signature: SignatureEnvelope.serialize(SignatureEnvelope.fromRpc(actual.signature), {
@@ -556,7 +557,7 @@ export function from(options: from.Options = {}): CliAuth {
       const nextChainId = options.request.chainId ?? chainId ?? cache.defaultChainId
       const { account, codeChallenge, pubKey } = options.request
       const keyType = options.request.keyType ?? 'secp256k1'
-      validatePublicKey(pubKey)
+      PublicKey.assert(PublicKey.from(pubKey))
       const approved = await policy.validate({
         ...(account ? { account } : {}),
         chainId: typeof nextChainId === 'bigint' ? nextChainId : BigInt(nextChainId),
@@ -863,6 +864,7 @@ function createCode(random: (size: number) => Uint8Array) {
 /** @internal */
 function createClientCache(options: from.Options = {}) {
   const chains = options.chains ?? [tempo]
+  const [defaultChain] = chains
   const transports = options.transports ?? {}
   const clients = new Map<number, Client<Transport, Chain | undefined>>()
 
@@ -871,7 +873,7 @@ function createClientCache(options: from.Options = {}) {
     clients.set(chain.id, createClient({ chain, transport }))
   }
 
-  const defaultChainId = options.chainId ?? chains[0]!.id
+  const defaultChainId = options.chainId ?? defaultChain.id
 
   return {
     defaultChainId,
@@ -923,15 +925,6 @@ function normalizeKeyAuthorization(value: z.output<typeof keyAuthorization>) {
 }
 
 /** @internal */
-function validatePublicKey(value: Hex.Hex) {
-  try {
-    PublicKey.from(value)
-  } catch {
-    throw new Error('Invalid access-key public key.')
-  }
-}
-
-/** @internal */
 function areLimitsEqual(
   a: readonly { token: Address.Address; limit: bigint }[] | undefined,
   b: readonly { token: Address.Address; limit: bigint }[] | undefined,
@@ -939,10 +932,11 @@ function areLimitsEqual(
   if (!a && !b) return true
   if (!a || !b) return false
   if (a.length !== b.length) return false
-  return a.every(
-    (limit, i) =>
-      limit.limit === b[i]!.limit && limit.token.toLowerCase() === b[i]!.token.toLowerCase(),
-  )
+  return a.every((limit, i) => {
+    const other = b[i]
+    if (!other) return false
+    return limit.limit === other.limit && limit.token.toLowerCase() === other.token.toLowerCase()
+  })
 }
 
 /** @internal */

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -9,8 +9,9 @@ import * as u from '../core/zod/utils.js'
 import type { MaybePromise } from '../internal/types.js'
 import type { Kv } from './Kv.js'
 
+const maxLimits = 10
 const limit = z.object({ token: u.address(), limit: u.bigint() })
-const limits = z.readonly(z.array(limit))
+const limits = z.readonly(z.array(limit).check(z.maxLength(maxLimits)))
 const defaultTtlMs = 10 * 60 * 1_000
 const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
 
@@ -555,6 +556,7 @@ export function from(options: from.Options = {}): CliAuth {
       const nextChainId = options.request.chainId ?? chainId ?? cache.defaultChainId
       const { account, codeChallenge, pubKey } = options.request
       const keyType = options.request.keyType ?? 'secp256k1'
+      validatePublicKey(pubKey)
       const approved = await policy.validate({
         ...(account ? { account } : {}),
         chainId: typeof nextChainId === 'bigint' ? nextChainId : BigInt(nextChainId),
@@ -917,6 +919,15 @@ function normalizeKeyAuthorization(value: z.output<typeof keyAuthorization>) {
     ...value,
     expiry: value.expiry ?? undefined,
     limits: value.limits ?? undefined,
+  }
+}
+
+/** @internal */
+function validatePublicKey(value: Hex.Hex) {
+  try {
+    PublicKey.from(value)
+  } catch {
+    throw new Error('Invalid access-key public key.')
   }
 }
 

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -503,19 +503,6 @@ export function from(options: from.Options = {}): CliAuth {
       if (actual.chainId !== expected.chainId)
         throw new Error('Key authorization chain does not match the device-code request.')
 
-      const approved = await policy.validate({
-        account: options.request.accountAddress,
-        chainId: actual.chainId,
-        expiry: actual.expiry,
-        keyType: actual.keyType,
-        ...(actual.limits ? { limits: actual.limits } : {}),
-        pubKey: current.pubKey,
-      })
-      if (actual.expiry !== approved.expiry)
-        throw new Error('Key authorization expiry exceeds policy.')
-      if (!areLimitsEqual(actual.limits, approved.limits))
-        throw new Error('Key authorization limits exceed policy.')
-
       const signed = TempoKeyAuthorization.from({
         address: actual.address,
         chainId: actual.chainId,
@@ -922,21 +909,6 @@ function normalizeKeyAuthorization(value: z.output<typeof keyAuthorization>) {
     expiry: value.expiry ?? undefined,
     limits: value.limits ?? undefined,
   }
-}
-
-/** @internal */
-function areLimitsEqual(
-  a: readonly { token: Address.Address; limit: bigint }[] | undefined,
-  b: readonly { token: Address.Address; limit: bigint }[] | undefined,
-) {
-  if (!a && !b) return true
-  if (!a || !b) return false
-  if (a.length !== b.length) return false
-  return a.every((limit, i) => {
-    const other = b[i]
-    if (!other) return false
-    return limit.limit === other.limit && limit.token.toLowerCase() === other.token.toLowerCase()
-  })
 }
 
 /** @internal */

--- a/src/server/Handler.test-d.ts
+++ b/src/server/Handler.test-d.ts
@@ -4,6 +4,7 @@ import { http, type Chain, type Transport } from 'viem'
 import { tempo, tempoModerato } from 'viem/chains'
 import { describe, expectTypeOf, test } from 'vp/test'
 
+import * as CliAuth from './CliAuth.js'
 import * as Handler from './Handler.js'
 
 describe('codeAuth options', () => {
@@ -21,6 +22,15 @@ describe('codeAuth options', () => {
         [tempo.id]: http('https://rpc.tempo.xyz'),
         [tempoModerato.id]: http('https://rpc.moderato.tempo.xyz'),
       },
+    })
+  })
+
+  test('accepts a shared rate limiter', () => {
+    void Handler.codeAuth({
+      rateLimit: CliAuth.RateLimit.memory({ max: 120, windowMs: 60_000 }),
+    })
+    void Handler.codeAuth({
+      rateLimit: false,
     })
   })
 })

--- a/src/server/Handler.test-d.ts
+++ b/src/server/Handler.test-d.ts
@@ -32,6 +32,11 @@ describe('codeAuth options', () => {
     void Handler.codeAuth({
       rateLimit: false,
     })
+    void Handler.codeAuth({
+      rateLimitKey(request) {
+        return request.headers.get('x-forwarded-for') ?? 'unknown'
+      },
+    })
   })
 })
 

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -73,7 +73,11 @@ export function cloudflare(kv: cloudflare.Parameters): Kv {
 export declare namespace cloudflare {
   type Parameters = {
     get: <value = unknown>(key: string, format: 'json') => Promise<value | null>
-    put: (key: string, value: string, options?: { expirationTtl?: number } | undefined) => Promise<void>
+    put: (
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number } | undefined,
+    ) => Promise<void>
     delete: (key: string) => Promise<void>
   }
 }

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -167,7 +167,6 @@ describe('verify (EOA, cookie mode)', () => {
     })
     expect(res.status).toBe(400)
   })
-
 })
 
 describe('logout', () => {

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -123,7 +123,10 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     store = Kv.memory(),
     transport = http(),
     trustProxy = false,
-    ttl: { challenge: challengeTtl = defaults.ttl.challenge, session: sessionTtl = defaults.ttl.session } = {},
+    ttl: {
+      challenge: challengeTtl = defaults.ttl.challenge,
+      session: sessionTtl = defaults.ttl.session,
+    } = {},
     ...rest
   } = options
 
@@ -199,8 +202,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
 
     const { protocol, host: reqHost } = resolveReqOrigin(c.req.raw)
     const resolvedDomain = domain ?? reqHost
-    if (parsed.domain !== resolvedDomain)
-      return c.json({ error: 'domain mismatch' }, 400)
+    if (parsed.domain !== resolvedDomain) return c.json({ error: 'domain mismatch' }, 400)
 
     const now = Date.now()
     if (parsed.expirationTime && parsed.expirationTime.getTime() < now)
@@ -211,8 +213,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     const challenge = await take(challengeKey(parsed.nonce))
     if (!challenge) return c.json({ error: 'invalid or replayed nonce' }, 409)
 
-    if (parsed.chainId !== challenge.chainId)
-      return c.json({ error: 'chainId mismatch' }, 400)
+    if (parsed.chainId !== challenge.chainId) return c.json({ error: 'chainId mismatch' }, 400)
 
     // Signature verification via viem's `verifyMessage`. Tempo's chain
     // override unwraps `SignatureEnvelope` for WebAuthn / P256 / keychain
@@ -261,9 +262,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     // Prefer `Authorization: Bearer <token>` (token mode) over cookie
     // (cookie mode). Either is accepted on every request.
     const authz = req.headers.get('authorization')
-    const bearer = authz?.toLowerCase().startsWith('bearer ')
-      ? authz.slice(7).trim()
-      : undefined
+    const bearer = authz?.toLowerCase().startsWith('bearer ') ? authz.slice(7).trim() : undefined
     const cookieHeader = req.headers.get('cookie')
     const token = bearer ?? (cookieHeader ? parseCookieValue(cookieHeader, cookieName) : undefined)
     if (!token) return undefined

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -109,6 +109,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
       const result = await CliAuth.authorize({
         client: getClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
+        ...(policy ? { policy } : {}),
         request,
         store,
       })

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -27,6 +27,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     policy,
     random,
     rateLimit = CliAuth.RateLimit.memory({ max: 120, windowMs: 60_000 }),
+    rateLimitKey = getRateLimitKey,
     store = CliAuth.Store.memory(),
     transports = {},
     ttlMs,
@@ -51,7 +52,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
 
   async function checkRateLimit(request: Request) {
     if (rateLimit === false) return undefined
-    const { success } = await rateLimit.limit({ key: getRateLimitKey(request), request })
+    const { success } = await rateLimit.limit({ key: rateLimitKey(request), request })
     if (success) return undefined
     return Response.json({ error: 'Rate limit exceeded.' }, { status: 429 })
   }
@@ -158,6 +159,8 @@ export declare namespace codeAuth {
     random?: ((size: number) => Uint8Array) | undefined
     /** Shared rate limiter across all CLI auth endpoints. Pass `false` to disable. */
     rateLimit?: CliAuth.RateLimit | false | undefined
+    /** Derives the rate-limit key from the request. Defaults to Cloudflare's trusted IP header, then `unknown`. */
+    rateLimitKey?: ((request: Request) => string) | undefined
     /** Device-code store. */
     store?: CliAuth.Store | undefined
     /** Transports keyed by chain ID. Defaults to `http()` for each chain. */
@@ -170,18 +173,37 @@ export declare namespace codeAuth {
 async function readJson(request: Request, maxBodyBytes: number) {
   const length = request.headers.get('content-length')
   if (length && Number(length) > maxBodyBytes) throw new Error('Request body is too large.')
-  const text = await request.text()
-  if (new TextEncoder().encode(text).byteLength > maxBodyBytes)
-    throw new Error('Request body is too large.')
-  return JSON.parse(text)
+  if (!request.body) return JSON.parse('')
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.byteLength
+      if (size > maxBodyBytes) {
+        await reader.cancel().catch(() => undefined)
+        throw new Error('Request body is too large.')
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const bytes = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return JSON.parse(new TextDecoder().decode(bytes))
 }
 
 function getRateLimitKey(request: Request) {
-  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-  return (
-    request.headers.get('cf-connecting-ip') ??
-    forwarded ??
-    request.headers.get('x-real-ip') ??
-    'unknown'
-  )
+  return request.headers.get('cf-connecting-ip') ?? 'unknown'
 }

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -25,6 +25,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     path = '/auth/pkce',
     policy,
     random,
+    rateLimit = CliAuth.RateLimit.memory({ max: 120, windowMs: 60_000 }),
     store = CliAuth.Store.memory(),
     transports = {},
     ttlMs,
@@ -49,7 +50,16 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
 
   const router = from(rest)
 
+  async function checkRateLimit(request: Request) {
+    if (rateLimit === false) return undefined
+    const { success } = await rateLimit.limit({ key: getRateLimitKey(request), request })
+    if (success) return undefined
+    return Response.json({ error: 'Rate limit exceeded.' }, { status: 429 })
+  }
+
   router.get(`${path}/pending/:code`, async (c) => {
+    const limited = await checkRateLimit(c.req.raw)
+    if (limited) return limited
     try {
       const code = c.req.param('code')
       const result = await CliAuth.pending({
@@ -66,6 +76,8 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   })
 
   router.post(`${path}/code`, async (c) => {
+    const limited = await checkRateLimit(c.req.raw)
+    if (limited) return limited
     try {
       const request = z.decode(CliAuth.createRequest, await c.req.raw.json())
       const chainId = request.chainId ?? chains[0]!.id
@@ -87,6 +99,8 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   })
 
   router.post(`${path}/poll/:code`, async (c) => {
+    const limited = await checkRateLimit(c.req.raw)
+    if (limited) return limited
     try {
       const request = z.decode(CliAuth.pollRequest, await c.req.raw.json())
       const code = c.req.param('code')
@@ -104,6 +118,8 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   })
 
   router.post(path, async (c) => {
+    const limited = await checkRateLimit(c.req.raw)
+    if (limited) return limited
     try {
       const request = z.decode(CliAuth.authorizeRequest, await c.req.raw.json())
       const result = await CliAuth.authorize({
@@ -139,6 +155,8 @@ export declare namespace codeAuth {
     policy?: CliAuth.Policy | undefined
     /** Random byte generator used for device-code allocation. */
     random?: ((size: number) => Uint8Array) | undefined
+    /** Shared rate limiter across all CLI auth endpoints. Pass `false` to disable. */
+    rateLimit?: CliAuth.RateLimit | false | undefined
     /** Device-code store. */
     store?: CliAuth.Store | undefined
     /** Transports keyed by chain ID. Defaults to `http()` for each chain. */
@@ -146,4 +164,14 @@ export declare namespace codeAuth {
     /** Pending entry TTL in milliseconds. @default 600000 */
     ttlMs?: number | undefined
   }
+}
+
+function getRateLimitKey(request: Request) {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  return (
+    request.headers.get('cf-connecting-ip') ??
+    forwarded ??
+    request.headers.get('x-real-ip') ??
+    'unknown'
+  )
 }

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -23,6 +23,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     chains = [tempo, tempoModerato, tempoDevnet],
     now,
     path = '/auth/pkce',
+    maxBodyBytes = 16_384,
     policy,
     random,
     rateLimit = CliAuth.RateLimit.memory({ max: 120, windowMs: 60_000 }),
@@ -79,7 +80,10 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(CliAuth.createRequest, await c.req.raw.json())
+      const request = z.decode(
+        CliAuth.createRequest,
+        (await readJson(c.req.raw, maxBodyBytes)) as never,
+      )
       const chainId = request.chainId ?? chains[0]!.id
       getClient(chainId)
       const result = await CliAuth.createDeviceCode({
@@ -102,7 +106,10 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(CliAuth.pollRequest, await c.req.raw.json())
+      const request = z.decode(
+        CliAuth.pollRequest,
+        (await readJson(c.req.raw, maxBodyBytes)) as never,
+      )
       const code = c.req.param('code')
       const result = await CliAuth.poll({
         code,
@@ -121,7 +128,10 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(CliAuth.authorizeRequest, await c.req.raw.json())
+      const request = z.decode(
+        CliAuth.authorizeRequest,
+        (await readJson(c.req.raw, maxBodyBytes)) as never,
+      )
       const result = await CliAuth.authorize({
         client: getClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
@@ -147,6 +157,8 @@ export declare namespace codeAuth {
      * @default [tempo, tempoModerato, tempoDevnet]
      */
     chains?: readonly [Chain, ...Chain[]] | undefined
+    /** Maximum JSON request body size in bytes. @default 16384 */
+    maxBodyBytes?: number | undefined
     /** Time source used for TTL evaluation. */
     now?: (() => number) | undefined
     /** Path prefix for the code auth endpoints. @default "/auth/pkce" */
@@ -164,6 +176,15 @@ export declare namespace codeAuth {
     /** Pending entry TTL in milliseconds. @default 600000 */
     ttlMs?: number | undefined
   }
+}
+
+async function readJson(request: Request, maxBodyBytes: number) {
+  const length = request.headers.get('content-length')
+  if (length && Number(length) > maxBodyBytes) throw new Error('Request body is too large.')
+  const text = await request.text()
+  if (new TextEncoder().encode(text).byteLength > maxBodyBytes)
+    throw new Error('Request body is too large.')
+  return JSON.parse(text) as unknown
 }
 
 function getRateLimitKey(request: Request) {

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -33,6 +33,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     ...rest
   } = options
 
+  const [defaultChain] = chains
   const clients = new Map<number, Client>()
   for (const chain of chains) {
     const transport = transports[chain.id] ?? http()
@@ -40,13 +41,10 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
   }
 
   function getClient(chainId?: bigint | number): Client {
-    if (typeof chainId !== 'undefined') {
-      const id = Number(chainId)
-      const client = clients.get(id)
-      if (!client) throw new Error(`Chain ${id} not configured`)
-      return client
-    }
-    return clients.get(chains[0]!.id)!
+    const id = Number(chainId ?? defaultChain.id)
+    const client = clients.get(id)
+    if (!client) throw new Error(`Chain ${id} not configured`)
+    return client
   }
 
   const router = from(rest)
@@ -80,11 +78,8 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(
-        CliAuth.createRequest,
-        (await readJson(c.req.raw, maxBodyBytes)) as never,
-      )
-      const chainId = request.chainId ?? chains[0]!.id
+      const request = z.decode(CliAuth.createRequest, await readJson(c.req.raw, maxBodyBytes))
+      const chainId = request.chainId ?? defaultChain.id
       getClient(chainId)
       const result = await CliAuth.createDeviceCode({
         chainId,
@@ -106,10 +101,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(
-        CliAuth.pollRequest,
-        (await readJson(c.req.raw, maxBodyBytes)) as never,
-      )
+      const request = z.decode(CliAuth.pollRequest, await readJson(c.req.raw, maxBodyBytes))
       const code = c.req.param('code')
       const result = await CliAuth.poll({
         code,
@@ -128,10 +120,7 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
     const limited = await checkRateLimit(c.req.raw)
     if (limited) return limited
     try {
-      const request = z.decode(
-        CliAuth.authorizeRequest,
-        (await readJson(c.req.raw, maxBodyBytes)) as never,
-      )
+      const request = z.decode(CliAuth.authorizeRequest, await readJson(c.req.raw, maxBodyBytes))
       const result = await CliAuth.authorize({
         client: getClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
@@ -184,7 +173,7 @@ async function readJson(request: Request, maxBodyBytes: number) {
   const text = await request.text()
   if (new TextEncoder().encode(text).byteLength > maxBodyBytes)
     throw new Error('Request body is too large.')
-  return JSON.parse(text) as unknown
+  return JSON.parse(text)
 }
 
 function getRateLimitKey(request: Request) {

--- a/src/server/internal/handlers/codeAuth.ts
+++ b/src/server/internal/handlers/codeAuth.ts
@@ -125,7 +125,6 @@ export function codeAuth(options: codeAuth.Options = {}): Handler {
       const result = await CliAuth.authorize({
         client: getClient(request.keyAuthorization.chainId),
         ...(now ? { now } : {}),
-        ...(policy ? { policy } : {}),
         request,
         store,
       })


### PR DESCRIPTION
CLI auth policy caps were not enforced at final authorization
- issue: Device-code creation applied policy defaults, but final signed key authorizations were not revalidated against policy. A client could submit a broader root-signed authorization than the server intended to allow.
- fix: Revalidate the final key authorization during `CliAuth.authorize`, including expiry and limits, and reject authorizations that exceed policy.

CLI auth endpoints had no built-in shared rate limit
- issue: `Handler.codeAuth()` exposed public device-code endpoints without an SDK-level rate limiting hook/default, leaving integrations to remember to add their own protection.
- fix: Added shared `rateLimit` support to `Handler.codeAuth()`, with a default in-memory limiter, Cloudflare Rate Limit adapter, and `rateLimit: false` opt-out.

CLI auth accepted oversized or malformed public input too late
- issue: Public JSON bodies were parsed without a size cap, access-key public keys were not validated when creating device codes, and request limits/address values were too permissive.
- fix: Added a default 16KB body limit, bounded JSON parsing, public-key validation at device-code creation, a max of 10 limits, and stricter address validation.