### PR TITLE
fix: include scopes in authorizeAccessKey examples

### DIFF
--- a/examples/cli/cli.ts
+++ b/examples/cli/cli.ts
@@ -30,6 +30,10 @@ Cli.create('example', {
               token,
             },
           ],
+          scopes: [
+            { address: token, selector: 'transfer(address,uint256)' },
+            { address: token, selector: 'transferWithMemo(address,uint256,bytes32)' },
+          ],
         },
       },
     })

--- a/examples/with-access-key-and-webauthn/src/config.ts
+++ b/examples/with-access-key-and-webauthn/src/config.ts
@@ -15,6 +15,10 @@ export const config = createConfig({
       authorizeAccessKey: () => ({
         expiry: Expiry.days(1),
         limits: [{ token: pathUsd, limit: parseUnits('100', 6) }],
+        scopes: [
+          { address: pathUsd, selector: 'transfer(address,uint256)' },
+          { address: pathUsd, selector: 'transferWithMemo(address,uint256,bytes32)' },
+        ],
       }),
     }),
   ],

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -39,6 +39,13 @@ const provider = Provider.create({
         limit: parseUnits('5', 6),
       },
     ],
+    scopes: [
+      { address: tokens.pathUSD, selector: 'transfer(address,uint256)' },
+      {
+        address: tokens.pathUSD,
+        selector: 'transferWithMemo(address,uint256,bytes32)',
+      },
+    ],
   }),
 })
 

--- a/playgrounds/wagmi/src/App.tsx
+++ b/playgrounds/wagmi/src/App.tsx
@@ -84,6 +84,16 @@ function Connect() {
                               limit: parseUnits('5', 6),
                             },
                           ],
+                          scopes: [
+                            {
+                              address: testnet ? tokens.pathUSD : tokens['USDC.e'],
+                              selector: 'transfer(address,uint256)',
+                            },
+                            {
+                              address: testnet ? tokens.pathUSD : tokens['USDC.e'],
+                              selector: 'transferWithMemo(address,uint256,bytes32)',
+                            },
+                          ],
                         },
                       },
                     }


### PR DESCRIPTION
The wallet now rejects `authorizeAccessKey` requests that omit either `limits` or `scopes` (`viem@2.48.8` enforces "must include at least one `limits` entry and one `scopes` entry"). Several playgrounds and examples passed `limits` only, so they fail at connect time.

Add matching `scopes` entries -- TIP-20 `transfer(address,uint256)` and `transferWithMemo(address,uint256,bytes32)` against the same token used in `limits` -- to the four call sites that were missing them, mirroring the shape already used in `examples/with-access-key`.

Updated:
- `playgrounds/react-native/App.tsx`
- `playgrounds/wagmi/src/App.tsx`
- `examples/with-access-key-and-webauthn/src/config.ts`
- `examples/cli/cli.ts`

The web playground and `ref-impls/cli-auth` already build params from user input, so no defaults change there.
