### PR TITLE
ci: bump pkg-pr-new to 0.0.70

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Build
         run: pnpm zile publish:prepare
 
-      - run: pnpx pkg-pr-new@0.0.66 publish --pnpm
+      - run: pnpx pkg-pr-new@0.0.70 publish --pnpm


### PR DESCRIPTION
Avoids `ERR_PNPM_TRUST_DOWNGRADE` on `@octokit/plugin-paginate-rest@9.2.2`. `pkg-pr-new@0.0.70` pulls in `@octokit/action@^8`, which sidesteps the broken transitive version.