### PR TITLE
feat(relay): add `feeToken` to `Handler.relay#feePayer` and propagate external errors

### DIFF
--- a/.changeset/relay-external-fee-payer-fix.md
+++ b/.changeset/relay-external-fee-payer-fix.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed support for external `feePayer` URLs on `Handler.relay`.

--- a/.changeset/relay-fee-payer-fee-token.md
+++ b/.changeset/relay-fee-payer-fee-token.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added `feeToken` to `Handler.relay`'s `feePayer` option so the sponsor can pin the fee token used on sponsored fills.

--- a/.changeset/relay-fee-payer-fee-token.md
+++ b/.changeset/relay-fee-payer-fee-token.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added `feeToken` to `Handler.relay`'s `feePayer` option so the sponsor can pin the fee token used on sponsored fills.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -267,7 +267,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -316,7 +316,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -356,7 +356,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -405,7 +405,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -454,7 +454,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -555,7 +555,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -3321,40 +3321,6 @@ packages:
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
 
-  '@wagmi/connectors@8.0.11':
-    resolution: {integrity: sha512-FELwiWAoRNty7D/TJtSoojjv7wmX/vCydSsXGkLPEJs7aQF8oTN6aoFcATY8dD4x47BpkF/pv3icX5pib5KSaQ==}
-    peerDependencies:
-      '@base-org/account': ^2.5.1
-      '@coinbase/wallet-sdk': ^4.3.6
-      '@metamask/connect-evm': ^1.0.0
-      '@safe-global/safe-apps-provider': ~0.18.6
-      '@safe-global/safe-apps-sdk': ^9.1.0
-      '@wagmi/core': 3.4.9
-      '@walletconnect/ethereum-provider': ^2.21.1
-      accounts: workspace:*
-      porto: ~0.2.35
-      typescript: '>=5.7.3'
-      viem: ^2.48.8
-    peerDependenciesMeta:
-      '@base-org/account':
-        optional: true
-      '@coinbase/wallet-sdk':
-        optional: true
-      '@metamask/connect-evm':
-        optional: true
-      '@safe-global/safe-apps-provider':
-        optional: true
-      '@safe-global/safe-apps-sdk':
-        optional: true
-      '@walletconnect/ethereum-provider':
-        optional: true
-      accounts:
-        optional: true
-      porto:
-        optional: true
-      typescript:
-        optional: true
-
   '@wagmi/connectors@8.0.12':
     resolution: {integrity: sha512-EjIPJVp78YPhdBMQ7f/vlwnzl3+30bzlPnYLqdfYQz4pDjxWdRKWYA0jGjtaIm32dNOu8C8kkQfzP0vpG6qdQQ==}
     peerDependencies:
@@ -3391,21 +3357,6 @@ packages:
 
   '@wagmi/core@3.4.10':
     resolution: {integrity: sha512-WDgJ/IRCBF3PI/JHfa9fubIms+xz4SlmLNoLdFYzEONrbaDWxtoN3L4GuW5FOG8yH+eNB5nSp7yYZP5cEgIqSQ==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      accounts: workspace:*
-      typescript: '>=5.7.3'
-      viem: ^2.48.8
-    peerDependenciesMeta:
-      '@tanstack/query-core':
-        optional: true
-      accounts:
-        optional: true
-      typescript:
-        optional: true
-
-  '@wagmi/core@3.4.9':
-    resolution: {integrity: sha512-/0siD63iayC/gRR+PQs9Isbr5y57taw1Oubzn/NZ81TYkPNkjKe9cLu0myYNX8WB6/itBQdHTH7nwLznPDGTxw==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       accounts: workspace:*
@@ -6596,17 +6547,6 @@ packages:
       typescript:
         optional: true
 
-  wagmi@3.6.11:
-    resolution: {integrity: sha512-dSNcPB4bGlRzNSzzFdFcTKDefJRNZZhVhY/R/fl/SV3+w/6hO2JS/dJRMSRuHr3xM3GyLC1P3FTe+3+l3sJMhA==}
-    peerDependencies:
-      '@tanstack/react-query': '>=5.0.0'
-      react: ^19.2.5
-      typescript: '>=5.7.3'
-      viem: ^2.48.8
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   wagmi@3.6.12:
     resolution: {integrity: sha512-EivDCxZmVde4nUF+Bhc+VZGcly6fM71QpHMDv76s7+iR+oBDqHi8+LJApaB6TxtcxJciHLbAkcplrzRNEqlgmg==}
     peerDependencies:
@@ -9569,14 +9509,6 @@ snapshots:
 
   '@vue/shared@3.5.33': {}
 
-  '@wagmi/connectors@8.0.11(@wagmi/core@3.4.9(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
-    dependencies:
-      '@wagmi/core': 3.4.9(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
-      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
-    optionalDependencies:
-      accounts: 'link:'
-      typescript: 5.9.3
-
   '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
@@ -9631,22 +9563,6 @@ snapshots:
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.5
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@3.4.9(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
-      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
-    optionalDependencies:
-      '@tanstack/query-core': 5.100.5
-      accounts: 'link:'
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -13164,29 +13080,6 @@ snapshots:
       '@vue/shared': 3.5.33
     optionalDependencies:
       typescript: 5.9.3
-
-  wagmi@3.6.11(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
-    dependencies:
-      '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.11(@wagmi/core@3.4.9(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.9(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
-      react: 19.2.5
-      use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@base-org/account'
-      - '@coinbase/wallet-sdk'
-      - '@metamask/connect-evm'
-      - '@safe-global/safe-apps-provider'
-      - '@safe-global/safe-apps-sdk'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@walletconnect/ethereum-provider'
-      - accounts
-      - immer
-      - porto
 
   wagmi@3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
     dependencies:

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -284,6 +284,90 @@ describe('behavior: with feePayer', () => {
   })
 })
 
+describe('behavior: with feePayer.feeToken', () => {
+  let server: Server
+  let client: ReturnType<typeof getClient<typeof chain>>
+
+  const sponsorFeeToken = '0x20c0000000000000000000000000000000000000' as const // pathUSD
+
+  beforeAll(async () => {
+    server = await createServer(
+      relay({
+        chains: [chain],
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          feeToken: sponsorFeeToken,
+        },
+        resolveTokens: () => localnetTokens,
+      }).listener,
+    )
+    client = getClient({ transport: http(server.url) })
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  test('default: sponsor.feeToken is used when request omits feeToken', async () => {
+    const { transaction } = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+    })
+    expect(transaction.feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+    expect(transaction.feePayerSignature).toBeDefined()
+  })
+
+  test('behavior: sponsor.feeToken overrides request feeToken on sponsored fills', async () => {
+    const { transaction } = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feeToken: addresses.alphaUsd as Address,
+    })
+    expect(transaction.feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+    expect(transaction.feePayerSignature).toBeDefined()
+  })
+
+  test('behavior: request feeToken wins when sponsorship is opted out via feePayer:false', async () => {
+    const { transaction } = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: false,
+      feeToken: addresses.alphaUsd as Address,
+    })
+    expect(transaction.feeToken?.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())
+    expect(transaction.feePayerSignature).toBeUndefined()
+  })
+
+  test('behavior: broadcast tx receipt records the sponsor.feeToken', async () => {
+    // Fill via relay (where override kicks in), then sign + broadcast manually.
+    // viem's `sendTransactionSync` with a hydrated account does local prep and
+    // would skip the relay's `eth_fillTransaction`, bypassing the override.
+    const { transaction } = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feeToken: addresses.alphaUsd as Address,
+    })
+    expect(transaction.feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+
+    const serialized = (await Transaction.serialize(transaction as never)) as `0x76${string}`
+    const envelope = TxEnvelopeTempo.deserialize(serialized)
+    const signature = await userAccount.sign({
+      hash: TxEnvelopeTempo.getSignPayload(envelope),
+    })
+    const signed = TxEnvelopeTempo.serialize(envelope, {
+      signature: SignatureEnvelope.from(signature),
+    })
+    const receipt = (await getClient().request({
+      method: 'eth_sendRawTransactionSync' as never,
+      params: [signed],
+    })) as { feePayer?: string | undefined; feeToken?: string | undefined }
+
+    expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    expect(receipt.feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+  })
+})
+
 describe('behavior: with app-provided feePayer URL', () => {
   let appServer: Server
   let walletServer: Server
@@ -488,6 +572,65 @@ describe('behavior: with app-provided feePayer URL + autoSwap', () => {
     expect(capabilities?.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
     expect(capabilities?.autoSwap?.minOut.symbol).toBe('EXTBASE')
     expect(capabilities?.autoSwap?.minOut.formatted).toBe('5')
+  })
+})
+
+describe('behavior: app-provided feePayer URL bypasses wallet validate', () => {
+  let appServer: Server
+  let walletServer: Server
+  let client: ReturnType<typeof getClient<typeof chain>>
+
+  beforeAll(async () => {
+    // App relay is the authoritative sponsor — it has its own fee payer
+    // account and signs sponsored transactions.
+    appServer = await createServer(
+      relay({
+        chains: [chain],
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          name: 'App Sponsor',
+          url: 'https://app.example.com',
+        },
+      }).listener,
+    )
+
+    // Wallet relay has its own fee payer with a `validate` that ALWAYS
+    // rejects. This guards the wallet's own fee payer; it must NOT gate
+    // sponsorship when the dapp supplies its own external feePayer URL.
+    walletServer = await createServer(
+      relay({
+        chains: [chain],
+        features: 'all',
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          name: 'Wallet Sponsor',
+          validate: () => false,
+        },
+      }).listener,
+    )
+
+    client = getClient({ transport: http(walletServer.url) })
+  })
+
+  afterAll(() => {
+    appServer.close()
+    walletServer.close()
+  })
+
+  test('behavior: external feePayer URL is sponsored even when wallet validate rejects', async () => {
+    const result = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: appServer.url as never,
+    })
+
+    expect(result.transaction.feePayerSignature).toBeDefined()
+    expect(result.transaction.maxFeePerGas).toBeDefined()
+    expect(result.transaction.maxFeePerGas).not.toBe(0n)
+    expect(result.capabilities?.sponsored).toBe(true)
+    expect(result.capabilities?.sponsor?.name).toBe('App Sponsor')
   })
 })
 

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -160,15 +160,24 @@ export function relay(options: relay.Options = {}): Handler {
 
           const { feePayer: _feePayer, ...normalized } =
             Utils.normalizeFillTransactionRequest(parameters)
+
+          // When sponsoring, the sponsor's preferred fee token (if set)
+          // overrides whatever the consumer asked for — the sponsor is
+          // paying, so the sponsor picks. Falls back to the request's
+          // feeToken otherwise.
+          const sponsoredFeeToken = requestsSponsorship
+            ? (feePayerOptions?.feeToken ?? requestFeeToken)
+            : requestFeeToken
+
           const baseTx = {
             ...normalized,
             ...(typeof chainId !== 'undefined' ? { chainId } : {}),
-            ...(requestFeeToken ? { feeToken: requestFeeToken } : {}),
+            ...(sponsoredFeeToken ? { feeToken: sponsoredFeeToken } : {}),
           }
 
           let filled: Awaited<ReturnType<typeof fill>>
           let sponsored = false
-          let feeToken = requestFeeToken
+          let feeToken = sponsoredFeeToken
 
           // Lazily resolve a swap source token when autoSwap needs one.
           const resolveFeeTokenForSwap = from
@@ -206,9 +215,13 @@ export function relay(options: relay.Options = {}): Handler {
               })
             : client
 
-          if (requestsSponsorship && !feePayerOptions?.validate) {
-            // Path A: sponsorship guaranteed (no validate) — skip fee token
-            // resolution, fill once with feePayer, then parallelize the rest.
+          if (requestsSponsorship && (externalFeePayerUrl || !feePayerOptions?.validate)) {
+            // Path A: sponsorship guaranteed — skip fee token resolution,
+            // fill once with feePayer, then parallelize the rest. Taken when:
+            //   - no validate is configured (no gating), OR
+            //   - the app supplied its own external fee payer URL (that
+            //     relay is the sponsorship authority — the wallet's own
+            //     `validate` only governs the wallet's own fee payer).
             const transaction = { ...baseTx, feePayer: true }
             if (Sponsorship.isPreparedTransaction(transaction)) {
               filled = {
@@ -579,6 +592,8 @@ export namespace relay {
       | {
           /** Account to use as the fee payer. */
           account: LocalAccount
+          /** Preferred fee token the sponsor wants to pay fees in. */
+          feeToken?: Address | undefined
           /**
            * Validates whether to sponsor the transaction. When omitted, all
            * transactions are sponsored. Return `false` to reject sponsorship.
@@ -695,15 +710,17 @@ async function fill(client: Client, options: fill.Options) {
     const sponsor = upstreamCapabilities?.sponsor as
       | { address: Address; name?: string; url?: string }
       | undefined
-    // External fee-payer relays surface chain reverts (e.g. InsufficientBalance)
-    // inside `capabilities.error` with a stub `tx` instead of throwing. Detect
-    // that here and re-throw so the autoSwap branch below can recover the same
-    // way it does for the direct-chain path.
+    // External fee-payer relays surface chain reverts (e.g. InsufficientBalance,
+    // InsufficientAllowance) inside `capabilities.error` with a stub `tx`
+    // instead of throwing. Re-throw all upstream errors so the outer handler
+    // either recovers via autoSwap (InsufficientBalance) or propagates the
+    // error to the caller. Without this, the wallet would otherwise sign the
+    // zero-stub tx with its own fee payer and broadcast garbage.
     const upstreamError = upstreamCapabilities?.error as
       | { errorName?: string; message?: string; data?: `0x${string}` }
       | undefined
-    if (upstreamError?.errorName === 'InsufficientBalance') {
-      const synthetic = new Error(upstreamError.message ?? 'InsufficientBalance')
+    if (upstreamError) {
+      const synthetic = new Error(upstreamError.message ?? upstreamError.errorName ?? 'UpstreamRevert')
       synthetic.name = 'UpstreamRevertError'
       ;(synthetic as { data?: `0x${string}` | undefined }).data = upstreamError.data
       throw synthetic


### PR DESCRIPTION
Adds a `feeToken` option to `Handler.relay`'s `feePayer` config so the sponsor can pin which TIP-20 token gas is paid in. When sponsoring, the sponsor's `feeToken` overrides whatever the dapp/wallet asked for -- the sponsor is paying, so the sponsor picks. Unsponsored fills (`feePayer: false`, or sponsorship rejected by `validate`) keep the request's `feeToken`.

Also fixes external `feePayer` URL handling on the relay. Path A (sponsorship-guaranteed) now also fires when the request supplies an external `feePayer` URL, so the wallet's own `validate` no longer gates app-routed sponsorship. Upstream errors surfaced inside `capabilities.error` (not just `InsufficientBalance`) are now re-thrown so the wallet doesn't accidentally sign and broadcast the zero-stub `tx`.
