### PR TITLE
fix: enforce byte-equality between submitted SIWE message and stored challenge

### DIFF
--- a/.changeset/auth-message-byte-equality.md
+++ b/.changeset/auth-message-byte-equality.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Required byte-equality between the submitted SIWE message and the stored challenge in the `auth` server handler's verify endpoint.

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -158,6 +158,37 @@ describe('verify (EOA, cookie mode)', () => {
     `)
   })
 
+  test('rejects tampered message (statement injection) with 400', async () => {
+    // Regression: an attacker could fetch a valid challenge, inject a
+    // benign-looking `statement` into the SIWE text, get a victim to sign
+    // it, and replay the signature here. The server must reject any
+    // message that doesn't byte-match the challenge it issued.
+    const { app } = setup()
+
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    // SIWE injects `statement` as the line between the address line and
+    // the blank line preceding `URI:`. Splice one in.
+    const tampered = message.replace(
+      /(0x0000000000000000000000000000000000000000\n)\n/,
+      '$1\nSign to prove you are human\n\n',
+    )
+    expect(tampered).not.toBe(message)
+    const signature = await account.signMessage({ message: tampered })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message: tampered,
+      signature,
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "message mismatch",
+      }
+    `)
+  })
+
   test('rejects malformed body with 400', async () => {
     const { app } = setup()
     const res = await app.request('/', {

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -211,6 +211,16 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     const challenge = await take(challengeKey(parsed.nonce))
     if (!challenge) return c.json({ error: 'invalid or replayed nonce' }, 409)
 
+    // Require exact byte-equality between the submitted message and the one
+    // we issued. Without this, the wallet (or anyone tampering with the
+    // message in flight) could swap fields we don't otherwise check
+    // (`statement`, `resources`, `uri`, `version`, the address placeholder)
+    // while keeping `nonce`/`domain`/`chainId` and still pass verification —
+    // enabling a phishing-style takeover where a victim signs a benign-looking
+    // message bound to an attacker's session.
+    if (message !== challenge.message)
+      return c.json({ error: 'message mismatch' }, 400)
+
     if (parsed.chainId !== challenge.chainId)
       return c.json({ error: 'chainId mismatch' }, 400)
 


### PR DESCRIPTION
The `auth` server handler's verify endpoint validated `nonce`, `domain`, and `chainId` from the submitted SIWE message but never compared the message itself against the one issued at challenge time. Fields the server doesn't otherwise check (`statement`, `resources`, `uri`, `version`, the address placeholder) could be altered between issuance and verify while still passing all other checks.

This change requires byte-equality between the submitted message and the stored challenge before signature verification, matching the behavior the challenge store comment already documented as intent.
