### PR TITLE
feat: add wallet_depositZone and wallet_withdrawZone RPC methods

### DIFF
--- a/.changeset/wallet-zone-rpc-methods.md
+++ b/.changeset/wallet-zone-rpc-methods.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added `wallet_depositZone` and `wallet_withdrawZone` RPC methods for moving funds between the parent Tempo chain and a private zone.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -85,6 +85,8 @@ export function App() {
       <Transactions />
       <WalletSend />
       <WalletSwap />
+      <WalletDepositZone />
+      <WalletWithdrawZone />
 
       <h2>Receipts &amp; Status</h2>
       <EthGetTransactionReceipt />
@@ -308,6 +310,94 @@ function WalletSwap() {
         }
       >
         Swap (buy 1 PathUSD)
+      </button>
+    </Method>
+  )
+}
+
+function WalletDepositZone() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="wallet_depositZone" result={result} error={error}>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_depositZone',
+              params: [{}],
+            }),
+          )
+        }
+      >
+        Deposit to zone
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_depositZone',
+              params: [{ token: tokens.pathUSD }],
+            }),
+          )
+        }
+      >
+        Deposit (PathUSD)
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_depositZone',
+              params: [{ amount: '1', token: tokens.pathUSD }],
+            }),
+          )
+        }
+      >
+        Deposit (1 PathUSD)
+      </button>
+    </Method>
+  )
+}
+
+function WalletWithdrawZone() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="wallet_withdrawZone" result={result} error={error}>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_withdrawZone',
+              params: [{}],
+            }),
+          )
+        }
+      >
+        Withdraw from zone
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_withdrawZone',
+              params: [{ token: tokens.pathUSD }],
+            }),
+          )
+        }
+      >
+        Withdraw (PathUSD)
+      </button>
+      <button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_withdrawZone',
+              params: [{ amount: '1', token: tokens.pathUSD }],
+            }),
+          )
+        }
+      >
+        Withdraw (1 PathUSD)
       </button>
     </Method>
   )

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -53,6 +53,13 @@ export type Instance = {
           request: EncodedRequest<Rpc.wallet_deposit.Encoded>,
         ) => Promise<deposit.ReturnType>)
       | undefined
+    /** Open the zone-deposit flow. */
+    depositZone?:
+      | ((
+          params: depositZone.Parameters,
+          request: EncodedRequest<Rpc.wallet_depositZone.Encoded>,
+        ) => Promise<depositZone.ReturnType>)
+      | undefined
     /** Disconnect hook for adapter-specific cleanup. */
     disconnect?: (() => Promise<void>) | undefined
     /** Discover existing accounts (e.g. WebAuthn assertion). */
@@ -108,6 +115,13 @@ export type Instance = {
     ) => Promise<Hex>
     /** Switch chain hook for adapter-specific handling. */
     switchChain?: ((params: switchChain.Parameters) => Promise<void>) | undefined
+    /** Open the zone-withdraw flow. */
+    withdrawZone?:
+      | ((
+          params: withdrawZone.Parameters,
+          request: EncodedRequest<Rpc.wallet_withdrawZone.Encoded>,
+        ) => Promise<withdrawZone.ReturnType>)
+      | undefined
   }
   /** Cleanup function called when the provider is destroyed. */
   cleanup?: (() => void) | undefined
@@ -179,6 +193,18 @@ export declare namespace createAccount {
 export declare namespace deposit {
   type Parameters = ActionRequest<typeof Rpc.wallet_deposit.schema>
   type ReturnType = Rpc.wallet_deposit.Encoded['returns']
+}
+
+/** Parameters and return type for the `wallet_depositZone` action. */
+export declare namespace depositZone {
+  type Parameters = ActionRequest<typeof Rpc.wallet_depositZone.schema>
+  type ReturnType = Rpc.wallet_depositZone.Encoded['returns']
+}
+
+/** Parameters and return type for the `wallet_withdrawZone` action. */
+export declare namespace withdrawZone {
+  type Parameters = ActionRequest<typeof Rpc.wallet_withdrawZone.schema>
+  type ReturnType = Rpc.wallet_withdrawZone.Encoded['returns']
 }
 
 export declare namespace loadAccounts {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -650,6 +650,37 @@ export function create(options: create.Options = {}): create.ReturnType {
                     )) satisfies Rpc.wallet_swap.Encoded['returns']
                   }
 
+                  case 'wallet_depositZone': {
+                    assertConnected()
+                    if (!actions.depositZone)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`depositZone` not supported by adapter.',
+                      })
+                    const decoded = request._decoded.params?.[0] ?? {}
+                    const parameters = {
+                      ...decoded,
+                      ...(typeof decoded.feePayer !== 'undefined'
+                        ? { feePayer: resolveFeePayer(decoded.feePayer) }
+                        : {}),
+                    } as Adapter.depositZone.Parameters
+                    return (await actions.depositZone(
+                      parameters,
+                      request,
+                    )) satisfies Rpc.wallet_depositZone.Encoded['returns']
+                  }
+
+                  case 'wallet_withdrawZone': {
+                    assertConnected()
+                    if (!actions.withdrawZone)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`withdrawZone` not supported by adapter.',
+                      })
+                    return (await actions.withdrawZone(
+                      (request._decoded.params?.[0] ?? {}) as Adapter.withdrawZone.Parameters,
+                      request,
+                    )) satisfies Rpc.wallet_withdrawZone.Encoded['returns']
+                  }
+
                   case 'wallet_switchEthereumChain': {
                     const { chainId } = request._decoded.params[0]
                     if (!chains.some((c) => c.id === chainId))

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -88,6 +88,7 @@ export const schema = from([
   Rpc.wallet_authorizeAccessKey.schema,
   Rpc.wallet_connect.schema,
   Rpc.wallet_deposit.schema,
+  Rpc.wallet_depositZone.schema,
   Rpc.wallet_disconnect.schema,
   Rpc.wallet_getBalances.schema,
   Rpc.wallet_getCallsStatus.schema,
@@ -97,6 +98,7 @@ export const schema = from([
   Rpc.wallet_sendCalls.schema,
   Rpc.wallet_swap.schema,
   Rpc.wallet_switchEthereumChain.schema,
+  Rpc.wallet_withdrawZone.schema,
 ])
 
 /** Ox-compatible RPC schema union for the provider. */

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -407,6 +407,20 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           return await provider.request(request)
         },
 
+        async depositZone(params, request) {
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.wallet_depositZone.parameters, params)] as const,
+          })
+        },
+
+        async withdrawZone(params, request) {
+          return await provider.request({
+            ...request,
+            params: [z.encode(Rpc.wallet_withdrawZone.parameters, params)] as const,
+          })
+        },
+
         async disconnect() {
           store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
         },

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -616,6 +616,59 @@ export namespace wallet_deposit {
   export type Decoded = Schema.Decoded<typeof schema>
 }
 
+/** Opens the wallet zone-deposit flow with optional pre-filled fields. */
+export namespace wallet_depositZone {
+  /** Parameters object for `wallet_depositZone`. */
+  export const parameters = z.object({
+    /** Human-readable amount to pre-fill (e.g. "1.5"). */
+    amount: z.optional(z.string()),
+    /**
+     * Fee payer override. `false` to disable the wallet's default fee
+     * payer, a URL string to use a custom fee payer service.
+     */
+    feePayer: z.optional(z.union([z.boolean(), z.string()])),
+    /** Token contract address to pre-fill. Omit to let the user choose. */
+    token: z.optional(u.address()),
+    /** Zone id to deposit into. */
+    zoneId: z.optional(u.number()),
+  })
+
+  export const schema = Schema.defineItem({
+    method: z.literal('wallet_depositZone'),
+    params: z.optional(z.readonly(z.tuple([parameters]))),
+    returns: z.object({
+      /** Receipt of the submitted deposit. */
+      receipt,
+    }),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
+/** Opens the wallet zone-withdraw flow with optional pre-filled fields. */
+export namespace wallet_withdrawZone {
+  /** Parameters object for `wallet_withdrawZone`. */
+  export const parameters = z.object({
+    /** Human-readable amount to pre-fill (e.g. "1.5"). */
+    amount: z.optional(z.string()),
+    /** Token contract address to pre-fill. Omit to let the user choose. */
+    token: z.optional(u.address()),
+    /** Zone id to withdraw from. */
+    zoneId: z.optional(u.number()),
+  })
+
+  export const schema = Schema.defineItem({
+    method: z.literal('wallet_withdrawZone'),
+    params: z.optional(z.readonly(z.tuple([parameters]))),
+    returns: z.object({
+      /** Receipt of the submitted withdrawal. */
+      receipt,
+    }),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
 /** Strict parameter schemas keyed by method name. */
 export const strictParameters = {
   wallet_authorizeAccessKey: wallet_authorizeAccessKey_strict.parameters,


### PR DESCRIPTION
Added `wallet_depositZone` and `wallet_withdrawZone` RPC methods for moving funds between the parent Tempo chain and a private zone.

Wired through Provider, Adapter, dialog adapter, and Schema. Updated the web playground to demo both flows.