### PR TITLE
refactor: unify tokenlist resolver across Handler.relay and Handler.exchange

### DIFF
--- a/src/server/internal/handlers/exchange.ts
+++ b/src/server/internal/handlers/exchange.ts
@@ -19,6 +19,7 @@ import { type Handler, from } from '../../Handler.js'
 import * as Kv from '../../Kv.js'
 import * as Hono from '../hono.js'
 import { cached } from '../kv.js'
+import * as Tokenlist from '../tokenlist.js'
 
 /** Default cache TTL in seconds (10 minutes). */
 const defaultCacheTtl = 10 * 60
@@ -144,10 +145,13 @@ export function exchange<const path extends string = '/exchange'>(
     kv = Kv.memory(),
     onRequest,
     path = '/exchange' as path,
-    resolveTokens = defaultResolveTokens,
+    resolveTokens,
     transports = {},
     ...rest
   } = options
+
+  const getTokens = (chainId: number) =>
+    Tokenlist.fetch(chainId, kv, { cacheTtl, resolver: resolveTokens })
 
   const clients = new Map<number, Client>()
   for (const chain of chains) {
@@ -170,12 +174,7 @@ export function exchange<const path extends string = '/exchange'>(
         const chain = chains.find((c) => c.id === chainId)
         if (!chain) throw new Error(`Chain ${chainId} is not supported.`)
 
-        const tokens = await cached(
-          kv,
-          `tokenlist:${chain.id}`,
-          async () => resolveTokens(chain.id),
-          { ttl: cacheTtl },
-        )
+        const tokens = await getTokens(chain.id)
 
         // Cache for `cacheTtl` and allow stale-while-revalidate for an
         // additional full TTL window so CDNs/browsers can serve immediately
@@ -202,12 +201,7 @@ export function exchange<const path extends string = '/exchange'>(
         const client = clients.get(chain.id)!
 
         // Resolve `token` and `pairToken` to addresses + metadata in parallel.
-        const tokens = await cached(
-          kv,
-          `tokenlist:${chain.id}`,
-          async () => resolveTokens(chain.id),
-          { ttl: cacheTtl },
-        )
+        const tokens = await getTokens(chain.id)
         const [tokenInfo, pairTokenInfo] = await Promise.all([
           resolveToken(client, { kv, ref: token, tokens }),
           resolveToken(client, { kv, ref: pairToken, tokens }),
@@ -477,22 +471,4 @@ function applySlippage(amount: bigint, slippage: number, dir: 'up' | 'down') {
 
 function toCall(call: { data: Hex.Hex; to: Address }) {
   return { data: call.data, to: call.to }
-}
-
-/**
- * Default `resolveTokens` implementation. Fetches the verified token list for
- * `chainId` from `https://tokenlist.tempo.xyz/list/:chainId`. Returns an empty
- * list on any non-OK response.
- */
-async function defaultResolveTokens(chainId: number): Promise<readonly Token[]> {
-  // TODO: deprecate tokenlist.tempo.xyz when TIP-1026 enshrined.
-  const response = await fetch(`https://tokenlist.tempo.xyz/list/${chainId}`)
-  if (!response.ok) return []
-  const data = (await response.json()) as {
-    tokens: readonly (Token & { logoURI?: string })[]
-  }
-  return data.tokens.map(({ logoURI, ...token }) => ({
-    ...token,
-    logoUri: token.logoUri ?? logoURI,
-  }))
 }

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -14,6 +14,18 @@ const userAccount = accounts[9]!
 const feePayerAccount = accounts[0]!
 const recipient = accounts[7]!
 
+/**
+ * Tokens the relay handler probes for fee-token resolution. The default
+ * `resolveTokens` fetches `tokenlist.tempo.xyz`, which doesn't know about
+ * the localnet chain — so tests inject this list explicitly.
+ */
+const localnetTokens = [
+  { address: '0x20c0000000000000000000000000000000000000', decimals: 6, name: 'pathUSD', symbol: 'pathUSD' },
+  { address: '0x20c0000000000000000000000000000000000001', decimals: 6, name: 'alphaUSD', symbol: 'alphaUSD' },
+  { address: '0x20c0000000000000000000000000000000000002', decimals: 6, name: 'betaUSD', symbol: 'betaUSD' },
+  { address: '0x20c0000000000000000000000000000000000003', decimals: 6, name: 'thetaUSD', symbol: 'thetaUSD' },
+] as const
+
 /** Case-insensitive lookup into balanceDiffs keyed by address. */
 function findDiffs(
   balanceDiffs: Capabilities.FillTransactionCapabilities['balanceDiffs'],
@@ -1110,6 +1122,7 @@ describe('behavior: path A — guaranteed sponsorship (no validate)', () => {
       relay({
         chains: [chain],
         features: 'all',
+        resolveTokens: () => localnetTokens,
         transports: { [chain.id]: http() },
         feePayer: {
           account: feePayerAccount,
@@ -1335,6 +1348,7 @@ describe('behavior: fee token resolution', () => {
       relay({
         chains: [chain],
         features: 'all',
+        resolveTokens: () => localnetTokens,
         transports: { [chain.id]: http() },
       }).listener,
     )
@@ -1366,30 +1380,62 @@ describe('behavior: fee token resolution', () => {
   })
 
   test('behavior: resolves to highest-balance token from token list', async () => {
-    // Mint different amounts of two tokens to a fresh account.
+    // Create a fresh TIP20 token "betaUsd" so we can test highest-balance
+    // selection without depending on a pre-deployed second token.
     const freshAccount = accounts[5]!
-    const betaUsd = '0x20c0000000000000000000000000000000000002'
-    const rpc = getClient()
-    await Actions.token.mintSync(rpc, {
-      account: accounts[0]!,
-      token: addresses.alphaUsd,
-      amount: 100n,
-      to: freshAccount.address,
+    const rpc = getClient({ account: accounts[0]! })
+    const { token: betaUsd } = await Actions.token.createSync(rpc, {
+      name: 'BetaUSD',
+      symbol: 'BetaUSD',
+      currency: 'USD',
+      quoteToken: addresses.alphaUsd,
     })
-    await Actions.token.mintSync(rpc, {
-      account: accounts[0]!,
-      token: betaUsd,
-      amount: 500n,
-      to: freshAccount.address,
+    await sendTransactionSync(rpc, {
+      calls: [
+        Actions.token.grantRoles.call({
+          token: betaUsd,
+          role: 'issuer',
+          to: rpc.account!.address,
+        }),
+        // Mint different amounts of two tokens to a fresh account. Amounts
+        // must be large enough to cover gas, otherwise autoSwap fires.
+        Actions.token.mint.call({
+          token: addresses.alphaUsd,
+          amount: parseUnits('100', 6),
+          to: freshAccount.address,
+        }),
+        Actions.token.mint.call({
+          token: betaUsd,
+          amount: parseUnits('500', 6),
+          to: freshAccount.address,
+        }),
+      ],
     })
 
-    const { transaction } = await fillTransaction(client, {
+    // Spin up a relay whose tokenlist includes the freshly created betaUsd
+    // alongside the localnet defaults so the highest-balance resolver can
+    // see both.
+    const customServer = await createServer(
+      relay({
+        chains: [chain],
+        features: 'all',
+        resolveTokens: () => [
+          ...localnetTokens,
+          { address: betaUsd, decimals: 6, name: 'BetaUSD', symbol: 'BetaUSD' },
+        ],
+        transports: { [chain.id]: http() },
+      }).listener,
+    )
+    const customClient = getClient({ transport: http(customServer.url) })
+
+    const { transaction } = await fillTransaction(customClient, {
       account: freshAccount.address,
       calls: [transferCall()],
     })
+    customServer.close()
 
     // betaUsd has higher balance (500 > 100).
-    expect(transaction.feeToken).toBe(betaUsd)
+    expect(transaction.feeToken?.toLowerCase()).toBe(betaUsd.toLowerCase())
   })
 
   test('behavior: falls back to pathUSD when no preference or balances', async () => {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -15,14 +15,19 @@ import {
 } from 'viem'
 import type { LocalAccount } from 'viem/accounts'
 import { simulateCalls } from 'viem/actions'
-import { tempo, tempoDevnet, tempoLocalnet, tempoMainnet, tempoModerato } from 'viem/chains'
+import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import { Abis, Actions, Addresses, Capabilities, Transaction } from 'viem/tempo'
 
 import * as ExecutionError from '../../../core/ExecutionError.js'
 import * as Schema from '../../../core/Schema.js'
 import { type Handler, from } from '../../Handler.js'
+import * as Kv from '../../Kv.js'
+import * as Tokenlist from '../tokenlist.js'
 import * as Sponsorship from './sponsorship.js'
 import * as Utils from './utils.js'
+
+/** Default cache TTL in seconds (10 minutes) for the verified tokenlist. */
+const defaultCacheTtl = 10 * 60
 
 /**
  * Instantiates a relay handler that proxies `eth_fillTransaction`
@@ -64,15 +69,24 @@ import * as Utils from './utils.js'
  */
 export function relay(options: relay.Options = {}): Handler {
   const {
+    cacheTtl = defaultCacheTtl,
     chains = [tempo, tempoModerato, tempoDevnet],
+    kv = Kv.memory(),
     onRequest,
     path = '/',
-    resolveTokens = (chainId) =>
-      relay.defaultTokens[chainId as keyof typeof relay.defaultTokens] ?? [],
+    resolveTokens,
     transports = {},
     ...rest
   } = options
   const feePayerOptions = options.feePayer
+
+  // Resolves the verified tokenlist for `chainId`, sharing the KV cache with
+  // `Handler.exchange` so a single `kv: Kv.cloudflare(env.KV)` covers both.
+  // The relay only needs addresses, so map down from the full metadata.
+  const getTokens = async (chainId: number): Promise<readonly Address[]> => {
+    const tokens = await Tokenlist.fetch(chainId, kv, { cacheTtl, resolver: resolveTokens })
+    return tokens.map((t) => t.address)
+  }
 
   const features = {
     autoSwap: options.autoSwap ?? options.features === 'all',
@@ -149,11 +163,11 @@ export function relay(options: relay.Options = {}): Handler {
 
           // Lazily resolve a swap source token when autoSwap needs one.
           const resolveFeeTokenForSwap = from
-            ? (insufficientToken: Address) =>
+            ? async (insufficientToken: Address) =>
                 resolveFeeToken(client, {
                   account: from,
                   feeToken: undefined,
-                  tokens: (resolveTokens(chainId) ?? []).filter(
+                  tokens: (await getTokens(chainId)).filter(
                     (t) => t.toLowerCase() !== insufficientToken.toLowerCase(),
                   ),
                 })
@@ -164,7 +178,7 @@ export function relay(options: relay.Options = {}): Handler {
           // the transaction is calling — typically the token being
           // transferred — so a user transferring USDC.e can pay gas in
           // USDC.e even when the configured list defaults to pathUSD.
-          const configuredTokens = resolveTokens(chainId)
+          const configuredTokens = await getTokens(chainId)
           const unsponsoredTokens = [
             ...configuredTokens,
             ...callTargetTokens(baseTx).filter(
@@ -273,7 +287,8 @@ export function relay(options: relay.Options = {}): Handler {
           const swap = 'swap' in filled ? filled.swap : undefined
           if (!feeToken)
             feeToken =
-              (transaction_filled.feeToken as Address | undefined) ?? resolveTokens(chainId)?.[0]
+              (transaction_filled.feeToken as Address | undefined) ??
+              (await getTokens(chainId))[0]
 
           // Parallelize: simulate, fee payer signing, and autoSwap metadata.
           const alreadySigned =
@@ -478,45 +493,6 @@ export function relay(options: relay.Options = {}): Handler {
 }
 
 export namespace relay {
-  /** Default token lists per chain ID for fee token resolution. */
-  // TODO: extract from tokenlist workspace.
-  export const defaultTokens = {
-    [tempoMainnet.id]: [
-      '0x20c0000000000000000000000000000000000000', // pathUSD
-      '0x20c000000000000000000000b9537d11c60e8b50', // USDC.e
-      '0x20c0000000000000000000001621e21f71cf12fb', // EURC.e
-      '0x20c00000000000000000000014f22ca97301eb73', // USDT0
-      '0x20c0000000000000000000003554d28269e0f3c2', // frxUSD
-      '0x20c0000000000000000000000520792dcccccccc', // cUSD
-      '0x20c0000000000000000000008ee4fcff88888888', // stcUSD
-      '0x20c0000000000000000000005c0bac7cef389a11', // GUSD
-      '0x20c0000000000000000000007f7ba549dd0251b9', // rUSD
-      '0x20c000000000000000000000aeed2ec36a54d0e5', // wsrUSD
-      '0x20c0000000000000000000009a4a4b17e0dc6651', // EURAU
-      '0x20c000000000000000000000383a23bacb546ab9', // reUSD
-    ],
-    [tempoModerato.id]: [
-      '0x20c0000000000000000000000000000000000000', // pathUSD
-      '0x20c0000000000000000000000000000000000001', // alphaUSD
-      '0x20c0000000000000000000000000000000000002', // betaUSD
-      '0x20c0000000000000000000000000000000000003', // thetaUSD
-      '0x20c0000000000000000000009e8d7eb59b783726', // USDC.e
-      '0x20c000000000000000000000d72572838bbee59c', // EURC.e
-    ],
-    [tempoDevnet.id]: [
-      '0x20c0000000000000000000000000000000000000', // pathUSD
-      '0x20c0000000000000000000000000000000000001', // alphaUSD
-      '0x20c0000000000000000000000000000000000002', // betaUSD
-      '0x20c0000000000000000000000000000000000003', // thetaUSD
-    ],
-    [tempoLocalnet.id]: [
-      '0x20c0000000000000000000000000000000000000', // pathUSD
-      '0x20c0000000000000000000000000000000000001', // alphaUSD
-      '0x20c0000000000000000000000000000000000002', // betaUSD
-      '0x20c0000000000000000000000000000000000003', // thetaUSD
-    ],
-  } as const
-
   export type Options = from.Options & {
     /**
      * Auto-swap options.
@@ -528,6 +504,11 @@ export namespace relay {
           slippage?: number | undefined
         }
       | undefined
+    /**
+     * TTL in seconds for cached `resolveTokens` results.
+     * @default 600 (10 minutes)
+     */
+    cacheTtl?: number | undefined
     /**
      * Supported chains. The handler resolves the client based on the
      * `chainId` in the incoming transaction.
@@ -556,11 +537,21 @@ export namespace relay {
         }
       | undefined
     /**
-     * Returns token addresses to check balances for during fee token resolution.
-     * The relay checks `balanceOf` for each token and picks the one with the
-     * highest balance.
+     * Kv store used to cache `resolveTokens` results across requests.
+     * Provide `Kv.cloudflare(env.KV)` for cross-instance caching, or omit
+     * for an in-process LRU.
+     * @default Kv.memory()
      */
-    resolveTokens?: ((chainId?: number | undefined) => readonly Address[]) | undefined
+    kv?: Kv.Kv | undefined
+    /**
+     * Resolves the list of known tokens for a chain. The relay checks
+     * `balanceOf` for each token and picks the one with the highest balance
+     * during fee token resolution.
+     * @default Fetches `https://tokenlist.tempo.xyz/list/:chainId`
+     */
+    resolveTokens?:
+      | ((chainId: number) => readonly Tokenlist.Token[] | Promise<readonly Tokenlist.Token[]>)
+      | undefined
     /**
      * Relay features.
      *

--- a/src/server/internal/kv.test.ts
+++ b/src/server/internal/kv.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'vp/test'
+
+import * as Kv from '../Kv.js'
+import { cached } from './kv.js'
+
+/**
+ * Wraps a memory Kv and records the number of `get`/`set` calls per key —
+ * lets the tests below assert that L1 cache hits short-circuit L2 reads.
+ */
+function counting() {
+  const inner = Kv.memory()
+  const calls = { get: 0, set: 0 }
+  const kv: Kv.Kv = {
+    async get(key) {
+      calls.get++
+      return inner.get(key)
+    },
+    async set(key, value) {
+      calls.set++
+      return inner.set(key, value)
+    },
+    async delete(key) {
+      return inner.delete(key)
+    },
+  }
+  return { calls, kv }
+}
+
+describe('cached', () => {
+  test('behavior: caches the result of fn for the configured ttl', async () => {
+    const { calls, kv } = counting()
+    let invocations = 0
+    const fn = async () => ++invocations
+
+    expect(await cached(kv, 'k', fn, { ttl: 60 })).toBe(1)
+    expect(await cached(kv, 'k', fn, { ttl: 60 })).toBe(1)
+    expect(invocations).toBe(1)
+    // First call writes through to L2; subsequent reads stay in L1.
+    expect(calls.set).toBe(1)
+  })
+
+  test('behavior: re-fetches after the entry expires', async () => {
+    const { kv } = counting()
+    let invocations = 0
+    const fn = async () => ++invocations
+
+    // ttl: 0 expires immediately (Date.now() + 0 is not strictly >).
+    expect(await cached(kv, 'k', fn, { ttl: 0 })).toBe(1)
+    expect(await cached(kv, 'k', fn, { ttl: 0 })).toBe(2)
+    expect(invocations).toBe(2)
+  })
+
+  test('behavior: L1 cache short-circuits L2 reads', async () => {
+    const { calls, kv } = counting()
+    await cached(kv, 'k', async () => 1, { ttl: 60 })
+    expect(calls.get).toBe(1) // miss → reads L2 once
+    await cached(kv, 'k', async () => 2, { ttl: 60 })
+    await cached(kv, 'k', async () => 3, { ttl: 60 })
+    // Subsequent calls hit L1 — no extra L2 reads.
+    expect(calls.get).toBe(1)
+  })
+
+  test('behavior: coalesces concurrent calls for the same key', async () => {
+    const { kv } = counting()
+    let invocations = 0
+    const fn = async () => {
+      invocations++
+      // Force the second call to start before fn() resolves.
+      await new Promise((r) => setTimeout(r, 10))
+      return invocations
+    }
+
+    const [a, b, c] = await Promise.all([
+      cached(kv, 'k', fn, { ttl: 60 }),
+      cached(kv, 'k', fn, { ttl: 60 }),
+      cached(kv, 'k', fn, { ttl: 60 }),
+    ])
+
+    expect(invocations).toBe(1)
+    expect([a, b, c]).toEqual([1, 1, 1])
+  })
+
+  test('behavior: isolates L1 cache per kv instance', async () => {
+    const a = counting()
+    const b = counting()
+    let invocations = 0
+    const fn = async () => ++invocations
+
+    await cached(a.kv, 'k', fn, { ttl: 60 })
+    await cached(b.kv, 'k', fn, { ttl: 60 })
+    expect(invocations).toBe(2)
+  })
+
+  test('behavior: falls back to fn when L2 read throws', async () => {
+    const failing: Kv.Kv = {
+      async get() {
+        throw new Error('boom')
+      },
+      async set() {},
+      async delete() {},
+    }
+
+    expect(await cached(failing, 'k', async () => 'value', { ttl: 60 })).toBe('value')
+  })
+
+  test('behavior: does not throw when L2 write fails', async () => {
+    const failing: Kv.Kv = {
+      async get() {
+        return null as never
+      },
+      async set() {
+        throw new Error('boom')
+      },
+      async delete() {},
+    }
+
+    expect(await cached(failing, 'k', async () => 'value', { ttl: 60 })).toBe('value')
+  })
+
+  test('behavior: caches forever when ttl is omitted', async () => {
+    const { kv } = counting()
+    let invocations = 0
+    const fn = async () => ++invocations
+
+    expect(await cached(kv, 'k', fn)).toBe(1)
+    expect(await cached(kv, 'k', fn)).toBe(1)
+    expect(invocations).toBe(1)
+  })
+})

--- a/src/server/internal/kv.ts
+++ b/src/server/internal/kv.ts
@@ -1,10 +1,33 @@
 import type * as Kv from '../Kv.js'
 
+type Entry = { expiresAt: number; value: unknown }
+
 /**
- * Reads `key` from `kv`. If absent or expired, calls `fn`, stores the result
- * with a `Date.now() + ttl * 1000` expiry, and returns it. Defaults to
- * caching forever (no expiry). Kv read/write failures are swallowed so cache
- * misses never break the caller.
+ * Per-`kv`-instance in-memory L1 cache. Lives for the lifetime of the worker
+ * (or process) and short-circuits the L2 `kv.get` on hot keys so a request
+ * with N callers that share the same `cached()` key only pays for one
+ * remote read.
+ *
+ * `WeakMap` keys mean dropping a `kv` reference releases its L1 entries
+ * automatically — no need to thread a lifecycle hook through callers.
+ */
+const memoryStore = new WeakMap<Kv.Kv, Map<string, Entry>>()
+
+/**
+ * Per-`kv`-instance in-flight dedupe table. Multiple concurrent
+ * `cached(kv, key, fn)` calls for the same key share a single `fn()`
+ * invocation instead of stampeding the upstream.
+ */
+const inflightStore = new WeakMap<Kv.Kv, Map<string, Promise<unknown>>>()
+
+/**
+ * Reads `key` from a two-tier cache (in-memory L1, `kv`-backed L2). If absent
+ * or expired in both tiers, calls `fn`, stores the result with a
+ * `Date.now() + ttl * 1000` expiry in both tiers, and returns it. Defaults
+ * to caching forever (no expiry). Kv read/write failures are swallowed so
+ * cache misses never break the caller.
+ *
+ * Concurrent calls for the same key share a single `fn()` invocation.
  */
 export async function cached<value>(
   kv: Kv.Kv,
@@ -14,13 +37,38 @@ export async function cached<value>(
 ): Promise<value> {
   const { ttl = Infinity } = options
 
-  const entry = await kv.get<{ expiresAt: number; value: value } | null>(key).catch(() => null)
-  if (entry && entry.expiresAt > Date.now()) return entry.value
+  // L1: in-memory.
+  const memory = memoryFor(kv)
+  const local = memory.get(key)
+  if (local && local.expiresAt > Date.now()) return local.value as value
 
-  const value = await fn()
-  const expiresAt = ttl === Infinity ? Infinity : Date.now() + ttl * 1000
-  await kv.set(key, { expiresAt, value }).catch(() => {})
-  return value
+  // Coalesce concurrent calls for the same key.
+  const inflight = inflightFor(kv)
+  const pending = inflight.get(key) as Promise<value> | undefined
+  if (pending) return pending
+
+  const promise = (async () => {
+    // L2: kv.
+    const entry = await kv.get<Entry | null>(key).catch(() => null)
+    if (entry && entry.expiresAt > Date.now()) {
+      memory.set(key, entry)
+      return entry.value as value
+    }
+
+    const value = await fn()
+    const expiresAt = ttl === Infinity ? Infinity : Date.now() + ttl * 1000
+    const fresh: Entry = { expiresAt, value }
+    memory.set(key, fresh)
+    await kv.set(key, fresh).catch(() => {})
+    return value
+  })()
+
+  inflight.set(key, promise)
+  try {
+    return await promise
+  } finally {
+    inflight.delete(key)
+  }
 }
 
 export declare namespace cached {
@@ -32,4 +80,22 @@ export declare namespace cached {
      */
     ttl?: number | undefined
   }
+}
+
+function memoryFor(kv: Kv.Kv) {
+  let map = memoryStore.get(kv)
+  if (!map) {
+    map = new Map()
+    memoryStore.set(kv, map)
+  }
+  return map
+}
+
+function inflightFor(kv: Kv.Kv) {
+  let map = inflightStore.get(kv)
+  if (!map) {
+    map = new Map()
+    inflightStore.set(kv, map)
+  }
+  return map
 }

--- a/src/server/internal/tokenlist.ts
+++ b/src/server/internal/tokenlist.ts
@@ -1,0 +1,91 @@
+import type { Address } from 'viem'
+
+import type * as Kv from '../Kv.js'
+import { cached } from './kv.js'
+
+/** Default cache TTL in seconds (10 minutes) for tokenlist responses. */
+const defaultCacheTtl = 10 * 60
+
+/** Default base URL for the verified tokenlist service. */
+const defaultBaseUrl = 'https://tokenlist.tempo.xyz'
+
+/** A single tokenlist entry. */
+export type Token = {
+  /** Token address. */
+  address: Address
+  /** Token decimals. */
+  decimals: number
+  /** Token logo URI. */
+  logoUri?: string | undefined
+  /** Token name. */
+  name: string
+  /** Token symbol. */
+  symbol: string
+}
+
+/**
+ * Fetches the verified tokenlist for `chainId`. Reads through `kv` so
+ * concurrent callers in the same scope share a single upstream request,
+ * and so independent handlers (e.g. `Handler.relay` + `Handler.exchange`)
+ * reuse the same KV cache key.
+ *
+ * Returns an empty list on any non-OK response — callers should fall back
+ * to chain-supplied behavior rather than treating an empty list as fatal.
+ *
+ * @param chainId - Chain id to fetch the tokenlist for.
+ * @param kv - Kv used to cache responses across requests.
+ * @param options - Options.
+ * @returns Tokens for the chain.
+ */
+export async function fetch(
+  chainId: number,
+  kv: Kv.Kv,
+  options: fetch.Options = {},
+): Promise<readonly Token[]> {
+  const { baseUrl = defaultBaseUrl, cacheTtl = defaultCacheTtl, resolver } = options
+  return cached(
+    kv,
+    `tokenlist:${chainId}`,
+    async () => (resolver ? resolver(chainId) : fetchUncached(chainId, baseUrl)),
+    { ttl: cacheTtl },
+  )
+}
+
+export declare namespace fetch {
+  /** Options for `fetch()`. */
+  type Options = {
+    /**
+     * Base URL of the tokenlist service.
+     * @default 'https://tokenlist.tempo.xyz'
+     */
+    baseUrl?: string | undefined
+    /**
+     * TTL in seconds for the cached response.
+     * @default 600 (10 minutes)
+     */
+    cacheTtl?: number | undefined
+    /**
+     * Override resolver. When provided, the cache hit path is unchanged but
+     * cache misses route through this function instead of fetching the
+     * default `tokenlist.tempo.xyz` URL. Useful for tests or for vendoring
+     * a curated list per app.
+     */
+    resolver?: ((chainId: number) => readonly Token[] | Promise<readonly Token[]>) | undefined
+  }
+}
+
+/**
+ * Default fetcher — resolves the verified tokenlist for `chainId` directly
+ * from `tokenlist.tempo.xyz`. Returns an empty list on any non-OK response.
+ */
+async function fetchUncached(chainId: number, baseUrl: string): Promise<readonly Token[]> {
+  const response = await globalThis.fetch(`${baseUrl}/list/${chainId}`)
+  if (!response.ok) return []
+  const data = (await response.json()) as {
+    tokens: readonly (Token & { logoURI?: string })[]
+  }
+  return data.tokens.map(({ logoURI, ...token }) => ({
+    ...token,
+    logoUri: token.logoUri ?? logoURI,
+  }))
+}


### PR DESCRIPTION
Extracts a shared internal `Tokenlist` module so both `Handler.relay` and `Handler.exchange` fetch `tokenlist.tempo.xyz` through the same KV-backed cache. A single `kv: Kv.cloudflare(env.KV)` now covers both handlers.

### Changes

- **`src/server/internal/tokenlist.ts` (new)** — centralized fetcher with custom resolver support.
- **`src/server/internal/kv.ts`** — two-tier (in-memory L1 + KV L2) cache with in-flight request dedupe.
- **`Handler.relay`** — `resolveTokens` option now returns `Token[]` (with `decimals`/`name`/`symbol`) instead of `Address[]` for parity with `Handler.exchange`. **Breaking change.**
- **`Handler.exchange`** — replaced inline `cached(...)` calls with shared `Tokenlist.fetch(...)`; removed local `defaultResolveTokens`.
- **Tests** — fixed the previously-failing `highest-balance` fee-token test by creating a real TIP20 token via `createSync` (the hardcoded `0x20c0...02` address didn't exist on localnet) and minting amounts large enough to cover gas.

### Test results

```
✓ src/server/internal/handlers/exchange.test.ts (17 tests)
✓ src/server/internal/handlers/relay.test.ts (40 tests)
✓ src/server/internal/handlers/webAuthn.test.ts (10 tests)
✓ src/server/internal/kv.test.ts (8 tests)

Tests  75 passed (75)
```