### PR TITLE
feat: migrate web playground to Regen

### DIFF
--- a/playgrounds/web/package.json
+++ b/playgrounds/web/package.json
@@ -15,15 +15,18 @@
     "mppx": "0.6.5",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "regen-ui": "^0.3.0",
     "viem": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:",
+    "@iconify/json": "^2.2.461",
     "@types/react": "catalog:default",
     "@types/react-dom": "catalog:default",
     "@vitejs/plugin-react": "catalog:default",
     "tsx": "catalog:",
     "typescript": "catalog:default",
+    "unplugin-icons": "^23.0.1",
     "vp": "catalog:",
     "wrangler": "^4.85.0"
   }

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -245,13 +245,22 @@ function useActiveSection() {
 }
 
 function useActiveNetwork() {
+  const p = provider as {
+    store: {
+      subscribe: (
+        selector: (state: { chainId: number }) => number,
+        listener: () => void,
+      ) => () => void
+      getState: () => { chainId: number }
+    }
+  }
   const chainId = useSyncExternalStore(
     (cb) =>
-      provider.store.subscribe(
+      p.store.subscribe(
         (state) => state.chainId,
         () => cb(),
       ),
-    () => provider.store.getState().chainId,
+    () => p.store.getState().chainId,
   )
 
   if (chainId === tempo.id) return 'mainnet'

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,6 +1,14 @@
 import { Expiry } from 'accounts'
 import { Hex, Json } from 'ox'
-import { useCallback, useEffect, useSyncExternalStore, useState } from 'react'
+import {
+  type ComponentProps,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useSyncExternalStore,
+  useState,
+} from 'react'
+import { Button as RegenButton } from 'regen-ui'
 import { parseUnits } from 'viem'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
@@ -21,9 +29,27 @@ import {
   tokens,
 } from './provider.js'
 
+const sectionLinks = [
+  { id: 'provider', title: 'Provider' },
+  { id: 'connection', title: 'Connection' },
+  { id: 'accounts-chain', title: 'Accounts & Chain' },
+  { id: 'balances-funding', title: 'Balances & Funding' },
+  { id: 'transactions', title: 'Transactions' },
+  { id: 'receipts-status', title: 'Receipts & Status' },
+  { id: 'access-keys', title: 'Access Keys' },
+  { id: 'signing-verification', title: 'Signing & Verification' },
+  { id: 'mpp', title: 'MPP' },
+  { id: 'email-verification', title: 'Email Verification' },
+  { id: 'rpc-proxy', title: 'RPC Proxy' },
+] as const
+
+type SectionId = (typeof sectionLinks)[number]['id']
+
 export function App() {
   const [adapterType, setAdapterType] = useState<AdapterType>('tempoWallet')
   const [, rerender] = useState(0)
+  const activeSection = useActiveSection()
+  const network = useActiveNetwork()
 
   function onSwitch(type: AdapterType) {
     switchAdapter(type)
@@ -32,95 +58,219 @@ export function App() {
   }
 
   return (
-    <div style={{ maxWidth: 640 }}>
-      <h1>accounts playground</h1>
+    <div className="playground min-h-dvh bg-background text-foreground" data-regen-radius="small">
+      <div className="playground-layout">
+        <aside className="playground-rail">
+          <div className="flex min-h-0 flex-col gap-[20px]">
+            <header className="flex flex-col gap-[6px]">
+              <h1 className="heading-32">accounts playground</h1>
+              <div className="label-13 text-foreground-secondary">{network}</div>
+            </header>
 
-      <h2>Configuration</h2>
-      <select value={adapterType} onChange={(e) => onSwitch(e.target.value as AdapterType)}>
-        <option value="tempoWallet">tempoWallet</option>
-        <option value="dialogRefImpl">dialogRefImpl</option>
-        <option value="webAuthn">webAuthn</option>
-        <option value="secp256k1">secp256k1</option>
-      </select>
+            <nav aria-label="Playground sections" className="section-nav">
+              {sectionLinks.map((link) => (
+                <a
+                  data-active={activeSection === link.id ? '' : undefined}
+                  href={`#${link.id}`}
+                  key={link.id}
+                >
+                  {link.title}
+                </a>
+              ))}
+            </nav>
+          </div>
+        </aside>
+
+        <main className="playground-content">
+          <PlaygroundSection id="provider" title="Provider">
+            <Events />
+            <ProviderState />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="connection" title="Connection">
+            <WalletConnect />
+            <EthRequestAccounts />
+            <WalletDisconnect />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="accounts-chain" title="Accounts & Chain">
+            <EthAccounts />
+            <EthChainId />
+            <WalletSwitchChain />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="balances-funding" title="Balances & Funding">
+            <WalletGetBalances />
+            <Faucet />
+            <WalletDeposit />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="transactions" title="Transactions">
+            <Transactions />
+            <WalletSend />
+            <WalletSwap />
+            <WalletDepositZone />
+            <WalletWithdrawZone />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="receipts-status" title="Receipts & Status">
+            <EthGetTransactionReceipt />
+            <WalletGetCallsStatus />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="access-keys" title="Access Keys">
+            <WalletAuthorizeAccessKey />
+            <WalletRevokeAccessKey />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="signing-verification" title="Signing & Verification">
+            <PersonalSign />
+            <PersonalSignSiwe />
+            <VerifyMessage />
+            <EthSignTypedData />
+            <VerifyTypedData />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="mpp" title="MPP">
+            <Fortune />
+            <MppZeroDollarAuth />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="email-verification" title="Email Verification">
+            <ManageEmail />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="rpc-proxy" title="RPC Proxy">
+            <EthBlockNumber />
+          </PlaygroundSection>
+        </main>
+
+        <aside className="playground-config">
+          <ConfigPanel
+            adapterType={adapterType}
+            onSwitch={onSwitch}
+            rerender={() => rerender((n) => n + 1)}
+          />
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+function ConfigPanel(props: {
+  adapterType: AdapterType
+  onSwitch: (type: AdapterType) => void
+  rerender: () => void
+}) {
+  const { adapterType, onSwitch, rerender } = props
+  return (
+    <section className="control-panel">
+      <h2 className="control-panel-title">Configuration</h2>
+      <div className="control-grid">
+        <label>
+          <span>Adapter</span>
+          <select value={adapterType} onChange={(e) => onSwitch(e.target.value as AdapterType)}>
+            <option value="tempoWallet">tempoWallet</option>
+            <option value="dialogRefImpl">dialogRefImpl</option>
+            <option value="webAuthn">webAuthn</option>
+            <option value="secp256k1">secp256k1</option>
+          </select>
+        </label>
+        {(adapterType === 'tempoWallet' || adapterType === 'dialogRefImpl') && (
+          <label>
+            <span>Mode</span>
+            <select
+              value={dialogMode}
+              onChange={(e) => {
+                switchDialogMode(e.target.value as DialogMode, adapterType)
+                rerender()
+              }}
+            >
+              <option value="iframe">iframe</option>
+              <option value="popup">popup</option>
+            </select>
+          </label>
+        )}
+      </div>
       {(adapterType === 'tempoWallet' || adapterType === 'dialogRefImpl') && (
         <>
-          {' '}
-          <select
-            value={dialogMode}
-            onChange={(e) => {
-              switchDialogMode(e.target.value as DialogMode, adapterType)
-              rerender((n) => n + 1)
-            }}
-          >
-            <option value="iframe">iframe</option>
-            <option value="popup">popup</option>
-          </select>
-          <h3>Theme</h3>
-          <ThemeConfig adapterType={adapterType} rerender={() => rerender((n) => n + 1)} />
-          <h3>Occlusion Test</h3>
+          <h3 className="control-panel-title">Theme</h3>
+          <ThemeConfig adapterType={adapterType} rerender={rerender} />
+          <h3 className="control-panel-title">Occlusion</h3>
           <OcclusionSimulator />
         </>
       )}
-      <ProviderState />
-
-      <h2>Events</h2>
-      <Events />
-
-      <h2>Connection</h2>
-      <WalletConnect />
-      <EthRequestAccounts />
-      <WalletDisconnect />
-
-      <h2>Accounts &amp; Chain</h2>
-      <EthAccounts />
-      <EthChainId />
-      <WalletSwitchChain />
-
-      <h2>Balances &amp; Funding</h2>
-      <WalletGetBalances />
-      <Faucet />
-      <WalletDeposit />
-
-      <h2>Transactions</h2>
-      <Transactions />
-      <WalletSend />
-      <WalletSwap />
-      <WalletDepositZone />
-      <WalletWithdrawZone />
-
-      <h2>Receipts &amp; Status</h2>
-      <EthGetTransactionReceipt />
-      <WalletGetCallsStatus />
-
-      <h2>Access Keys</h2>
-      <WalletAuthorizeAccessKey />
-      <WalletRevokeAccessKey />
-
-      <h2>Signing &amp; Verification</h2>
-      <PersonalSign />
-      <PersonalSignSiwe />
-      <VerifyMessage />
-      <EthSignTypedData />
-      <VerifyTypedData />
-
-      <h2>MPP</h2>
-      <Fortune />
-      <MppZeroDollarAuth />
-
-      <h2>Email Verification</h2>
-      <ManageEmail />
-
-      <h2>RPC Proxy (fallthrough)</h2>
-      <EthBlockNumber />
-    </div>
+    </section>
   )
+}
+
+function PlaygroundSection(props: { children: ReactNode; id: string; title: ReactNode }) {
+  const { children, id, title } = props
+  return (
+    <section className="scroll-mt-[24px] flex flex-col gap-[14px]" id={id}>
+      <div className="section-heading">
+        <h2>{title}</h2>
+      </div>
+      <div className="grid gap-[12px]">{children}</div>
+    </section>
+  )
+}
+
+function useActiveSection() {
+  const [active, setActive] = useState<SectionId>(sectionLinks[0].id)
+
+  useEffect(() => {
+    function update() {
+      let next: SectionId = sectionLinks[0].id
+
+      for (const link of sectionLinks) {
+        const section = document.getElementById(link.id)
+        if (!section) continue
+        if (section.getBoundingClientRect().top <= 120) next = link.id
+        else break
+      }
+
+      setActive(next)
+    }
+
+    update()
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [])
+
+  return active
+}
+
+function useActiveNetwork() {
+  const chainId = useSyncExternalStore(
+    (cb) =>
+      provider.store.subscribe(
+        (state) => state.chainId,
+        () => cb(),
+      ),
+    () => provider.store.getState().chainId,
+  )
+
+  if (chainId === tempo.id) return 'mainnet'
+  if (chainId === tempoModerato.id) return 'testnet'
+  if (chainId === tempoDevnet.id) return 'devnet'
+  return `chain ${chainId}`
+}
+
+function Button(props: ComponentProps<typeof RegenButton>) {
+  const { size = 'small', ...rest } = props
+  return <RegenButton size={size} {...rest} />
 }
 
 function Faucet() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="tempo_fundAddress" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(async () => {
             const accounts = await provider.request({ method: 'eth_accounts' })
@@ -133,7 +283,7 @@ function Faucet() {
         }
       >
         Fund Account
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -142,7 +292,7 @@ function WalletDeposit() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="wallet_deposit" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -153,8 +303,8 @@ function WalletDeposit() {
         }
       >
         Deposit
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -165,8 +315,8 @@ function WalletDeposit() {
         }
       >
         Deposit ($50)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -177,7 +327,7 @@ function WalletDeposit() {
         }
       >
         Deposit (displayName: DoorDash)
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -209,7 +359,7 @@ function WalletSend() {
           </label>
         ))}
       </fieldset>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -220,8 +370,8 @@ function WalletSend() {
         }
       >
         Send
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -232,8 +382,8 @@ function WalletSend() {
         }
       >
         Send (PathUSD)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -251,7 +401,7 @@ function WalletSend() {
         }
       >
         Send ($1 PathUSD)
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -263,7 +413,7 @@ function WalletSwap() {
 
   return (
     <Method method="wallet_swap" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -274,8 +424,8 @@ function WalletSwap() {
         }
       >
         Swap
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -286,8 +436,8 @@ function WalletSwap() {
         }
       >
         Swap (pair)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -298,8 +448,8 @@ function WalletSwap() {
         }
       >
         Swap (sell 1 PathUSD)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -310,7 +460,7 @@ function WalletSwap() {
         }
       >
         Swap (buy 1 PathUSD)
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -319,7 +469,7 @@ function WalletDepositZone() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="wallet_depositZone" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -330,8 +480,8 @@ function WalletDepositZone() {
         }
       >
         Deposit to zone
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -342,8 +492,8 @@ function WalletDepositZone() {
         }
       >
         Deposit (PathUSD)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -354,7 +504,7 @@ function WalletDepositZone() {
         }
       >
         Deposit (1 PathUSD)
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -363,7 +513,7 @@ function WalletWithdrawZone() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="wallet_withdrawZone" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -374,8 +524,8 @@ function WalletWithdrawZone() {
         }
       >
         Withdraw from zone
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -386,8 +536,8 @@ function WalletWithdrawZone() {
         }
       >
         Withdraw (PathUSD)
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -398,12 +548,13 @@ function WalletWithdrawZone() {
         }
       >
         Withdraw (1 PathUSD)
-      </button>
+      </Button>
     </Method>
   )
 }
 
 function ProviderState() {
+  const [open, setOpen] = useState(true)
   const p = provider as {
     store: {
       subscribe: (cb: () => void) => () => void
@@ -415,10 +566,17 @@ function ProviderState() {
     () => p.store.getState(),
   )
   return (
-    <details>
-      <summary>View</summary>
-      <pre>{Json.stringify(state, null, 2)}</pre>
-    </details>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>provider store</h3>
+        <Button className="method-header-action" onClick={() => setOpen((value) => !value)}>
+          {open ? 'Collapse' : 'Expand'}
+        </Button>
+      </header>
+      {open && (
+        <pre className="method-result provider-state-result">{Json.stringify(state, null, 2)}</pre>
+      )}
+    </article>
   )
 }
 
@@ -598,18 +756,18 @@ function WalletConnect() {
                         ))}
                     </select>
                   )}
-                  <button
+                  <Button
                     disabled={limits.length === 1}
                     onClick={() => removeLimit(i)}
                     type="button"
                   >
                     ×
-                  </button>
+                  </Button>
                 </div>
               ))}
-              <button onClick={addLimit} type="button">
+              <Button onClick={addLimit} type="button">
                 + Add limit
-              </button>
+              </Button>
               <div
                 style={{
                   display: 'flex',
@@ -635,12 +793,12 @@ function WalletConnect() {
             </>
           )}
         </fieldset>
-        <button type="submit" value="login">
+        <Button type="submit" value="login">
           Login
-        </button>
-        <button type="submit" value="register">
+        </Button>
+        <Button type="submit" value="register">
           Register
-        </button>
+        </Button>
       </form>
     </Method>
   )
@@ -650,9 +808,9 @@ function EthRequestAccounts() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="eth_requestAccounts" result={result} error={error}>
-      <button onClick={() => execute(() => provider.request({ method: 'eth_requestAccounts' }))}>
+      <Button onClick={() => execute(() => provider.request({ method: 'eth_requestAccounts' }))}>
         Request Accounts
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -661,7 +819,7 @@ function WalletDisconnect() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="wallet_disconnect" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(async () => {
             await provider.request({ method: 'wallet_disconnect' })
@@ -670,7 +828,7 @@ function WalletDisconnect() {
         }
       >
         Disconnect
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -679,9 +837,9 @@ function EthAccounts() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="eth_accounts" result={result} error={error}>
-      <button onClick={() => execute(() => provider.request({ method: 'eth_accounts' }))}>
+      <Button onClick={() => execute(() => provider.request({ method: 'eth_accounts' }))}>
         Get Accounts
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -690,9 +848,9 @@ function EthChainId() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="eth_chainId" result={result} error={error}>
-      <button onClick={() => execute(() => provider.request({ method: 'eth_chainId' }))}>
+      <Button onClick={() => execute(() => provider.request({ method: 'eth_chainId' }))}>
         Get Chain ID
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -702,7 +860,7 @@ function WalletSwitchChain() {
   return (
     <Method method="wallet_switchEthereumChain" result={result} error={error}>
       {provider.chains.map((c: { id: number; name?: string | undefined }) => (
-        <button
+        <Button
           key={c.id}
           onClick={() =>
             execute(async () => {
@@ -715,7 +873,7 @@ function WalletSwitchChain() {
           }
         >
           {c.name}
-        </button>
+        </Button>
       ))}
     </Method>
   )
@@ -781,8 +939,10 @@ function Transactions() {
   })()
 
   return (
-    <div>
-      <h3>Send</h3>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>Send</h3>
+      </header>
       <table style={{ borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>
         <colgroup>
           <col style={{ width: '15%' }} />
@@ -841,15 +1001,15 @@ function Transactions() {
                 />
               </td>
               <td>
-                <button onClick={() => setRows((prev) => prev.filter((_, j) => j !== i))}>×</button>
+                <Button onClick={() => setRows((prev) => prev.filter((_, j) => j !== i))}>×</Button>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-      <button onClick={() => setRows((prev) => [...prev, defaultRow(prev.length)])}>
+      <Button onClick={() => setRows((prev) => [...prev, defaultRow(prev.length)])}>
         + Add Call
-      </button>
+      </Button>
 
       <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
         <legend>Fee Payer</legend>
@@ -866,8 +1026,8 @@ function Transactions() {
           </label>
         ))}
       </fieldset>
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <button
+      <div className="method-body">
+        <Button
           onClick={() =>
             send('eth_sendTransaction', () =>
               provider.request({
@@ -878,9 +1038,9 @@ function Transactions() {
           }
         >
           eth_sendTransaction
-        </button>
+        </Button>
 
-        <button
+        <Button
           onClick={() =>
             send('eth_sendTransactionSync', () =>
               provider.request({
@@ -891,9 +1051,9 @@ function Transactions() {
           }
         >
           eth_sendTransactionSync
-        </button>
+        </Button>
 
-        <button
+        <Button
           onClick={() =>
             send('wallet_sendCalls', () =>
               provider.request({
@@ -904,9 +1064,9 @@ function Transactions() {
           }
         >
           wallet_sendCalls
-        </button>
+        </Button>
 
-        <button
+        <Button
           onClick={() =>
             send('wallet_sendCalls (sync)', () =>
               provider.request({
@@ -917,9 +1077,9 @@ function Transactions() {
           }
         >
           wallet_sendCalls (sync)
-        </button>
+        </Button>
 
-        <button
+        <Button
           onClick={() =>
             send('eth_signTransaction', () =>
               provider.request({
@@ -930,13 +1090,19 @@ function Transactions() {
           }
         >
           eth_signTransaction
-        </button>
+        </Button>
       </div>
 
-      {method && <h4>{method}</h4>}
-      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
-      {result !== undefined && <pre>{Json.stringify(result, null, 2)}</pre>}
-    </div>
+      {method && (
+        <header className="method-header">
+          <h3>{method}</h3>
+        </header>
+      )}
+      {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {result !== undefined && (
+        <pre className="method-result">{Json.stringify(result, null, 2)}</pre>
+      )}
+    </article>
   )
 }
 
@@ -966,7 +1132,7 @@ function PersonalSign() {
           placeholder="Message"
           style={{ flex: 1 }}
         />
-        <button type="submit">Sign</button>
+        <Button type="submit">Sign</Button>
       </form>
     </Method>
   )
@@ -976,51 +1142,57 @@ function PersonalSignSiwe() {
   const [result, setResult] = useState<{ message: string; signature: string }>()
   const [error, setError] = useState<Error>()
   return (
-    <div>
-      <h3>personal_sign (SIWE)</h3>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          const domain =
-            (new FormData(e.currentTarget).get('domain') as string) || window.location.host
-          ;(async () => {
-            try {
-              setError(undefined)
-              const accounts = await provider.request({ method: 'eth_accounts' })
-              if (accounts.length === 0) throw new Error('No accounts connected')
-              const siweMessage = createSiweMessage({
-                address: accounts[0],
-                chainId: 42069,
-                domain,
-                nonce: generateSiweNonce(),
-                statement: 'Sign in to the playground app.',
-                uri: `https://${domain}`,
-                version: '1',
-              })
-              const signature = await provider.request({
-                method: 'personal_sign',
-                params: [Hex.fromString(siweMessage), accounts[0]],
-              })
-              setResult({ message: siweMessage, signature })
-            } catch (e) {
-              setResult(undefined)
-              setError(e instanceof Error ? e : new Error(String(e)))
-            }
-          })()
-        }}
-        style={{ display: 'flex', gap: 8, alignItems: 'center' }}
-      >
-        <input
-          name="domain"
-          defaultValue={window.location.host}
-          placeholder="Domain…"
-          style={{ flex: 1 }}
-        />
-        <button type="submit">Sign (SIWE)</button>
-      </form>
-      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
-      {result && <pre>{`message:\n${result.message}\n\nsignature:\n${result.signature}`}</pre>}
-    </div>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>personal_sign (SIWE)</h3>
+      </header>
+      <div className="method-body">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            const domain =
+              (new FormData(e.currentTarget).get('domain') as string) || window.location.host
+            ;(async () => {
+              try {
+                setError(undefined)
+                const accounts = await provider.request({ method: 'eth_accounts' })
+                if (accounts.length === 0) throw new Error('No accounts connected')
+                const siweMessage = createSiweMessage({
+                  address: accounts[0],
+                  chainId: 42069,
+                  domain,
+                  nonce: generateSiweNonce(),
+                  statement: 'Sign in to the playground app.',
+                  uri: `https://${domain}`,
+                  version: '1',
+                })
+                const signature = await provider.request({
+                  method: 'personal_sign',
+                  params: [Hex.fromString(siweMessage), accounts[0]],
+                })
+                setResult({ message: siweMessage, signature })
+              } catch (e) {
+                setResult(undefined)
+                setError(e instanceof Error ? e : new Error(String(e)))
+              }
+            })()
+          }}
+          style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+        >
+          <input
+            name="domain"
+            defaultValue={window.location.host}
+            placeholder="Domain…"
+            style={{ flex: 1 }}
+          />
+          <Button type="submit">Sign (SIWE)</Button>
+        </form>
+      </div>
+      {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {result && (
+        <pre className="method-result">{`message:\n${result.message}\n\nsignature:\n${result.signature}`}</pre>
+      )}
+    </article>
   )
 }
 
@@ -1030,7 +1202,7 @@ function EthSignTypedData() {
 
   function signTypedData(label: string, data: object) {
     return (
-      <button
+      <Button
         key={label}
         onClick={async () => {
           try {
@@ -1050,7 +1222,7 @@ function EthSignTypedData() {
         }}
       >
         {label}
-      </button>
+      </Button>
     )
   }
 
@@ -1216,7 +1388,7 @@ function VerifyMessage() {
             style={{ flex: 1, fontFamily: 'monospace' }}
           />
         </div>
-        <button type="submit">Verify</button>
+        <Button type="submit">Verify</Button>
       </form>
     </Method>
   )
@@ -1282,7 +1454,7 @@ function VerifyTypedData() {
             style={{ flex: 1, fontFamily: 'monospace' }}
           />
         </div>
-        <button type="submit">Verify</button>
+        <Button type="submit">Verify</Button>
       </form>
     </Method>
   )
@@ -1311,7 +1483,7 @@ function EthGetTransactionReceipt() {
           placeholder="Enter tx hash (0x...)"
           style={{ flex: 1, fontFamily: 'monospace' }}
         />
-        <button type="submit">Get Receipt</button>
+        <Button type="submit">Get Receipt</Button>
       </form>
     </Method>
   )
@@ -1340,7 +1512,7 @@ function WalletGetCallsStatus() {
           placeholder="Enter calls ID (0x...)"
           style={{ flex: 1, fontFamily: 'monospace' }}
         />
-        <button type="submit">Get Status</button>
+        <Button type="submit">Get Status</Button>
       </form>
     </Method>
   )
@@ -1360,7 +1532,7 @@ function WalletGetBalances() {
   const balances = result as TokenBalance[] | undefined
   return (
     <Method method="wallet_getBalances" result={result} error={error}>
-      <button
+      <Button
         onClick={() =>
           execute(() =>
             provider.request({
@@ -1375,7 +1547,7 @@ function WalletGetBalances() {
         }
       >
         Get Balances
-      </button>
+      </Button>
       {balances && balances.length > 0 && (
         <table style={{ marginTop: 8, borderCollapse: 'collapse' }}>
           <thead>
@@ -1577,14 +1749,14 @@ function WalletAuthorizeAccessKey() {
                     ))}
                 </select>
               )}
-              <button disabled={limits.length === 1} onClick={() => removeLimit(i)} type="button">
+              <Button disabled={limits.length === 1} onClick={() => removeLimit(i)} type="button">
                 ×
-              </button>
+              </Button>
             </div>
           ))}
-          <button onClick={addLimit} type="button">
+          <Button onClick={addLimit} type="button">
             + Add limit
-          </button>
+          </Button>
         </fieldset>
 
         <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
@@ -1597,7 +1769,7 @@ function WalletAuthorizeAccessKey() {
             ))}
           </select>
         </div>
-        <button type="submit">Authorize</button>
+        <Button type="submit">Authorize</Button>
       </form>
     </Method>
   )
@@ -1632,7 +1804,7 @@ function WalletRevokeAccessKey() {
             style={{ flex: 1, fontFamily: 'monospace' }}
           />
         </div>
-        <button type="submit">Revoke</button>
+        <Button type="submit">Revoke</Button>
       </form>
     </Method>
   )
@@ -1642,9 +1814,9 @@ function Fortune() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="fetch /fortune" result={result} error={error}>
-      <button onClick={() => execute(() => fetch('/fortune').then((r) => r.json()))}>
+      <Button onClick={() => execute(() => fetch('/fortune').then((r) => r.json()))}>
         Get Fortune (0.01 pathUSD)
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -1653,9 +1825,9 @@ function MppZeroDollarAuth() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="fetch /zero-dollar-auth" result={result} error={error}>
-      <button onClick={() => execute(() => fetch('/zero-dollar-auth').then((r) => r.json()))}>
+      <Button onClick={() => execute(() => fetch('/zero-dollar-auth').then((r) => r.json()))}>
         Zero-Dollar Auth
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -1663,12 +1835,16 @@ function MppZeroDollarAuth() {
 function ManageEmail() {
   const walletHost = import.meta.env.VITE_WALLET_HOST ?? ''
   return (
-    <div>
-      <h3>Manage Email</h3>
-      <a href={`${walletHost}/email`} target="_blank" rel="noopener noreferrer">
-        Open email settings →
-      </a>
-    </div>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>Manage Email</h3>
+      </header>
+      <div className="method-body">
+        <a href={`${walletHost}/email`} target="_blank" rel="noopener noreferrer">
+          Open email settings →
+        </a>
+      </div>
+    </article>
   )
 }
 
@@ -1676,9 +1852,9 @@ function EthBlockNumber() {
   const [result, error, execute] = useRequest()
   return (
     <Method method="eth_blockNumber" result={result} error={error}>
-      <button onClick={() => execute(() => provider.request({ method: 'eth_blockNumber' }))}>
+      <Button onClick={() => execute(() => provider.request({ method: 'eth_blockNumber' }))}>
         Get Block Number
-      </button>
+      </Button>
     </Method>
   )
 }
@@ -1690,7 +1866,7 @@ function Events() {
 
   useEffect(() => {
     function push(name: string, data: unknown) {
-      setEvents((prev) => [...prev, { name, data, time: new Date().toLocaleTimeString() }])
+      setEvents((prev) => [...prev, { name, data, time: formatEventTime(new Date()) }])
     }
     const onAccountsChanged = (accounts: unknown) => push('accountsChanged', accounts)
     const onChainChanged = (chainId: unknown) => push('chainChanged', chainId)
@@ -1710,35 +1886,55 @@ function Events() {
   }, [])
 
   return (
-    <div>
-      <button onClick={() => setEvents([])}>Clear</button>
-      <table style={{ tableLayout: 'fixed', width: '100%' }}>
-        <colgroup>
-          <col style={{ width: 100 }} />
-          <col style={{ width: 150 }} />
-          <col />
-        </colgroup>
-        <thead>
-          <tr>
-            <th style={{ textAlign: 'left' }}>Timestamp</th>
-            <th style={{ textAlign: 'left' }}>Event</th>
-            <th style={{ textAlign: 'left' }}>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          {events.map((e, i) => (
-            <tr key={i}>
-              <td>{e.time}</td>
-              <td>{e.name}</td>
-              <td>
-                <pre style={{ margin: 0, whiteSpace: 'nowrap' }}>{Json.stringify(e.data)}</pre>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>provider events</h3>
+        <Button className="method-header-action" onClick={() => setEvents([])}>
+          Clear
+        </Button>
+      </header>
+      {events.length === 0 ? (
+        <div className="events-empty">No events yet</div>
+      ) : (
+        <div className="events-table-wrap">
+          <table className="events-table">
+            <colgroup>
+              <col className="events-table-time" />
+              <col className="events-table-name" />
+              <col />
+            </colgroup>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left' }}>Time</th>
+                <th style={{ textAlign: 'left' }}>Event</th>
+                <th style={{ textAlign: 'left' }}>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e, i) => (
+                <tr key={i}>
+                  <td>{e.time}</td>
+                  <td>{e.name}</td>
+                  <td>
+                    <code className="events-table-value">{formatEventValue(e.data)}</code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </article>
   )
+}
+
+function formatEventTime(date: Date) {
+  return date.toTimeString().slice(0, 8)
+}
+
+function formatEventValue(value: unknown) {
+  if (typeof value === 'string') return value
+  return Json.stringify(value, null, 2)
 }
 
 function useRequest() {
@@ -1805,34 +2001,48 @@ function OcclusionSimulator() {
 
   return (
     <div>
-      <button onClick={() => setActive((v) => !v)}>
+      <Button onClick={() => setActive((v) => !v)}>
         {active ? 'Remove Overlay' : 'Simulate Occlusion'}
-      </button>
-      <p style={{ fontSize: 12, color: '#666' }}>
-        Injects an overlay inside the {'<dialog>'} to trigger IO v2 occlusion detection.
-      </p>
+      </Button>
     </div>
   )
 }
 
-const accentOptions = ['', 'neutral', 'blue', 'red', 'amber', 'green', 'purple'] as const
+const accentOptions = ['', 'neutral', 'blue', 'red', 'amber', 'green', 'purple', 'custom'] as const
 const radiusOptions = ['', 'none', 'small', 'medium', 'large', 'full'] as const
 const schemeOptions = ['', 'light', 'dark'] as const
+type AccentOption = (typeof accentOptions)[number]
+
+function isAccentOption(value: string): value is AccentOption {
+  return accentOptions.includes(value as AccentOption)
+}
 
 function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) {
-  const [accent, setAccent] = useState(theme?.accent ?? '')
+  const initialAccent = theme?.accent ?? ''
+  const [accent, setAccent] = useState<AccentOption>(
+    isAccentOption(initialAccent) ? initialAccent : 'custom',
+  )
   const [radius, setRadius] = useState(theme?.radius ?? '')
   const [scheme, setScheme] = useState(theme?.scheme ?? '')
-  const [customAccent, setCustomAccent] = useState('#6366f1')
+  const [customAccent, setCustomAccent] = useState(
+    initialAccent && !isAccentOption(initialAccent) ? initialAccent : '#6366f1',
+  )
 
-  function apply(next: { accent?: string; radius?: string; scheme?: string }) {
+  function apply(next: {
+    accent?: AccentOption | undefined
+    customAccent?: string | undefined
+    radius?: string | undefined
+    scheme?: string | undefined
+  }) {
     const a = next.accent ?? accent
+    const c = next.customAccent ?? customAccent
     const r = next.radius ?? radius
     const s = next.scheme ?? scheme
+    const accentValue = a === 'custom' ? c : a
     const t =
-      a || r || s
+      accentValue || r || s
         ? {
-            accent: a || undefined,
+            accent: accentValue || undefined,
             radius: (r || undefined) as never,
             scheme: (s || undefined) as never,
           }
@@ -1842,14 +2052,16 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <label>Accent</label>
+    <div className="control-grid">
+      <label>
+        <span>Accent</span>
         <select
           value={accent}
           onChange={(e) => {
-            setAccent(e.target.value)
-            apply({ accent: e.target.value })
+            const next = e.target.value
+            if (!isAccentOption(next)) return
+            setAccent(next)
+            apply({ accent: next })
           }}
         >
           {accentOptions.map((v) => (
@@ -1858,18 +2070,19 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
             </option>
           ))}
         </select>
-        <input
-          type="color"
-          value={customAccent}
-          onChange={(e) => {
-            setCustomAccent(e.target.value)
-            setAccent(e.target.value)
-            apply({ accent: e.target.value })
-          }}
-        />
-      </div>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <label>Radius</label>
+        {accent === 'custom' && (
+          <input
+            type="color"
+            value={customAccent}
+            onChange={(e) => {
+              setCustomAccent(e.target.value)
+              apply({ customAccent: e.target.value })
+            }}
+          />
+        )}
+      </label>
+      <label>
+        <span>Radius</span>
         <select
           value={radius}
           onChange={(e) => {
@@ -1883,9 +2096,9 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
             </option>
           ))}
         </select>
-      </div>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <label>Scheme</label>
+      </label>
+      <label>
+        <span>Scheme</span>
         <select
           value={scheme}
           onChange={(e) => {
@@ -1899,7 +2112,7 @@ function ThemeConfig(props: { adapterType: AdapterType; rerender: () => void }) 
             </option>
           ))}
         </select>
-      </div>
+      </label>
     </div>
   )
 }
@@ -1913,14 +2126,18 @@ function Method({
   method: string
   result: unknown
   error?: Error | undefined
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
-    <div>
-      <h3>{method}</h3>
-      {children}
-      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
-      {result !== undefined && <pre>{Json.stringify(result, null, 2)}</pre>}
-    </div>
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>{method}</h3>
+      </header>
+      <div className="method-body">{children}</div>
+      {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {result !== undefined && (
+        <pre className="method-result">{Json.stringify(result, null, 2)}</pre>
+      )}
+    </article>
   )
 }

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,4 +1,3 @@
-import { Expiry } from 'accounts'
 import { Hex, Json } from 'ox'
 import {
   type ComponentProps,

--- a/playgrounds/web/src/index.css
+++ b/playgrounds/web/src/index.css
@@ -1,3 +1,443 @@
+@import 'tailwindcss' source(none);
+@import 'regen-ui/tailwind.css';
+
+@source './';
+
+body {
+  margin: 0;
+}
+
 html {
+  scroll-behavior: smooth;
+}
+
+.playground {
   color-scheme: light dark;
+}
+
+.playground-layout {
+  display: grid;
+  gap: 32px;
+  grid-template-areas: 'rail content config';
+  grid-template-columns: 220px minmax(0, 1fr) 300px;
+  margin: 0 auto;
+  max-width: 1400px;
+  padding: 28px 32px;
+  width: 100%;
+}
+
+.playground-rail {
+  grid-area: rail;
+}
+
+.playground-content {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+  grid-area: content;
+  min-width: 0;
+  padding: 0;
+}
+
+.playground-config {
+  grid-area: config;
+}
+
+@media (width >= 1024px) {
+  .playground-rail,
+  .playground-config {
+    position: sticky;
+    top: 28px;
+  }
+
+  .playground-rail {
+    max-height: calc(100dvh - 56px);
+  }
+
+  .playground-config {
+    max-height: calc(100dvh - 56px);
+  }
+}
+
+.control-panel {
+  background: var(--background-color-surface);
+  border: 1px solid var(--border-color-border);
+  border-radius: var(--radius-body);
+  display: grid;
+  gap: 14px;
+  max-height: inherit;
+  overflow: auto;
+  padding: 14px;
+}
+
+.control-panel-title {
+  color: var(--text-color-foreground);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.control-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.control-grid label {
+  display: grid;
+  gap: 6px;
+}
+
+.control-grid label:has(input[type='color']) {
+  grid-template-columns: minmax(0, 1fr) 36px;
+}
+
+.control-grid label:has(input[type='color']) span {
+  grid-column: 1 / -1;
+}
+
+.section-nav {
+  display: grid;
+  gap: 2px;
+  min-height: 0;
+  overflow: auto;
+  padding: 4px 0;
+}
+
+.section-nav a {
+  border-radius: var(--radius-button);
+  color: var(--text-color-foreground-secondary);
+  display: block;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 7px 10px;
+  text-decoration: none;
+}
+
+.section-nav a:hover {
+  background: var(--background-color-secondary-hover);
+  color: var(--text-color-foreground);
+}
+
+.section-nav a[data-active] {
+  background: var(--background-color-secondary);
+  box-shadow: inset 3px 0 0 var(--accent-color);
+  color: var(--text-color-foreground);
+}
+
+.section-heading {
+  align-items: center;
+  border-bottom: 1px solid var(--border-color-border);
+  display: flex;
+  min-height: 36px;
+}
+
+.section-heading h2 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.method-panel {
+  background: var(--background-color-surface);
+  border: 1px solid var(--border-color-border-pane);
+  border-radius: var(--radius-body);
+  display: grid;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.method-header {
+  align-items: center;
+  background: color-mix(
+    in oklch,
+    var(--background-color-surface),
+    var(--background-color-pane) 45%
+  );
+  border-bottom: 1px solid var(--border-color-border-pane);
+  display: flex;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.method-header-action {
+  margin-left: auto;
+}
+
+.method-header::before {
+  background: var(--accent-color);
+  border-radius: 999px;
+  content: '';
+  height: 7px;
+  width: 7px;
+}
+
+.method-header h3 {
+  color: var(--text-color-foreground);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.method-body {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.method-panel > fieldset,
+.method-panel > table,
+.method-panel > .events-table-wrap {
+  margin: 12px;
+  width: calc(100% - 24px) !important;
+}
+
+.method-panel > button {
+  justify-self: start;
+  margin: 0 12px 12px;
+}
+
+.method-panel > table + .method-body,
+.method-panel > fieldset + .method-body {
+  padding-top: 0;
+}
+
+.method-body > div,
+.method-body > details,
+.method-body > fieldset,
+.method-body > form,
+.method-body > table {
+  width: 100%;
+}
+
+.playground .method-result,
+.playground .method-error {
+  border: 0;
+  border-radius: 0;
+  border-top: 1px solid var(--border-color-border-pane);
+  margin: 0;
+}
+
+.playground .method-error {
+  background: color-mix(
+    in oklch,
+    var(--background-color-negative),
+    var(--background-color-surface) 88%
+  );
+  color: var(--text-color-negative-text);
+}
+
+.playground .method-result {
+  background: var(--background-color-pane);
+}
+
+.playground .provider-state-result {
+  background: var(--background-color-surface);
+  border-top: 0;
+}
+
+.playground input:not([type='checkbox']):not([type='radio']):not([type='color']),
+.playground select,
+.playground textarea {
+  background: var(--background-color-secondary);
+  border: 2px solid transparent;
+  border-radius: var(--radius-body);
+  box-sizing: border-box;
+  color: var(--text-color-foreground);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+  min-height: 32px;
+  padding: 4px 10px;
+}
+
+.playground input:not([type='checkbox']):not([type='radio']):not([type='color']):hover,
+.playground select:hover,
+.playground textarea:hover {
+  background: var(--background-color-secondary-hover);
+}
+
+.playground input:not([type='checkbox']):not([type='radio']):not([type='color']):focus,
+.playground select:focus,
+.playground textarea:focus {
+  background: var(--background-color-secondary-hover);
+  border-color: var(--border-color-focus);
+  outline: none;
+}
+
+.playground input[type='color'] {
+  height: 32px;
+  padding: 0;
+  width: 36px;
+}
+
+.playground fieldset {
+  border: 1px solid var(--border-color-border);
+  border-radius: var(--radius-body);
+  padding: 12px;
+}
+
+.playground form,
+.playground details {
+  width: 100%;
+}
+
+.playground legend,
+.playground label,
+.playground th {
+  color: var(--text-color-foreground-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.playground label span {
+  color: var(--text-color-foreground-secondary);
+}
+
+.playground table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.events-table-wrap {
+  overflow-x: auto;
+}
+
+.events-empty {
+  color: var(--text-color-foreground-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 12px;
+}
+
+.events-table {
+  min-width: 520px;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.events-table th,
+.events-table td {
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.events-table-time {
+  width: 104px;
+}
+
+.events-table-name {
+  width: 160px;
+}
+
+.events-table td:first-child,
+.events-table th:first-child {
+  white-space: nowrap;
+}
+
+.events-table td:nth-child(2),
+.events-table th:nth-child(2) {
+  white-space: nowrap;
+}
+
+.events-table td:last-child,
+.events-table th:last-child {
+  text-align: left;
+}
+
+.events-table-value {
+  display: block;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.playground th,
+.playground td {
+  border-bottom: 1px solid var(--border-color-border-pane);
+  padding: 7px 8px;
+  vertical-align: middle;
+}
+
+.playground pre {
+  background: var(--background-color-pane);
+  border: 1px solid var(--border-color-border-pane);
+  border-radius: var(--radius-body);
+  color: var(--text-color-foreground);
+  font-size: 12px;
+  line-height: 1.5;
+  max-width: 100%;
+  overflow: auto;
+  padding: 12px;
+}
+
+.playground details summary {
+  color: var(--text-color-foreground-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.playground a {
+  color: var(--text-color-foreground);
+  text-decoration-color: color-mix(in oklch, currentColor, transparent 60%);
+  text-underline-offset: 3px;
+}
+
+.playground a:hover {
+  color: var(--text-color-foreground-secondary-hover);
+}
+
+@media (width < 1024px) {
+  .playground-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 24px 20px;
+  }
+
+  .playground-config {
+    order: 2;
+  }
+
+  .playground-content {
+    order: 3;
+  }
+
+  .section-nav {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
+@media (width >= 1024px) and (width < 1280px) {
+  .playground-layout {
+    gap: 24px;
+    grid-template-areas:
+      'rail config'
+      'rail content';
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .playground-config {
+    max-height: none;
+    overflow: visible;
+    position: static;
+  }
 }

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -57,7 +57,7 @@ export const host =
   new URLSearchParams(window.location.search).get('host') ?? import.meta.env.VITE_WALLET_HOST
 
 export let dialogMode: DialogMode = 'iframe'
-export let theme: DialogNs.Theme | undefined = { radius: 'small' }
+export let theme: DialogNs.Theme | undefined
 export let provider: ProviderValue = createProvider('tempoWallet')
 
 export function createProvider(adapterType: AdapterType): ProviderValue {

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -57,7 +57,7 @@ export const host =
   new URLSearchParams(window.location.search).get('host') ?? import.meta.env.VITE_WALLET_HOST
 
 export let dialogMode: DialogMode = 'iframe'
-export let theme: DialogNs.Theme | undefined
+export let theme: DialogNs.Theme | undefined = { radius: 'small' }
 export let provider: ProviderValue = createProvider('tempoWallet')
 
 export function createProvider(adapterType: AdapterType): ProviderValue {

--- a/playgrounds/web/vite.config.ts
+++ b/playgrounds/web/vite.config.ts
@@ -1,5 +1,7 @@
 import { cloudflare } from '@cloudflare/vite-plugin'
 import react from '@vitejs/plugin-react'
+import regen from 'regen-ui/vite'
+import icons from 'unplugin-icons/vite'
 import { defineConfig } from 'vp'
 
 export default defineConfig({
@@ -10,5 +12,5 @@ export default defineConfig({
     cors: true,
     allowedHosts: true,
   },
-  plugins: [react(), cloudflare()],
+  plugins: [react(), icons({ compiler: 'jsx', jsx: 'react' }), regen(), cloudflare()],
 })

--- a/playgrounds/web/vite.config.ts
+++ b/playgrounds/web/vite.config.ts
@@ -12,5 +12,31 @@ export default defineConfig({
     cors: true,
     allowedHosts: true,
   },
-  plugins: [react(), icons({ compiler: 'jsx', jsx: 'react' }), regen(), cloudflare()],
+  plugins: [
+    react(),
+    icons({
+      compiler: {
+        compiler: reactIconCompiler,
+        extension: 'jsx',
+      },
+    }),
+    regen(),
+    cloudflare(),
+  ],
 })
+
+function reactIconCompiler(svg: string) {
+  const jsx = svg
+    .replace(/\s([\w:-]*[-:][\w:-]*)=/g, (_, name: string) => ` ${toJsxAttribute(name)}=`)
+    .replace(/\sclass=/g, ' className=')
+    .replace(/\sfor=/g, ' htmlFor=')
+    .replace(/<svg([^>]*)>/, '<svg$1 {...props}>')
+
+  return `export default function Icon(props) {
+  return ${jsx}
+}`
+}
+
+function toJsxAttribute(name: string) {
+  return name.replace(/[-:]([a-z])/g, (_, char: string) => char.toUpperCase())
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      regen-ui:
+        specifier: ^0.3.0
+        version: 0.3.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(vite@8.0.10)(zod@4.3.6)
       viem:
         specifier: ^2.48.8
         version: 2.48.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -594,6 +597,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
         version: 1.33.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)(vite@8.0.10)(workerd@1.20260424.1)(wrangler@4.85.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@iconify/json':
+        specifier: ^2.2.461
+        version: 2.2.469
       '@types/react':
         specifier: catalog:default
         version: 19.2.14
@@ -609,6 +615,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.9.3
+      unplugin-icons:
+        specifier: ^23.0.1
+        version: 23.0.1(@vue/compiler-sfc@3.5.33)
       vp:
         specifier: npm:vite-plus@~0.1.18
         version: vite-plus@0.1.18(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(bufferutil@4.0.9)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(vite@8.0.10)(yaml@2.8.3)
@@ -709,6 +718,9 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1147,6 +1159,33 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^19.2.5
+      react-dom: ^19.2.5
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -1810,6 +1849,12 @@ packages:
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: ^19.2.5
+      react-dom: ^19.2.5
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -1836,6 +1881,15 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@iconify/json@2.2.469':
+    resolution: {integrity: sha512-ARAC23HXrR1QpoR/z+tjGqI3kWgkYsYKJwezWLc8m47dvGpuvZTmQYXSIJVpnHGtUPKylC3jqWb0udXfoDLWeg==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.1':
+    resolution: {integrity: sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2858,6 +2912,100 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tailwindcss/node@4.2.4':
+    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.4':
+    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.4':
+    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
@@ -3875,6 +4023,9 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -3948,6 +4099,16 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cuer@0.0.3:
+    resolution: {integrity: sha512-f/UNxRMRCYtfLEGECAViByA3JNflZImOk11G9hwSd+44jvzrc99J35u5l+fbdQ2+ZG441GvOpaeGYBmWquZsbQ==}
+    peerDependencies:
+      react: ^19.2.5
+      react-dom: ^19.2.5
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
@@ -4358,6 +4519,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -4994,6 +5158,10 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  local-pkg@1.1.2:
+    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
+    engines: {node: '>=14'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -5694,6 +5862,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -5801,6 +5972,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qr@0.6.0:
+    resolution: {integrity: sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA==}
+    engines: {node: '>= 20.19.0'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -5925,6 +6100,15 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  regen-ui@0.3.0:
+    resolution: {integrity: sha512-3AH4nqjV4yUwkj99YkWDf2/u7sH5lwefgsYaaTvyx7+RDOM+Tm2PoB9aZgwWhpSN6Qv6gHbQs3PsYhnT4FtLqQ==}
+    peerDependencies:
+      react: ^19.2.5
+      react-dom: ^19.2.5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -5956,6 +6140,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -6274,6 +6461,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -6336,10 +6526,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -6505,6 +6691,23 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-icons@23.0.1:
+    resolution: {integrity: sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ==}
+    peerDependencies:
+      '@svgr/core': '>=7.0.0'
+      '@svgx/core': ^1.0.1
+      '@vue/compiler-sfc': ^3.0.2
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@svgr/core':
+        optional: true
+      '@svgx/core':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      svelte:
+        optional: true
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -7004,6 +7207,11 @@ snapshots:
     optional: true
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -7559,6 +7767,29 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@balena/dockerignore@1.0.2': {}
+
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -8333,6 +8564,12 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@floating-ui/utils@0.2.11': {}
 
   '@grpc/grpc-js@1.14.2':
@@ -8360,6 +8597,19 @@ snapshots:
     dependencies:
       hono: 4.12.15
     optional: true
+
+  '@iconify/json@2.2.469':
+    dependencies:
+      '@iconify/types': 2.0.0
+      pathe: 2.0.3
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.1':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.2
 
   '@img/colour@1.1.0': {}
 
@@ -9185,6 +9435,74 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tailwindcss/node@4.2.4':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.0
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.4
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.4':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-x64': 4.2.4
+      '@tailwindcss/oxide-freebsd-x64': 4.2.4
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+
+  '@tailwindcss/vite@4.2.4(vite@8.0.10)':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
   '@tanstack/history@1.161.6': {}
 
   '@tanstack/query-core@5.100.5': {}
@@ -9633,7 +9951,7 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
+      tinyexec: 1.1.1
       tinyglobby: 0.2.16
       vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -10405,6 +10723,8 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  confbox@0.2.4: {}
+
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -10480,6 +10800,14 @@ snapshots:
     optional: true
 
   csstype@3.2.3: {}
+
+  cuer@0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+    dependencies:
+      qr: 0.6.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      typescript: 5.9.3
 
   d3-path@3.1.0: {}
 
@@ -10622,7 +10950,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-    optional: true
 
   enquirer@2.4.1:
     dependencies:
@@ -10958,6 +11285,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@1.0.8: {}
 
   extendable-error@0.1.7: {}
 
@@ -11581,6 +11910,12 @@ snapshots:
 
   loader-runner@4.3.2:
     optional: true
+
+  local-pkg@1.1.2:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
 
   locate-path@5.0.0:
     dependencies:
@@ -12441,6 +12776,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
   playwright-core@1.59.1: {}
 
   plist@3.1.1:
@@ -12558,6 +12899,8 @@ snapshots:
 
   punycode@2.3.1:
     optional: true
+
+  qr@0.6.0: {}
 
   qs@6.14.0:
     dependencies:
@@ -12722,6 +13065,23 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  regen-ui@0.3.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(vite@8.0.10)(zod@4.3.6):
+    dependencies:
+      '@base-ui/react': 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tailwindcss/vite': 4.2.4(vite@8.0.10)
+      cuer: 0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
+      react: 19.2.5
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react'
+      - date-fns
+      - typescript
+      - vite
+      - zod
+
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -12751,6 +13111,8 @@ snapshots:
     optional: true
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -13129,8 +13491,9 @@ snapshots:
   symbol-tree@3.2.4:
     optional: true
 
-  tapable@2.3.3:
-    optional: true
+  tailwindcss@4.2.4: {}
+
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -13234,8 +13597,6 @@ snapshots:
   throat@5.0.0: {}
 
   tinybench@2.9.0: {}
-
-  tinyexec@1.0.4: {}
 
   tinyexec@1.1.1: {}
 
@@ -13367,6 +13728,16 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-icons@23.0.1(@vue/compiler-sfc@3.5.33):
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/utils': 3.1.1
+      local-pkg: 1.1.2
+      obug: 2.1.1
+      unplugin: 2.3.11
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.33
 
   unplugin@2.3.11:
     dependencies:
@@ -13610,7 +13981,7 @@ snapshots:
 
   webauthx@0.1.1(typescript@5.9.3)(zod@4.3.6):
     dependencies:
-      ox: 0.14.18(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ minimumReleaseAgeExclude:
   - incur
   - mppx
   - ox
+  - regen-ui
   - secretlint
   - viem
   - vite-plus


### PR DESCRIPTION
Migrate the web playground UI to Regen.

Reorganize the playground layout with sticky nav, right-side configuration, and provider events/state.

<img width="2880" height="1540" alt="image" src="https://github.com/user-attachments/assets/e26474e5-d9b7-4b9c-aee7-3d985cb5844c" />
