### PR TITLE
feat: include receipts in wallet_deposit RPC response

### DIFF
--- a/.changeset/wallet-deposit-receipts.md
+++ b/.changeset/wallet-deposit-receipts.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `receipts` to the `wallet_deposit` RPC response.

--- a/.changeset/wallet-zone-rpc-methods.md
+++ b/.changeset/wallet-zone-rpc-methods.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added `wallet_depositZone` and `wallet_withdrawZone` RPC methods for moving funds between the parent Tempo chain and a private zone.

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -610,7 +610,16 @@ export namespace wallet_deposit {
         }),
       ]),
     ),
-    returns: z.void(),
+    returns: z.optional(
+      z.object({
+        /**
+         * Receipts of any onchain operations performed during the
+         * deposit (e.g. testnet faucet drops). Absent for offchain
+         * paths like Apple Pay where funds arrive asynchronously.
+         */
+        receipts: z.optional(z.readonly(z.array(receipt))),
+      }),
+    ),
   })
   export type Encoded = Schema.Encoded<typeof schema>
   export type Decoded = Schema.Decoded<typeof schema>


### PR DESCRIPTION
Adds an optional `receipts` field to the `wallet_deposit` RPC return type so callers can optimistically apply on-chain deposits (e.g. testnet faucet drops) before the indexer catches up.

Off-chain paths (Apple Pay, referral codes) leave `receipts` undefined.