### PR TITLE
feat(webAuthn): cookie issuance and `auth`-handler patterns

### DIFF
--- a/.changeset/auth-session-and-hook-response.md
+++ b/.changeset/auth-session-and-hook-response.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `session` option to `Handler.auth` and allowed `onAuthenticate` to return a `Response` whose body and status are merged onto the verify response.

--- a/.changeset/webauthn-challenge-ttl-rename.md
+++ b/.changeset/webauthn-challenge-ttl-rename.md
@@ -1,5 +1,5 @@
 ---
-'accounts': major
+'accounts': minor
 ---
 
 Renamed `Handler.webAuthn` option `challengeTtl` to `ttl.challenge`.

--- a/.changeset/webauthn-challenge-ttl-rename.md
+++ b/.changeset/webauthn-challenge-ttl-rename.md
@@ -2,7 +2,7 @@
 'accounts': minor
 ---
 
-Renamed `Handler.webAuthn` option `challengeTtl` to `ttl.challenge`.
+**Breaking:** Renamed `Handler.webAuthn` option `challengeTtl` to `ttl.challenge`.
 
 ```diff
   Handler.webAuthn({

--- a/.changeset/webauthn-challenge-ttl-rename.md
+++ b/.changeset/webauthn-challenge-ttl-rename.md
@@ -1,0 +1,16 @@
+---
+'accounts': major
+---
+
+Renamed `Handler.webAuthn` option `challengeTtl` to `ttl.challenge`.
+
+```diff
+  Handler.webAuthn({
+    kv,
+    origin: 'https://example.com',
+    rpId: 'example.com',
+-   challengeTtl: 600,
++   ttl: { challenge: 600 },
+  })
+```
+

--- a/.changeset/webauthn-onauthenticate-throw-status.md
+++ b/.changeset/webauthn-onauthenticate-throw-status.md
@@ -1,5 +1,5 @@
 ---
-'accounts': major
+'accounts': minor
 ---
 
 Changed `Handler.webAuthn`'s `onAuthenticate` hook rejection status from `400` to `401` when the hook throws.

--- a/.changeset/webauthn-onauthenticate-throw-status.md
+++ b/.changeset/webauthn-onauthenticate-throw-status.md
@@ -2,7 +2,7 @@
 'accounts': minor
 ---
 
-Changed `Handler.webAuthn`'s `onAuthenticate` hook rejection status from `400` to `401` when the hook throws.
+**Breaking:** Changed `Handler.webAuthn`'s `onAuthenticate` hook rejection status from `400` to `401` when the hook throws.
 
 ```diff
   // POST /login response when `onAuthenticate` throws `new Error('blocked')`:

--- a/.changeset/webauthn-onauthenticate-throw-status.md
+++ b/.changeset/webauthn-onauthenticate-throw-status.md
@@ -1,0 +1,15 @@
+---
+'accounts': major
+---
+
+Changed `Handler.webAuthn`'s `onAuthenticate` hook rejection status from `400` to `401` when the hook throws.
+
+```diff
+  // POST /login response when `onAuthenticate` throws `new Error('blocked')`:
+- HTTP/1.1 400 Bad Request
++ HTTP/1.1 401 Unauthorized
+  Content-Type: application/json
+
+  {"error":"blocked"}
+```
+

--- a/.changeset/webauthn-session-default.md
+++ b/.changeset/webauthn-session-default.md
@@ -2,7 +2,7 @@
 'accounts': minor
 ---
 
-Made `Handler.webAuthn` issue a session cookie and persist a session entry under `session:<token>` in `kv` on successful `/login` by default -- opt out via `session: false` or `cookie: false`.
+**Breaking:** Made `Handler.webAuthn` issue a session cookie and persist a session entry under `session:<token>` in `kv` on successful `/login` by default -- opt out via `session: false` or `cookie: false`.
 
 ```diff
   // Default behavior -- `/login` now sets a cookie and writes to kv.

--- a/.changeset/webauthn-session-default.md
+++ b/.changeset/webauthn-session-default.md
@@ -1,11 +1,11 @@
 ---
-'accounts': major
+'accounts': minor
 ---
 
-Made `Handler.webAuthn` issue a session cookie and persist a session entry under `session:<token>` in `kv` on successful `/login` by default — opt out via `session: false` or `cookie: false`.
+Made `Handler.webAuthn` issue a session cookie and persist a session entry under `session:<token>` in `kv` on successful `/login` by default -- opt out via `session: false` or `cookie: false`.
 
 ```diff
-  // Default behavior — `/login` now sets a cookie and writes to kv.
+  // Default behavior -- `/login` now sets a cookie and writes to kv.
   Handler.webAuthn({ kv, origin, rpId })
 
   // Pre-PR behavior (no cookie, no kv session writes, no `/logout`):

--- a/.changeset/webauthn-session-default.md
+++ b/.changeset/webauthn-session-default.md
@@ -1,0 +1,17 @@
+---
+'accounts': major
+---
+
+Made `Handler.webAuthn` issue a session cookie and persist a session entry under `session:<token>` in `kv` on successful `/login` by default — opt out via `session: false` or `cookie: false`.
+
+```diff
+  // Default behavior — `/login` now sets a cookie and writes to kv.
+  Handler.webAuthn({ kv, origin, rpId })
+
+  // Pre-PR behavior (no cookie, no kv session writes, no `/logout`):
++ Handler.webAuthn({ kv, origin, rpId, session: false })
+
+  // Or just disable cookie issuance and return the token in the body:
++ Handler.webAuthn({ kv, origin, rpId, cookie: false })
+```
+

--- a/.changeset/webauthn-session-options.md
+++ b/.changeset/webauthn-session-options.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added `cookie`, `cookieName`, `session`, and `ttl.session` options, a `getSession()` method, and a `/logout` route to `Handler.webAuthn`.

--- a/.changeset/webauthn-session-options.md
+++ b/.changeset/webauthn-session-options.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added `cookie`, `cookieName`, `session`, and `ttl.session` options, a `getSession()` method, and a `/logout` route to `Handler.webAuthn`.

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -336,6 +336,97 @@ describe('cookie: false', () => {
   })
 })
 
+describe('session: false', () => {
+  test('verify returns {} with no token, no Set-Cookie, no store write', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({ session: false, store })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchInlineSnapshot(`{}`)
+    expect(res.headers.get('set-cookie')).toBeNull()
+
+    // getSession always resolves undefined; even a manually-seeded
+    // session token must not leak through.
+    await store.set('session:tok', { address: account.address }, { ttl: 60 })
+    const req = new Request('http://wallet.example/', {
+      headers: { authorization: 'Bearer tok' },
+    })
+    expect(await handler.getSession(req)).toBeUndefined()
+  })
+
+  test('returnToken: true is ignored when session: false', async () => {
+    const { app } = setup({ session: false })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+      returnToken: true,
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchInlineSnapshot(`{}`)
+  })
+
+  test('logout route is not mounted (returns 404)', async () => {
+    const store = Kv.memory()
+    const { app } = setup({ session: false, store })
+
+    await store.set('session:tok', { address: account.address }, { ttl: 60 })
+
+    const res = await app.request('/logout', {
+      method: 'POST',
+      headers: { host: 'wallet.example', authorization: 'Bearer tok' },
+    })
+    expect(res.status).toBe(404)
+    // The seeded entry survives — no logout route, nothing to delete.
+    expect(await store.get('session:tok')).toBeDefined()
+  })
+
+  test('onAuthenticate still runs and can reject before the short-circuit', async () => {
+    let invoked = false
+    const { app } = setup({
+      session: false,
+      onAuthenticate: () => {
+        invoked = true
+        throw new Error('blocked')
+      },
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(401)
+    expect(invoked).toBe(true)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "blocked",
+      }
+    `)
+  })
+})
+
 describe('onAuthenticate', () => {
   test('invoked with verified address, chainId, message, signature, request', async () => {
     const calls: Array<{
@@ -427,6 +518,67 @@ describe('onAuthenticate', () => {
       }
     `)
     expect(res.headers.get('set-cookie')).toBeNull()
+  })
+
+  test('returning a Response merges body fields and status onto the verify response', async () => {
+    const { app } = setup({
+      onAuthenticate: () =>
+        Response.json({ jwt: 'eyJ...', userId: 'u_42' }, { status: 201 }),
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+      returnToken: true,
+    })
+
+    expect(res.status).toBe(201)
+    const { token, ...rest } = (await res.json()) as Record<string, unknown>
+    expect(token).toMatch(/^[a-z0-9]+$/)
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "jwt": "eyJ...",
+        "userId": "u_42",
+      }
+    `)
+  })
+
+  test('returned Response without `session: false` still issues a session token', async () => {
+    const store = Kv.memory()
+    const { handler, app } = setup({
+      store,
+      onAuthenticate: () => Response.json({ extra: 'meta' }),
+    })
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const signature = await account.signMessage({ message })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature,
+    })
+
+    expect(res.status).toBe(200)
+    expect(((await res.json()) as Record<string, unknown>).extra).toBe('meta')
+
+    const setCookie = res.headers.get('set-cookie')
+    expect(setCookie).toContain('accounts_auth=')
+    const token = setCookie!.split(';')[0]!.split('=')[1]!
+    expect(await store.get(`session:${token}`)).toBeDefined()
+
+    // getSession resolves the issued session via the cookie.
+    const followUp = new Request('http://wallet.example/', {
+      headers: { cookie: setCookie!.split(';')[0]! },
+    })
+    const sessionPayload = await handler.getSession(followUp)
+    expect(sessionPayload?.address).toBe(account.address)
   })
 
   test('async hook is awaited before issuing the session', async () => {

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -1,4 +1,3 @@
-import { setCookie } from 'hono/cookie'
 import { Hex } from 'ox'
 import type { Address, Transport } from 'viem'
 import { createClient, http, zeroAddress } from 'viem'
@@ -11,6 +10,7 @@ import * as u from '../../../core/zod/utils.js'
 import { type Handler, from } from '../../Handler.js'
 import * as Kv from '../../Kv.js'
 import * as Hono from '../hono.js'
+import * as Session from './session.js'
 
 const defaults = {
   cookieName: 'accounts_auth',
@@ -123,6 +123,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     onAuthenticate,
     path = '/',
     origin: origin_option,
+    session = true,
     store = Kv.memory(),
     transport = http(),
     trustProxy = false,
@@ -230,25 +231,28 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     if (!valid) return c.json({ error: 'signature does not match address' }, 401)
 
     const issuedAt = Math.floor(now / 1000)
-    const session: SessionPayload = {
+    const payload: SessionPayload = {
       address,
       chainId: parsed.chainId,
       issuedAt,
       expiresAt: issuedAt + sessionTtl,
     }
 
-    // Hook for side effects (e.g. user provisioning, analytics). Throwing
-    // rejects the authentication and surfaces a 401 so the caller can
-    // gate auth on application-level checks.
+    // Hook for side effects (e.g. user provisioning, analytics). Returning
+    // a `Response` merges its JSON body and status onto the verify
+    // response (matches `webAuthn`'s contract). Throwing rejects with
+    // `401` and surfaces the error's message in the response body.
+    let hookResponse: Response | undefined
     if (onAuthenticate) {
       try {
-        await onAuthenticate({
+        const result = await onAuthenticate({
           address,
           chainId: parsed.chainId,
           message,
           request: c.req.raw,
           signature,
         })
+        if (result) hookResponse = result
       } catch (error) {
         return c.json(
           { error: error instanceof Error ? error.message : 'authentication rejected' },
@@ -257,45 +261,44 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
       }
     }
 
-    const token = generateSiweNonce()
-    await store.set(sessionKey(token), session, { ttl: sessionTtl })
+    // `session: false` short-circuits — verify acts as a stateless
+    // signature check. No token, no cookie, no store write. Useful for
+    // hosts that mint their own session in `onAuthenticate` (e.g. JWTs).
+    if (!session) return Session.mergeResponse({}, hookResponse)
 
-    // Token mode: caller sends `Authorization: Bearer <token>`. Forced when
-    // `cookie: false`, opt-in via `returnToken: true` otherwise.
+    const token = Session.generateToken()
+    await store.set(sessionKey(token), payload, { ttl: sessionTtl })
+
+    // Token mode: caller sends `Authorization: Bearer <token>`. Forced
+    // when `cookie: false`, opt-in via `returnToken: true` otherwise.
     // Cookie mode (default): browser carries the cookie automatically.
-    if (!cookie || returnToken) return c.json(z.encode(schema.verify.returns, { token }))
+    const tokenMode = !cookie || returnToken
+    const cookieHeader = tokenMode
+      ? undefined
+      : Session.serializeCookie({
+          name: cookieName,
+          protocol,
+          ttl: sessionTtl,
+          value: token,
+        })
 
-    setCookie(c, cookieName, token, {
-      httpOnly: true,
-      sameSite: 'Lax',
-      secure: protocol === 'https:',
-      path: '/',
-      maxAge: sessionTtl,
+    return Session.mergeResponse(tokenMode ? { token } : {}, hookResponse, cookieHeader)
+  })
+
+  // Logout has no meaning when sessions are disabled — skip mounting the
+  // route entirely so callers get a clean `404` instead of a misleading
+  // `204` no-op.
+  if (session)
+    router.post(logoutPath, async (c) => {
+      const token = Session.tokenFromRequest(c.req.raw, { cookie, cookieName })
+      if (token) await store.delete(sessionKey(token))
+      if (cookie) Session.clearCookie(c, cookieName)
+      return c.body(null, 204)
     })
 
-    return c.json(z.encode(schema.verify.returns, {}))
-  })
-
-  // Resolves the session token from a request. Prefers
-  // `Authorization: Bearer <token>` over the cookie. When `cookie: false`,
-  // the cookie is ignored even if present.
-  const tokenFromRequest = (req: Request): string | undefined => {
-    const bearer = bearerToken(req.headers.get('authorization'))
-    if (bearer) return bearer
-    if (!cookie) return undefined
-    const cookieHeader = req.headers.get('cookie')
-    return cookieHeader ? parseCookieValue(cookieHeader, cookieName) : undefined
-  }
-
-  router.post(logoutPath, async (c) => {
-    const token = tokenFromRequest(c.req.raw)
-    if (token) await store.delete(sessionKey(token))
-    if (cookie) setCookie(c, cookieName, '', { path: '/', maxAge: 0 })
-    return c.body(null, 204)
-  })
-
   const getSession: auth.getSession = async (req) => {
-    const token = tokenFromRequest(req)
+    if (!session) return undefined
+    const token = Session.tokenFromRequest(req, { cookie, cookieName })
     if (!token) return undefined
     return await store.get<SessionPayload>(sessionKey(token))
   }
@@ -312,7 +315,10 @@ export declare namespace auth {
 
   /**
    * Hook invoked after a SIWE signature is verified but before the
-   * session token is issued. Throw to reject the authentication.
+   * session token is issued. Returning a `Response` merges its JSON
+   * body and status onto the verify response. Throwing rejects with
+   * `401` — the thrown error's `message` is surfaced as the response
+   * `error` field — and no session is issued.
    */
   type onAuthenticate = (params: {
     /** Verified address that signed the SIWE message. */
@@ -325,7 +331,7 @@ export declare namespace auth {
     request: Request
     /** Signature provided by the wallet. */
     signature: Hex.Hex
-  }) => void | Promise<void>
+  }) => Response | Promise<Response> | void | Promise<void>
 
   type Options = from.Options & {
     /**
@@ -364,6 +370,17 @@ export declare namespace auth {
      * and a spoofed `x-forwarded-proto: http` from disabling `Secure`.
      */
     origin?: string | undefined
+    /**
+     * Whether to issue a session on successful verify. When `false`,
+     * verify acts as a stateless signature check — no token is generated,
+     * no entry is written to the session store, and no cookie is sent.
+     * The verify response is `{}`. `getSession` always returns
+     * `undefined` and `/logout` is a no-op (still returns `204`). Use
+     * this when the host application mints its own session token (e.g.
+     * a JWT inside `onAuthenticate`).
+     * @default true
+     */
+    session?: boolean | undefined
     /**
      * Backing store for both single-use challenges (nonces) and issued
      * sessions. Keys are namespaced internally (`challenge:…`, `session:…`).
@@ -439,18 +456,4 @@ function resolveOrigin(
   }
 }
 
-function bearerToken(authorization: string | null): string | undefined {
-  if (!authorization) return undefined
-  if (!authorization.toLowerCase().startsWith('bearer ')) return undefined
-  return authorization.slice(7).trim() || undefined
-}
 
-function parseCookieValue(header: string, name: string): string | undefined {
-  for (const part of header.split(';')) {
-    const trimmed = part.trim()
-    const eq = trimmed.indexOf('=')
-    if (eq === -1) continue
-    if (trimmed.slice(0, eq) === name) return decodeURIComponent(trimmed.slice(eq + 1))
-  }
-  return undefined
-}

--- a/src/server/internal/handlers/session.ts
+++ b/src/server/internal/handlers/session.ts
@@ -1,0 +1,146 @@
+import type { Context } from 'hono'
+import { setCookie as core_setCookie } from 'hono/cookie'
+import { Hex } from 'ox'
+
+/**
+ * Shared session helpers used by SDK handlers that issue server-side
+ * sessions (e.g. `auth`, `webAuthn`). Each handler is responsible for its
+ * own session payload shape and storage; this module only provides the
+ * token-extraction, cookie-issuance, and token-generation primitives so
+ * the conventions stay consistent.
+ */
+
+/** Default `Set-Cookie` attributes for handler-issued session cookies. */
+export const defaults = {
+  httpOnly: true,
+  sameSite: 'Lax',
+  path: '/',
+} as const
+
+/**
+ * Parse a `Bearer <token>` value out of an `Authorization` header. Returns
+ * `undefined` when the header is missing, doesn't use the `Bearer`
+ * scheme, or contains an empty token.
+ */
+export function bearerToken(authorization: string | null): string | undefined {
+  if (!authorization) return undefined
+  if (!authorization.toLowerCase().startsWith('bearer ')) return undefined
+  return authorization.slice(7).trim() || undefined
+}
+
+/**
+ * Extract the value of a single cookie from a raw `Cookie` header.
+ * Returns `undefined` when the cookie is absent.
+ */
+export function parseCookieValue(header: string, name: string): string | undefined {
+  for (const part of header.split(';')) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) continue
+    if (trimmed.slice(0, eq) === name) return decodeURIComponent(trimmed.slice(eq + 1))
+  }
+  return undefined
+}
+
+/**
+ * Resolve the session token for a request. Prefers `Authorization: Bearer
+ * <token>` over the cookie. When `cookie: false`, the cookie is ignored
+ * even if present so callers cannot opt back into cookie mode by sending
+ * a stale `Set-Cookie` value.
+ */
+export function tokenFromRequest(
+  req: Request,
+  options: {
+    /** Whether cookie issuance is enabled for this handler. */
+    cookie: boolean
+    /** Cookie name when cookie mode is enabled. */
+    cookieName: string
+  },
+): string | undefined {
+  const bearer = bearerToken(req.headers.get('authorization'))
+  if (bearer) return bearer
+  if (!options.cookie) return undefined
+  const cookieHeader = req.headers.get('cookie')
+  return cookieHeader ? parseCookieValue(cookieHeader, options.cookieName) : undefined
+}
+
+/**
+ * Build the raw `Set-Cookie` header value for a session cookie. Use this
+ * when the route handler returns a freshly-constructed `Response` (which
+ * bypasses Hono's context header merging) — append the returned string
+ * to the response's `Set-Cookie` header directly.
+ */
+export function serializeCookie(options: {
+  /** Cookie name. */
+  name: string
+  /** Token value. */
+  value: string
+  /** Cookie max-age in seconds. */
+  ttl: number
+  /** Resolved request protocol — drives the `Secure` attribute. */
+  protocol: string
+}): string {
+  const parts = [`${options.name}=${encodeURIComponent(options.value)}`]
+  parts.push(`Max-Age=${options.ttl}`)
+  parts.push(`Path=${defaults.path}`)
+  parts.push(`SameSite=${defaults.sameSite}`)
+  if (defaults.httpOnly) parts.push('HttpOnly')
+  if (options.protocol === 'https:') parts.push('Secure')
+  return parts.join('; ')
+}
+
+/**
+ * Build the raw `Set-Cookie` header value that clears a previously
+ * issued session cookie.
+ */
+export function clearCookieHeader(name: string): string {
+  return `${name}=; Max-Age=0; Path=${defaults.path}`
+}
+
+/**
+ * Clear a previously-issued session cookie by writing an empty value with
+ * `Max-Age=0`.
+ */
+export function clearCookie(c: Context, name: string): void {
+  core_setCookie(c, name, '', { path: '/', maxAge: 0 })
+}
+
+/**
+ * Generate a 256-bit cryptographically-random session token, encoded as
+ * lowercase hex without the `0x` prefix.
+ */
+export function generateToken(): string {
+  return Hex.fromBytes(crypto.getRandomValues(new Uint8Array(32))).slice(2)
+}
+
+/**
+ * Build the final JSON response for a verify/login route, merging an
+ * optional hook `Response` (extra body fields, status, custom headers)
+ * with the handler's own JSON and an optional `Set-Cookie` header.
+ *
+ * The hook contract — return a `Response` whose body fields and status
+ * are folded onto the default response — is shared by `auth` and
+ * `webAuthn`. Hook fields take precedence over the handler's defaults
+ * via spread order.
+ */
+export async function mergeResponse(
+  json: Record<string, unknown>,
+  hook?: Response | undefined,
+  cookieHeader?: string | undefined,
+): Promise<Response> {
+  const headers = hook ? new Headers(hook.headers) : new Headers()
+  headers.set('content-type', 'application/json')
+  if (cookieHeader) headers.append('set-cookie', cookieHeader)
+
+  if (!hook)
+    return new Response(JSON.stringify(json), {
+      headers,
+      status: 200,
+    })
+
+  const extra = (await hook.json().catch(() => ({}))) as Record<string, unknown>
+  return new Response(JSON.stringify({ ...json, ...extra }), {
+    headers,
+    status: hook.status,
+  })
+}

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vp/test'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
 
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
 import * as Kv from '../../Kv.js'
-import { webAuthn } from './webAuthn.js'
+import { type SessionPayload, webAuthn } from './webAuthn.js'
 
 let server: Server
 let ceremony: WebAuthnCeremony.WebAuthnCeremony
@@ -166,5 +166,150 @@ describe('hooks', () => {
     expect(called).toBe(false)
 
     await hookServer.closeAsync()
+  })
+})
+
+// Successful login requires a real authenticator, so the cookie / session
+// surfaces are exercised by manually seeding the session in the shared
+// `kv` and hitting `getSession` and `/logout` directly.
+describe('session — getSession & /logout', () => {
+  let kv: Kv.Kv
+  let handler: ReturnType<typeof webAuthn>
+  let s: Server
+
+  const seedSession = async (token = 'tok-default'): Promise<SessionPayload> => {
+    const issuedAt = Math.floor(Date.now() / 1000)
+    const payload: SessionPayload = {
+      credentialId: 'cred-1',
+      publicKey: '0xpub',
+      userId: 'user-1',
+      issuedAt,
+      expiresAt: issuedAt + 60,
+    }
+    await kv.set(`session:${token}`, payload, { ttl: 60 })
+    return payload
+  }
+
+  afterEach(async () => {
+    if (s) await s.closeAsync()
+  })
+
+  test('default (cookie mode): getSession resolves bearer or cookie; /logout clears cookie + revokes', async () => {
+    kv = Kv.memory()
+    handler = webAuthn({ kv, origin: 'http://localhost', rpId: 'localhost' })
+    s = await createServer(handler.listener)
+
+    await seedSession('tok-A')
+
+    const bearerSession = await handler.getSession(
+      new Request('http://localhost/', { headers: { authorization: 'Bearer tok-A' } }),
+    )
+    expect(bearerSession?.credentialId).toBe('cred-1')
+
+    const cookieSession = await handler.getSession(
+      new Request('http://localhost/', { headers: { cookie: 'accounts_webauthn=tok-A' } }),
+    )
+    expect(cookieSession?.credentialId).toBe('cred-1')
+
+    const noAuthSession = await handler.getSession(new Request('http://localhost/'))
+    expect(noAuthSession).toBeUndefined()
+
+    const logout = await fetch(`${s.url}/logout`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer tok-A' },
+    })
+    expect(logout.status).toBe(204)
+    const setCookie = logout.headers.get('set-cookie')
+    expect(setCookie).toContain('accounts_webauthn=')
+    expect(setCookie).toContain('Max-Age=0')
+
+    expect(await kv.get('session:tok-A')).toBeUndefined()
+    const after = await handler.getSession(
+      new Request('http://localhost/', { headers: { authorization: 'Bearer tok-A' } }),
+    )
+    expect(after).toBeUndefined()
+  })
+
+  test('cookie: false: getSession ignores cookies; /logout returns 204 without Set-Cookie', async () => {
+    kv = Kv.memory()
+    handler = webAuthn({ kv, cookie: false, origin: 'http://localhost', rpId: 'localhost' })
+    s = await createServer(handler.listener)
+
+    await seedSession('tok-B')
+
+    const bearer = await handler.getSession(
+      new Request('http://localhost/', { headers: { authorization: 'Bearer tok-B' } }),
+    )
+    expect(bearer?.credentialId).toBe('cred-1')
+
+    const cookieIgnored = await handler.getSession(
+      new Request('http://localhost/', { headers: { cookie: 'accounts_webauthn=tok-B' } }),
+    )
+    expect(cookieIgnored).toBeUndefined()
+
+    const logout = await fetch(`${s.url}/logout`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer tok-B' },
+    })
+    expect(logout.status).toBe(204)
+    expect(logout.headers.get('set-cookie')).toBeNull()
+    expect(await kv.get('session:tok-B')).toBeUndefined()
+  })
+
+  test('custom cookieName is honored on getSession and /logout', async () => {
+    kv = Kv.memory()
+    handler = webAuthn({
+      kv,
+      cookieName: 'custom_cookie',
+      origin: 'http://localhost',
+      rpId: 'localhost',
+    })
+    s = await createServer(handler.listener)
+
+    await seedSession('tok-C')
+
+    expect(
+      await handler.getSession(
+        new Request('http://localhost/', { headers: { cookie: 'custom_cookie=tok-C' } }),
+      ),
+    ).toBeTruthy()
+    expect(
+      await handler.getSession(
+        new Request('http://localhost/', { headers: { cookie: 'accounts_webauthn=tok-C' } }),
+      ),
+    ).toBeUndefined()
+
+    const logout = await fetch(`${s.url}/logout`, { method: 'POST' })
+    expect(logout.headers.get('set-cookie')).toContain('custom_cookie=')
+  })
+
+  test('/logout returns 204 even without a session token', async () => {
+    kv = Kv.memory()
+    handler = webAuthn({ kv, origin: 'http://localhost', rpId: 'localhost' })
+    s = await createServer(handler.listener)
+
+    const res = await fetch(`${s.url}/logout`, { method: 'POST' })
+    expect(res.status).toBe(204)
+  })
+
+  test('session: false: getSession always undefined; /logout route is not mounted (404)', async () => {
+    kv = Kv.memory()
+    handler = webAuthn({ kv, origin: 'http://localhost', rpId: 'localhost', session: false })
+    s = await createServer(handler.listener)
+
+    // Even with a manually-seeded session in kv, getSession ignores it.
+    await seedSession('tok-D')
+    const bearer = await handler.getSession(
+      new Request('http://localhost/', { headers: { authorization: 'Bearer tok-D' } }),
+    )
+    expect(bearer).toBeUndefined()
+
+    const logout = await fetch(`${s.url}/logout`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer tok-D' },
+    })
+    expect(logout.status).toBe(404)
+    // The seeded entry must survive — no logout route, nothing to delete.
+    expect(await kv.get('session:tok-D')).toBeDefined()
   })
 })

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -8,16 +8,53 @@ import {
 
 import { type Handler, from } from '../../Handler.js'
 import * as Kv from '../../Kv.js'
+import * as Session from './session.js'
+
+const defaults = {
+  cookieName: 'accounts_webauthn',
+  ttl: {
+    challenge: 5 * 60, // 5 minutes
+    session: 24 * 60 * 60, // 24 hours
+  },
+} as const
+
+const sessionKey = (token: string) => `session:${token}`
+
+/**
+ * Session payload persisted in the session store and surfaced via
+ * `getSession`. Mirrors the shape of the WebAuthn login response so
+ * downstream handlers can identify the authenticated credential without
+ * an extra round-trip.
+ */
+export type SessionPayload = {
+  /** Credential ID returned by the authenticator. */
+  credentialId: string
+  /** Credential public key (hex). */
+  publicKey: string
+  /** Optional `userHandle` returned by the authenticator. */
+  userId?: string | undefined
+  /** Unix timestamp (seconds) when the session was issued. */
+  issuedAt: number
+  /** Unix timestamp (seconds) when the session expires. */
+  expiresAt: number
+}
 
 /**
  * Instantiates a WebAuthn ceremony handler that manages registration and
  * authentication flows server-side.
  *
- * Exposes 4 POST endpoints following the webauthx convention:
- * - `POST /register/options` — generate credential creation options
- * - `POST /register` — verify registration and store credential
- * - `POST /login/options` — generate credential request options
- * - `POST /login` — verify authentication
+ * Mounts five POST endpoints under `path`:
+ * - `POST {path}/register/options` — generate credential creation options
+ * - `POST {path}/register` — verify registration and store credential
+ * - `POST {path}/login/options` — generate credential request options
+ * - `POST {path}/login` — verify authentication and issue a session
+ *   (cookie via `Set-Cookie`, or `{ token }` body when `cookie: false`
+ *   or the request opts in via `returnToken: true`)
+ * - `POST {path}/logout` — revoke the session and clear the cookie
+ *
+ * The returned handler also exposes `getSession(req)` for resolving the
+ * current session from a follow-up request's cookie or `Authorization:
+ * Bearer` header.
  *
  * @example
  * ```ts
@@ -35,8 +72,22 @@ import * as Kv from '../../Kv.js'
  * @param options - Options.
  * @returns Request handler.
  */
-export function webAuthn(options: webAuthn.Options): Handler {
-  const { challengeTtl = 300, kv, onAuthenticate, onRegister, path = '', rpId, ...rest } = options
+export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
+  const {
+    cookie = true,
+    cookieName = defaults.cookieName,
+    kv,
+    onAuthenticate,
+    onRegister,
+    path = '',
+    rpId,
+    session = true,
+    ttl: {
+      challenge: challengeTtl = defaults.ttl.challenge,
+      session: sessionTtl = defaults.ttl.session,
+    } = {},
+    ...rest
+  } = options
   const origin = options.origin as string | string[]
 
   const router = from(rest)
@@ -57,7 +108,7 @@ export function webAuthn(options: webAuthn.Options): Handler {
         ...(userId ? { user: { id: new TextEncoder().encode(userId), name } } : undefined),
       })
 
-      await kv.set(`challenge:${challenge}`, { created: Date.now(), name })
+      await kv.set(`challenge:${challenge}`, { created: Date.now(), name }, { ttl: challengeTtl })
 
       return Response.json({ options })
     } catch (error) {
@@ -98,7 +149,7 @@ export function webAuthn(options: webAuthn.Options): Handler {
         }),
         kv.delete(`challenge:${challenge}`),
       ])
-      return mergeResponse(json, hook)
+      return Session.mergeResponse(json, hook || undefined)
     } catch (error) {
       return Response.json({ error: (error as Error).message }, { status: 400 })
     }
@@ -126,7 +177,7 @@ export function webAuthn(options: webAuthn.Options): Handler {
       })
       const options = mediation ? { ...authOptions, mediation } : authOptions
 
-      await kv.set(`challenge:${challenge}`, Date.now())
+      await kv.set(`challenge:${challenge}`, Date.now(), { ttl: challengeTtl })
 
       return Response.json({ options })
     } catch (error) {
@@ -136,7 +187,10 @@ export function webAuthn(options: webAuthn.Options): Handler {
 
   router.post(`${path}/login`, async (c) => {
     try {
-      const response = (await c.req.raw.json()) as Authentication.Response
+      const body = (await c.req.raw.json()) as Authentication.Response & {
+        returnToken?: boolean
+      }
+      const { returnToken, ...response } = body
 
       const clientData = JSON.parse(response.metadata.clientDataJSON) as {
         challenge: string
@@ -162,29 +216,136 @@ export function webAuthn(options: webAuthn.Options): Handler {
       const rawResponse = response.raw?.response as unknown as Record<string, string> | undefined
       const userHandle = rawResponse?.userHandle
 
-      const json = {
-        credentialId: response.id,
-        publicKey: credentialData.publicKey,
-        ...(userHandle && userHandle.length > 0 ? { userId: userHandle } : undefined),
+      const credentialId = response.id
+      const publicKey = credentialData.publicKey
+      const userId = userHandle && userHandle.length > 0 ? userHandle : undefined
+
+      // Hook for side effects (user provisioning, analytics, allow/deny).
+      // The legacy contract — return a `Response` to merge fields onto
+      // the JSON body — is preserved. Throwing now rejects the request
+      // with `401` (vs the outer `400`) so callers can tell hook errors
+      // apart from protocol errors.
+      let hookResponse: Response | undefined
+      if (onAuthenticate) {
+        try {
+          const result = await onAuthenticate({
+            credentialId,
+            publicKey,
+            request: c.req.raw,
+            ...(userId ? { userId } : {}),
+          })
+          if (result) hookResponse = result
+        } catch (error) {
+          await kv.delete(`challenge:${challenge}`)
+          return Response.json(
+            { error: error instanceof Error ? error.message : 'authentication rejected' },
+            { status: 401 },
+          )
+        }
       }
-      const [hook] = await Promise.all([
-        onAuthenticate?.({ ...json, request: c.req.raw }),
+
+      // `session: false` short-circuits — login acts as a stateless
+      // verification. No token, no cookie, no kv write. Useful for
+      // hosts that mint their own session in `onAuthenticate` (e.g. JWTs).
+      if (!session) {
+        await kv.delete(`challenge:${challenge}`)
+        return Session.mergeResponse(
+          {
+            credentialId,
+            publicKey,
+            ...(userId ? { userId } : {}),
+          },
+          hookResponse,
+        )
+      }
+
+      const issuedAt = Math.floor(Date.now() / 1000)
+      const payload: SessionPayload = {
+        credentialId,
+        publicKey,
+        ...(userId ? { userId } : {}),
+        issuedAt,
+        expiresAt: issuedAt + sessionTtl,
+      }
+      const token = Session.generateToken()
+      await Promise.all([
+        kv.set(sessionKey(token), payload, { ttl: sessionTtl }),
         kv.delete(`challenge:${challenge}`),
       ])
-      return mergeResponse(json, hook)
+
+      const json = {
+        credentialId,
+        publicKey,
+        ...(userId ? { userId } : {}),
+        // Token mode: forced when `cookie: false`, opt-in via
+        // `returnToken: true` otherwise. Cookie mode (default) carries
+        // the token in `Set-Cookie` and omits it from the body.
+        ...(!cookie || returnToken ? { token } : {}),
+      }
+
+      // Cookie is appended on the merged response below — the route
+      // builds its own `Response`, so Hono's context-stashed headers
+      // wouldn't carry through.
+      const cookieHeader =
+        cookie && !returnToken
+          ? Session.serializeCookie({
+              name: cookieName,
+              protocol: new URL(c.req.url).protocol,
+              ttl: sessionTtl,
+              value: token,
+            })
+          : undefined
+
+      return Session.mergeResponse(json, hookResponse, cookieHeader)
     } catch (error) {
       return Response.json({ error: (error as Error).message }, { status: 400 })
     }
   })
 
-  return router
+  // Logout has no meaning when sessions are disabled — skip mounting the
+  // route entirely so callers get a clean `404` instead of a misleading
+  // `204` no-op.
+  if (session)
+    router.post(`${path}/logout`, async (c) => {
+      const token = Session.tokenFromRequest(c.req.raw, { cookie, cookieName })
+      if (token) await kv.delete(sessionKey(token))
+      const headers = new Headers()
+      if (cookie) headers.append('set-cookie', Session.clearCookieHeader(cookieName))
+      return new Response(null, { status: 204, headers })
+    })
+
+  const getSession: webAuthn.getSession = async (req) => {
+    if (!session) return undefined
+    const token = Session.tokenFromRequest(req, { cookie, cookieName })
+    if (!token) return undefined
+    return await kv.get<SessionPayload>(sessionKey(token))
+  }
+
+  return Object.assign(router, { getSession })
 }
 
 export declare namespace webAuthn {
+  /** Return type of `webAuthn()` — a `Handler` extended with `getSession`. */
+  type ReturnType = Handler & { getSession: getSession }
+
+  /** Resolves the current session from a request's cookie or bearer token. */
+  type getSession = (req: Request) => Promise<SessionPayload | undefined>
+
   type Options = from.Options & {
-    /** Maximum age of a challenge in seconds before it expires. @default 300 */
-    challengeTtl?: number | undefined
-    /** Key-value store for challenges and credentials. */
+    /**
+     * Whether to issue a session cookie on successful login. When
+     * `false`, the login response always contains `{ token }` in the
+     * body, no `Set-Cookie` header is sent, logout does not clear a
+     * cookie, and `getSession` ignores any incoming cookie — only
+     * `Authorization: Bearer <token>` is honored. Use this when the SDK
+     * lives in a non-browser context or the host app already manages
+     * its own auth cookies.
+     * @default true
+     */
+    cookie?: boolean | undefined
+    /** Cookie name for the session token. @default "accounts_webauthn" */
+    cookieName?: string | undefined
+    /** Key-value store for challenges, credentials, and sessions. */
     kv: Kv.Kv
     /** Called after a successful registration. The returned response is merged onto the default JSON response. */
     onRegister?: (parameters: {
@@ -194,7 +355,14 @@ export declare namespace webAuthn {
       publicKey: string
       request: Request
     }) => Response | Promise<Response> | void | Promise<void>
-    /** Called after a successful authentication. The returned response is merged onto the default JSON response. */
+    /**
+     * Called after a successful authentication, before the session
+     * token is issued. Returning a `Response` merges its JSON body and
+     * status onto the default login response (legacy contract).
+     * Throwing rejects the request with `401` — the thrown error's
+     * `message` is surfaced as the response `error` field — and no
+     * session is issued.
+     */
     onAuthenticate?: (parameters: {
       credentialId: string
       publicKey: string
@@ -207,19 +375,28 @@ export declare namespace webAuthn {
     path?: string | undefined
     /** Relying Party ID (e.g. `"example.com"`). */
     rpId: string
+    /**
+     * Whether to issue a session on successful login. When `false`,
+     * login acts as a stateless WebAuthn verification — no token is
+     * generated, no entry is written to the kv, and no cookie is sent.
+     * The login response still carries `{ credentialId, publicKey,
+     * userId? }`. `getSession` always returns `undefined` and `/logout`
+     * is a no-op (still returns `204`). Use this when the host
+     * application mints its own session token (e.g. a JWT inside
+     * `onAuthenticate`).
+     * @default true
+     */
+    session?: boolean | undefined
+    /** TTLs in seconds. */
+    ttl?:
+      | {
+          /** Challenge TTL. @default 300 (5m) */
+          challenge?: number | undefined
+          /** Session TTL. @default 86400 (24h) */
+          session?: number | undefined
+        }
+      | undefined
   }
 }
 
-async function mergeResponse(
-  json: Record<string, unknown>,
-  hook?: Response | void,
-): Promise<Response> {
-  if (!hook) return Response.json(json)
-  const extra = (await hook.json().catch(() => ({}))) as Record<string, unknown>
-  const headers = new Headers(hook.headers)
-  headers.set('content-type', 'application/json')
-  return new Response(JSON.stringify({ ...json, ...extra }), {
-    headers,
-    status: hook.status,
-  })
-}
+


### PR DESCRIPTION
Brings `Handler.webAuthn` in line with `Handler.auth`'s session model. Successful `/login` now issues an opaque session token -- set as a cookie by default, or returned in the body when `cookie: false` -- and persists the payload under `session:<token>` in `kv`.

The handler also exposes `getSession(req)` and mounts `/logout`. `session: false` opts out of all session machinery for hosts that mint their own token (e.g. JWT in `onAuthenticate`).

Shared cookie/token plumbing was hoisted to `internal/handlers/session.ts` so both `auth` and `webAuthn` use one implementation. `auth`'s `onAuthenticate` now also accepts a `Response` return -- its body and status are merged onto the verify response.

Three breaking changes on `webAuthn`, all detailed in the changesets with migration diffs:

- `challengeTtl` renamed to `ttl.challenge`.
- `/login` issues a session by default (opt out with `session: false`).
- `onAuthenticate` throw now responds `401` (was `400`).