### PR TITLE
feat(examples): add MPP + scopes to with-access-key example

### DIFF
--- a/examples/with-access-key/src/config.ts
+++ b/examples/with-access-key/src/config.ts
@@ -11,9 +11,11 @@ export const config = createConfig({
   connectors: [
     tempoWallet({
       testnet: true,
+      mpp: true,
       authorizeAccessKey: () => ({
         expiry: Expiry.days(1),
         limits: [{ token: pathUsd, limit: parseUnits('100', 6) }],
+        scopes: [{ address: pathUsd, selector: 'transferWithMemo(address,uint256,bytes32)' }],
       }),
     }),
   ],

--- a/examples/with-access-key/src/config.ts
+++ b/examples/with-access-key/src/config.ts
@@ -15,7 +15,10 @@ export const config = createConfig({
       authorizeAccessKey: () => ({
         expiry: Expiry.days(1),
         limits: [{ token: pathUsd, limit: parseUnits('100', 6) }],
-        scopes: [{ address: pathUsd, selector: 'transferWithMemo(address,uint256,bytes32)' }],
+        scopes: [
+          { address: pathUsd, selector: 'transfer(address,uint256)' },
+          { address: pathUsd, selector: 'transferWithMemo(address,uint256,bytes32)' },
+        ],
       }),
     }),
   ],


### PR DESCRIPTION
Adds MPP support to the `with-access-key` example per [this thread](https://tempoxyz.slack.com/archives/C0A99L9RLHZ/p1746403383513229):

1. **`mpp: true`** on `tempoWallet` connector — enables Machine Payment Protocol client.
2. **`scopes`** on `authorizeAccessKey` — scopes the access key to `transferWithMemo(address,uint256,bytes32)` on pathUSD, which is required post-T3 and for MPP pull payments.