### PR TITLE
feat(auth): add `onAuthenticate` hook and `cookie` flag

### DIFF
--- a/.changeset/auth-handler-hooks.md
+++ b/.changeset/auth-handler-hooks.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `onAuthenticate` hook and `cookie` flag to `Handler.auth`.

--- a/.changeset/auth-handler-hooks.md
+++ b/.changeset/auth-handler-hooks.md
@@ -1,5 +1,0 @@
----
-'accounts': patch
----
-
-Added `onAuthenticate` hook and `cookie` flag to `Handler.auth`.

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -106,7 +106,7 @@ export declare namespace cloudflare {
  *   fetch(req, env) {
  *     const handler = Handler.auth({
  *       store: Kv.durableObject(env.NONCE_DO),
- *       publicOrigin: 'https://app.example.com',
+ *       origin: 'https://app.example.com',
  *     })
  *     return handler.fetch(req)
  *   }

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -249,6 +249,222 @@ describe('verify (token mode)', () => {
   })
 })
 
+describe('cookie: false', () => {
+  test('verify always returns { token } in body and never sets a cookie', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ cookie: false, store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    // Even without `returnToken: true`, the body carries the token and
+    // no Set-Cookie is emitted.
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('set-cookie')).toBeNull()
+
+    const { token } = (await res.json()) as { token: string }
+    expect(token).toMatch(/^[a-z0-9]+$/)
+    expect(await store.get(`session:${token}`)).toBeDefined()
+
+    const followUp = new Request('http://wallet.example/', {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    expect((await handler.getSession(followUp))?.address).toBe(account.address)
+  })
+
+  test('getSession ignores cookies even when present', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ cookie: false, store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+    const verify = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+    const { token } = (await verify.json()) as { token: string }
+
+    // Cookie carrying the very token that's valid in the store — but
+    // cookie mode is disabled, so it must not resolve a session.
+    const req = new Request('http://wallet.example/', {
+      headers: { cookie: `accounts_auth=${token}` },
+    })
+    expect(await handler.getSession(req)).toBeUndefined()
+
+    // Bearer mode still works against the same token.
+    const bearerReq = new Request('http://wallet.example/', {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    expect((await handler.getSession(bearerReq))?.address).toBe(account.address)
+  })
+
+  test('logout via Authorization: Bearer revokes the session and skips Set-Cookie', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ cookie: false, store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+    const verify = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+    const { token } = (await verify.json()) as { token: string }
+    expect(await store.get(`session:${token}`)).toBeDefined()
+
+    const logout = await app.request('/logout', {
+      method: 'POST',
+      headers: { host: 'wallet.example', authorization: `Bearer ${token}` },
+    })
+    expect(logout.status).toBe(204)
+    expect(logout.headers.get('set-cookie')).toBeNull()
+
+    expect(await store.get(`session:${token}`)).toBeUndefined()
+    const followUp = new Request('http://wallet.example/', {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    expect(await handler.getSession(followUp)).toBeUndefined()
+  })
+})
+
+describe('onAuthenticate', () => {
+  test('invoked with verified address, chainId, message, signature, request', async () => {
+    const calls: Array<{
+      address: string
+      chainId: number
+      message: string
+      signature: string
+      requestUrl: string
+    }> = []
+
+    const { app } = setup({
+      onAuthenticate: ({ address, chainId, message, signature, request }) => {
+        calls.push({
+          address,
+          chainId,
+          message,
+          signature,
+          requestUrl: request.url,
+        })
+      },
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      address: account.address,
+      chainId: 1,
+      message,
+      signature,
+    })
+    expect(calls[0]?.requestUrl).toContain('/')
+  })
+
+  test('not invoked when signature verification fails', async () => {
+    let invoked = false
+    const { app } = setup({
+      onAuthenticate: () => {
+        invoked = true
+      },
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: otherAccount.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(401)
+    expect(invoked).toBe(false)
+  })
+
+  test('throwing rejects the request with 401 and surfaces the error message', async () => {
+    const store = Kv.memory()
+    const { app } = setup({
+      store,
+      onAuthenticate: () => {
+        throw new Error('user is blocked')
+      },
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "user is blocked",
+      }
+    `)
+    expect(res.headers.get('set-cookie')).toBeNull()
+  })
+
+  test('async hook is awaited before issuing the session', async () => {
+    let resolveHook: (() => void) | undefined
+    const blocker = new Promise<void>((resolve) => {
+      resolveHook = resolve
+    })
+    let hookFinished = false
+
+    const { app } = setup({
+      onAuthenticate: async () => {
+        await blocker
+        hookFinished = true
+      },
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const verifyPromise = postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    // Yield once to let verify dispatch into the hook.
+    await new Promise((r) => setTimeout(r, 10))
+    expect(hookFinished).toBe(false)
+
+    resolveHook!()
+    const res = await verifyPromise
+    expect(res.status).toBe(200)
+    expect(hookFinished).toBe(true)
+  })
+})
+
 describe('getSession', () => {
   test('returns undefined when no cookie is present', async () => {
     const { handler } = setup()

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -327,7 +327,7 @@ describe('store: atomic `take` preferred, non-atomic fallback', () => {
   })
 })
 
-describe('publicOrigin / trustProxy', () => {
+describe('origin / trustProxy', () => {
   test('default: ignores `x-forwarded-host` and `x-forwarded-proto`', async () => {
     // No domain pin — relies on host header. trustProxy defaults to false.
     const handler = auth()
@@ -370,9 +370,9 @@ describe('publicOrigin / trustProxy', () => {
     expect(parsed.uri).toBe('https://app.example')
   })
 
-  test('publicOrigin: pinned origin overrides host and forwarded headers', async () => {
+  test('origin: pinned origin overrides host and forwarded headers', async () => {
     const handler = auth({
-      publicOrigin: 'https://app.example.com',
+      origin: 'https://app.example.com',
       trustProxy: true,
     })
     const app = new Hono()
@@ -394,9 +394,9 @@ describe('publicOrigin / trustProxy', () => {
     expect(parsed.uri).toBe('https://app.example.com')
   })
 
-  test('publicOrigin: invalid URL throws at construction time', async () => {
-    expect(() => auth({ publicOrigin: 'not-a-url' })).toThrowErrorMatchingInlineSnapshot(
-      `[Error: \`auth({ publicOrigin })\` must be a valid absolute URL. Got: not-a-url]`,
+  test('origin: invalid URL throws at construction time', async () => {
+    expect(() => auth({ origin: 'not-a-url' })).toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`auth({ origin })\` must be a valid absolute URL. Got: not-a-url]`,
     )
   })
 })

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -119,7 +119,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     cookieName = defaults.cookieName,
     domain,
     path = '/',
-    publicOrigin: publicOrigin_option,
+    origin: origin_option,
     store = Kv.memory(),
     transport = http(),
     trustProxy = false,
@@ -135,16 +135,16 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     return value
   }
 
-  // Pre-parse `publicOrigin` so a misconfiguration fails loudly at handler
+  // Pre-parse `origin` so a misconfiguration fails loudly at handler
   // construction time rather than per-request.
   const pinnedOrigin = (() => {
-    if (!publicOrigin_option) return undefined
+    if (!origin_option) return undefined
     try {
-      const url = new URL(publicOrigin_option)
+      const url = new URL(origin_option)
       return { protocol: url.protocol, host: url.host }
     } catch {
       throw new Error(
-        `\`auth({ publicOrigin })\` must be a valid absolute URL. Got: ${publicOrigin_option}`,
+        `\`auth({ origin })\` must be a valid absolute URL. Got: ${origin_option}`,
       )
     }
   })()
@@ -296,7 +296,7 @@ export declare namespace auth {
      * prevents a spoofed `x-forwarded-host` from shifting the SIWE domain
      * and a spoofed `x-forwarded-proto: http` from disabling `Secure`.
      */
-    publicOrigin?: string | undefined
+    origin?: string | undefined
     /**
      * Backing store for both single-use challenges (nonces) and issued
      * sessions. Keys are namespaced internally (`challenge:…`, `session:…`).
@@ -317,7 +317,7 @@ export declare namespace auth {
      * terminates TLS (OrbStack on `*.tempo.local`, a CDN, etc.). When
      * `false`, forwarded headers are ignored to prevent spoofing on
      * deployments that expose the origin server directly. Ignored when
-     * `publicOrigin` is set.
+     * `origin` is set.
      * @default false
      */
     trustProxy?: boolean | undefined
@@ -336,7 +336,7 @@ export declare namespace auth {
 /**
  * Resolves the public-facing protocol and host for a request.
  *
- * - When `pinnedOrigin` is set (operator passed `auth({ publicOrigin })`),
+ * - When `pinnedOrigin` is set (operator passed `auth({ origin })`),
  *   that origin is the source of truth — forwarded headers and request URL
  *   are ignored. This prevents a spoofed `x-forwarded-host` from shifting
  *   SIWE `domain` and a spoofed `x-forwarded-proto: http` from disabling

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -1,4 +1,5 @@
-import { getCookie, setCookie } from 'hono/cookie'
+import { setCookie } from 'hono/cookie'
+import { Hex } from 'ox'
 import type { Address, Transport } from 'viem'
 import { createClient, http, zeroAddress } from 'viem'
 import { verifyMessage } from 'viem/actions'
@@ -116,8 +117,10 @@ export namespace schema {
  */
 export function auth(options: auth.Options = {}): auth.ReturnType {
   const {
+    cookie = true,
     cookieName = defaults.cookieName,
     domain,
+    onAuthenticate,
     path = '/',
     origin: origin_option,
     store = Kv.memory(),
@@ -232,12 +235,34 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
       issuedAt,
       expiresAt: issuedAt + sessionTtl,
     }
+
+    // Hook for side effects (e.g. user provisioning, analytics). Throwing
+    // rejects the authentication and surfaces a 401 so the caller can
+    // gate auth on application-level checks.
+    if (onAuthenticate) {
+      try {
+        await onAuthenticate({
+          address,
+          chainId: parsed.chainId,
+          message,
+          request: c.req.raw,
+          signature,
+        })
+      } catch (error) {
+        return c.json(
+          { error: error instanceof Error ? error.message : 'authentication rejected' },
+          401,
+        )
+      }
+    }
+
     const token = generateSiweNonce()
     await store.set(sessionKey(token), session, { ttl: sessionTtl })
 
-    // Token mode (opt-in): caller will send `Authorization: Bearer <token>`.
+    // Token mode: caller sends `Authorization: Bearer <token>`. Forced when
+    // `cookie: false`, opt-in via `returnToken: true` otherwise.
     // Cookie mode (default): browser carries the cookie automatically.
-    if (returnToken) return c.json(z.encode(schema.verify.returns, { token }))
+    if (!cookie || returnToken) return c.json(z.encode(schema.verify.returns, { token }))
 
     setCookie(c, cookieName, token, {
       httpOnly: true,
@@ -250,22 +275,26 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     return c.json(z.encode(schema.verify.returns, {}))
   })
 
+  // Resolves the session token from a request. Prefers
+  // `Authorization: Bearer <token>` over the cookie. When `cookie: false`,
+  // the cookie is ignored even if present.
+  const tokenFromRequest = (req: Request): string | undefined => {
+    const bearer = bearerToken(req.headers.get('authorization'))
+    if (bearer) return bearer
+    if (!cookie) return undefined
+    const cookieHeader = req.headers.get('cookie')
+    return cookieHeader ? parseCookieValue(cookieHeader, cookieName) : undefined
+  }
+
   router.post(logoutPath, async (c) => {
-    const token = getCookie(c, cookieName)
+    const token = tokenFromRequest(c.req.raw)
     if (token) await store.delete(sessionKey(token))
-    setCookie(c, cookieName, '', { path: '/', maxAge: 0 })
+    if (cookie) setCookie(c, cookieName, '', { path: '/', maxAge: 0 })
     return c.body(null, 204)
   })
 
   const getSession: auth.getSession = async (req) => {
-    // Prefer `Authorization: Bearer <token>` (token mode) over cookie
-    // (cookie mode). Either is accepted on every request.
-    const authz = req.headers.get('authorization')
-    const bearer = authz?.toLowerCase().startsWith('bearer ')
-      ? authz.slice(7).trim()
-      : undefined
-    const cookieHeader = req.headers.get('cookie')
-    const token = bearer ?? (cookieHeader ? parseCookieValue(cookieHeader, cookieName) : undefined)
+    const token = tokenFromRequest(req)
     if (!token) return undefined
     return await store.get<SessionPayload>(sessionKey(token))
   }
@@ -280,11 +309,48 @@ export declare namespace auth {
   /** Resolves the current session from a request's cookie. */
   type getSession = (req: Request) => Promise<SessionPayload | undefined>
 
+  /**
+   * Hook invoked after a SIWE signature is verified but before the
+   * session token is issued. Throw to reject the authentication.
+   */
+  type onAuthenticate = (params: {
+    /** Verified address that signed the SIWE message. */
+    address: Address
+    /** Chain ID parsed from the SIWE message. */
+    chainId: number
+    /** Verbatim SIWE message that was signed. */
+    message: string
+    /** Underlying request — useful for headers, IP, etc. */
+    request: Request
+    /** Signature provided by the wallet. */
+    signature: Hex.Hex
+  }) => void | Promise<void>
+
   type Options = from.Options & {
+    /**
+     * Whether to issue a session cookie on successful verify. When
+     * `false`, the verify response always contains `{ token }` in the
+     * body (the per-request `returnToken` flag is ignored), no
+     * `Set-Cookie` header is sent, logout does not clear a cookie, and
+     * `getSession` ignores any incoming cookie — only
+     * `Authorization: Bearer <token>` is honored. Use this when the SDK
+     * lives in a non-browser context (CLI, server-to-server) or when
+     * the host app already manages auth cookies.
+     * @default true
+     */
+    cookie?: boolean | undefined
     /** Cookie name for the session token. @default "accounts_auth" */
     cookieName?: string | undefined
     /** Domain echoed into challenge messages. @default request `Host` header */
     domain?: string | undefined
+    /**
+     * Hook invoked after the SIWE signature is verified but before the
+     * session token is issued. Use to provision a user record, emit
+     * analytics, or apply application-level allow/deny rules. Throwing
+     * from this hook rejects the request with `401` and the thrown
+     * error's `message` is surfaced as the response `error` field.
+     */
+    onAuthenticate?: onAuthenticate | undefined
     /** Path prefix for the auth endpoints. @default "/" */
     path?: string | undefined
     /**
@@ -370,6 +436,12 @@ function resolveOrigin(
     protocol: reqUrl.protocol,
     host: headers.get('host') || reqUrl.host,
   }
+}
+
+function bearerToken(authorization: string | null): string | undefined {
+  if (!authorization) return undefined
+  if (!authorization.toLowerCase().startsWith('bearer ')) return undefined
+  return authorization.slice(7).trim() || undefined
 }
 
 function parseCookieValue(header: string, name: string): string | undefined {


### PR DESCRIPTION
Adds two extension points to `Handler.auth`. The `onAuthenticate` hook runs after signature verification but before the session token is issued, so consumers can provision users, emit analytics, or apply application-level allow/deny rules. Throwing from the hook surfaces as a `401` with the error's message in the response body.

The `cookie` flag (default `true`) toggles session-cookie issuance. When `false`, verify always returns `{ token }` in the body, no `Set-Cookie` is emitted, and `getSession` only honors `Authorization: Bearer` — the right shape for non-browser hosts and apps that already manage their own auth cookies. Logout also accepts `Authorization: Bearer` so token-mode sessions can be revoked symmetrically.

Also rolls in the `publicOrigin` → `origin` rename from the prior commit on this branch.