### PR TITLE
feat(server): include token logo URIs in /exchange/tokens

### DIFF
--- a/.changeset/exchange-tokens-logo.md
+++ b/.changeset/exchange-tokens-logo.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Included token logo URIs (`logoUri`) in the `GET /exchange/tokens` response.

--- a/src/server/internal/handlers/exchange.test-d.ts
+++ b/src/server/internal/handlers/exchange.test-d.ts
@@ -58,6 +58,7 @@ describe('exchange handler', () => {
         tokens: readonly {
           address: `0x${string}`
           decimals: number
+          logoUri?: string | undefined
           name: string
           symbol: string
         }[]

--- a/src/server/internal/handlers/exchange.ts
+++ b/src/server/internal/handlers/exchange.ts
@@ -28,6 +28,7 @@ export namespace schema {
   const token = z.object({
     address: u.address(),
     decimals: z.number(),
+    logoUri: z.optional(z.string()),
     name: z.string(),
     symbol: z.string(),
   })
@@ -313,6 +314,8 @@ export declare namespace exchange {
     address: Address
     /** Token decimals. */
     decimals: number
+    /** Token logo URI. */
+    logoUri?: string | undefined
     /** Token name. */
     name: string
     /** Token symbol. */
@@ -483,6 +486,11 @@ function toCall(call: { data: Hex.Hex; to: Address }) {
 async function defaultResolveTokens(chainId: number): Promise<readonly Token[]> {
   const response = await fetch(`https://tokenlist.tempo.xyz/list/${chainId}`)
   if (!response.ok) return []
-  const data = (await response.json()) as { tokens: readonly Token[] }
-  return data.tokens
+  const data = (await response.json()) as {
+    tokens: readonly (Token & { logoURI?: string })[]
+  }
+  return data.tokens.map(({ logoURI, ...token }) => ({
+    ...token,
+    logoUri: token.logoUri ?? logoURI,
+  }))
 }


### PR DESCRIPTION
Includes token logo URIs in the `GET /exchange/tokens` response.

- Adds an optional `logoUri` field to the token schema and the `exchange.Token` type.
- The default `resolveTokens` implementation passes through `logoURI` from the upstream Tempo tokenlist as `logoUri`.
- Updated type tests to reflect the new field.

Stacked on #297.
