### PR TITLE
chore: add turnkey adapter changeset

### DIFF
--- a/.changeset/silent-turnkeys-kick.md
+++ b/.changeset/silent-turnkeys-kick.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+Added a Turnkey adapter for connecting and signing with app-provided Turnkey wallet accounts.


### PR DESCRIPTION
## Summary
Adds the missing Changesets entry for the Turnkey adapter.

## Motivation
The Turnkey adapter landed in `src/core/adapters/turnkey.ts` without release metadata, so the next release would omit its version bump and changelog note.

## Changes
- Added `.changeset/silent-turnkeys-kick.md` with a minor bump for `accounts`.
- Described the Turnkey adapter connection/signing support for the release notes.

## Testing
- `pnpm exec changeset status --since=origin/main` - stopped after pnpm attempted to install missing workspace dependencies and hit `ENOTFOUND` fetching npm tarballs in the restricted network. No code tests were run; this is release metadata only.