### PR TITLE
fix: treat undefined as no-value in Storage.combine reads

### DIFF
--- a/.changeset/storage-combine-undefined.md
+++ b/.changeset/storage-combine-undefined.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Treated `undefined` as "no value" in `Storage.combine` reads so adapters that return `undefined` for missing keys (Map-backed, custom caches) fell through to the next adapter instead of short-circuiting.

--- a/src/core/Storage.ts
+++ b/src/core/Storage.ts
@@ -37,7 +37,7 @@ export function combine(...storages: readonly Storage[]): Storage {
   return {
     async getItem<value>(name: string) {
       const results = await Promise.allSettled(storages.map((x) => x.getItem<value>(name)))
-      const result = results.find((x) => x.status === 'fulfilled' && x.value !== null)
+      const result = results.find((x) => x.status === 'fulfilled' && x.value != null)
       if (result?.status !== 'fulfilled') return null
       return result.value as value
     },


### PR DESCRIPTION
## Problem

`Storage.combine` returned the first `fulfilled && value !== null` result. Adapters that return `undefined` for missing keys (Map-backed in-memory stores, custom cache layers, anything wrapping an external store that uses `undefined` instead of `null`) caused `combine` to short-circuit on a non-existent value instead of falling through to the next adapter.

## Fix

Used loose-equality `!= null` so both `null` and `undefined` were treated as "no value", and `combine` continued to the next storage in those cases.