### PR TITLE
feat: add personalSign capability to wallet_connect

### DIFF
--- a/.changeset/personal-sign-capability.md
+++ b/.changeset/personal-sign-capability.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added a `personalSign` capability to `wallet_connect`.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -595,6 +595,7 @@ function WalletConnect() {
   const [expiry, setExpiry] = useState('86400')
   const [limits, setLimits] = useState<LimitInput[]>([{ token: '', amount: '100', period: '' }])
   const [scopeSelector, setScopeSelector] = useState('transfer(address,uint256)')
+  const [personalSignEnabled, setPersonalSignEnabled] = useState(false)
 
   // Once the tokenlist resolves, hydrate any unselected limit row with the first token.
   useEffect(() => {
@@ -642,6 +643,19 @@ function WalletConnect() {
         })()
       : undefined
 
+    const personalSign = personalSignEnabled
+      ? {
+          message: createSiweMessage({
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: 0,
+            domain: window.location.host,
+            nonce: generateSiweNonce(),
+            uri: window.location.origin,
+            version: '1',
+          }),
+        }
+      : undefined
+
     const capabilities =
       method === 'register'
         ? ({
@@ -649,10 +663,12 @@ function WalletConnect() {
             ...(name ? { name } : {}),
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
+            ...(personalSign ? { personalSign } : {}),
           } as const)
         : {
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
+            ...(personalSign ? { personalSign } : {}),
           }
 
     execute(() =>
@@ -800,6 +816,18 @@ function WalletConnect() {
               </div>
             </>
           )}
+        </fieldset>
+        <fieldset style={{ marginBottom: 8 }}>
+          <legend>
+            <label>
+              <input
+                checked={personalSignEnabled}
+                onChange={(e) => setPersonalSignEnabled(e.target.checked)}
+                type="checkbox"
+              />{' '}
+              Sign in with Tempo (SIWE)
+            </label>
+          </legend>
         </fieldset>
         <Button type="submit" value="login">
           Login

--- a/playgrounds/web/vite.config.ts
+++ b/playgrounds/web/vite.config.ts
@@ -12,6 +12,20 @@ export default defineConfig({
     cors: true,
     allowedHosts: true,
   },
+  // The `regen-ui` plugin source-aliases `regen-ui` to its `src/` folder, so
+  // Vite's dep scanner doesn't crawl through it and misses these transitive
+  // deps. Pre-bundle them explicitly so their CJS-style `react/jsx-runtime`
+  // imports are rewritten to the optimized output, and so Vite's ESM interop
+  // can synthesize the named `useSyncExternalStore(WithSelector)` exports
+  // from `use-sync-external-store`.
+  optimizeDeps: {
+    include: [
+      '@base-ui/react/otp-field',
+      '@base-ui/react/select',
+      'use-sync-external-store/shim',
+      'use-sync-external-store/shim/with-selector',
+    ],
+  },
   plugins: [
     react(),
     icons({

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -174,6 +174,13 @@ export declare namespace createAccount {
     digest?: Hex | undefined
     /** Display name for the new account (e.g. credential name for WebAuthn). */
     name: string
+    /**
+     * `personal_sign` (EIP-191) request folded into the create-account
+     * ceremony. The wallet computes `hashMessage(message)` and signs it
+     * in the same passkey prompt that creates the account, so this costs
+     * no extra prompt over a plain `wallet_connect` register.
+     */
+    personalSign?: { message: string } | undefined
     /** Opaque user identifier (e.g. for WebAuthn `user.id`). */
     userId?: string | undefined
   }
@@ -183,6 +190,13 @@ export declare namespace createAccount {
     email?: string | null | undefined
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
+    /**
+     * Echo of the `personalSign` request, present iff the caller supplied
+     * `personalSign`. The signature lives on the top-level `signature`
+     * field — the message is echoed so consumers can verify locally
+     * without round-tripping it.
+     */
+    personalSign?: { message: string } | undefined
     /** Signature over the digest, if one was provided. */
     signature?: Hex | undefined
     /** Username associated with the account. */
@@ -215,6 +229,13 @@ export declare namespace loadAccounts {
     credentialId?: string | undefined
     /** Digest to sign. */
     digest?: Hex | undefined
+    /**
+     * `personal_sign` (EIP-191) request folded into the load-accounts
+     * ceremony. The wallet computes `hashMessage(message)` and signs it
+     * in the same passkey prompt that loads the account, so this costs
+     * no extra prompt over a plain `wallet_connect`.
+     */
+    personalSign?: { message: string } | undefined
     /** When `true`, prompts the user to pick from all available credentials instead of using the last-used one. */
     selectAccount?: boolean | undefined
   }
@@ -225,6 +246,13 @@ export declare namespace loadAccounts {
     email?: string | null | undefined
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
+    /**
+     * Echo of the `personalSign` request, present iff the caller supplied
+     * `personalSign`. The signature lives on the top-level `signature`
+     * field — the message is echoed so consumers can verify locally
+     * without round-tripping it.
+     */
+    personalSign?: { message: string } | undefined
     /** Signature over the digest, if one was provided. */
     signature?: Hex | undefined
     /** Username associated with the account. */

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -225,6 +225,102 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       })
       expect(valid).toMatchInlineSnapshot(`true`)
     })
+
+    test('behavior: login with personalSign surfaces { message, signature } and suppresses top-level signature', async () => {
+      const provider = Provider.create({ adapter: adapter() })
+
+      await connect(provider)
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { personalSign: { message: 'hello' } } }],
+      })
+
+      expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+        message: 'hello',
+        signature: expect.stringMatching(/^0x[0-9a-f]+$/),
+      })
+      // Top-level `signature` must not leak when personalSign consumed the slot.
+      expect(result.accounts[0]!.capabilities.signature).toBeUndefined()
+    })
+
+    test('behavior: login personalSign signature is verifiable via verifyMessage', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const client = provider.getClient()
+
+      await connect(provider)
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { personalSign: { message: 'hello' } } }],
+      })
+
+      const valid = await verifyMessage(client, {
+        address: result.accounts[0]!.address,
+        message: 'hello',
+        signature: result.accounts[0]!.capabilities.personalSign!.signature,
+      })
+      expect(valid).toMatchInlineSnapshot(`true`)
+    })
+
+    test('behavior: register with personalSign surfaces { message, signature }', async () => {
+      const provider = Provider.create({ adapter: adapter() })
+
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [
+          {
+            capabilities: { method: 'register', personalSign: { message: 'hi' } },
+          },
+        ],
+      })
+
+      expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+        message: 'hi',
+        signature: expect.stringMatching(/^0x[0-9a-f]+$/),
+      })
+      expect(result.accounts[0]!.capabilities.signature).toBeUndefined()
+    })
+
+    test('behavior: register personalSign signature is verifiable via verifyMessage', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const client = provider.getClient()
+
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [
+          {
+            capabilities: { method: 'register', personalSign: { message: 'hi' } },
+          },
+        ],
+      })
+
+      const valid = await verifyMessage(client, {
+        address: result.accounts[0]!.address,
+        message: 'hi',
+        signature: result.accounts[0]!.capabilities.personalSign!.signature,
+      })
+      expect(valid).toMatchInlineSnapshot(`true`)
+    })
+
+    test('error: personalSign + digest is rejected as invalid params', async () => {
+      const provider = Provider.create({ adapter: adapter() })
+      await connect(provider)
+
+      await expect(
+        provider.request({
+          method: 'wallet_connect',
+          params: [
+            {
+              capabilities: {
+                digest: '0x1234',
+                personalSign: { message: 'hello' },
+              },
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[RpcResponse.InvalidParamsError: \`digest\` and \`personalSign\` cannot both be set on \`wallet_connect\`.]`,
+      )
+    })
   })
 
   describe('wallet_disconnect', () => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -500,6 +500,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const capabilities = request._decoded.params?.[0]?.capabilities
                     const authorizeAccessKey =
                       capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.()
+                    const personalSign = capabilities?.personalSign
 
                     const { keyAuthorization, accounts, email, signature, username } =
                       await (async () => {
@@ -521,6 +522,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                                 credentialId: existing.credential?.id,
                                 digest: capabilities.digest,
                                 authorizeAccessKey,
+                                ...(personalSign ? { personalSign } : {}),
                               },
                               request,
                             )
@@ -530,6 +532,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                               authorizeAccessKey,
                               name: capabilities.name ?? 'default',
                               userId: capabilities.userId ?? Hex.random(16),
+                              ...(personalSign ? { personalSign } : {}),
                             },
                             request,
                           )
@@ -540,6 +543,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             digest: capabilities?.digest,
                             authorizeAccessKey,
                             selectAccount: capabilities?.selectAccount,
+                            ...(personalSign ? { personalSign } : {}),
                           },
                           request,
                         )
@@ -562,7 +566,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                                       },
                                     }
                                   : {}),
-                                ...(signature && capabilities?.digest ? { signature } : {}),
+                                ...(signature ? { signature } : {}),
                                 ...(email !== undefined ? { email } : {}),
                                 ...(username !== undefined ? { username } : {}),
                               }

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -1,3 +1,5 @@
+import type { Hex } from 'viem'
+import { hashMessage, verifyMessage } from 'viem'
 import { tempoLocalnet } from 'viem/chains'
 import { describe, expect, test } from 'vp/test'
 
@@ -10,6 +12,7 @@ import {
 import * as Account from '../Account.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
+import type * as Adapter from '../Adapter.js'
 import { local } from './local.js'
 
 describe('local', () => {
@@ -27,6 +30,105 @@ describe('local', () => {
           "0x1ecBa262e4510F333FB5051743e2a53a765deBD0",
         ]
       `)
+    })
+  })
+
+  describe('loadAccounts: personalSign', () => {
+    test('default: signs hashMessage(message) and echoes the message back', async () => {
+      const captured: { digest: Hex | undefined }[] = []
+      const { adapter } = setup({
+        loadAccounts: makeLoadAccounts(0, captured),
+      })
+
+      const result = await adapter.actions.loadAccounts(
+        { personalSign: { message: 'hello' } },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect(captured).toHaveLength(1)
+      expect(captured[0]!.digest).toBe(hashMessage('hello'))
+      expect(result.personalSign).toEqual({ message: 'hello' })
+
+      // The signature is a real EIP-191 signature over 'hello' from
+      // accounts[0], verifiable end-to-end with viem's verifyMessage.
+      expect(
+        await verifyMessage({
+          address: core_accounts[0]!.address,
+          message: 'hello',
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+    })
+
+    test('default: empty message still produces a verifiable signature', async () => {
+      const captured: { digest: Hex | undefined }[] = []
+      const { adapter } = setup({
+        loadAccounts: makeLoadAccounts(0, captured),
+      })
+
+      const result = await adapter.actions.loadAccounts(
+        { personalSign: { message: '' } },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect(captured[0]!.digest).toBe(hashMessage(''))
+      expect(result.personalSign).toEqual({ message: '' })
+      expect(
+        await verifyMessage({
+          address: core_accounts[0]!.address,
+          message: '',
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+    })
+
+    test('default: personalSign + authorizeAccessKey produces two distinct signatures', async () => {
+      const captured: { digest: Hex | undefined }[] = []
+      const { adapter } = setup({
+        loadAccounts: makeLoadAccounts(0, captured),
+      })
+
+      const result = await adapter.actions.loadAccounts(
+        {
+          personalSign: { message: 'hello' },
+          authorizeAccessKey: { expiry: 0 },
+        },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      // loadAccounts saw the personalSign digest, NOT the keyAuth digest.
+      expect(captured[0]!.digest).toBe(hashMessage('hello'))
+
+      // The personalSign signature is a real EIP-191 signature over 'hello'.
+      expect(
+        await verifyMessage({
+          address: core_accounts[0]!.address,
+          message: 'hello',
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+
+      // The key-auth signature was produced by a *separate* ceremony — it
+      // signs the key-auth digest, not the personalSign digest, so the two
+      // signatures must differ.
+      expect(result.keyAuthorization?.signature).toBeDefined()
+      expect(result.keyAuthorization?.signature).not.toBe(result.signature)
+    })
+
+    test('error: rejects when personalSign and digest are both set', async () => {
+      const { adapter } = setup()
+
+      await expect(
+        adapter.actions.loadAccounts(
+          {
+            digest: '0x1234',
+            personalSign: { message: 'hello' },
+          },
+          { method: 'wallet_connect', params: undefined },
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[ProviderRpcError: \`digest\` and \`personalSign\` cannot both be set on \`wallet_connect\`.]`,
+      )
     })
   })
 
@@ -56,6 +158,62 @@ describe('local', () => {
       `)
     })
 
+    test('default: personalSign folds into the createAccount ceremony', async () => {
+      const captured: { digest: Hex | undefined }[] = []
+      const { adapter } = setup({
+        createAccount: async (params) => {
+          captured.push({ digest: params.digest })
+          return {
+            accounts: [
+              {
+                address: core_accounts[1].address,
+                keyType: 'secp256k1' as const,
+                privateKey: privateKeys[1]!,
+              },
+            ],
+          }
+        },
+      })
+
+      const result = await adapter.actions.createAccount(
+        { name: 'test', personalSign: { message: 'hello' } },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect(captured[0]!.digest).toBe(hashMessage('hello'))
+      expect(result.personalSign).toEqual({ message: 'hello' })
+      expect(
+        await verifyMessage({
+          address: core_accounts[1]!.address,
+          message: 'hello',
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+    })
+
+    test('error: createAccount rejects when personalSign and digest are both set', async () => {
+      const { adapter } = setup({
+        createAccount: async () => ({
+          accounts: [
+            {
+              address: core_accounts[1].address,
+              keyType: 'secp256k1' as const,
+              privateKey: privateKeys[1]!,
+            },
+          ],
+        }),
+      })
+
+      await expect(
+        adapter.actions.createAccount(
+          { name: 'test', digest: '0x1234', personalSign: { message: 'hello' } },
+          { method: 'wallet_connect', params: undefined },
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[ProviderRpcError: \`digest\` and \`personalSign\` cannot both be set on \`wallet_connect\`.]`,
+      )
+    })
+
     test('error: throws when createAccount not configured', async () => {
       const { adapter } = setup()
 
@@ -70,6 +228,32 @@ describe('local', () => {
     })
   })
 })
+
+/**
+ * Builds a `loadAccounts` callback backed by `privateKeys[index]` (secp256k1)
+ * that records each `digest` it receives into `captured`. Returns the account
+ * but no signature, so the local adapter signs the digest itself via
+ * `account.sign({ hash })` — exercising the real signing path end-to-end.
+ */
+function makeLoadAccounts(
+  index: number,
+  captured: { digest: Hex | undefined }[],
+): (
+  params?: Adapter.loadAccounts.Parameters,
+) => Promise<Adapter.loadAccounts.ReturnType> {
+  return async (params) => {
+    captured.push({ digest: params?.digest })
+    return {
+      accounts: [
+        {
+          address: core_accounts[index]!.address,
+          keyType: 'secp256k1' as const,
+          privateKey: privateKeys[index]!,
+        },
+      ],
+    }
+  }
+}
 
 function setup(overrides: Partial<local.Options> = {}) {
   const storage = Storage.memory()

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,6 +1,6 @@
 import { Address as ox_Address, Hex, Provider as ox_Provider, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { BaseError } from 'viem'
+import { BaseError, hashMessage } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 
@@ -119,8 +119,24 @@ export function local(options: local.Options): Adapter.Adapter {
             throw new ox_Provider.UnsupportedMethodError({
               message: '`createAccount` not configured on adapter.',
             })
-          const { authorizeAccessKey: grantOptions, ...rest } = parameters
-          const { accounts, email, signature, username } = await createAccount(rest)
+          const { authorizeAccessKey: grantOptions, personalSign, ...rest } = parameters
+
+          // `personalSign` claims the ceremony's challenge slot. It conflicts
+          // with a caller-supplied `digest` because both target the single
+          // WebAuthn challenge in the create-account ceremony.
+          if (personalSign && rest.digest)
+            throw new ox_Provider.ProviderRpcError(
+              -32602,
+              '`digest` and `personalSign` cannot both be set on `wallet_connect`.',
+            )
+
+          const peronsalSign_digest = personalSign ? hashMessage(personalSign.message) : undefined
+          const digest = peronsalSign_digest ?? rest.digest
+
+          const { accounts, email, signature, username } = await createAccount({
+            ...rest,
+            digest,
+          })
 
           // Hydrate the first account for signing. Must be done here (not via
           // the store) because accounts aren't merged into the store until
@@ -129,8 +145,7 @@ export function local(options: local.Options): Adapter.Adapter {
 
           // If the caller requested a digest signature but the adapter didn't
           // produce one (e.g. secp256k1 adapters), sign it ourselves.
-          const signature_ =
-            rest.digest && !signature ? await account.sign({ hash: rest.digest }) : signature
+          const signature_ = digest && !signature ? await account.sign({ hash: digest }) : signature
 
           const keyAuthorization = await (async () => {
             if (!grantOptions) return undefined
@@ -138,7 +153,14 @@ export function local(options: local.Options): Adapter.Adapter {
             return await signKeyAuthorization(account, prepared)
           })()
 
-          return { accounts, email, keyAuthorization, signature: signature_, username }
+          return {
+            accounts,
+            email,
+            keyAuthorization,
+            signature: signature_,
+            username,
+            ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
+          }
         },
         async authorizeAccessKey(parameters) {
           const prepared = await prepareKeyAuthorization(parameters)
@@ -149,19 +171,37 @@ export function local(options: local.Options): Adapter.Adapter {
           return { keyAuthorization, rootAddress: account.address }
         },
         async loadAccounts(parameters) {
-          const { authorizeAccessKey, ...rest } =
+          const { authorizeAccessKey, personalSign, ...rest } =
             parameters ?? ({} as Adapter.loadAccounts.Parameters)
+
+          // `personalSign` claims the ceremony's challenge slot. It conflicts
+          // with a caller-supplied `digest` because both target the single
+          // WebAuthn challenge in the load-accounts ceremony.
+          if (personalSign && rest.digest)
+            throw new ox_Provider.ProviderRpcError(
+              -32602,
+              '`digest` and `personalSign` cannot both be set on `wallet_connect`.',
+            )
+
+          const peronsalSign_digest = personalSign ? hashMessage(personalSign.message) : undefined
 
           const keyAuthorization_unsigned = authorizeAccessKey
             ? await prepareKeyAuthorization(authorizeAccessKey)
             : undefined
 
-          const digest = (() => {
-            if (rest.digest) return rest.digest
-            if (keyAuthorization_unsigned?.keyAuthorization)
-              return KeyAuthorization.getSignPayload(keyAuthorization_unsigned.keyAuthorization)
-            return undefined
-          })()
+          // Slot allocation:
+          //   1. `personalSign` digest, if present.
+          //   2. Else key-auth digest (existing 1-prompt fold for `authorizeAccessKey`).
+          //   3. Else caller's `rest.digest`.
+          // When BOTH `personalSign` and `authorizeAccessKey` are present,
+          // `personalSign` wins the load-accounts ceremony and the key
+          // authorization gets its own follow-up `account.sign` ceremony
+          // (2 prompts total).
+          const digest =
+            peronsalSign_digest ??
+            (keyAuthorization_unsigned
+              ? KeyAuthorization.getSignPayload(keyAuthorization_unsigned.keyAuthorization)
+              : rest.digest)
 
           // Pass the prepared digest (or the caller's) into loadAccounts so
           // the ceremony can sign it in a single biometric prompt.
@@ -175,14 +215,27 @@ export function local(options: local.Options): Adapter.Adapter {
           let signature_ = signature
           if (digest && !signature_ && account) signature_ = await account.sign({ hash: digest })
 
-          const keyAuthorization =
-            keyAuthorization_unsigned && account
-              ? await signKeyAuthorization(account, keyAuthorization_unsigned, {
-                  signature: signature_,
-                })
-              : undefined
+          // Key auth signing path:
+          //   - If `personalSign` took the ceremony slot AND `authorizeAccessKey`
+          //     is set, we need a SECOND ceremony to sign the key-auth digest.
+          //   - Else (key-auth digest took the slot), reuse `signature_`.
+          const keyAuthorization = await (async () => {
+            if (!keyAuthorization_unsigned || !account) return undefined
+            if (peronsalSign_digest)
+              return await signKeyAuthorization(account, keyAuthorization_unsigned)
+            return await signKeyAuthorization(account, keyAuthorization_unsigned, {
+              signature: signature_,
+            })
+          })()
 
-          return { accounts, email, keyAuthorization, signature: signature_, username }
+          return {
+            accounts,
+            email,
+            keyAuthorization,
+            signature: signature_,
+            username,
+            ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
+          }
         },
         async revokeAccessKey(parameters) {
           const account = getAccount({ accessKey: false, signable: true })

--- a/src/core/zod/request.test.ts
+++ b/src/core/zod/request.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vp/test'
+import * as z from 'zod/mini'
 
 import * as Schema from '../Schema.js'
 import * as RpcRequest from './request.js'
+import * as Rpc from './rpc.js'
 
 describe('validate', () => {
   test('default: validates eth_accounts', () => {
@@ -163,6 +165,99 @@ describe('validate', () => {
     )
   })
 
+  test('default: validates wallet_connect with personalSign capability (login branch)', () => {
+    const result = RpcRequest.validate(Schema.Request, {
+      method: 'wallet_connect',
+      params: [{ capabilities: { personalSign: { message: 'hello' } } }],
+    })
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_connect",
+        "params": [
+          {
+            "capabilities": {
+              "personalSign": {
+                "message": "hello",
+              },
+            },
+          },
+        ],
+      }
+    `)
+  })
+
+  test('default: validates wallet_connect with personalSign capability (register branch)', () => {
+    const result = RpcRequest.validate(Schema.Request, {
+      method: 'wallet_connect',
+      params: [
+        { capabilities: { method: 'register', personalSign: { message: 'hello' } } },
+      ],
+    })
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_connect",
+        "params": [
+          {
+            "capabilities": {
+              "method": "register",
+              "personalSign": {
+                "message": "hello",
+              },
+            },
+          },
+        ],
+      }
+    `)
+  })
+
+  test('default: validates wallet_connect with personalSign empty message', () => {
+    const result = RpcRequest.validate(Schema.Request, {
+      method: 'wallet_connect',
+      params: [{ capabilities: { personalSign: { message: '' } } }],
+    })
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_connect",
+        "params": [
+          {
+            "capabilities": {
+              "personalSign": {
+                "message": "",
+              },
+            },
+          },
+        ],
+      }
+    `)
+  })
+
+  test('error: rejects wallet_connect personalSign as a string', () => {
+    expect(() =>
+      RpcRequest.validate(Schema.Request, {
+        method: 'wallet_connect',
+        params: [{ capabilities: { personalSign: 'hello' } }],
+      }),
+    ).toThrowError(/Invalid params/)
+  })
+
+  test('error: rejects wallet_connect personalSign without message', () => {
+    expect(() =>
+      RpcRequest.validate(Schema.Request, {
+        method: 'wallet_connect',
+        params: [{ capabilities: { personalSign: {} } }],
+      }),
+    ).toThrowError(/Invalid params/)
+  })
+
+  test('error: rejects wallet_connect personalSign with non-string message', () => {
+    expect(() =>
+      RpcRequest.validate(Schema.Request, {
+        method: 'wallet_connect',
+        params: [{ capabilities: { personalSign: { message: 0 } } }],
+      }),
+    ).toThrowError(/Invalid params/)
+  })
+
   test('error: rejects wallet_swap with out-of-range slippage', () => {
     expect(() =>
       RpcRequest.validate(Schema.Request, {
@@ -189,5 +284,46 @@ describe('validate', () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `[ProviderRpcError: Invalid params: params.0.slippage: Invalid input]`,
     )
+  })
+})
+
+describe('wallet_connect_strict.parameters', () => {
+  test('default: parses personalSign on the strict (login) branch', () => {
+    const result = z.parse(Rpc.wallet_connect_strict.parameters, {
+      capabilities: { personalSign: { message: 'hello' } },
+    })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "capabilities": {
+          "personalSign": {
+            "message": "hello",
+          },
+        },
+      }
+    `)
+  })
+
+  test('default: parses personalSign on the strict (register) branch', () => {
+    const result = z.parse(Rpc.wallet_connect_strict.parameters, {
+      capabilities: { method: 'register', personalSign: { message: 'hello' } },
+    })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "capabilities": {
+          "method": "register",
+          "personalSign": {
+            "message": "hello",
+          },
+        },
+      }
+    `)
+  })
+
+  test('error: rejects strict personalSign without message', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: { personalSign: {} },
+      }),
+    ).toThrowError()
   })
 })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -425,6 +425,21 @@ export namespace wallet_revokeAccessKey {
 export namespace wallet_connect {
   export const authorizeAccessKey = z.optional(wallet_authorizeAccessKey.parameters)
 
+  /**
+   * Request a `personal_sign` (EIP-191) over the supplied message during
+   * `wallet_connect`. The wallet computes `hashMessage(message)` and signs
+   * the resulting 32-byte digest in the same passkey ceremony that loads
+   * or creates the account, so this costs no extra prompt over a plain
+   * `wallet_connect`. The signature is returned via the top-level
+   * `capabilities.signature` field on the connected account.
+   */
+  export const personalSign = z.optional(
+    z.object({
+      /** Message to sign. The wallet applies the EIP-191 prehash. */
+      message: z.string(),
+    }),
+  )
+
   export const capabilities = {
     request: z.optional(
       z.union([
@@ -433,6 +448,7 @@ export namespace wallet_connect {
           authorizeAccessKey,
           method: z.literal('register'),
           name: z.optional(z.string()),
+          personalSign,
           userId: z.optional(z.string()),
         }),
         z.object({
@@ -440,6 +456,7 @@ export namespace wallet_connect {
           credentialId: z.optional(z.string()),
           authorizeAccessKey,
           method: z.optional(z.literal('login')),
+          personalSign,
           selectAccount: z.optional(z.boolean()),
         }),
       ]),
@@ -482,6 +499,7 @@ export namespace wallet_connect {
 
 export namespace wallet_connect_strict {
   const authorizeAccessKey = z.optional(wallet_authorizeAccessKey_strict.parameters)
+  const personalSign = wallet_connect.personalSign
 
   export const parameters = z.object({
     capabilities: z.optional(
@@ -491,6 +509,7 @@ export namespace wallet_connect_strict {
           authorizeAccessKey,
           method: z.literal('register'),
           name: z.optional(z.string()),
+          personalSign,
           userId: z.optional(z.string()),
         }),
         z.object({
@@ -498,6 +517,7 @@ export namespace wallet_connect_strict {
           credentialId: z.optional(z.string()),
           authorizeAccessKey,
           method: z.optional(z.literal('login')),
+          personalSign,
           selectAccount: z.optional(z.boolean()),
         }),
       ]),


### PR DESCRIPTION
Adds a `personalSign` capability to `wallet_connect` so apps can request an EIP-191 `personal_sign` over an arbitrary message during the connect ceremony. The wallet folds `hashMessage(message)` into the existing `loadAccounts` / `createAccount` passkey assertion challenge, producing the signature in the same prompt — no extra round-trip and no extra ceremony.

The signature is returned via the top-level `capabilities.signature` field on the connected account. `personalSign` and `digest` cannot both be set on the same `wallet_connect` since they would target the same WebAuthn challenge slot.

Underpins SIWE / Sign-In-with-Tempo flows: the dapp builds an EIP-4361 message, passes it as `personalSign.message`, and verifies the returned signature with `viem/siwe`'s `verifySiweMessage` (the WebAuthn envelope retains its magic suffix so verification stays stateless).