### PR TITLE
refactor: map remote themes to Regen

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1725,38 +1725,25 @@ function OcclusionSimulator() {
   )
 }
 
-const accentOptions = ['', 'invert', 'blue', 'red', 'amber', 'green', 'purple'] as const
+const accentOptions = ['', 'neutral', 'blue', 'red', 'amber', 'green', 'purple'] as const
 const radiusOptions = ['', 'none', 'small', 'medium', 'large', 'full'] as const
-const fontOptions = [
-  '',
-  'System',
-  'Pilat',
-  'TT Norms',
-  'Inter',
-  'DM Sans',
-  'Geist',
-  'Outfit',
-] as const
 const schemeOptions = ['', 'light', 'dark'] as const
 
 function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) {
   const [accent, setAccent] = useState(theme?.accent ?? '')
   const [radius, setRadius] = useState(theme?.radius ?? '')
-  const [font, setFont] = useState(theme?.font ?? '')
   const [scheme, setScheme] = useState(theme?.scheme ?? '')
   const [customAccent, setCustomAccent] = useState('#6366f1')
 
-  function apply(next: { accent?: string; radius?: string; font?: string; scheme?: string }) {
+  function apply(next: { accent?: string; radius?: string; scheme?: string }) {
     const a = next.accent ?? accent
     const r = next.radius ?? radius
-    const f = next.font ?? font
     const s = next.scheme ?? scheme
     const t =
-      a || r || f || s
+      a || r || s
         ? {
             accent: a || undefined,
             radius: (r || undefined) as never,
-            font: f || undefined,
             scheme: (s || undefined) as never,
           }
         : undefined
@@ -1801,22 +1788,6 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
           }}
         >
           {radiusOptions.map((v) => (
-            <option key={v} value={v}>
-              {v || '(default)'}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <label>Font</label>
-        <select
-          value={font}
-          onChange={(e) => {
-            setFont(e.target.value)
-            apply({ font: e.target.value })
-          }}
-        >
-          {fontOptions.map((v) => (
             <option key={v} value={v}>
               {v || '(default)'}
             </option>

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -49,7 +49,6 @@ export type Theme = {
     | 'amber'
     | 'green'
     | 'purple'
-    | 'invert'
     | (string & {})
     | undefined
   /** Border radius preset. */

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -41,12 +41,19 @@ export declare namespace SetupFn {
 
 /** Visual theme configuration for the dialog embed. */
 export type Theme = {
-  /** Accent color — a preset name or a hex color (e.g. `'#6366f1'`). */
-  accent?: 'blue' | 'red' | 'amber' | 'green' | 'purple' | 'invert' | (string & {}) | undefined
+  /** Accent color — a Regen preset name or a hex color (e.g. `'#6366f1'`). */
+  accent?:
+    | 'neutral'
+    | 'blue'
+    | 'red'
+    | 'amber'
+    | 'green'
+    | 'purple'
+    | 'invert'
+    | (string & {})
+    | undefined
   /** Border radius preset. */
   radius?: 'none' | 'small' | 'medium' | 'large' | 'full' | undefined
-  /** Font family — a bundled name (`'Pilat'`, `'TT Norms'`) or a Google Font. */
-  font?: string | undefined
   /** Color scheme — controls light/dark appearance. Defaults to `'light dark'` (follows OS). */
   scheme?: 'light' | 'dark' | undefined
 }
@@ -56,7 +63,6 @@ function applyThemeParams(url: URL, theme: Theme | undefined) {
   if (!theme) return
   if (theme.accent) url.searchParams.set('accent', theme.accent)
   if (theme.radius) url.searchParams.set('radius', theme.radius)
-  if (theme.font) url.searchParams.set('font', theme.font)
   if (theme.scheme) url.searchParams.set('scheme', theme.scheme)
 }
 

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -73,7 +73,6 @@ export type Schema = [
     payload: {
       accent?: string | undefined
       radius?: string | undefined
-      font?: string | undefined
     }
   },
 ]

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -79,28 +79,32 @@ export function useState(
   return useStore(remote.store, selector as never)
 }
 
-const bundledFonts = new Set(['Pilat', 'TT Norms', 'iA Writer Quattro'])
-
 /** Applies theme overrides from URL search params and live messenger updates. */
 export function useTheme(remote?: CoreRemote.Remote | undefined) {
+  const snapshot = useRef<ThemeSnapshot | undefined>(undefined)
+
   useEffect(() => {
     if (typeof window === 'undefined') return
 
+    snapshot.current = captureTheme()
     const params = new URLSearchParams(window.location.search)
+    restoreTheme(snapshot.current)
     applyTheme({
       accent: params.get('accent') ?? undefined,
       radius: params.get('radius') ?? undefined,
-      font: params.get('font') ?? undefined,
       scheme: params.get('scheme') ?? undefined,
     })
 
-    return () => clearTheme()
+    return () => {
+      if (snapshot.current) restoreTheme(snapshot.current)
+      snapshot.current = undefined
+    }
   }, [])
 
   useEffect(() => {
     if (!remote) return
     return remote.messenger.on('theme', (payload) => {
-      clearTheme()
+      if (snapshot.current) restoreTheme(snapshot.current)
       applyTheme(payload)
     })
   }, [remote])
@@ -110,48 +114,66 @@ export function useTheme(remote?: CoreRemote.Remote | undefined) {
 function applyTheme(theme: {
   accent?: string | undefined
   radius?: string | undefined
-  font?: string | undefined
   scheme?: string | undefined
 }) {
   const root = document.documentElement
-  const { accent, radius, font, scheme } = theme
+  const { accent, radius, scheme } = theme
 
   if (accent) {
-    const isHex = accent.startsWith('#')
-    root.setAttribute('data-accent', isHex ? 'custom' : accent)
-    if (isHex) root.style.setProperty('--accent-base', accent)
+    root.removeAttribute('data-regen-color')
+    root.style.removeProperty('--regen-accent')
+    root.style.setProperty('--regen-accent', getAccentValue(accent))
   }
   if (scheme) root.style.colorScheme = scheme
-  if (radius) root.setAttribute('data-radius', radius)
-  if (font) {
-    root.setAttribute('data-font', font === 'System' ? 'system' : font)
-    if (font === 'System') {
-      root.style.setProperty('--font-body', 'ui-sans-serif, system-ui, sans-serif')
-      return
-    }
-    if (!bundledFonts.has(font)) {
-      const id = `gf-${font.replace(/\s/g, '-')}`
-      if (!document.getElementById(id)) {
-        const link = document.createElement('link')
-        link.id = id
-        link.rel = 'stylesheet'
-        link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(font)}:wght@400;500;600&display=swap`
-        document.head.appendChild(link)
-      }
-    }
-    root.style.setProperty('--font-body', `'${font}', sans-serif`)
+  if (radius) root.setAttribute('data-regen-radius', radius)
+}
+
+function captureTheme(): ThemeSnapshot {
+  const root = document.documentElement
+  return {
+    accent: root.style.getPropertyValue('--regen-accent'),
+    color: root.getAttribute('data-regen-color'),
+    colorScheme: root.style.colorScheme,
+    radius: root.getAttribute('data-regen-radius'),
   }
 }
 
-/** Removes all theme overrides from the document root. */
-function clearTheme() {
+function restoreTheme(snapshot: ThemeSnapshot) {
   const root = document.documentElement
-  root.removeAttribute('data-accent')
-  root.removeAttribute('data-radius')
-  root.removeAttribute('data-font')
-  root.style.removeProperty('color-scheme')
-  root.style.removeProperty('--accent-base')
-  root.style.removeProperty('--font-body')
+  restoreAttribute(root, 'data-regen-color', snapshot.color)
+  restoreAttribute(root, 'data-regen-radius', snapshot.radius)
+  if (snapshot.accent) root.style.setProperty('--regen-accent', snapshot.accent)
+  else root.style.removeProperty('--regen-accent')
+  root.style.colorScheme = snapshot.colorScheme
+}
+
+function restoreAttribute(element: HTMLElement, name: string, value: string | null) {
+  if (value === null) element.removeAttribute(name)
+  else element.setAttribute(name, value)
+}
+
+function getAccentValue(accent: string) {
+  if (accent === 'invert') return 'var(--regen-accent-neutral)'
+  if (isAccentPreset(accent)) return `var(--regen-accent-${accent})`
+  return accent
+}
+
+function isAccentPreset(accent: string) {
+  return (
+    accent === 'neutral' ||
+    accent === 'blue' ||
+    accent === 'red' ||
+    accent === 'amber' ||
+    accent === 'green' ||
+    accent === 'purple'
+  )
+}
+
+type ThemeSnapshot = {
+  accent: string
+  color: string | null
+  colorScheme: string
+  radius: string | null
 }
 
 export declare namespace useEnsureVisibility {

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -120,7 +120,6 @@ function applyTheme(theme: {
   const { accent, radius, scheme } = theme
 
   if (accent) {
-    root.removeAttribute('data-regen-color')
     root.style.removeProperty('--regen-accent')
     root.style.setProperty('--regen-accent', getAccentValue(accent))
   }
@@ -132,7 +131,6 @@ function captureTheme(): ThemeSnapshot {
   const root = document.documentElement
   return {
     accent: root.style.getPropertyValue('--regen-accent'),
-    color: root.getAttribute('data-regen-color'),
     colorScheme: root.style.colorScheme,
     radius: root.getAttribute('data-regen-radius'),
   }
@@ -140,7 +138,6 @@ function captureTheme(): ThemeSnapshot {
 
 function restoreTheme(snapshot: ThemeSnapshot) {
   const root = document.documentElement
-  restoreAttribute(root, 'data-regen-color', snapshot.color)
   restoreAttribute(root, 'data-regen-radius', snapshot.radius)
   if (snapshot.accent) root.style.setProperty('--regen-accent', snapshot.accent)
   else root.style.removeProperty('--regen-accent')
@@ -153,7 +150,6 @@ function restoreAttribute(element: HTMLElement, name: string, value: string | nu
 }
 
 function getAccentValue(accent: string) {
-  if (accent === 'invert') return 'var(--regen-accent-neutral)'
   if (isAccentPreset(accent)) return `var(--regen-accent-${accent})`
   return accent
 }
@@ -171,7 +167,6 @@ function isAccentPreset(accent: string) {
 
 type ThemeSnapshot = {
   accent: string
-  color: string | null
   colorScheme: string
   radius: string | null
 }


### PR DESCRIPTION
Map remote wallet theme overrides to Regen's current accent and radius contract.

Remove the old remote font theme path now that wallet typography is owned by Regen.