### PR TITLE
fix(relay): surface upstream RPC errors as JSON-RPC errors

### DIFF
--- a/.changeset/export-execution-error.md
+++ b/.changeset/export-execution-error.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Exported `ExecutionError`.

--- a/.changeset/relay-surface-rpc-errors.md
+++ b/.changeset/relay-surface-rpc-errors.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed relay default pass-through to return upstream RPC errors as structured JSON-RPC errors instead of HTTP 500.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * as IntersectionObserver from './core/IntersectionObserver.js'
 export * as Dialog from './core/Dialog.js'
+export * as ExecutionError from './core/ExecutionError.js'
 export * as Messenger from './core/Messenger.js'
 export * as Schema from './core/Schema.js'
 export * as Provider from './core/Provider.js'

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -77,6 +77,49 @@ describe('default', () => {
     expect(Number(chainId)).toMatchInlineSnapshot(`${chain.id}`)
   })
 
+  test('behavior: surfaces upstream RPC errors as JSON-RPC errors', async () => {
+    // grantRoles reverts with Unauthorized when caller is not an admin
+    // (eth_call defaults `from` to the zero address). We expect the relay to
+    // forward the revert as a structured JSON-RPC error response (HTTP 200
+    // with `error.code`/`error.data`), not a 500.
+    const call = Actions.token.grantRoles.call({
+      token: addresses.alphaUsd,
+      role: 'issuer',
+      to: recipient.address,
+    })
+
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_call',
+        params: [{ to: call.to, data: call.data }, 'latest'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      id: number
+      jsonrpc: string
+      error: { code: number; message: string; data?: string }
+    }
+    // Drop `message` from the snapshot — it embeds the upstream RPC URL/port
+    // and viem version, which are nondeterministic.
+    const { message: _message, ...errorRest } = body.error
+    expect({ ...body, error: errorRest }).toMatchInlineSnapshot(`
+    	{
+    	  "error": {
+    	    "code": 3,
+    	    "data": "0x82b42900",
+    	  },
+    	  "id": 1,
+    	  "jsonrpc": "2.0",
+    	}
+    `)
+  })
+
   test('behavior: handles JSON-RPC batch requests', async () => {
     const response = await fetch(server.url, {
       method: 'POST',

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -409,8 +409,12 @@ export function relay(options: relay.Options = {}): Handler {
       }
 
       default: {
-        const result = await client.request(request as never)
-        return RpcResponse.from({ result }, { request })
+        try {
+          const result = await client.request(request as never)
+          return RpcResponse.from({ result }, { request })
+        } catch (error) {
+          return Utils.rpcErrorJson(request, error)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Currently, when an upstream RPC call (e.g. `eth_call`) returns an error — for example a contract revert like `PairDoesNotExist` from the Stablecoin DEX — the relay default branch lets the error propagate to the framework, which responds with HTTP 500 Internal Server Error. The revert data is lost in transit, so wallets and dapps cannot decode and surface the actual reason.

## Changes

- **`src/server/internal/handlers/relay.ts`** — wrap the default RPC pass-through case in `try/catch` and reuse the existing `Utils.rpcErrorJson` helper. Upstream errors now come back as a structured JSON-RPC error response with `code`, `message`, and `data` fields.
- **`src/index.ts`** — export `ExecutionError` from the package root so consumers can call `ExecutionError.parse(error)` to turn a viem error into a human-readable message (e.g. 'Pair does not exist.').
- **Test** — added `behavior: surfaces upstream RPC errors as JSON-RPC errors` covering an `eth_call` to `grantRoles` (reverts with `Unauthorized`) and asserting HTTP 200 + structured error payload.

## Repro

```sh
curl 'https://wallet.tempo.local/api/relay/42431' \
  -H 'content-type: application/json' \
  --data-raw '{"jsonrpc":"2.0","id":24,"method":"eth_call","params":[{"data":"0xe7c98f1a…","to":"0xdec0000000000000000000000000000000000000"},"latest"]}'
```

**Before:** `Internal Server Error` (HTTP 500).
**After:** HTTP 200 with `{ error: { code: 3, message: 'execution reverted', data: '0xc5fc4bf4' } }` (selector for `PairDoesNotExist`).