### PR TITLE
fix: keep docker vite cache ephemeral

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,8 @@ services:
     volumes:
       - .:/app
       - node_modules:/app/node_modules
+    tmpfs:
+      - /app/playgrounds/web/node_modules/.vite
     ports:
       - '5173:5173'
     labels:
@@ -51,6 +53,8 @@ services:
     volumes:
       - .:/app
       - node_modules:/app/node_modules
+    tmpfs:
+      - /app/playgrounds/wagmi/node_modules/.vite
     ports:
       - '5175:5175'
     labels:
@@ -78,6 +82,8 @@ services:
     volumes:
       - .:/app
       - node_modules:/app/node_modules
+    tmpfs:
+      - /app/ref-impls/dialog/node_modules/.vite
     ports:
       - '5174:5174'
     labels:


### PR DESCRIPTION
## Summary
- mount Vite optimizer caches as tmpfs for Docker dev services
- keep node_modules persistent while making dev-server cache reset on container recreation

## Why
Vite caches optimized dependencies under node_modules/.vite. In Docker dev, that cache can outlive dependency rewiring and serve stale optimized modules after restarts.

## Validation
- docker compose config --quiet