### PR TITLE
Enable pnpm global virtual store for git worktrees

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
 
 blockExoticSubdeps: true
 
+enableGlobalVirtualStore: true
+
 catalog:
   '@cloudflare/vite-plugin': ^1.31.2
   '@cloudflare/workers-types': ^4.20260317.1


### PR DESCRIPTION
Adds `enableGlobalVirtualStore: true` to `pnpm-workspace.yaml`.

With this enabled, git worktrees share a single content-addressable store via symlinks instead of per-worktree hardlink copies. This makes `pnpm install` in new worktrees near-instant — especially useful for Codex parallel development.

Reference: https://pnpm.io/git-worktrees