### PR TITLE
feat: server auth

### DIFF
--- a/.changeset/auth-capability.md
+++ b/.changeset/auth-capability.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added an `auth` capability to `wallet_connect`.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -37,6 +37,7 @@ const sectionLinks = [
   { id: 'receipts-status', title: 'Receipts & Status' },
   { id: 'access-keys', title: 'Access Keys' },
   { id: 'signing-verification', title: 'Signing & Verification' },
+  { id: 'auth', title: 'Server Authentication' },
   { id: 'mpp', title: 'MPP' },
   { id: 'email-verification', title: 'Email Verification' },
   { id: 'rpc-proxy', title: 'RPC Proxy' },
@@ -133,6 +134,11 @@ export function App() {
           <PlaygroundSection id="mpp" title="MPP">
             <Fortune />
             <MppZeroDollarAuth />
+          </PlaygroundSection>
+
+          <PlaygroundSection id="auth" title="Server Authentication">
+            <Authenticate />
+            <Me />
           </PlaygroundSection>
 
           <PlaygroundSection id="email-verification" title="Email Verification">
@@ -595,7 +601,7 @@ function WalletConnect() {
   const [expiry, setExpiry] = useState('86400')
   const [limits, setLimits] = useState<LimitInput[]>([{ token: '', amount: '100', period: '' }])
   const [scopeSelector, setScopeSelector] = useState('transfer(address,uint256)')
-  const [personalSignEnabled, setPersonalSignEnabled] = useState(false)
+  const [authEnabled, setAuthEnabled] = useState(false)
 
   // Once the tokenlist resolves, hydrate any unselected limit row with the first token.
   useEffect(() => {
@@ -643,18 +649,9 @@ function WalletConnect() {
         })()
       : undefined
 
-    const personalSign = personalSignEnabled
-      ? {
-          message: createSiweMessage({
-            address: '0x0000000000000000000000000000000000000000',
-            chainId: 0,
-            domain: window.location.host,
-            nonce: generateSiweNonce(),
-            uri: window.location.origin,
-            version: '1',
-          }),
-        }
-      : undefined
+    // Server Authentication: the SDK absolutizes relative URLs against
+    // the dapp's origin before forwarding to the wallet host.
+    const auth = authEnabled ? '/auth' : undefined
 
     const capabilities =
       method === 'register'
@@ -663,12 +660,12 @@ function WalletConnect() {
             ...(name ? { name } : {}),
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
-            ...(personalSign ? { personalSign } : {}),
+            ...(auth ? { auth } : {}),
           } as const)
         : {
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
-            ...(personalSign ? { personalSign } : {}),
+            ...(auth ? { auth } : {}),
           }
 
     execute(() =>
@@ -821,11 +818,11 @@ function WalletConnect() {
           <legend>
             <label>
               <input
-                checked={personalSignEnabled}
-                onChange={(e) => setPersonalSignEnabled(e.target.checked)}
+                checked={authEnabled}
+                onChange={(e) => setAuthEnabled(e.target.checked)}
                 type="checkbox"
               />{' '}
-              Sign in with Tempo (SIWE)
+              Authenticate with Server
             </label>
           </legend>
         </fieldset>
@@ -1863,6 +1860,64 @@ function MppZeroDollarAuth() {
     <Method method="fetch /zero-dollar-auth" result={result} error={error}>
       <Button onClick={() => execute(() => fetch('/zero-dollar-auth').then((r) => r.json()))}>
         Zero-Dollar Auth
+      </Button>
+    </Method>
+  )
+}
+
+function Authenticate() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="wallet_connect (auth)" result={result} error={error}>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: { auth: '/auth' },
+                  chainId: Hex.fromNumber(
+                    env === 'devnet' ? tempoDevnet.id : testnet ? tempoModerato.id : tempo.id,
+                  ),
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Authenticate
+      </Button>
+    </Method>
+  )
+}
+
+function Me() {
+  const [result, error, execute] = useRequest()
+  return (
+    <Method method="fetch /me" result={result} error={error}>
+      <Button
+        onClick={() =>
+          execute(async () => {
+            const res = await fetch('/me', { credentials: 'include' })
+            return { status: res.status, body: await res.json() }
+          })
+        }
+      >
+        GET /me
+      </Button>
+      <Button
+        onClick={() =>
+          execute(async () => {
+            const res = await fetch('/auth/logout', {
+              method: 'POST',
+              credentials: 'include',
+            })
+            return { status: res.status }
+          })
+        }
+      >
+        POST /auth/logout
       </Button>
     </Method>
   )

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -13,6 +13,8 @@ const payment = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
 })
 
+const auth = Handler.auth({ path: '/auth' })
+
 const handler = Handler.compose([
   Handler.webAuthn({
     kv: Kv.memory(),
@@ -28,6 +30,7 @@ const handler = Handler.compose([
     },
     path: '/relay',
   }),
+  auth,
 ])
 
 export default {
@@ -54,6 +57,14 @@ export default {
       return result.withReceipt(
         Response.json({ fortune: 'Your code will compile on the first try.' }),
       )
+    }
+
+    // Reads the SIWE-issued session and returns the connected address.
+    // Demonstrates how an authenticated endpoint consumes Handler.auth.
+    if (url.pathname === '/me') {
+      const session = await auth.getSession(request)
+      if (!session) return Response.json({ error: 'unauthenticated' }, { status: 401 })
+      return Response.json({ address: session.address, chainId: session.chainId })
     }
 
     return handler.fetch(request)

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -6,6 +6,15 @@
   "main": "./worker/index.ts",
   "assets": {
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/cli-auth/*", "/webauthn/*", "/relay", "/fortune", "/zero-dollar-auth"],
+    "run_worker_first": [
+      "/auth",
+      "/auth/*",
+      "/me",
+      "/cli-auth/*",
+      "/webauthn/*",
+      "/relay",
+      "/fortune",
+      "/zero-dollar-auth",
+    ],
   },
 }

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -125,6 +125,17 @@ export type Instance = {
   }
   /** Cleanup function called when the provider is destroyed. */
   cleanup?: (() => void) | undefined
+  /**
+   * When `true`, the provider skips Server Authentication orchestration on
+   * `wallet_connect` and forwards `capabilities.auth` to the adapter
+   * verbatim. Used by remote-forwarding adapters (e.g. `dialog`) so the
+   * wallet host's own Provider runs the orchestration instead of racing
+   * the dapp-side Provider for the challenge.
+   *
+   * Wallet-host adapters (`local`, `webAuthn`, `dangerous_secp256k1`)
+   * leave this unset.
+   */
+  forwardsAuth?: boolean | undefined
   /** When `true`, the provider merges new accounts onto existing ones instead of replacing. */
   persistAccounts?: boolean | undefined
 }

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -226,7 +226,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(valid).toMatchInlineSnapshot(`true`)
     })
 
-    test('behavior: login with personalSign surfaces { message, signature } and suppresses top-level signature', async () => {
+    test('behavior: login with personalSign echoes { message } and surfaces signature at root', async () => {
       const provider = Provider.create({ adapter: adapter() })
 
       await connect(provider)
@@ -235,12 +235,8 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         params: [{ capabilities: { personalSign: { message: 'hello' } } }],
       })
 
-      expect(result.accounts[0]!.capabilities.personalSign).toEqual({
-        message: 'hello',
-        signature: expect.stringMatching(/^0x[0-9a-f]+$/),
-      })
-      // Top-level `signature` must not leak when personalSign consumed the slot.
-      expect(result.accounts[0]!.capabilities.signature).toBeUndefined()
+      expect(result.accounts[0]!.capabilities.personalSign).toEqual({ message: 'hello' })
+      expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
     })
 
     test('behavior: login personalSign signature is verifiable via verifyMessage', async () => {
@@ -256,12 +252,12 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const valid = await verifyMessage(client, {
         address: result.accounts[0]!.address,
         message: 'hello',
-        signature: result.accounts[0]!.capabilities.personalSign!.signature,
+        signature: result.accounts[0]!.capabilities.signature!,
       })
       expect(valid).toMatchInlineSnapshot(`true`)
     })
 
-    test('behavior: register with personalSign surfaces { message, signature }', async () => {
+    test('behavior: register with personalSign echoes { message } and surfaces signature at root', async () => {
       const provider = Provider.create({ adapter: adapter() })
 
       const result = await provider.request({
@@ -273,11 +269,8 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         ],
       })
 
-      expect(result.accounts[0]!.capabilities.personalSign).toEqual({
-        message: 'hi',
-        signature: expect.stringMatching(/^0x[0-9a-f]+$/),
-      })
-      expect(result.accounts[0]!.capabilities.signature).toBeUndefined()
+      expect(result.accounts[0]!.capabilities.personalSign).toEqual({ message: 'hi' })
+      expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
     })
 
     test('behavior: register personalSign signature is verifiable via verifyMessage', async () => {
@@ -296,7 +289,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       const valid = await verifyMessage(client, {
         address: result.accounts[0]!.address,
         message: 'hi',
-        signature: result.accounts[0]!.capabilities.personalSign!.signature,
+        signature: result.accounts[0]!.capabilities.signature!,
       })
       expect(valid).toMatchInlineSnapshot(`true`)
     })
@@ -319,6 +312,348 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `[RpcResponse.InvalidParamsError: \`digest\` and \`personalSign\` cannot both be set on \`wallet_connect\`.]`,
+      )
+    })
+
+    describe('auth (Server Authentication)', () => {
+      let server: Server
+      let badServer: Server
+      let authBase: string
+
+      beforeAll(async () => {
+        // Real Hono app: mount the auth handler under `/auth` and add a
+        // protected `/me` route — exactly as a dapp would compose them
+        // — so the e2e test below exercises the full flow.
+        const auth = Handler.auth()
+        const app = Handler.compose([auth], { path: '/auth' })
+        app.get('/me', async (c) => {
+          const session = await auth.getSession(c.req.raw)
+          if (!session) return c.json({ error: 'unauthenticated' }, 401)
+          return c.json({ address: session.address, chainId: session.chainId })
+        })
+        server = await createServer(app.listener)
+        authBase = `${server.url}/auth`
+
+        badServer = await createServer((req, res) => {
+          const url = req.url ?? ''
+          if (url.endsWith('/challenge-500')) {
+            res.statusCode = 500
+            res.end('{"error":"boom"}')
+            return
+          }
+          if (url.endsWith('/challenge-empty')) {
+            res.statusCode = 200
+            res.setHeader('content-type', 'application/json')
+            res.end('{}')
+            return
+          }
+          if (url.endsWith('/challenge-evil-domain')) {
+            res.statusCode = 200
+            res.setHeader('content-type', 'application/json')
+            // Auth message bound to attacker.com — the SDK must refuse to
+            // sign it since the auth endpoint is localhost.
+            res.end(
+              JSON.stringify({
+                message: [
+                  'evil.example wants you to sign in with your Ethereum account:',
+                  '0x0000000000000000000000000000000000000000',
+                  '',
+                  '',
+                  'URI: https://evil.example',
+                  'Version: 1',
+                  'Chain ID: 0',
+                  'Nonce: deadbeef00',
+                  'Issued At: 2025-01-01T00:00:00Z',
+                ].join('\n'),
+              }),
+            )
+            return
+          }
+          res.statusCode = 404
+          res.end()
+        })
+      })
+
+      afterAll(() => {
+        server.close()
+        badServer.close()
+      })
+
+      test(
+        'default: auth as string shorthand fetches challenge, signs once, posts verify',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          const result = await provider.request({
+            method: 'wallet_connect',
+            params: [{ capabilities: { method: 'register', auth: authBase } }],
+          })
+
+          const capabilities = result.accounts[0]!.capabilities
+          expect(capabilities.auth).toEqual({ token: expect.any(String) })
+          expect(capabilities.personalSign).toEqual({
+            message: expect.stringContaining('wants you to sign in'),
+          })
+          expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+        },
+      )
+
+      test(
+        'default: object-form auth with explicit endpoints uses the override URLs',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          const result = await provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: {
+                    challenge: `${authBase}/challenge`,
+                    verify: authBase,
+                  },
+                },
+              },
+            ],
+          })
+
+          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+        },
+      )
+
+      test(
+        'error: verify endpoint returns 401 → InternalError; user already signed',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+          const failVerify = await createServer((_req, res) => {
+            res.statusCode = 401
+            res.end('{"error":"unauthorized"}')
+          })
+
+          try {
+            await expect(
+              provider.request({
+                method: 'wallet_connect',
+                params: [
+                  {
+                    capabilities: {
+                      method: 'register',
+                      auth: {
+                        challenge: `${authBase}/challenge`,
+                        verify: failVerify.url,
+                      },
+                    },
+                  },
+                ],
+              }),
+            ).rejects.toThrow(
+              /Server Authentication verify endpoint `http:\/\/localhost:\d+` returned 401\./,
+            )
+          } finally {
+            failVerify.close()
+          }
+        },
+      )
+
+      test('error: auth + personalSign throws InvalidParamsError synchronously', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        await expect(
+          provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: authBase,
+                  personalSign: { message: 'hi' },
+                },
+              },
+            ],
+          }),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `[RpcResponse.InvalidParamsError: \`auth\` and \`personalSign\` cannot both be set on \`wallet_connect\`.]`,
+        )
+      })
+
+      test(
+        'default: auth + authorizeAccessKey surfaces both capabilities (two ceremonies)',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          const result = await provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: authBase,
+                  authorizeAccessKey: { expiry: 0 },
+                },
+              },
+            ],
+          })
+
+          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+          expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
+          expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+            message: expect.any(String),
+          })
+          expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+        },
+      )
+
+      test(
+        'error: challenge endpoint returns 500 → InvalidParamsError; no verify',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${badServer.url}/challenge-500`,
+                      verify: authBase,
+                    },
+                  },
+                },
+              ],
+            }),
+          ).rejects.toThrow(
+            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/challenge-500` returned 500\./,
+          )
+        },
+      )
+
+      test(
+        'error: challenge response missing `message` → InvalidParamsError',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${badServer.url}/challenge-empty`,
+                      verify: authBase,
+                    },
+                  },
+                },
+              ],
+            }),
+          ).rejects.toThrow(
+            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/challenge-empty` response missing `message`\./,
+          )
+        },
+      )
+
+      test(
+        'error: challenge bound to a different domain → InvalidParamsError; never signs',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${badServer.url}/challenge-evil-domain`,
+                      verify: authBase,
+                    },
+                  },
+                },
+              ],
+            }),
+          ).rejects.toThrow(/returned a message bound to `evil\.example`/)
+        },
+      )
+
+      test('default: no auth capability → no auth/personalSign on result', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { method: 'register' } }],
+        })
+
+        expect(result.accounts[0]!.capabilities.auth).toBeUndefined()
+        expect(result.accounts[0]!.capabilities.personalSign).toBeUndefined()
+      })
+
+      test(
+        'default: login (post-register) + auth populates capabilities.auth',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          // Register first so login has an account to load.
+          await provider.request({
+            method: 'wallet_connect',
+            params: [{ capabilities: { method: 'register' } }],
+          })
+
+          const result = await provider.request({
+            method: 'wallet_connect',
+            params: [{ capabilities: { auth: authBase } }],
+          })
+
+          expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+          expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+            message: expect.stringContaining(
+              'wants you to sign in',
+            ),
+          })
+          expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+        },
+      )
+
+      test(
+        'end-to-end: connect → call protected /me with bearer token',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          // Token mode: the server returns the session token in the body
+          // (no cookie) and the SDK surfaces it on `capabilities.auth.token`.
+          const result = await provider.request({
+            method: 'wallet_connect',
+            params: [
+              {
+                capabilities: {
+                  method: 'register',
+                  auth: { url: authBase, returnToken: true },
+                },
+              },
+            ],
+          })
+
+          const token = result.accounts[0]!.capabilities.auth?.token
+          expect(token).toMatch(/^[a-z0-9]+$/)
+
+          // Authenticated request resolves the connected address.
+          const me = await fetch(`${server.url}/me`, {
+            headers: { authorization: `Bearer ${token}` },
+          })
+          expect(me.status).toBe(200)
+          expect(await me.json()).toEqual({
+            address: result.accounts[0]!.address,
+            chainId: expect.any(Number),
+          })
+
+          // Unauthenticated request is rejected.
+          const anon = await fetch(`${server.url}/me`)
+          expect(anon.status).toBe(401)
+        },
       )
     })
   })

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -331,44 +331,36 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           if (!session) return c.json({ error: 'unauthenticated' }, 401)
           return c.json({ address: session.address, chainId: session.chainId })
         })
+        // Bad-challenge / bad-verify endpoints mounted on the same origin
+        // as `/auth` so the same-origin enforcement (`absolutizeAuth`)
+        // doesn't reject the request before the bad-content paths under
+        // test can run. `app.all` so we don't depend on the SDK's request
+        // method (POST).
+        app.all('/bad/verify-401', (c) => c.json({ error: 'unauthorized' }, 401))
+        app.all('/bad/challenge-500', (c) => c.json({ error: 'boom' }, 500))
+        app.all('/bad/challenge-empty', (c) => c.json({}))
+        app.all('/bad/challenge-evil-domain', (c) =>
+          c.json({
+            message: [
+              'evil.example wants you to sign in with your Ethereum account:',
+              '0x0000000000000000000000000000000000000000',
+              '',
+              '',
+              'URI: https://evil.example',
+              'Version: 1',
+              'Chain ID: 0',
+              'Nonce: deadbeef00',
+              'Issued At: 2025-01-01T00:00:00Z',
+            ].join('\n'),
+          }),
+        )
         server = await createServer(app.listener)
         authBase = `${server.url}/auth`
 
-        badServer = await createServer((req, res) => {
-          const url = req.url ?? ''
-          if (url.endsWith('/challenge-500')) {
-            res.statusCode = 500
-            res.end('{"error":"boom"}')
-            return
-          }
-          if (url.endsWith('/challenge-empty')) {
-            res.statusCode = 200
-            res.setHeader('content-type', 'application/json')
-            res.end('{}')
-            return
-          }
-          if (url.endsWith('/challenge-evil-domain')) {
-            res.statusCode = 200
-            res.setHeader('content-type', 'application/json')
-            // Auth message bound to attacker.com — the SDK must refuse to
-            // sign it since the auth endpoint is localhost.
-            res.end(
-              JSON.stringify({
-                message: [
-                  'evil.example wants you to sign in with your Ethereum account:',
-                  '0x0000000000000000000000000000000000000000',
-                  '',
-                  '',
-                  'URI: https://evil.example',
-                  'Version: 1',
-                  'Chain ID: 0',
-                  'Nonce: deadbeef00',
-                  'Issued At: 2025-01-01T00:00:00Z',
-                ].join('\n'),
-              }),
-            )
-            return
-          }
+        // Cross-origin bad server kept around for the same-origin enforcement
+        // tests below — its only job is to be on a different port from
+        // `server` so origins genuinely differ.
+        badServer = await createServer((_req, res) => {
           res.statusCode = 404
           res.end()
         })
@@ -426,33 +418,25 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         'error: verify endpoint returns 401 → InternalError; user already signed',
         async () => {
           const provider = Provider.create({ adapter: adapter() })
-          const failVerify = await createServer((_req, res) => {
-            res.statusCode = 401
-            res.end('{"error":"unauthorized"}')
-          })
 
-          try {
-            await expect(
-              provider.request({
-                method: 'wallet_connect',
-                params: [
-                  {
-                    capabilities: {
-                      method: 'register',
-                      auth: {
-                        challenge: `${authBase}/challenge`,
-                        verify: failVerify.url,
-                      },
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${authBase}/challenge`,
+                      verify: `${server.url}/bad/verify-401`,
                     },
                   },
-                ],
-              }),
-            ).rejects.toThrow(
-              /Server Authentication verify endpoint `http:\/\/localhost:\d+` returned 401\./,
-            )
-          } finally {
-            failVerify.close()
-          }
+                },
+              ],
+            }),
+          ).rejects.toThrow(
+            /Server Authentication verify endpoint `http:\/\/localhost:\d+\/bad\/verify-401` returned 401\./,
+          )
         },
       )
 
@@ -517,7 +501,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
                   capabilities: {
                     method: 'register',
                     auth: {
-                      challenge: `${badServer.url}/challenge-500`,
+                      challenge: `${server.url}/bad/challenge-500`,
                       verify: authBase,
                     },
                   },
@@ -525,7 +509,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
               ],
             }),
           ).rejects.toThrow(
-            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/challenge-500` returned 500\./,
+            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-500` returned 500\./,
           )
         },
       )
@@ -543,7 +527,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
                   capabilities: {
                     method: 'register',
                     auth: {
-                      challenge: `${badServer.url}/challenge-empty`,
+                      challenge: `${server.url}/bad/challenge-empty`,
                       verify: authBase,
                     },
                   },
@@ -551,7 +535,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
               ],
             }),
           ).rejects.toThrow(
-            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/challenge-empty` response missing `message`\./,
+            /Server Authentication challenge endpoint `http:\/\/localhost:\d+\/bad\/challenge-empty` response missing `message`\./,
           )
         },
       )
@@ -569,7 +553,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
                   capabilities: {
                     method: 'register',
                     auth: {
-                      challenge: `${badServer.url}/challenge-evil-domain`,
+                      challenge: `${server.url}/bad/challenge-evil-domain`,
                       verify: authBase,
                     },
                   },
@@ -577,6 +561,62 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
               ],
             }),
           ).rejects.toThrow(/returned a message bound to `evil\.example`/)
+        },
+      )
+
+      test(
+        'error: `challenge` and `verify` on different origins → InvalidParamsError',
+        async () => {
+          // Phishing guard: a malicious dapp must not be able to point
+          // `challenge` at the victim and `verify` at attacker.com to
+          // harvest a valid signed payload.
+          const provider = Provider.create({ adapter: adapter() })
+
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${authBase}/challenge`,
+                      verify: `${badServer.url}/collect`,
+                    },
+                  },
+                },
+              ],
+            }),
+          ).rejects.toThrow(
+            /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
+          )
+        },
+      )
+
+      test(
+        'error: `logout` on a different origin → InvalidParamsError',
+        async () => {
+          const provider = Provider.create({ adapter: adapter() })
+
+          await expect(
+            provider.request({
+              method: 'wallet_connect',
+              params: [
+                {
+                  capabilities: {
+                    method: 'register',
+                    auth: {
+                      challenge: `${authBase}/challenge`,
+                      verify: authBase,
+                      logout: `${badServer.url}/logout`,
+                    },
+                  },
+                },
+              ],
+            }),
+          ).rejects.toThrow(
+            /`auth` endpoints \(`challenge`, `verify`, `logout`\) must share the same origin\./,
+          )
         },
       )
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -609,10 +609,15 @@ export function create(options: create.Options = {}): create.ReturnType {
                       activeAccount: 0,
                       // Persist absolutized auth URLs so a later
                       // `wallet_disconnect` can hit logout even when the
-                      // URL was passed per-call.
-                      ...(auth_request && typeof auth_request === 'object'
-                        ? { auth: auth_request }
-                        : {}),
+                      // URL was passed per-call. Always overwrite (never
+                      // merge) so a connect WITHOUT auth clears stale
+                      // state from a prior connect — otherwise a later
+                      // disconnect could POST to a logout URL the
+                      // current page never opted into.
+                      auth:
+                        auth_request && typeof auth_request === 'object'
+                          ? auth_request
+                          : undefined,
                     })
 
                     const accountAddress = accounts[0]?.address
@@ -1002,12 +1007,39 @@ function absolutizeAuth(
   const hasChallenge = hasUrl || (typeof auth === 'object' && Boolean(auth.challenge))
   const hasVerify = hasUrl || (typeof auth === 'object' && Boolean(auth.verify))
   const hasLogout = hasUrl || (typeof auth === 'object' && Boolean(auth.logout))
-  return {
+  const resolved = {
     ...(hasChallenge ? { challenge: resolveAuthEndpoint(auth, 'challenge') } : {}),
     ...(hasVerify ? { verify: resolveAuthEndpoint(auth, 'verify') } : {}),
     ...(hasLogout ? { logout: resolveAuthEndpoint(auth, 'logout') } : {}),
     ...(typeof auth === 'object' && auth.returnToken ? { returnToken: true } : {}),
   }
+  assertSameAuthOrigin(resolved)
+  return resolved
+}
+
+function assertSameAuthOrigin(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+): void {
+  if (typeof auth !== 'object') return
+  const urls = [auth.challenge, auth.verify, auth.logout].filter(
+    (u): u is string => typeof u === 'string',
+  )
+  if (urls.length < 2) return
+  const origins = urls.map((url) => {
+    try {
+      return new URL(url).origin
+    } catch {
+      throw new RpcResponse.InvalidParamsError({
+        message: `\`auth\` endpoint is not a valid URL: ${url}`,
+      })
+    }
+  })
+  const first = origins[0]!
+  if (origins.some((origin) => origin !== first))
+    throw new RpcResponse.InvalidParamsError({
+      message:
+        '`auth` endpoints (`challenge`, `verify`, `logout`) must share the same origin.',
+    })
 }
 
 /**

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,9 +1,10 @@
 import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
-import { Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
+import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import type { Chain, Client as ViemClient, Transport } from 'viem'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
+import { parseSiweMessage } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
 import * as z from 'zod/mini'
 
@@ -500,9 +501,57 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const capabilities = request._decoded.params?.[0]?.capabilities
                     const authorizeAccessKey =
                       capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.()
-                    const personalSign = capabilities?.personalSign
 
-                    const { keyAuthorization, accounts, email, signature, username } =
+                    // Server Authentication: pre-resolve `auth` URLs against
+                    // this dapp-side Provider's `window.location.origin`. The
+                    // wallet host (different origin in dialog mode) cannot
+                    // reconstruct the dapp's origin, so forwarding the raw
+                    // relative URLs would resolve to the wrong host. We then
+                    // fetch the challenge BEFORE the ceremony so we can fold
+                    // its message into the existing `personalSign` capability.
+                    // Forwarding adapters (dialog) skip orchestration — the
+                    // wallet host's Provider runs it instead.
+                    const auth_input = capabilities?.auth ?? options.auth
+                    const auth_request = auth_input
+                      ? absolutizeAuth(
+                          auth_input as NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+                        )
+                      : undefined
+                    if (auth_request && capabilities?.personalSign)
+                      throw new RpcResponse.InvalidParamsError({
+                        message:
+                          '`auth` and `personalSign` cannot both be set on `wallet_connect`.',
+                      })
+
+                    // Patch the raw request so forwarding adapters carry the
+                    // absolutized auth URLs downstream.
+                    if (auth_request)
+                      request = {
+                        ...request,
+                        params: [
+                          {
+                            ...request.params?.[0],
+                            capabilities: {
+                              ...request.params?.[0]?.capabilities,
+                              auth: auth_request,
+                            },
+                          },
+                        ] as never,
+                      }
+
+                    const auth =
+                      auth_request && !instance.forwardsAuth
+                        ? await fetchAuthChallenge(
+                            auth_request,
+                            chainId ?? store.getState().chainId ?? 0,
+                          )
+                        : undefined
+
+                    const personalSign_request = auth
+                      ? { message: auth.message }
+                      : capabilities?.personalSign
+
+                    const { keyAuthorization, accounts, email, personalSign, signature, username } =
                       await (async () => {
                         if (capabilities?.method === 'register') {
                           // If a stored account already has this label, sign in
@@ -522,7 +571,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                                 credentialId: existing.credential?.id,
                                 digest: capabilities.digest,
                                 authorizeAccessKey,
-                                ...(personalSign ? { personalSign } : {}),
+                                ...(personalSign_request
+                                  ? { personalSign: personalSign_request }
+                                  : {}),
                               },
                               request,
                             )
@@ -532,7 +583,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                               authorizeAccessKey,
                               name: capabilities.name ?? 'default',
                               userId: capabilities.userId ?? Hex.random(16),
-                              ...(personalSign ? { personalSign } : {}),
+                              ...(personalSign_request
+                                ? { personalSign: personalSign_request }
+                                : {}),
                             },
                             request,
                           )
@@ -543,15 +596,51 @@ export function create(options: create.Options = {}): create.ReturnType {
                             digest: capabilities?.digest,
                             authorizeAccessKey,
                             selectAccount: capabilities?.selectAccount,
-                            ...(personalSign ? { personalSign } : {}),
+                            ...(personalSign_request
+                              ? { personalSign: personalSign_request }
+                              : {}),
                           },
                           request,
                         )
                       })()
 
-                    store.setState({ accounts: resolveAccounts(accounts), activeAccount: 0 })
+                    store.setState({
+                      accounts: resolveAccounts(accounts),
+                      activeAccount: 0,
+                      // Persist absolutized auth URLs so a later
+                      // `wallet_disconnect` can hit logout even when the
+                      // URL was passed per-call.
+                      ...(auth_request && typeof auth_request === 'object'
+                        ? { auth: auth_request }
+                        : {}),
+                    })
 
                     const accountAddress = accounts[0]?.address
+
+                    // Server Authentication verify: POST the signed SIWE message
+                    // to the verify endpoint. Skipped when the auth capability
+                    // omits `verify` — typical when the wallet host strips it
+                    // so the dapp-origin Provider does the verify call (and
+                    // receives the session cookie on the dapp's origin).
+                    //
+                    // The signed message comes from one of two places:
+                    // - terminal Provider (wallet host): `auth.message` we just fetched.
+                    // - forwarding Provider (dapp): `personalSign.message` echoed back
+                    //   by the wallet host's Provider.
+                    const verifyUrl =
+                      auth_request && typeof auth_request === 'object'
+                        ? auth_request.verify
+                        : undefined
+                    const verifyMessage = auth?.message ?? personalSign?.message
+                    const auth_result =
+                      auth_request && verifyUrl && verifyMessage && signature && accountAddress
+                        ? await verifyAuthMessage(auth_request, {
+                            address: accountAddress,
+                            message: verifyMessage,
+                            signature,
+                          })
+                        : undefined
+
                     return {
                       accounts: accounts.map((a) => ({
                         address: a.address,
@@ -569,16 +658,51 @@ export function create(options: create.Options = {}): create.ReturnType {
                                 ...(signature ? { signature } : {}),
                                 ...(email !== undefined ? { email } : {}),
                                 ...(username !== undefined ? { username } : {}),
+                                ...(auth_result ? { auth: auth_result } : {}),
+                                ...(personalSign
+                                  ? { personalSign: { message: personalSign.message } }
+                                  : {}),
                               }
                             : {},
                       })),
                     } satisfies Rpc.wallet_connect.Encoded['returns']
                   }
 
-                  case 'wallet_disconnect':
+                  case 'wallet_disconnect': {
+                    // Best-effort logout. Source of the URL, in order:
+                    // 1. Last-connected `auth` URLs persisted in the store
+                    //    (handles per-call `auth` passed via wallet_connect).
+                    // 2. Provider.create({ auth }) option fallback.
+                    // Swallows all errors — disconnect must succeed even
+                    // when the session is already gone or the server is
+                    // unreachable.
+                    const logoutUrl = (() => {
+                      const stored = store.getState().auth
+                      if (stored?.logout) return stored.logout
+                      if (!options.auth) return undefined
+                      try {
+                        const absolute = absolutizeAuth(
+                          options.auth as NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+                        )
+                        return typeof absolute === 'object' ? absolute.logout : undefined
+                      } catch {
+                        return undefined
+                      }
+                    })()
+                    if (logoutUrl)
+                      await fetch(logoutUrl, {
+                        method: 'POST',
+                        credentials: 'include',
+                      }).catch(() => {})
                     await actions.disconnect?.()
-                    store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
+                    store.setState({
+                      accessKeys: [],
+                      accounts: [],
+                      activeAccount: 0,
+                      auth: undefined,
+                    })
                     return
+                  }
 
                   case 'wallet_authorizeAccessKey': {
                     if (!actions.authorizeAccessKey)
@@ -766,6 +890,14 @@ export declare namespace create {
     /** Adapter to use for account management. @default dialog() */
     adapter?: Adapter.Adapter | undefined
     /**
+     * Default Server Authentication configuration for `wallet_connect`.
+     *
+     * When set, every `wallet_connect` call orchestrates the round-trip
+     * against this endpoint unless the caller passes their own
+     * `capabilities.auth` (per-call override).
+     */
+    auth?: z.input<typeof Rpc.wallet_connect.auth> | undefined
+    /**
      * Default access key parameters for `wallet_connect`.
      *
      * When set, `wallet_connect` will automatically authorize an access key.
@@ -793,4 +925,181 @@ export declare namespace create {
     testnet?: boolean | undefined
   }
   type ReturnType = Provider
+}
+
+/**
+ * Heuristic for whether the current runtime carries cookies on
+ * `fetch(..., { credentials: 'include' })`:
+ *
+ * - **Browser**: `document.cookie` exists → uses the browser cookie jar.
+ * - **React Native**: `navigator.product === 'ReactNative'` → uses the
+ *   native cookie store.
+ * - **Node / CLI**: neither — `credentials: 'include'` is a no-op.
+ *
+ * False negatives are possible (Node with `tough-cookie` shimmed in); the
+ * caller can always force token mode via `auth: { returnToken: true }`.
+ */
+function hasCookieJar(): boolean {
+  if (typeof document !== 'undefined' && typeof document.cookie === 'string') return true
+  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') return true
+  return false
+}
+
+/**
+ * Resolves a Server Authentication endpoint from the `auth` capability
+ * into an absolute URL.
+ *
+ * - `auth: '/api/auth'`            → `/api/auth/challenge`, `/api/auth` (verify), `/api/auth/logout`
+ * - `auth: { url: '/api/auth' }`   → same as above
+ * - `auth: { challenge, verify }`  → explicit per-endpoint
+ * - Mix: explicit endpoint wins over derivation from `url`.
+ *
+ * Relative paths (`/api/auth`, `auth/challenge`) are absolutized against
+ * `window.location.origin` when available — same shape as `resolveFeePayer`.
+ * Already-absolute `http(s)://` URLs pass through verbatim.
+ */
+function resolveAuthEndpoint(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+  kind: 'challenge' | 'verify' | 'logout',
+): string {
+  const path = (() => {
+    if (typeof auth === 'string') {
+      const base = auth.endsWith('/') ? auth.slice(0, -1) : auth
+      return kind === 'verify' ? base : `${base}/${kind}`
+    }
+    const explicit = auth[kind]
+    if (explicit) return explicit
+    if (auth.url) {
+      const base = auth.url.endsWith('/') ? auth.url.slice(0, -1) : auth.url
+      return kind === 'verify' ? base : `${base}/${kind}`
+    }
+    throw new RpcResponse.InvalidParamsError({
+      message: `\`auth\` capability must include either \`url\` or an explicit \`${kind}\` endpoint.`,
+    })
+  })()
+  if (path.startsWith('http://') || path.startsWith('https://')) return path
+  if (typeof window !== 'undefined') return new URL(path, window.location.origin).href
+  return path
+}
+
+/**
+ * Pre-resolves the `auth` capability into its absolute, fully-explicit
+ * object form. Run once at the dapp-side Provider so forwarding adapters
+ * (dialog) carry absolute URLs to the wallet host — the wallet's
+ * `window.location.origin` belongs to the wallet, not the dapp, and
+ * cannot resolve relative paths correctly.
+ *
+ * `logout` is omitted when the input doesn't supply enough info to derive
+ * one (it's optional in the protocol).
+ */
+function absolutizeAuth(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+): NonNullable<z.output<typeof Rpc.wallet_connect.auth>> {
+  // Wallet-host re-entry can strip endpoints (e.g. drop `verify` so the
+  // dapp-origin Provider runs verify). Only resolve endpoints the input
+  // can derive — pass through everything else as-is.
+  const hasUrl = typeof auth === 'string' || Boolean(auth.url)
+  const hasChallenge = hasUrl || (typeof auth === 'object' && Boolean(auth.challenge))
+  const hasVerify = hasUrl || (typeof auth === 'object' && Boolean(auth.verify))
+  const hasLogout = hasUrl || (typeof auth === 'object' && Boolean(auth.logout))
+  return {
+    ...(hasChallenge ? { challenge: resolveAuthEndpoint(auth, 'challenge') } : {}),
+    ...(hasVerify ? { verify: resolveAuthEndpoint(auth, 'verify') } : {}),
+    ...(hasLogout ? { logout: resolveAuthEndpoint(auth, 'logout') } : {}),
+    ...(typeof auth === 'object' && auth.returnToken ? { returnToken: true } : {}),
+  }
+}
+
+/**
+ * Fetches an auth challenge from the auth endpoint and validates that the
+ * server-supplied message is bound to the auth endpoint's origin and the
+ * requested chain.
+ *
+ * Expects an absolutized auth capability (post-`absolutizeAuth`).
+ *
+ * The signature produced from this challenge is a portable artifact: once
+ * the wallet signs, anyone holding the bytes can replay it against any
+ * auth verifier that accepts the embedded domain. We therefore refuse to
+ * sign a message whose `domain`/`uri` doesn't match the auth endpoint —
+ * otherwise a compromised auth provider could trick the wallet into
+ * signing "Sign in to attacker.com" and use it to log in as the user
+ * elsewhere.
+ */
+async function fetchAuthChallenge(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+  chainId: number,
+): Promise<{ message: string }> {
+  const url = typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge')
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ chainId }),
+  })
+  if (!res.ok)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned ${res.status}.`,
+    })
+  const body = (await res.json().catch(() => ({}))) as { message?: string }
+  if (!body.message)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` response missing \`message\`.`,
+    })
+
+  const parsed = parseSiweMessage(body.message)
+  const expected = new URL(url)
+
+  if (parsed.version !== '1')
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned a non-SIWE-v1 message.`,
+    })
+  if (!parsed.nonce)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` response is missing a \`nonce\`.`,
+    })
+  if (parsed.domain !== expected.host)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned a message bound to \`${parsed.domain}\` (expected \`${expected.host}\`).`,
+    })
+  if (parsed.uri !== expected.origin)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned a message with \`uri\` \`${parsed.uri}\` (expected \`${expected.origin}\`).`,
+    })
+  if (parsed.chainId !== chainId)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned a message bound to chainId \`${parsed.chainId}\` (expected \`${chainId}\`).`,
+    })
+
+  return { message: body.message }
+}
+
+/**
+ * Posts the signed message to the auth `verify` endpoint and returns
+ * the SDK-shaped `auth` capability output (`{ token }` in token mode,
+ * `{}` in cookie mode).
+ */
+async function verifyAuthMessage(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+  body: { address: Address.Address; message: string; signature: Hex.Hex },
+): Promise<{ token?: string }> {
+  const url = typeof auth === 'object' ? auth.verify! : resolveAuthEndpoint(auth, 'verify')
+  // Auto-request the token in environments without a cookie jar (Node
+  // CLI). Browser / React Native let the cookie do the work; explicit
+  // `returnToken: true` always wins.
+  const explicitReturnToken = typeof auth === 'object' && auth.returnToken === true
+  const returnToken = explicitReturnToken || !hasCookieJar()
+  const res = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      ...body,
+      ...(returnToken ? { returnToken: true } : {}),
+    }),
+  })
+  if (!res.ok)
+    throw new RpcResponse.InternalError({
+      message: `Server Authentication verify endpoint \`${url}\` returned ${res.status}.`,
+    })
+  const json = (await res.json().catch(() => ({}))) as { token?: string }
+  return json.token ? { token: json.token } : {}
 }

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -18,6 +18,20 @@ export type State = {
   accounts: readonly Account[]
   /** Index of the active account. */
   activeAccount: number
+  /**
+   * Absolutized Server Authentication endpoints from the most recent
+   * `wallet_connect` (or the Provider's `auth` option). Persisted so
+   * `wallet_disconnect` can call `logout` even after a page reload, even
+   * when the URL was passed per-call rather than at Provider creation.
+   */
+  auth?:
+    | {
+        challenge?: string | undefined
+        verify?: string | undefined
+        logout?: string | undefined
+        returnToken?: boolean | undefined
+      }
+    | undefined
   /** Active chain ID. */
   chainId: number
   /** Queued RPC requests pending resolution by the dialog. */
@@ -111,6 +125,7 @@ export function create(options: Options): Store {
               accounts,
               activeAccount: state.activeAccount,
               ...(persistCredentials ? { accessKeys: state.accessKeys } : {}),
+              ...(state.auth ? { auth: state.auth } : {}),
               chainId: state.chainId,
             } as unknown as State
           },

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -196,6 +196,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         unsubscribe()
         dialogInstance?.destroy()
       },
+      forwardsAuth: true,
       actions: {
         async createAccount(parameters, request) {
           const accessKey = await generateAccessKey(parameters.authorizeAccessKey)
@@ -231,6 +232,9 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             ...(keyAuthorization ? { keyAuthorization } : {}),
             ...(accounts[0]?.capabilities.signature
               ? { signature: accounts[0].capabilities.signature }
+              : {}),
+            ...(accounts[0]?.capabilities.personalSign
+              ? { personalSign: accounts[0].capabilities.personalSign }
               : {}),
           }
         },
@@ -269,6 +273,9 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             ...(keyAuthorization ? { keyAuthorization } : {}),
             ...(accounts[0]?.capabilities.signature
               ? { signature: accounts[0].capabilities.signature }
+              : {}),
+            ...(accounts[0]?.capabilities.personalSign
+              ? { personalSign: accounts[0].capabilities.personalSign }
               : {}),
           }
         },

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'vp/test'
+import * as z from 'zod/mini'
+
+import * as Rpc from './rpc.js'
+
+describe('wallet_connect.capabilities.request: auth', () => {
+  test('accepts string shorthand', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: '/api/auth',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": "/api/auth",
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts object with `url`', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { url: '/api/auth' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "url": "/api/auth",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts object with `url` and `returnToken`', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { url: '/api/auth', returnToken: true },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "returnToken": true,
+          "url": "/api/auth",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts explicit endpoints (challenge + verify + logout)', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { challenge: '/c', verify: '/v', logout: '/l' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "challenge": "/c",
+          "logout": "/l",
+          "verify": "/v",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts explicit endpoints with `returnToken` and no `logout`', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { challenge: '/c', verify: '/v', returnToken: true },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "challenge": "/c",
+          "returnToken": true,
+          "verify": "/v",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts explicit endpoints without `logout`', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { challenge: '/c', verify: '/v' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "challenge": "/c",
+          "verify": "/v",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts logout-only object (cross-field validation lives outside zod)', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { logout: '/l' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "logout": "/l",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('rejects auth as number', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: 42,
+      }),
+    ).toThrow()
+  })
+
+  test('rejects auth.url as number', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { url: 1 },
+      }),
+    ).toThrow()
+  })
+
+  test('rejects auth.returnToken as string', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { returnToken: 'yes' },
+      }),
+    ).toThrow()
+  })
+
+  test('accepts auth alongside register branch', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'register',
+        auth: '/api/auth',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": "/api/auth",
+        "method": "register",
+      }
+    `)
+  })
+})
+
+describe('wallet_connect.capabilities.result: auth + personalSign', () => {
+  test('accepts auth with token + personalSign echo + root signature', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.result, {
+        auth: { token: 'sess_abc' },
+        personalSign: { message: 'hello' },
+        signature: '0xdeadbeef',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "token": "sess_abc",
+        },
+        "personalSign": {
+          "message": "hello",
+        },
+        "signature": "0xdeadbeef",
+      }
+    `)
+  })
+
+  test('accepts cookie-mode auth (empty object, no token)', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.result, {
+        auth: {},
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {},
+      }
+    `)
+  })
+
+  test('accepts result without auth/personalSign', () => {
+    expect(z.parse(Rpc.wallet_connect.capabilities.result, {})).toMatchInlineSnapshot(`{}`)
+  })
+})
+
+describe('wallet_connect_strict.parameters: auth', () => {
+  test('accepts string shorthand', () => {
+    expect(
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: {
+          method: 'login',
+          auth: '/api/auth',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "capabilities": {
+          "auth": "/api/auth",
+          "method": "login",
+        },
+      }
+    `)
+  })
+
+  test('accepts object form with all fields', () => {
+    expect(
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: {
+          method: 'login',
+          auth: { url: '/api/auth', returnToken: true },
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "capabilities": {
+          "auth": {
+            "returnToken": true,
+            "url": "/api/auth",
+          },
+          "method": "login",
+        },
+      }
+    `)
+  })
+})

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -426,6 +426,38 @@ export namespace wallet_connect {
   export const authorizeAccessKey = z.optional(wallet_authorizeAccessKey.parameters)
 
   /**
+   * SIWE round-trip configuration. Bare string is shorthand for `{ url }`.
+   *
+   * - `auth: '/api/auth'` derives `${url}/challenge`, `${url}` (verify), `${url}/logout`.
+   * - Object form lets callers override individual endpoints, opt into a
+   *   `{ token }` body via `returnToken`, etc.
+   *
+   * Cross-field validation (must include `url` or both `challenge` + `verify`)
+   * is enforced inside `prepareSiwe`, not in zod, so the error message can be
+   * specific.
+   */
+  export const auth = z.optional(
+    z.union([
+      z.string(),
+      z.object({
+        /** Base URL. SDK derives `${url}/challenge` and `${url}/logout`; `${url}` itself is verify. */
+        url: z.optional(z.string()),
+        /** Override individual endpoints. Either `url` or both `challenge` + `verify` must be set. */
+        challenge: z.optional(z.string()),
+        verify: z.optional(z.string()),
+        logout: z.optional(z.string()),
+        /**
+         * Ask the verify endpoint to also return `{ token }` in the JSON body.
+         * Default `false` — cookie mode relies on `Set-Cookie` only.
+         * Set this for non-browser clients (RN, CLI) that can't store cookies, or
+         * to surface the JWT alongside a cookie in dual-transport setups.
+         */
+        returnToken: z.optional(z.boolean()),
+      }),
+    ]),
+  )
+
+  /**
    * Request a `personal_sign` (EIP-191) over the supplied message during
    * `wallet_connect`. The wallet computes `hashMessage(message)` and signs
    * the resulting 32-byte digest in the same passkey ceremony that loads
@@ -446,6 +478,7 @@ export namespace wallet_connect {
         z.object({
           digest: z.optional(u.hex()),
           authorizeAccessKey,
+          auth,
           method: z.literal('register'),
           name: z.optional(z.string()),
           personalSign,
@@ -455,6 +488,7 @@ export namespace wallet_connect {
           digest: z.optional(u.hex()),
           credentialId: z.optional(z.string()),
           authorizeAccessKey,
+          auth,
           method: z.optional(z.literal('login')),
           personalSign,
           selectAccount: z.optional(z.boolean()),
@@ -466,6 +500,27 @@ export namespace wallet_connect {
       keyAuthorization: z.optional(keyAuthorization),
       signature: z.optional(u.hex()),
       username: z.optional(z.nullable(z.string())),
+      /**
+       * SIWE round-trip output, populated when the request `auth` capability was set.
+       * `token` is present in JWT mode or when the request set `returnToken: true`.
+       * Cookie-mode default = `{}` (the session arrived via `Set-Cookie`).
+       */
+      auth: z.optional(
+        z.object({
+          token: z.optional(z.string()),
+        }),
+      ),
+      /**
+       * Echo of the `personalSign` request, present iff the caller set
+       * `capabilities.personalSign` (or `capabilities.auth` folded a SIWE
+       * message into the same slot). The signature itself lives on the
+       * top-level `capabilities.signature` field.
+       */
+      personalSign: z.optional(
+        z.object({
+          message: z.string(),
+        }),
+      ),
     }),
   }
 
@@ -499,6 +554,7 @@ export namespace wallet_connect {
 
 export namespace wallet_connect_strict {
   const authorizeAccessKey = z.optional(wallet_authorizeAccessKey_strict.parameters)
+  const auth = wallet_connect.auth
   const personalSign = wallet_connect.personalSign
 
   export const parameters = z.object({
@@ -507,6 +563,7 @@ export namespace wallet_connect_strict {
         z.object({
           digest: z.optional(u.hex()),
           authorizeAccessKey,
+          auth,
           method: z.literal('register'),
           name: z.optional(z.string()),
           personalSign,
@@ -516,6 +573,7 @@ export namespace wallet_connect_strict {
           digest: z.optional(u.hex()),
           credentialId: z.optional(z.string()),
           authorizeAccessKey,
+          auth,
           method: z.optional(z.literal('login')),
           personalSign,
           selectAccount: z.optional(z.boolean()),

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -4,6 +4,7 @@ import type { ExtractSchema, MergeSchemaPath, Schema } from 'hono/types'
 import type { UnionToIntersection } from '../internal/types.js'
 import * as RequestListener from './internal/requestListener.js'
 
+export { auth } from './internal/handlers/auth.js'
 export { codeAuth } from './internal/handlers/codeAuth.js'
 export { exchange } from './internal/handlers/exchange.js'
 export { relay } from './internal/handlers/relay.js'

--- a/src/server/Kv.test.ts
+++ b/src/server/Kv.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vp/test'
+
+import * as Kv from './Kv.js'
+
+describe('memory', () => {
+  test('default: round-trips set/get/delete', async () => {
+    const kv = Kv.memory()
+
+    await kv.set('a', { value: 1 })
+    expect(await kv.get('a')).toMatchInlineSnapshot(`
+      {
+        "value": 1,
+      }
+    `)
+
+    await kv.delete('a')
+    expect(await kv.get('a')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('ttl: returns value before expiry', async () => {
+    let now = 1_000_000
+    const kv = Kv.memory({ now: () => now })
+
+    await kv.set('a', 'v', { ttl: 60 })
+    now += 30_000
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v"`)
+  })
+
+  test('ttl: returns undefined after expiry', async () => {
+    let now = 1_000_000
+    const kv = Kv.memory({ now: () => now })
+
+    await kv.set('a', 'v', { ttl: 60 })
+    now += 60_001
+    expect(await kv.get('a')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('ttl: expiry deletes the entry (lazy eviction)', async () => {
+    let now = 1_000_000
+    const kv = Kv.memory({ now: () => now })
+
+    await kv.set('a', 'v', { ttl: 1 })
+    now += 2_000
+    await kv.get('a')
+    // Re-set without TTL; previous expired entry should be gone, not lingering.
+    await kv.set('a', 'v2')
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v2"`)
+  })
+})
+
+describe('cloudflare', () => {
+  test('default: forwards set/get/delete to underlying KV', async () => {
+    const calls: { method: string; args: unknown[] }[] = []
+    const fakeKv = {
+      get: async (key: string, format: 'json') => {
+        calls.push({ method: 'get', args: [key, format] })
+        return 'value' as never
+      },
+      put: async (key: string, value: string, options?: unknown) => {
+        calls.push({ method: 'put', args: [key, value, options] })
+      },
+      delete: async (key: string) => {
+        calls.push({ method: 'delete', args: [key] })
+      },
+    }
+    const kv = Kv.cloudflare(fakeKv)
+
+    await kv.set('a', { value: 1 })
+    await kv.get('a')
+    await kv.delete('a')
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "args": [
+            "a",
+            "{"value":1}",
+            undefined,
+          ],
+          "method": "put",
+        },
+        {
+          "args": [
+            "a",
+            "json",
+          ],
+          "method": "get",
+        },
+        {
+          "args": [
+            "a",
+          ],
+          "method": "delete",
+        },
+      ]
+    `)
+  })
+
+  test('ttl: passes expirationTtl seconds to underlying put', async () => {
+    const puts: { key: string; value: string; options: unknown }[] = []
+    const fakeKv = {
+      get: async () => undefined as never,
+      put: async (key: string, value: string, options?: unknown) => {
+        puts.push({ key, value, options })
+      },
+      delete: async () => {},
+    }
+    const kv = Kv.cloudflare(fakeKv)
+
+    await kv.set('a', 'v', { ttl: 60 })
+
+    expect(puts).toMatchInlineSnapshot(`
+      [
+        {
+          "key": "a",
+          "options": {
+            "expirationTtl": 60,
+          },
+          "value": ""v"",
+        },
+      ]
+    `)
+  })
+})

--- a/src/server/Kv.test.ts
+++ b/src/server/Kv.test.ts
@@ -46,6 +46,127 @@ describe('memory', () => {
     await kv.set('a', 'v2')
     expect(await kv.get('a')).toMatchInlineSnapshot(`"v2"`)
   })
+
+  test('take: returns the value and removes the entry', async () => {
+    const kv = Kv.memory()
+
+    await kv.set('n', { nonce: 'abc' })
+    expect(await kv.take!('n')).toMatchInlineSnapshot(`
+      {
+        "nonce": "abc",
+      }
+    `)
+    expect(await kv.get('n')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('take: returns undefined for missing or expired keys', async () => {
+    let now = 1_000_000
+    const kv = Kv.memory({ now: () => now })
+
+    expect(await kv.take!('missing')).toMatchInlineSnapshot(`undefined`)
+
+    await kv.set('e', 'v', { ttl: 1 })
+    now += 2_000
+    expect(await kv.take!('e')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('take: concurrent callers — only one observes the value', async () => {
+    // The whole point: read+delete is atomic across awaits, so two
+    // verifies racing on the same nonce can never both succeed.
+    const kv = Kv.memory()
+    await kv.set('nonce', 'one-time')
+
+    const [a, b] = await Promise.all([kv.take!('nonce'), kv.take!('nonce')])
+    const winners = [a, b].filter((v) => v !== undefined)
+    expect(winners).toMatchInlineSnapshot(`
+      [
+        "one-time",
+      ]
+    `)
+  })
+})
+
+describe('durableObject + NonceStorage', () => {
+  /**
+   * In-process simulation: a single `NonceStorage` instance backed by a
+   * Map, exposed via the same fetch protocol the real DO would use.
+   * This is exactly what the CF runtime gives us — single-actor, no
+   * concurrent requests interleaving inside the DO — so the same
+   * atomicity guarantees apply.
+   */
+  function fakeDurableObject() {
+    const map = new Map<string, unknown>()
+    const storage = {
+      async get<T>(key: string) {
+        return map.get(key) as T | undefined
+      },
+      async put(key: string, value: unknown) {
+        map.set(key, value)
+      },
+      async delete(key: string) {
+        map.delete(key)
+      },
+    }
+    const instance = new Kv.NonceStorage({ storage })
+    // Mimic the CF DO runtime's actor model: requests to the same DO
+    // instance are serialized — never two `fetch` invocations executing
+    // interleaved in the same actor.
+    let queue: Promise<unknown> = Promise.resolve()
+    const serialized = (req: Request) => {
+      const next = queue.then(() => instance.fetch(req))
+      queue = next.catch(() => {})
+      return next
+    }
+    return {
+      idFromName: (name: string) => name,
+      get: () => ({
+        fetch: (input: string, init?: unknown) =>
+          serialized(new Request(input, init as RequestInit)),
+      }),
+    }
+  }
+
+  test('round-trips set/get/delete via the DO fetch protocol', async () => {
+    const kv = Kv.durableObject(fakeDurableObject())
+
+    await kv.set('a', { value: 1 })
+    expect(await kv.get('a')).toMatchInlineSnapshot(`
+      {
+        "value": 1,
+      }
+    `)
+    await kv.delete('a')
+    expect(await kv.get('a')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('take: removes the entry and returns the value', async () => {
+    const kv = Kv.durableObject(fakeDurableObject())
+
+    await kv.set('n', 'one-time')
+    expect(await kv.take!('n')).toMatchInlineSnapshot(`"one-time"`)
+    expect(await kv.get('n')).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('take: concurrent callers — only one wins', async () => {
+    // The whole point of the DO adapter: even with parallel `take` calls
+    // only one observer receives the value. The DO actor serializes
+    // requests, so this is guaranteed by the runtime.
+    const kv = Kv.durableObject(fakeDurableObject())
+    await kv.set('nonce', 'consume-once')
+
+    const [a, b] = await Promise.all([kv.take!('nonce'), kv.take!('nonce')])
+    const winners = [a, b].filter((v) => v !== undefined)
+    expect(winners).toMatchInlineSnapshot(`
+      [
+        "consume-once",
+      ]
+    `)
+  })
+
+  test('take: missing key returns undefined', async () => {
+    const kv = Kv.durableObject(fakeDurableObject())
+    expect(await kv.take!('missing')).toMatchInlineSnapshot(`undefined`)
+  })
 })
 
 describe('cloudflare', () => {
@@ -94,6 +215,15 @@ describe('cloudflare', () => {
         },
       ]
     `)
+  })
+
+  test('take: NOT implemented (CF KV is not linearizable)', () => {
+    const kv = Kv.cloudflare({
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {},
+    })
+    expect(kv.take).toBeUndefined()
   })
 
   test('ttl: passes expirationTtl seconds to underlying put', async () => {

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -1,46 +1,100 @@
 import { Json } from 'ox'
 
+/**
+ * Minimal key-value store interface used by the SDK's server primitives
+ * (e.g. SIWE nonce store, session store).
+ *
+ * Values are JSON-serialized when stored. TTLs are optional; consumers that
+ * need expiry pass `{ ttl }` (in seconds) to `set` and the implementation
+ * lazily evicts (memory) or relies on the backing store's native expiry
+ * (Cloudflare KV).
+ */
 export type Kv = {
-  get: <value = unknown>(key: string) => Promise<value>
-  set: (key: string, value: unknown) => Promise<void>
+  /** Read a value by key. Returns `undefined` when missing or expired. */
+  get: <value = unknown>(key: string) => Promise<value | undefined>
+  /** Write a value. When `ttl` is set, the entry expires after the given duration in seconds. */
+  set: (key: string, value: unknown, options?: set.Options | undefined) => Promise<void>
+  /** Delete a value by key. */
   delete: (key: string) => Promise<void>
 }
 
+export declare namespace set {
+  type Options = {
+    /** Time-to-live in seconds. After this duration, `get` returns `undefined`. */
+    ttl?: number | undefined
+  }
+}
+
+/** Wrap an existing `Kv`-shaped object so the SDK accepts it as a `Kv`. */
 export function from<kv extends Kv>(kv: kv): kv {
   return kv
 }
 
+/**
+ * Adapt a Cloudflare Workers KV namespace (or compatible binding) into a
+ * `Kv`. Uses the underlying store's native `expirationTtl` for TTL.
+ *
+ * Cloudflare KV's minimum TTL is 60 seconds; the platform enforces its own
+ * minimum independent of what's passed here.
+ */
 export function cloudflare(kv: cloudflare.Parameters): Kv {
   return from({
     delete: kv.delete.bind(kv),
     async get(key) {
-      return kv.get(key, 'json')
+      return (await kv.get(key, 'json')) ?? undefined
     },
-    async set(key, value) {
-      return kv.put(key, Json.stringify(value))
+    async set(key, value, options) {
+      const expirationTtl = options?.ttl
+      await kv.put(key, Json.stringify(value), expirationTtl ? { expirationTtl } : undefined)
     },
   })
 }
 
 export declare namespace cloudflare {
-  export type Parameters = {
-    get: <value = unknown>(key: string, format: 'json') => Promise<value>
-    put: (key: string, value: string) => Promise<void>
+  type Parameters = {
+    get: <value = unknown>(key: string, format: 'json') => Promise<value | null>
+    put: (key: string, value: string, options?: { expirationTtl?: number } | undefined) => Promise<void>
     delete: (key: string) => Promise<void>
   }
 }
 
-export function memory(): Kv {
-  const store = new Map<string, unknown>()
+/**
+ * In-memory `Kv` for tests and single-process deployments. Lazily evicts
+ * expired entries on read/write.
+ *
+ * Pass `now` to control the clock in tests.
+ */
+export function memory(options: memory.Options = {}): Kv {
+  const now = options.now ?? Date.now
+  const store = new Map<string, { value: unknown; expiresAt?: number }>()
+
+  function isExpired(entry: { expiresAt?: number }) {
+    return entry.expiresAt !== undefined && now() >= entry.expiresAt
+  }
+
   return from({
     async delete(key) {
-      Promise.resolve(store.delete(key))
+      store.delete(key)
     },
     async get(key) {
-      return store.get(key) as any
+      const entry = store.get(key)
+      if (!entry) return undefined
+      if (isExpired(entry)) {
+        store.delete(key)
+        return undefined
+      }
+      return entry.value as never
     },
-    async set(key, value) {
-      store.set(key, value)
+    async set(key, value, options) {
+      const expiresAt = options?.ttl ? now() + options.ttl * 1000 : undefined
+      store.set(key, expiresAt !== undefined ? { value, expiresAt } : { value })
     },
   })
+}
+
+export declare namespace memory {
+  type Options = {
+    /** Clock function for TTL accounting. Defaults to `Date.now`. */
+    now?: (() => number) | undefined
+  }
 }

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -16,6 +16,20 @@ export type Kv = {
   set: (key: string, value: unknown, options?: set.Options | undefined) => Promise<void>
   /** Delete a value by key. */
   delete: (key: string) => Promise<void>
+  /**
+   * Atomic read-and-delete. Returns the value if present, `undefined` if
+   * missing or expired. Across concurrent callers, exactly one observer
+   * receives a non-`undefined` return for a given key, and the key is
+   * removed exactly once.
+   *
+   * Optional. Required for one-time-consume semantics (e.g. SIWE
+   * challenge nonces). Backends without a linearizable read+delete
+   * primitive (e.g. eventually-consistent stores like Cloudflare KV)
+   * should leave this undefined; the consuming handler will refuse to
+   * accept the store at construction time and fall back to a different
+   * backend (e.g. a Durable Object).
+   */
+  take?: <value = unknown>(key: string) => Promise<value | undefined>
 }
 
 export declare namespace set {
@@ -36,6 +50,12 @@ export function from<kv extends Kv>(kv: kv): kv {
  *
  * Cloudflare KV's minimum TTL is 60 seconds; the platform enforces its own
  * minimum independent of what's passed here.
+ *
+ * **Not safe for one-time-consume semantics.** Cloudflare KV is eventually
+ * consistent across data centers — concurrent read+delete races can let
+ * the same key be "consumed" twice. `take` is intentionally NOT
+ * implemented. Use a Durable Object (or another linearizable backend)
+ * for the SIWE challenge nonce store.
  */
 export function cloudflare(kv: cloudflare.Parameters): Kv {
   return from({
@@ -56,6 +76,167 @@ export declare namespace cloudflare {
     put: (key: string, value: string, options?: { expirationTtl?: number } | undefined) => Promise<void>
     delete: (key: string) => Promise<void>
   }
+}
+
+/**
+ * Adapt a Cloudflare Durable Object namespace into a `Kv` with atomic
+ * `take`. Unlike `Kv.cloudflare`, a Durable Object's storage is
+ * single-actor and linearizable — `take` (read+delete) is guaranteed
+ * atomic across concurrent callers, which makes this the recommended
+ * backend for SIWE challenge nonce storage on Cloudflare Workers.
+ *
+ * Pair with `Kv.NonceStorage` (or your own DO class implementing the
+ * same fetch protocol).
+ *
+ * Example:
+ *
+ * ```ts
+ * // wrangler.jsonc
+ * // {
+ * //   "durable_objects": {
+ * //     "bindings": [{ "name": "NONCE_DO", "class_name": "NonceStorage" }]
+ * //   },
+ * //   "migrations": [{ "tag": "v1", "new_classes": ["NonceStorage"] }]
+ * // }
+ *
+ * // worker.ts
+ * export { NonceStorage } from 'accounts/server'
+ *
+ * export default {
+ *   fetch(req, env) {
+ *     const handler = Handler.auth({
+ *       store: Kv.durableObject(env.NONCE_DO),
+ *       publicOrigin: 'https://app.example.com',
+ *     })
+ *     return handler.fetch(req)
+ *   }
+ * }
+ * ```
+ */
+export function durableObject(
+  namespace: durableObject.Namespace,
+  options: durableObject.Options = {},
+): Kv {
+  const instanceName = options.name ?? 'default'
+  const stub = () => namespace.get(namespace.idFromName(instanceName))
+
+  async function rpc(op: string, key: string, body?: unknown): Promise<unknown> {
+    const url = `https://do.invalid/${op}?key=${encodeURIComponent(key)}`
+    const init: RequestInit =
+      body !== undefined
+        ? {
+            method: 'POST',
+            body: Json.stringify(body),
+            headers: { 'content-type': 'application/json' },
+          }
+        : { method: 'POST' }
+    const res = await stub().fetch(url, init as never)
+    if (!res.ok) throw new Error(`Kv.durableObject ${op} failed: ${res.status}`)
+    return await res.json()
+  }
+
+  return from({
+    async get(key) {
+      const { value } = (await rpc('get', key)) as { value: unknown }
+      return value as never
+    },
+    async set(key, value, options) {
+      await rpc('set', key, { value, ttl: options?.ttl })
+    },
+    async delete(key) {
+      await rpc('delete', key)
+    },
+    async take(key) {
+      const { value } = (await rpc('take', key)) as { value: unknown }
+      return value as never
+    },
+  })
+}
+
+export declare namespace durableObject {
+  /**
+   * Minimal shape of a Cloudflare Durable Object namespace binding.
+   * Compatible with `DurableObjectNamespace` from `@cloudflare/workers-types`.
+   */
+  type Namespace = {
+    idFromName: (name: string) => unknown
+    get: (id: unknown) => { fetch: (input: string, init?: unknown) => Promise<Response> }
+  }
+  type Options = {
+    /**
+     * Durable Object instance name. Defaults to `'default'` (a single
+     * shared actor). Use a per-tenant name if you need isolation.
+     */
+    name?: string | undefined
+  }
+}
+
+/**
+ * Reference Durable Object class implementing the `Kv.durableObject`
+ * fetch protocol. Export from your Worker entry and bind it under
+ * `class_name: "NonceStorage"` in `wrangler.jsonc`.
+ *
+ * The class is framework-agnostic — it doesn't import `cloudflare:workers`
+ * so it works with both the legacy DO API (`fetch(req)` only) and the
+ * newer `extends DurableObject` API.
+ */
+export class NonceStorage {
+  state: NonceStorage.State
+
+  constructor(state: NonceStorage.State, _env?: unknown) {
+    this.state = state
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    const op = url.pathname.replace(/^\//, '')
+    const key = url.searchParams.get('key')
+    if (!key) return Response.json({ error: 'missing `key`' }, { status: 400 })
+
+    const isExpired = (entry: { expiresAt?: number } | undefined) =>
+      Boolean(entry?.expiresAt && Date.now() >= entry.expiresAt)
+
+    if (op === 'get') {
+      const entry = await this.state.storage.get<NonceStorage.Entry>(key)
+      if (!entry || isExpired(entry)) return Response.json({ value: undefined })
+      return Response.json({ value: entry.value })
+    }
+    if (op === 'take') {
+      const entry = await this.state.storage.get<NonceStorage.Entry>(key)
+      if (!entry || isExpired(entry)) {
+        if (entry) await this.state.storage.delete(key)
+        return Response.json({ value: undefined })
+      }
+      await this.state.storage.delete(key)
+      return Response.json({ value: entry.value })
+    }
+    if (op === 'set') {
+      const body = (await request.json()) as { value: unknown; ttl?: number }
+      const entry: NonceStorage.Entry = body.ttl
+        ? { value: body.value, expiresAt: Date.now() + body.ttl * 1000 }
+        : { value: body.value }
+      await this.state.storage.put(key, entry)
+      return Response.json({})
+    }
+    if (op === 'delete') {
+      await this.state.storage.delete(key)
+      return Response.json({})
+    }
+    return Response.json({ error: `unknown op: ${op}` }, { status: 400 })
+  }
+}
+
+export declare namespace NonceStorage {
+  /** Subset of `DurableObjectState` actually used by `NonceStorage`. */
+  type State = {
+    storage: {
+      get: <T = unknown>(key: string) => Promise<T | undefined>
+      put: (key: string, value: unknown) => Promise<void>
+      delete: (key: string) => Promise<void>
+    }
+  }
+  /** Internal storage shape: value plus optional absolute expiry timestamp (ms). */
+  type Entry = { value: unknown; expiresAt?: number }
 }
 
 /**
@@ -88,6 +269,16 @@ export function memory(options: memory.Options = {}): Kv {
     async set(key, value, options) {
       const expiresAt = options?.ttl ? now() + options.ttl * 1000 : undefined
       store.set(key, expiresAt !== undefined ? { value, expiresAt } : { value })
+    },
+    // Atomic in-process: the synchronous `Map.get` + `Map.delete` runs
+    // in a single microtask, so concurrent `take(key)` callers (within
+    // the same Node/Bun/Worker process) cannot both observe the value.
+    async take(key) {
+      const entry = store.get(key)
+      if (!entry) return undefined
+      store.delete(key)
+      if (isExpired(entry)) return undefined
+      return entry.value as never
     },
   })
 }

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -1,0 +1,345 @@
+import { Hono } from 'hono'
+import { privateKeyToAccount } from 'viem/accounts'
+import { parseSiweMessage } from 'viem/siwe'
+import { describe, expect, test } from 'vp/test'
+
+import * as Handler from '../../Handler.js'
+import * as Kv from '../../Kv.js'
+import { auth } from './auth.js'
+
+const account = privateKeyToAccount(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+)
+const otherAccount = privateKeyToAccount(
+  '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
+)
+
+describe('challenge', () => {
+  test('returns challenge message with chainId, nonce, zero-address placeholder', async () => {
+    const { app } = setup()
+
+    const { status, body } = await getChallenge(app, { chainId: 1 })
+
+    expect(status).toBe(200)
+    const parsed = parseSiweMessage(body.message!)
+    expect(parsed.address).toBe('0x0000000000000000000000000000000000000000')
+    expect(parsed.chainId).toBe(1)
+    expect(parsed.domain).toBe('wallet.example')
+    expect(parsed.uri).toBe('http://wallet.example')
+    expect(parsed.version).toBe('1')
+    expect(parsed.nonce).toMatch(/^[a-z0-9]+$/)
+  })
+
+  test('defaults chainId to 0 when omitted', async () => {
+    const { app } = setup()
+
+    const res = await app.request('/challenge', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'wallet.example' },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(200)
+    const { message } = (await res.json()) as { message: string }
+    expect(parseSiweMessage(message).chainId).toBe(0)
+  })
+
+  test('persists the nonce in the store with TTL', async () => {
+    const store = Kv.memory()
+    const { app } = setup({ store })
+
+    const { body } = await getChallenge(app, { chainId: 1 })
+    const nonce = parseSiweMessage(body.message!).nonce!
+
+    expect(await store.get(`challenge:${nonce}`)).toMatchObject({ chainId: 1 })
+  })
+})
+
+describe('verify (EOA, cookie mode)', () => {
+  test('default: verifies signature, sets cookie, persists session', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchInlineSnapshot(`{}`)
+
+    const setCookie = res.headers.get('set-cookie')
+    expect(setCookie).toContain('accounts_auth=')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('SameSite=Lax')
+
+    // getSession resolves the persisted payload from a follow-up request.
+    const followUp = new Request('http://wallet.example/', {
+      headers: { cookie: setCookie!.split(';')[0]! },
+    })
+    const session = await handler.getSession(followUp)
+    expect(session?.address).toBe(account.address)
+    expect(session?.chainId).toBe(1)
+
+    // Session is also persisted in the store under `session:` prefix.
+    const token = setCookie!.split(';')[0]!.split('=')[1]!
+    expect(await store.get(`session:${token}`)).toBeDefined()
+  })
+
+  test('rejects replayed nonce with 409', async () => {
+    const { app } = setup()
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const ok = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+    expect(ok.status).toBe(200)
+
+    const replay = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+    expect(replay.status).toBe(409)
+    expect(await replay.json()).toMatchInlineSnapshot(`
+      {
+        "error": "invalid or replayed nonce",
+      }
+    `)
+  })
+
+  test('rejects signature for a different address with 401', async () => {
+    const { app } = setup()
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: otherAccount.address,
+      message,
+      signature,
+    })
+    expect(res.status).toBe(401)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "signature does not match address",
+      }
+    `)
+  })
+
+  test('rejects domain mismatch with 400', async () => {
+    const { app } = setup()
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const tampered = challengeBody.message!.replace('wallet.example', 'evil.example')
+    const signature = await account.signMessage({ message: tampered })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message: tampered,
+      signature,
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "domain mismatch",
+      }
+    `)
+  })
+
+  test('rejects malformed body with 400', async () => {
+    const { app } = setup()
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'wallet.example' },
+      body: '',
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('logout', () => {
+  test('clears the session cookie and deletes the store entry', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const verify = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+    const sessionCookie = verify.headers.get('set-cookie')!.split(';')[0]!
+    const token = sessionCookie.split('=')[1]!
+
+    expect(await store.get(`session:${token}`)).toBeDefined()
+
+    const logout = await app.request('/logout', {
+      method: 'POST',
+      headers: { cookie: sessionCookie, host: 'wallet.example' },
+    })
+    expect(logout.status).toBe(204)
+
+    const clearCookie = logout.headers.get('set-cookie')!
+    expect(clearCookie).toContain('accounts_auth=')
+    expect(clearCookie).toContain('Max-Age=0')
+
+    expect(await store.get(`session:${token}`)).toBeUndefined()
+    const followUp = new Request('http://wallet.example/', {
+      headers: { cookie: sessionCookie },
+    })
+    expect(await handler.getSession(followUp)).toBeUndefined()
+  })
+
+  test('204 unconditionally even without a session cookie', async () => {
+    const { app } = setup()
+    const res = await app.request('/logout', {
+      method: 'POST',
+      headers: { host: 'wallet.example' },
+    })
+    expect(res.status).toBe(204)
+  })
+})
+
+describe('verify (token mode)', () => {
+  test('returnToken=true returns { token } in body and skips Set-Cookie', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+      returnToken: true,
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('set-cookie')).toBeNull()
+
+    const { token } = (await res.json()) as { token: string }
+    expect(token).toMatch(/^[a-z0-9]+$/)
+
+    expect(await store.get(`session:${token}`)).toBeDefined()
+
+    // Bearer-mode getSession resolves the token.
+    const followUp = new Request('http://wallet.example/', {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    const session = await handler.getSession(followUp)
+    expect(session?.address).toBe(account.address)
+  })
+})
+
+describe('getSession', () => {
+  test('returns undefined when no cookie is present', async () => {
+    const { handler } = setup()
+    const req = new Request('http://wallet.example/')
+    expect(await handler.getSession(req)).toBeUndefined()
+  })
+
+  test('prefers Authorization: Bearer over cookie', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ store })
+
+    // Issue session #1 via cookie mode.
+    const ch1 = await getChallenge(app, { chainId: 1 })
+    const sig1 = await account.signMessage({ message: ch1.body.message! })
+    const v1 = await postVerify(app, {
+      address: account.address,
+      message: ch1.body.message!,
+      signature: sig1,
+    })
+    const cookie = v1.headers.get('set-cookie')!.split(';')[0]!
+
+    // Issue session #2 via token mode for a different address.
+    const ch2 = await getChallenge(app, { chainId: 1 })
+    const sig2 = await otherAccount.signMessage({ message: ch2.body.message! })
+    const v2 = await postVerify(app, {
+      address: otherAccount.address,
+      message: ch2.body.message!,
+      signature: sig2,
+      returnToken: true,
+    })
+    const { token } = (await v2.json()) as { token: string }
+
+    // When both are present, the bearer wins.
+    const req = new Request('http://wallet.example/', {
+      headers: { cookie, authorization: `Bearer ${token}` },
+    })
+    const session = await handler.getSession(req)
+    expect(session?.address).toBe(otherAccount.address)
+  })
+})
+
+describe('Handler.compose integration', () => {
+  test('mounts under a custom path and routes correctly', async () => {
+    const composed = Handler.compose([auth({ domain: 'wallet.example' })], {
+      path: '/api/auth',
+    })
+
+    const challengeRes = await composed.request('/api/auth/challenge', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'wallet.example' },
+      body: JSON.stringify({ chainId: 1 }),
+    })
+    expect(challengeRes.status).toBe(200)
+
+    const notFound = await composed.request('/api/auth/whatever', {
+      method: 'GET',
+      headers: { host: 'wallet.example' },
+    })
+    expect(notFound.status).toBe(404)
+  })
+})
+
+function setup(options: Parameters<typeof auth>[0] = {}) {
+  const handler = auth({ domain: 'wallet.example', ...options })
+  // Mount under '/' so tests hit /challenge, /, /logout directly.
+  const app = new Hono()
+  app.route('/', handler)
+  return { handler, app }
+}
+
+async function getChallenge(app: Hono, body: { chainId: number }) {
+  const res = await app.request('/challenge', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: 'wallet.example' },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: (await res.json()) as { message?: string; error?: string } }
+}
+
+async function postVerify(
+  app: Hono,
+  body: {
+    address: string
+    message: string
+    signature: string
+    returnToken?: boolean
+  },
+) {
+  const res = await app.request('/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: 'wallet.example' },
+    body: JSON.stringify(body),
+  })
+  return res
+}

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -167,6 +167,7 @@ describe('verify (EOA, cookie mode)', () => {
     })
     expect(res.status).toBe(400)
   })
+
 })
 
 describe('logout', () => {
@@ -286,6 +287,117 @@ describe('getSession', () => {
     })
     const session = await handler.getSession(req)
     expect(session?.address).toBe(otherAccount.address)
+  })
+})
+
+describe('store: atomic `take` preferred, non-atomic fallback', () => {
+  test('Kv.memory() (has `take`) is accepted', () => {
+    expect(() => auth({ store: Kv.memory() })).not.toThrow()
+  })
+
+  test('store without `take` falls back to non-atomic get + delete', async () => {
+    // The fallback path is racy on eventually-consistent stores but
+    // works correctly in single-process serial usage. Verify the
+    // handler still constructs and the verify endpoint can consume a
+    // challenge end-to-end.
+    const noTake: Kv.Kv = (() => {
+      const map = new Map<string, unknown>()
+      return {
+        async get(key) {
+          return map.get(key) as never
+        },
+        async set(key, value) {
+          map.set(key, value)
+        },
+        async delete(key) {
+          map.delete(key)
+        },
+      }
+    })()
+    const handler = auth({ domain: 'wallet.example', store: noTake })
+    const app = new Hono()
+    app.route('/', handler)
+
+    const challenge = await app.request('/challenge', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'wallet.example' },
+      body: JSON.stringify({ chainId: 1 }),
+    })
+    expect(challenge.status).toBe(200)
+  })
+})
+
+describe('publicOrigin / trustProxy', () => {
+  test('default: ignores `x-forwarded-host` and `x-forwarded-proto`', async () => {
+    // No domain pin — relies on host header. trustProxy defaults to false.
+    const handler = auth()
+    const app = new Hono()
+    app.route('/', handler)
+
+    const res = await app.request('/challenge', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        host: 'real.example',
+        'x-forwarded-host': 'attacker.example',
+        'x-forwarded-proto': 'http',
+      },
+      body: JSON.stringify({ chainId: 1 }),
+    })
+    const body = (await res.json()) as { message: string }
+    const parsed = parseSiweMessage(body.message)
+    expect(parsed.domain).toBe('real.example')
+  })
+
+  test('trustProxy: true → honors `x-forwarded-host` and `x-forwarded-proto`', async () => {
+    const handler = auth({ trustProxy: true })
+    const app = new Hono()
+    app.route('/', handler)
+
+    const res = await app.request('/challenge', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        host: 'internal.example',
+        'x-forwarded-host': 'app.example',
+        'x-forwarded-proto': 'https',
+      },
+      body: JSON.stringify({ chainId: 1 }),
+    })
+    const body = (await res.json()) as { message: string }
+    const parsed = parseSiweMessage(body.message)
+    expect(parsed.domain).toBe('app.example')
+    expect(parsed.uri).toBe('https://app.example')
+  })
+
+  test('publicOrigin: pinned origin overrides host and forwarded headers', async () => {
+    const handler = auth({
+      publicOrigin: 'https://app.example.com',
+      trustProxy: true,
+    })
+    const app = new Hono()
+    app.route('/', handler)
+
+    const res = await app.request('/challenge', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        host: 'internal.example',
+        'x-forwarded-host': 'attacker.example',
+        'x-forwarded-proto': 'http',
+      },
+      body: JSON.stringify({ chainId: 1 }),
+    })
+    const body = (await res.json()) as { message: string }
+    const parsed = parseSiweMessage(body.message)
+    expect(parsed.domain).toBe('app.example.com')
+    expect(parsed.uri).toBe('https://app.example.com')
+  })
+
+  test('publicOrigin: invalid URL throws at construction time', async () => {
+    expect(() => auth({ publicOrigin: 'not-a-url' })).toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`auth({ publicOrigin })\` must be a valid absolute URL. Got: not-a-url]`,
+    )
   })
 })
 

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -1,0 +1,302 @@
+import { getCookie, setCookie } from 'hono/cookie'
+import type { Address, Transport } from 'viem'
+import { createClient, http, zeroAddress } from 'viem'
+import { verifyMessage } from 'viem/actions'
+import { tempo } from 'viem/chains'
+import { createSiweMessage, generateSiweNonce, parseSiweMessage } from 'viem/siwe'
+import * as z from 'zod/mini'
+
+import * as u from '../../../core/zod/utils.js'
+import { type Handler, from } from '../../Handler.js'
+import * as Kv from '../../Kv.js'
+import * as Hono from '../hono.js'
+
+const defaults = {
+  cookieName: 'accounts_auth',
+  ttl: {
+    challenge: 10 * 60, // 10 minutes
+    session: 24 * 60 * 60, // 24 hours
+  },
+} as const
+
+/**
+ * Session payload persisted in the session store and surfaced via
+ * `getSession`. `address` is the account address that signed the
+ * authentication challenge; `chainId` is the chain echoed in the message.
+ */
+export type SessionPayload = {
+  /** Address of the account. */
+  address: Address
+  /** Chain ID echoed into the challenge message. */
+  chainId: number
+  /** Unix timestamp (seconds) when the session was issued. */
+  issuedAt: number
+  /** Unix timestamp (seconds) when the session expires. */
+  expiresAt: number
+}
+
+/**
+ * Internal challenge-store entry. Tracked separately from the session
+ * payload because challenges are single-use and the address isn't bound at
+ * challenge time — the account supplies the address at verify time and the
+ * server uses the supplied address as the session subject.
+ */
+type ChallengePayload = {
+  chainId: number
+  expiresAt: number
+}
+
+const challengeKey = (nonce: string) => `challenge:${nonce}`
+const sessionKey = (token: string) => `session:${token}`
+
+/** Zod schemas for the auth handler's request and response payloads. */
+export namespace schema {
+  /** Schemas for `POST {path}/challenge`. */
+  export namespace challenge {
+    /** Request body schema. */
+    export const parameters = z.object({
+      chainId: z.optional(z.number()),
+    })
+
+    /** Response body schema. */
+    export const returns = z.object({
+      message: z.string(),
+    })
+  }
+
+  /** Schemas for `POST {path}` (verify). */
+  export namespace verify {
+    /** Request body schema. */
+    export const parameters = z.object({
+      address: u.address(),
+      message: z.string(),
+      signature: u.hex(),
+      /**
+       * When `true`, the server returns the issued session token in the
+       * response body as `{ token }` and does NOT set a session cookie.
+       * The caller is responsible for sending it as
+       * `Authorization: Bearer <token>` on subsequent requests.
+       */
+      returnToken: z.optional(z.boolean()),
+    })
+
+    /** Response body schema. */
+    export const returns = z.object({
+      token: z.optional(z.string()),
+    })
+  }
+}
+
+/**
+ * Server Authentication request handler. Mounts three routes under `path`:
+ *
+ * - `POST {path}/challenge` → `{ message }`
+ * - `POST {path}` → verify and issue a session (cookie via `Set-Cookie`)
+ * - `POST {path}/logout` → clear the session cookie
+ *
+ * The returned handler also exposes `getSession(req)` for resolving the
+ * current session from a follow-up request's cookie.
+ *
+ * The challenge message is wire-formatted as EIP-4361 (SIWE) for ecosystem
+ * compatibility, but address binding is deferred: the SDK can fold the
+ * challenge digest into the connect ceremony before the account knows
+ * which address it will sign with. The wallet supplies the real address at
+ * verify time and the server uses it as the session subject.
+ */
+export function auth(options: auth.Options = {}): auth.ReturnType {
+  const {
+    cookieName = defaults.cookieName,
+    domain,
+    path = '/',
+    store = Kv.memory(),
+    transport = http(),
+    ttl: { challenge: challengeTtl = defaults.ttl.challenge, session: sessionTtl = defaults.ttl.session } = {},
+    ...rest
+  } = options
+
+  const client = createClient({ chain: tempo, transport })
+
+  const router = from(rest)
+  const verifyPath = path === '/' ? '/' : path
+  const challengePath = path === '/' ? '/challenge' : `${path}/challenge`
+  const logoutPath = path === '/' ? '/logout' : `${path}/logout`
+
+  router.post(challengePath, Hono.validate('json', schema.challenge.parameters), async (c) => {
+    const { chainId = 0 } = c.req.valid('json')
+
+    const { protocol, host: reqHost } = publicOrigin(c.req.raw)
+    const resolvedDomain = domain ?? reqHost
+
+    const nonce = generateSiweNonce()
+    const issuedAt = new Date()
+    const expirationTime = new Date(issuedAt.getTime() + challengeTtl * 1000)
+
+    const message = createSiweMessage({
+      address: zeroAddress,
+      chainId,
+      domain: resolvedDomain,
+      uri: `${protocol}//${resolvedDomain}`,
+      version: '1',
+      nonce,
+      issuedAt,
+      expirationTime,
+    })
+
+    await store.set(
+      challengeKey(nonce),
+      { chainId, expiresAt: Math.floor(expirationTime.getTime() / 1000) },
+      { ttl: challengeTtl },
+    )
+
+    return c.json(z.encode(schema.challenge.returns, { message }))
+  })
+
+  router.post(verifyPath, Hono.validate('json', schema.verify.parameters), async (c) => {
+    const { address, message, signature, returnToken } = c.req.valid('json')
+
+    const parsed = parseSiweMessage(message)
+    if (!parsed.nonce) return c.json({ error: 'message missing `nonce`' }, 400)
+
+    const { protocol, host: reqHost } = publicOrigin(c.req.raw)
+    const resolvedDomain = domain ?? reqHost
+    if (parsed.domain !== resolvedDomain)
+      return c.json({ error: 'domain mismatch' }, 400)
+
+    const now = Date.now()
+    if (parsed.expirationTime && parsed.expirationTime.getTime() < now)
+      return c.json({ error: 'message expired' }, 400)
+    if (parsed.notBefore && parsed.notBefore.getTime() > now)
+      return c.json({ error: 'message not yet valid' }, 400)
+
+    // Atomically consume the challenge: read + delete + assert it existed.
+    const challenge = await store.get<ChallengePayload>(challengeKey(parsed.nonce))
+    if (!challenge) return c.json({ error: 'invalid or replayed nonce' }, 409)
+    await store.delete(challengeKey(parsed.nonce))
+
+    if (parsed.chainId !== challenge.chainId)
+      return c.json({ error: 'chainId mismatch' }, 400)
+
+    // Signature verification via viem's `verifyMessage`. Tempo's chain
+    // override unwraps `SignatureEnvelope` for WebAuthn / P256 / keychain
+    // sigs and falls back to ECDSA recovery for plain EOAs.
+    let valid: boolean
+    try {
+      valid = await verifyMessage(client, { address, message, signature })
+    } catch {
+      return c.json({ error: 'invalid signature' }, 401)
+    }
+    if (!valid) return c.json({ error: 'signature does not match address' }, 401)
+
+    const issuedAt = Math.floor(now / 1000)
+    const session: SessionPayload = {
+      address,
+      chainId: parsed.chainId,
+      issuedAt,
+      expiresAt: issuedAt + sessionTtl,
+    }
+    const token = generateSiweNonce()
+    await store.set(sessionKey(token), session, { ttl: sessionTtl })
+
+    // Token mode (opt-in): caller will send `Authorization: Bearer <token>`.
+    // Cookie mode (default): browser carries the cookie automatically.
+    if (returnToken) return c.json(z.encode(schema.verify.returns, { token }))
+
+    setCookie(c, cookieName, token, {
+      httpOnly: true,
+      sameSite: 'Lax',
+      secure: protocol === 'https:',
+      path: '/',
+      maxAge: sessionTtl,
+    })
+
+    return c.json(z.encode(schema.verify.returns, {}))
+  })
+
+  router.post(logoutPath, async (c) => {
+    const token = getCookie(c, cookieName)
+    if (token) await store.delete(sessionKey(token))
+    setCookie(c, cookieName, '', { path: '/', maxAge: 0 })
+    return c.body(null, 204)
+  })
+
+  const getSession: auth.getSession = async (req) => {
+    // Prefer `Authorization: Bearer <token>` (token mode) over cookie
+    // (cookie mode). Either is accepted on every request.
+    const authz = req.headers.get('authorization')
+    const bearer = authz?.toLowerCase().startsWith('bearer ')
+      ? authz.slice(7).trim()
+      : undefined
+    const cookieHeader = req.headers.get('cookie')
+    const token = bearer ?? (cookieHeader ? parseCookieValue(cookieHeader, cookieName) : undefined)
+    if (!token) return undefined
+    return await store.get<SessionPayload>(sessionKey(token))
+  }
+
+  return Object.assign(router, { getSession })
+}
+
+export declare namespace auth {
+  /** Return type of `auth()` — a `Handler` extended with `getSession`. */
+  type ReturnType = Handler & { getSession: getSession }
+
+  /** Resolves the current session from a request's cookie. */
+  type getSession = (req: Request) => Promise<SessionPayload | undefined>
+
+  type Options = from.Options & {
+    /** Cookie name for the session token. @default "accounts_auth" */
+    cookieName?: string | undefined
+    /** Domain echoed into challenge messages. @default request `Host` header */
+    domain?: string | undefined
+    /** Path prefix for the auth endpoints. @default "/" */
+    path?: string | undefined
+    /**
+     * Backing store for both single-use challenges (nonces) and issued
+     * sessions. Keys are namespaced internally (`challenge:…`, `session:…`).
+     * @default `Kv.memory()`
+     */
+    store?: Kv.Kv | undefined
+    /**
+     * Viem transport for the Tempo client used to verify signatures. The
+     * client is always built against the `tempo` chain — Tempo's
+     * `chain.verifyHash` natively understands `SignatureEnvelope` and
+     * falls back to ECDSA recovery for plain EOAs.
+     * @default `http()`
+     */
+    transport?: Transport | undefined
+    /** TTLs in seconds. */
+    ttl?:
+      | {
+          /** Challenge (nonce) TTL. @default 600 (10m) */
+          challenge?: number | undefined
+          /** Session TTL. @default 86400 (24h) */
+          session?: number | undefined
+        }
+      | undefined
+  }
+}
+
+/**
+ * Resolves the public-facing protocol and host for a request, honoring
+ * `x-forwarded-proto` / `x-forwarded-host` so SIWE `domain`/`uri` reflect
+ * the browser-visible origin behind reverse proxies (OrbStack, Cloudflare
+ * tunnels, etc.). Falls back to the `host` header and the request URL.
+ */
+function publicOrigin(req: Request): { protocol: string; host: string } {
+  const headers = req.headers
+  const forwardedHost = headers.get('x-forwarded-host')?.split(',')[0]?.trim()
+  const forwardedProto = headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
+  const reqUrl = new URL(req.url)
+  const host = forwardedHost || headers.get('host') || reqUrl.host
+  const protocol = forwardedProto ? `${forwardedProto}:` : reqUrl.protocol
+  return { protocol, host }
+}
+
+function parseCookieValue(header: string, name: string): string | undefined {
+  for (const part of header.split(';')) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) continue
+    if (trimmed.slice(0, eq) === name) return decodeURIComponent(trimmed.slice(eq + 1))
+  }
+  return undefined
+}

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -40,10 +40,21 @@ export type SessionPayload = {
  * payload because challenges are single-use and the address isn't bound at
  * challenge time — the account supplies the address at verify time and the
  * server uses the supplied address as the session subject.
+ *
+ * The full issued SIWE message is persisted so verify can require exact
+ * byte-equality between the submitted message and the one we issued.
+ * Without this, the wallet (or anyone who tampered with the message in
+ * flight) could swap fields the server doesn't otherwise check
+ * (`statement`, `resources`, `uri`, `version`, the address placeholder)
+ * while keeping `nonce`/`domain`/`chainId` and still pass verification.
  */
 type ChallengePayload = {
+  /** Echoed for defense-in-depth even though it's also in `message`. */
   chainId: number
+  /** Unix seconds. The Kv TTL also enforces this; kept for traceability. */
   expiresAt: number
+  /** Verbatim issued SIWE message. Verify rejects any mismatch. */
+  message: string
 }
 
 const challengeKey = (nonce: string) => `challenge:${nonce}`
@@ -108,11 +119,36 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     cookieName = defaults.cookieName,
     domain,
     path = '/',
+    publicOrigin: publicOrigin_option,
     store = Kv.memory(),
     transport = http(),
+    trustProxy = false,
     ttl: { challenge: challengeTtl = defaults.ttl.challenge, session: sessionTtl = defaults.ttl.session } = {},
     ...rest
   } = options
+
+  async function take(key: string): Promise<ChallengePayload | undefined> {
+    if (store.take) return store.take<ChallengePayload>(key)
+    const value = await store.get<ChallengePayload>(key)
+    if (value === undefined) return undefined
+    await store.delete(key)
+    return value
+  }
+
+  // Pre-parse `publicOrigin` so a misconfiguration fails loudly at handler
+  // construction time rather than per-request.
+  const pinnedOrigin = (() => {
+    if (!publicOrigin_option) return undefined
+    try {
+      const url = new URL(publicOrigin_option)
+      return { protocol: url.protocol, host: url.host }
+    } catch {
+      throw new Error(
+        `\`auth({ publicOrigin })\` must be a valid absolute URL. Got: ${publicOrigin_option}`,
+      )
+    }
+  })()
+  const resolveReqOrigin = (req: Request) => resolveOrigin(req, { pinnedOrigin, trustProxy })
 
   const client = createClient({ chain: tempo, transport })
 
@@ -124,7 +160,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
   router.post(challengePath, Hono.validate('json', schema.challenge.parameters), async (c) => {
     const { chainId = 0 } = c.req.valid('json')
 
-    const { protocol, host: reqHost } = publicOrigin(c.req.raw)
+    const { protocol, host: reqHost } = resolveReqOrigin(c.req.raw)
     const resolvedDomain = domain ?? reqHost
 
     const nonce = generateSiweNonce()
@@ -144,7 +180,11 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
 
     await store.set(
       challengeKey(nonce),
-      { chainId, expiresAt: Math.floor(expirationTime.getTime() / 1000) },
+      {
+        message,
+        chainId,
+        expiresAt: Math.floor(expirationTime.getTime() / 1000),
+      },
       { ttl: challengeTtl },
     )
 
@@ -157,7 +197,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     const parsed = parseSiweMessage(message)
     if (!parsed.nonce) return c.json({ error: 'message missing `nonce`' }, 400)
 
-    const { protocol, host: reqHost } = publicOrigin(c.req.raw)
+    const { protocol, host: reqHost } = resolveReqOrigin(c.req.raw)
     const resolvedDomain = domain ?? reqHost
     if (parsed.domain !== resolvedDomain)
       return c.json({ error: 'domain mismatch' }, 400)
@@ -168,10 +208,8 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     if (parsed.notBefore && parsed.notBefore.getTime() > now)
       return c.json({ error: 'message not yet valid' }, 400)
 
-    // Atomically consume the challenge: read + delete + assert it existed.
-    const challenge = await store.get<ChallengePayload>(challengeKey(parsed.nonce))
+    const challenge = await take(challengeKey(parsed.nonce))
     if (!challenge) return c.json({ error: 'invalid or replayed nonce' }, 409)
-    await store.delete(challengeKey(parsed.nonce))
 
     if (parsed.chainId !== challenge.chainId)
       return c.json({ error: 'chainId mismatch' }, 400)
@@ -250,6 +288,16 @@ export declare namespace auth {
     /** Path prefix for the auth endpoints. @default "/" */
     path?: string | undefined
     /**
+     * Pinned canonical public origin (e.g. `'https://app.example.com'`).
+     * When set, the SIWE `domain` and `uri`, and the cookie `Secure` flag,
+     * are derived from this URL — request `Host`, request URL, and
+     * `x-forwarded-*` headers are ignored. This is the recommended setting
+     * for production deployments behind a CDN or reverse proxy: it
+     * prevents a spoofed `x-forwarded-host` from shifting the SIWE domain
+     * and a spoofed `x-forwarded-proto: http` from disabling `Secure`.
+     */
+    publicOrigin?: string | undefined
+    /**
      * Backing store for both single-use challenges (nonces) and issued
      * sessions. Keys are namespaced internally (`challenge:…`, `session:…`).
      * @default `Kv.memory()`
@@ -263,6 +311,16 @@ export declare namespace auth {
      * @default `http()`
      */
     transport?: Transport | undefined
+    /**
+     * Honor `x-forwarded-proto` / `x-forwarded-host` to derive the public
+     * origin. Required when running behind a trusted reverse proxy that
+     * terminates TLS (OrbStack on `*.tempo.local`, a CDN, etc.). When
+     * `false`, forwarded headers are ignored to prevent spoofing on
+     * deployments that expose the origin server directly. Ignored when
+     * `publicOrigin` is set.
+     * @default false
+     */
+    trustProxy?: boolean | undefined
     /** TTLs in seconds. */
     ttl?:
       | {
@@ -276,19 +334,42 @@ export declare namespace auth {
 }
 
 /**
- * Resolves the public-facing protocol and host for a request, honoring
- * `x-forwarded-proto` / `x-forwarded-host` so SIWE `domain`/`uri` reflect
- * the browser-visible origin behind reverse proxies (OrbStack, Cloudflare
- * tunnels, etc.). Falls back to the `host` header and the request URL.
+ * Resolves the public-facing protocol and host for a request.
+ *
+ * - When `pinnedOrigin` is set (operator passed `auth({ publicOrigin })`),
+ *   that origin is the source of truth — forwarded headers and request URL
+ *   are ignored. This prevents a spoofed `x-forwarded-host` from shifting
+ *   SIWE `domain` and a spoofed `x-forwarded-proto: http` from disabling
+ *   the cookie `Secure` flag on an HTTPS deployment.
+ * - When `trustProxy` is set, `x-forwarded-proto` / `x-forwarded-host` are
+ *   honored (needed behind a reverse proxy like OrbStack or a CDN that
+ *   terminates TLS).
+ * - Default falls back to the request `host` header and request URL
+ *   protocol — safe even on multi-hop deployments because forwarded
+ *   headers are ignored.
  */
-function publicOrigin(req: Request): { protocol: string; host: string } {
+function resolveOrigin(
+  req: Request,
+  options: {
+    pinnedOrigin?: { protocol: string; host: string } | undefined
+    trustProxy?: boolean | undefined
+  },
+): { protocol: string; host: string } {
+  if (options.pinnedOrigin) return options.pinnedOrigin
   const headers = req.headers
-  const forwardedHost = headers.get('x-forwarded-host')?.split(',')[0]?.trim()
-  const forwardedProto = headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
   const reqUrl = new URL(req.url)
-  const host = forwardedHost || headers.get('host') || reqUrl.host
-  const protocol = forwardedProto ? `${forwardedProto}:` : reqUrl.protocol
-  return { protocol, host }
+  if (options.trustProxy) {
+    const forwardedHost = headers.get('x-forwarded-host')?.split(',')[0]?.trim()
+    const forwardedProto = headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
+    return {
+      protocol: forwardedProto ? `${forwardedProto}:` : reqUrl.protocol,
+      host: forwardedHost || headers.get('host') || reqUrl.host,
+    }
+  }
+  return {
+    protocol: reqUrl.protocol,
+    host: headers.get('host') || reqUrl.host,
+  }
 }
 
 function parseCookieValue(header: string, name: string): string | undefined {


### PR DESCRIPTION
Adds Server Authentication (SIWE) to `wallet_connect` via a new `auth` capability and a `Handler.auth` server factory.

The wallet fetches a SIWE challenge from the consumer's auth endpoint, folds the digest into the existing passkey ceremony (no extra prompt), and the dapp-origin Provider posts verify so the session cookie lands on the dapp's origin. `Provider.create({ auth })` mirrors the `feePayer` option as a per-Provider default; per-call `capabilities.auth` overrides it. Absolute URLs are persisted in the store so `wallet_disconnect` can call logout across reloads. Cookie vs token mode is auto-selected from a runtime cookie-jar heuristic, with explicit `returnToken: true` always honored.