### PR TITLE
revert: undo Regen remote theme mapping

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1815,25 +1815,38 @@ function OcclusionSimulator() {
   )
 }
 
-const accentOptions = ['', 'neutral', 'blue', 'red', 'amber', 'green', 'purple'] as const
+const accentOptions = ['', 'invert', 'blue', 'red', 'amber', 'green', 'purple'] as const
 const radiusOptions = ['', 'none', 'small', 'medium', 'large', 'full'] as const
+const fontOptions = [
+  '',
+  'System',
+  'Pilat',
+  'TT Norms',
+  'Inter',
+  'DM Sans',
+  'Geist',
+  'Outfit',
+] as const
 const schemeOptions = ['', 'light', 'dark'] as const
 
 function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) {
   const [accent, setAccent] = useState(theme?.accent ?? '')
   const [radius, setRadius] = useState(theme?.radius ?? '')
+  const [font, setFont] = useState(theme?.font ?? '')
   const [scheme, setScheme] = useState(theme?.scheme ?? '')
   const [customAccent, setCustomAccent] = useState('#6366f1')
 
-  function apply(next: { accent?: string; radius?: string; scheme?: string }) {
+  function apply(next: { accent?: string; radius?: string; font?: string; scheme?: string }) {
     const a = next.accent ?? accent
     const r = next.radius ?? radius
+    const f = next.font ?? font
     const s = next.scheme ?? scheme
     const t =
-      a || r || s
+      a || r || f || s
         ? {
             accent: a || undefined,
             radius: (r || undefined) as never,
+            font: f || undefined,
             scheme: (s || undefined) as never,
           }
         : undefined
@@ -1878,6 +1891,22 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
           }}
         >
           {radiusOptions.map((v) => (
+            <option key={v} value={v}>
+              {v || '(default)'}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <label>Font</label>
+        <select
+          value={font}
+          onChange={(e) => {
+            setFont(e.target.value)
+            apply({ font: e.target.value })
+          }}
+        >
+          {fontOptions.map((v) => (
             <option key={v} value={v}>
               {v || '(default)'}
             </option>

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -41,18 +41,12 @@ export declare namespace SetupFn {
 
 /** Visual theme configuration for the dialog embed. */
 export type Theme = {
-  /** Accent color — a Regen preset name or a hex color (e.g. `'#6366f1'`). */
-  accent?:
-    | 'neutral'
-    | 'blue'
-    | 'red'
-    | 'amber'
-    | 'green'
-    | 'purple'
-    | (string & {})
-    | undefined
+  /** Accent color — a preset name or a hex color (e.g. `'#6366f1'`). */
+  accent?: 'blue' | 'red' | 'amber' | 'green' | 'purple' | 'invert' | (string & {}) | undefined
   /** Border radius preset. */
   radius?: 'none' | 'small' | 'medium' | 'large' | 'full' | undefined
+  /** Font family — a bundled name (`'Pilat'`, `'TT Norms'`) or a Google Font. */
+  font?: string | undefined
   /** Color scheme — controls light/dark appearance. Defaults to `'light dark'` (follows OS). */
   scheme?: 'light' | 'dark' | undefined
 }
@@ -62,6 +56,7 @@ function applyThemeParams(url: URL, theme: Theme | undefined) {
   if (!theme) return
   if (theme.accent) url.searchParams.set('accent', theme.accent)
   if (theme.radius) url.searchParams.set('radius', theme.radius)
+  if (theme.font) url.searchParams.set('font', theme.font)
   if (theme.scheme) url.searchParams.set('scheme', theme.scheme)
 }
 

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -73,6 +73,7 @@ export type Schema = [
     payload: {
       accent?: string | undefined
       radius?: string | undefined
+      font?: string | undefined
     }
   },
 ]

--- a/src/react/Remote.ts
+++ b/src/react/Remote.ts
@@ -79,32 +79,28 @@ export function useState(
   return useStore(remote.store, selector as never)
 }
 
+const bundledFonts = new Set(['Pilat', 'TT Norms', 'iA Writer Quattro'])
+
 /** Applies theme overrides from URL search params and live messenger updates. */
 export function useTheme(remote?: CoreRemote.Remote | undefined) {
-  const snapshot = useRef<ThemeSnapshot | undefined>(undefined)
-
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    snapshot.current = captureTheme()
     const params = new URLSearchParams(window.location.search)
-    restoreTheme(snapshot.current)
     applyTheme({
       accent: params.get('accent') ?? undefined,
       radius: params.get('radius') ?? undefined,
+      font: params.get('font') ?? undefined,
       scheme: params.get('scheme') ?? undefined,
     })
 
-    return () => {
-      if (snapshot.current) restoreTheme(snapshot.current)
-      snapshot.current = undefined
-    }
+    return () => clearTheme()
   }, [])
 
   useEffect(() => {
     if (!remote) return
     return remote.messenger.on('theme', (payload) => {
-      if (snapshot.current) restoreTheme(snapshot.current)
+      clearTheme()
       applyTheme(payload)
     })
   }, [remote])
@@ -114,61 +110,48 @@ export function useTheme(remote?: CoreRemote.Remote | undefined) {
 function applyTheme(theme: {
   accent?: string | undefined
   radius?: string | undefined
+  font?: string | undefined
   scheme?: string | undefined
 }) {
   const root = document.documentElement
-  const { accent, radius, scheme } = theme
+  const { accent, radius, font, scheme } = theme
 
   if (accent) {
-    root.style.removeProperty('--regen-accent')
-    root.style.setProperty('--regen-accent', getAccentValue(accent))
+    const isHex = accent.startsWith('#')
+    root.setAttribute('data-accent', isHex ? 'custom' : accent)
+    if (isHex) root.style.setProperty('--accent-base', accent)
   }
   if (scheme) root.style.colorScheme = scheme
-  if (radius) root.setAttribute('data-regen-radius', radius)
-}
-
-function captureTheme(): ThemeSnapshot {
-  const root = document.documentElement
-  return {
-    accent: root.style.getPropertyValue('--regen-accent'),
-    colorScheme: root.style.colorScheme,
-    radius: root.getAttribute('data-regen-radius'),
+  if (radius) root.setAttribute('data-radius', radius)
+  if (font) {
+    root.setAttribute('data-font', font === 'System' ? 'system' : font)
+    if (font === 'System') {
+      root.style.setProperty('--font-body', 'ui-sans-serif, system-ui, sans-serif')
+      return
+    }
+    if (!bundledFonts.has(font)) {
+      const id = `gf-${font.replace(/\s/g, '-')}`
+      if (!document.getElementById(id)) {
+        const link = document.createElement('link')
+        link.id = id
+        link.rel = 'stylesheet'
+        link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(font)}:wght@400;500;600&display=swap`
+        document.head.appendChild(link)
+      }
+    }
+    root.style.setProperty('--font-body', `'${font}', sans-serif`)
   }
 }
 
-function restoreTheme(snapshot: ThemeSnapshot) {
+/** Removes all theme overrides from the document root. */
+function clearTheme() {
   const root = document.documentElement
-  restoreAttribute(root, 'data-regen-radius', snapshot.radius)
-  if (snapshot.accent) root.style.setProperty('--regen-accent', snapshot.accent)
-  else root.style.removeProperty('--regen-accent')
-  root.style.colorScheme = snapshot.colorScheme
-}
-
-function restoreAttribute(element: HTMLElement, name: string, value: string | null) {
-  if (value === null) element.removeAttribute(name)
-  else element.setAttribute(name, value)
-}
-
-function getAccentValue(accent: string) {
-  if (isAccentPreset(accent)) return `var(--regen-accent-${accent})`
-  return accent
-}
-
-function isAccentPreset(accent: string) {
-  return (
-    accent === 'neutral' ||
-    accent === 'blue' ||
-    accent === 'red' ||
-    accent === 'amber' ||
-    accent === 'green' ||
-    accent === 'purple'
-  )
-}
-
-type ThemeSnapshot = {
-  accent: string
-  colorScheme: string
-  radius: string | null
+  root.removeAttribute('data-accent')
+  root.removeAttribute('data-radius')
+  root.removeAttribute('data-font')
+  root.style.removeProperty('color-scheme')
+  root.style.removeProperty('--accent-base')
+  root.style.removeProperty('--font-body')
 }
 
 export declare namespace useEnsureVisibility {


### PR DESCRIPTION
Reverts the merged Regen remote theme mapping from #308 (agent got too enthusiastic).