### PR TITLE
feat: add Privy adapter

### DIFF
--- a/.changeset/stale-pears-hunt.md
+++ b/.changeset/stale-pears-hunt.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added a Privy adapter for app-provided Privy clients and embedded EVM wallet providers.

--- a/package.json
+++ b/package.json
@@ -144,6 +144,11 @@
       "src": "./src/react/index.ts",
       "default": "./dist/react/index.js"
     },
+    "./privy": {
+      "types": "./dist/privy/index.d.ts",
+      "src": "./src/privy/index.ts",
+      "default": "./dist/privy/index.js"
+    },
     "./wagmi": {
       "types": "./dist/wagmi/index.d.ts",
       "src": "./src/wagmi/index.ts",

--- a/src/core/adapters/privy.test-d.ts
+++ b/src/core/adapters/privy.test-d.ts
@@ -1,0 +1,77 @@
+import { describe, expectTypeOf, test } from 'vp/test'
+
+import { privy } from './privy.js'
+
+describe('privy', () => {
+  test('accepts a structural Core client', () => {
+    expectTypeOf<privy.Client>().toMatchTypeOf<{
+      auth?: { logout: (parameters: { userId: string }) => Promise<void> | void } | undefined
+      getAuthenticatedUser?: (() => Promise<{ id: string } | null | undefined>) | undefined
+      initialize?: (() => Promise<void> | void) | undefined
+      logout?: (() => Promise<void> | void) | undefined
+      user?: { get: () => Promise<{ user?: { id: string } | null | undefined }> } | undefined
+    }>()
+  })
+
+  test('accepts a structural EIP-1193 provider', () => {
+    expectTypeOf<privy.EthereumProvider>().toMatchTypeOf<{
+      request: (parameters: { method: string; params?: unknown[] | undefined }) => Promise<unknown>
+    }>()
+    expectTypeOf<{
+      request: (parameters: { method: string; params?: unknown[] | undefined }) => Promise<unknown>
+      on: (event: string, listener: (...args: unknown[]) => void) => unknown
+      removeListener: (event: string | symbol, listener: (...args: unknown[]) => void) => unknown
+    }>().toMatchTypeOf<privy.EthereumProvider>()
+  })
+
+  test('accepts structural Privy embedded wallet restore APIs', () => {
+    expectTypeOf<{
+      embeddedWallet?: {
+        getEthereumProvider?: (parameters: {
+          entropyId: string
+          entropyIdVerifier: 'ethereum-address-verifier'
+          wallet: privy.EmbeddedWallet
+        }) => Promise<privy.EthereumProvider>
+        getProvider?: (wallet: privy.EmbeddedWallet) => Promise<privy.EthereumProvider>
+      }
+      getAuthenticatedUser?:
+        | (() => Promise<{
+            id: string
+            linkedAccounts?: readonly privy.LinkedAccount[] | undefined
+          } | null>)
+        | undefined
+      user?: {
+        get: () => Promise<{
+          user?: { id: string; linked_accounts?: readonly privy.LinkedAccount[] | undefined }
+        }>
+      }
+    }>().toMatchTypeOf<privy.Client>()
+  })
+
+  test('callback accounts only require address and provider', () => {
+    expectTypeOf<privy.WalletAccount>().toMatchTypeOf<{
+      address: string
+      provider: privy.EthereumProvider
+    }>()
+  })
+
+  test('callbacks preserve the concrete client type', () => {
+    const client = {
+      custom: {
+        getWallets: async () => [] as privy.WalletAccount[],
+      },
+      initialize() {},
+    }
+    privy({
+      client,
+      createAccount: async ({ client }) => {
+        expectTypeOf(client.custom.getWallets).toEqualTypeOf<() => Promise<privy.WalletAccount[]>>()
+        return { address: '0x0', provider: { request: async () => '0x0' } }
+      },
+      loadAccounts: async ({ client }) => {
+        expectTypeOf(client.custom.getWallets).toEqualTypeOf<() => Promise<privy.WalletAccount[]>>()
+        return []
+      },
+    })
+  })
+})

--- a/src/core/adapters/privy.test-d.ts
+++ b/src/core/adapters/privy.test-d.ts
@@ -45,43 +45,6 @@ describe('privy', () => {
     }>().toMatchTypeOf<privy.Client>()
   })
 
-  test('restoreAccounts preserves the concrete client type', () => {
-    const client = {
-      custom: {
-        getWallets: async () => [] as privy.WalletAccount[],
-      },
-      auth: {
-        async logout() {},
-      },
-      embeddedWallet: {
-        async getProvider() {
-          return { request: async () => '0x0' }
-        },
-      },
-      async getAccessToken() {
-        return 'token'
-      },
-      initialize() {},
-      user: {
-        async get() {
-          return { user: { id: 'user_1' } }
-        },
-      },
-    }
-    privy({
-      client,
-      createAccount: async () => {
-        return { address: '0x0', provider: { request: async () => '0x0' } }
-      },
-      loadAccounts: async () => [],
-      restoreAccounts: async ({ client, user }) => {
-        expectTypeOf(client.custom.getWallets).toEqualTypeOf<() => Promise<privy.WalletAccount[]>>()
-        expectTypeOf(user.id).toEqualTypeOf<string>()
-        return []
-      },
-    })
-  })
-
   test('callback accounts only require address and provider', () => {
     expectTypeOf<privy.WalletAccount>().toMatchTypeOf<{
       address: string

--- a/src/core/adapters/privy.test-d.ts
+++ b/src/core/adapters/privy.test-d.ts
@@ -5,7 +5,14 @@ import { privy } from './privy.js'
 describe('privy', () => {
   test('accepts a structural Core client', () => {
     expectTypeOf<privy.Client>().toMatchTypeOf<{
-      auth?: { logout: (parameters: { userId: string }) => Promise<void> | void } | undefined
+      auth?:
+        | {
+            logout: (
+              parameters?: { userId?: string | undefined } | undefined,
+            ) => Promise<void> | void
+          }
+        | undefined
+      getAccessToken?: (() => Promise<string | null | undefined>) | undefined
       getAuthenticatedUser?: (() => Promise<{ id: string } | null | undefined>) | undefined
       initialize?: (() => Promise<void> | void) | undefined
       logout?: (() => Promise<void> | void) | undefined
@@ -27,11 +34,6 @@ describe('privy', () => {
   test('accepts structural Privy embedded wallet restore APIs', () => {
     expectTypeOf<{
       embeddedWallet?: {
-        getEthereumProvider?: (parameters: {
-          entropyId: string
-          entropyIdVerifier: 'ethereum-address-verifier'
-          wallet: privy.EmbeddedWallet
-        }) => Promise<privy.EthereumProvider>
         getProvider?: (wallet: privy.EmbeddedWallet) => Promise<privy.EthereumProvider>
       }
       getAuthenticatedUser?:
@@ -46,6 +48,32 @@ describe('privy', () => {
         }>
       }
     }>().toMatchTypeOf<privy.Client>()
+  })
+
+  test('restoreAccounts preserves the concrete client type', () => {
+    const client = {
+      custom: {
+        getWallets: async () => [] as privy.WalletAccount[],
+      },
+      initialize() {},
+      user: {
+        async get() {
+          return { user: { id: 'user_1' } }
+        },
+      },
+    }
+    privy({
+      client,
+      createAccount: async () => {
+        return { address: '0x0', provider: { request: async () => '0x0' } }
+      },
+      loadAccounts: async () => [],
+      restoreAccounts: async ({ client, user }) => {
+        expectTypeOf(client.custom.getWallets).toEqualTypeOf<() => Promise<privy.WalletAccount[]>>()
+        expectTypeOf(user.id).toEqualTypeOf<string>()
+        return []
+      },
+    })
   })
 
   test('callback accounts only require address and provider', () => {

--- a/src/core/adapters/privy.test-d.ts
+++ b/src/core/adapters/privy.test-d.ts
@@ -5,18 +5,15 @@ import { privy } from './privy.js'
 describe('privy', () => {
   test('accepts a structural Core client', () => {
     expectTypeOf<privy.Client>().toMatchTypeOf<{
-      auth?:
-        | {
-            logout: (
-              parameters?: { userId?: string | undefined } | undefined,
-            ) => Promise<void> | void
-          }
-        | undefined
-      getAccessToken?: (() => Promise<string | null | undefined>) | undefined
-      getAuthenticatedUser?: (() => Promise<{ id: string } | null | undefined>) | undefined
+      auth: {
+        logout: (parameters?: { userId: string } | undefined) => Promise<void> | void
+      }
+      embeddedWallet: {
+        getProvider: (wallet: privy.EmbeddedWallet) => Promise<privy.EthereumProvider>
+      }
+      getAccessToken: () => Promise<string | null>
       initialize?: (() => Promise<void> | void) | undefined
-      logout?: (() => Promise<void> | void) | undefined
-      user?: { get: () => Promise<{ user?: { id: string } | null | undefined }> } | undefined
+      user: { get: () => Promise<{ user: { id: string } }> }
     }>()
   })
 
@@ -33,18 +30,16 @@ describe('privy', () => {
 
   test('accepts structural Privy embedded wallet restore APIs', () => {
     expectTypeOf<{
-      embeddedWallet?: {
-        getProvider?: (wallet: privy.EmbeddedWallet) => Promise<privy.EthereumProvider>
+      auth: {
+        logout: (parameters?: { userId: string } | undefined) => Promise<void> | void
       }
-      getAuthenticatedUser?:
-        | (() => Promise<{
-            id: string
-            linkedAccounts?: readonly privy.LinkedAccount[] | undefined
-          } | null>)
-        | undefined
-      user?: {
+      embeddedWallet: {
+        getProvider: (wallet: privy.EmbeddedWallet) => Promise<privy.EthereumProvider>
+      }
+      getAccessToken: () => Promise<string | null>
+      user: {
         get: () => Promise<{
-          user?: { id: string; linked_accounts?: readonly privy.LinkedAccount[] | undefined }
+          user: { id: string; linked_accounts?: readonly privy.LinkedAccount[] | undefined }
         }>
       }
     }>().toMatchTypeOf<privy.Client>()
@@ -54,6 +49,17 @@ describe('privy', () => {
     const client = {
       custom: {
         getWallets: async () => [] as privy.WalletAccount[],
+      },
+      auth: {
+        async logout() {},
+      },
+      embeddedWallet: {
+        async getProvider() {
+          return { request: async () => '0x0' }
+        },
+      },
+      async getAccessToken() {
+        return 'token'
       },
       initialize() {},
       user: {
@@ -88,7 +94,23 @@ describe('privy', () => {
       custom: {
         getWallets: async () => [] as privy.WalletAccount[],
       },
+      auth: {
+        async logout() {},
+      },
+      embeddedWallet: {
+        async getProvider() {
+          return { request: async () => '0x0' }
+        },
+      },
+      async getAccessToken() {
+        return 'token'
+      },
       initialize() {},
+      user: {
+        async get() {
+          return { user: { id: 'user_1' } }
+        },
+      },
     }
     privy({
       client,

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -1,0 +1,459 @@
+import { Hex } from 'ox'
+import { describe, expect, test } from 'vp/test'
+
+import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
+import { privy } from './privy.js'
+
+const address = '0x0000000000000000000000000000000000000001'
+const other = '0x0000000000000000000000000000000000000002'
+const signature = Hex.concat(Hex.padLeft('0x11', 32), Hex.padLeft('0x22', 32), '0x1b')
+
+describe('privy', () => {
+  test('default: createAccount delegates registration and raw-signs the requested digest', async () => {
+    const { adapter, client, provider } = setup()
+
+    const result = await adapter.actions.createAccount(
+      { digest: '0x1234', name: 'Ada' },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(client.initCalls).toMatchInlineSnapshot(`1`)
+    expect(provider.requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "secp256k1_sign",
+          "params": [
+            "0x1234",
+          ],
+        },
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+            "label": "Ada",
+          },
+        ],
+        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
+      }
+    `)
+  })
+
+  test('default: loadAccounts delegates login and caches providers for personal signing', async () => {
+    const { adapter, client, provider } = setup()
+
+    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    const result = await adapter.actions.signPersonalMessage(
+      { address, data: '0x68656c6c6f' },
+      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+    )
+
+    expect(client.initCalls).toMatchInlineSnapshot(`1`)
+    expect(client.loadCalls).toMatchInlineSnapshot(`1`)
+    expect(provider.requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "personal_sign",
+          "params": [
+            "0x68656c6c6f",
+            "0x0000000000000000000000000000000000000001",
+          ],
+        },
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(
+      `"0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
+    )
+  })
+
+  test('default: loadAccounts can provision an external access key', async () => {
+    const { adapter, provider } = setup()
+
+    const result = await adapter.actions.loadAccounts(
+      {
+        authorizeAccessKey: {
+          address: other,
+          expiry: 123,
+          keyType: 'secp256k1',
+        },
+      },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(provider.signPayloads).toMatchInlineSnapshot(`
+      [
+        "0x219d0ef7a59d2a40d6ff9e115e32fb6b53eb7fa518ea3364b7b806990fad3944",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "keyAuthorization": {
+          "chainId": "0x1",
+          "expiry": "0x7b",
+          "keyId": "0x0000000000000000000000000000000000000002",
+          "keyType": "secp256k1",
+          "limits": undefined,
+          "signature": {
+            "r": "0x0000000000000000000000000000000000000000000000000000000000000011",
+            "s": "0x0000000000000000000000000000000000000000000000000000000000000022",
+            "type": "secp256k1",
+            "yParity": "0x0",
+          },
+        },
+        "signature": undefined,
+      }
+    `)
+  })
+
+  test('default: authorizeAccessKey restores persisted accounts through the Privy client', async () => {
+    const { adapter, client, store } = setup()
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const result = await adapter.actions.authorizeAccessKey!(
+      {
+        address: other,
+        expiry: 123,
+        keyType: 'secp256k1',
+      },
+      { method: 'wallet_authorizeAccessKey', params: [{ expiry: 123 }] },
+    )
+
+    expect(client.loadCalls).toMatchInlineSnapshot(`0`)
+    expect(client.providerCalls.map((wallet) => wallet.address)).toMatchInlineSnapshot(`
+      [
+        "0x0000000000000000000000000000000000000001",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "keyAuthorization": {
+          "chainId": "0x1",
+          "expiry": "0x7b",
+          "keyId": "0x0000000000000000000000000000000000000002",
+          "keyType": "secp256k1",
+          "limits": undefined,
+          "signature": {
+            "r": "0x0000000000000000000000000000000000000000000000000000000000000011",
+            "s": "0x0000000000000000000000000000000000000000000000000000000000000022",
+            "type": "secp256k1",
+            "yParity": "0x0",
+          },
+        },
+        "rootAddress": "0x0000000000000000000000000000000000000001",
+      }
+    `)
+  })
+
+  test('default: signTypedData forwards to the EIP-1193 provider', async () => {
+    const { adapter, provider } = setup()
+    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+
+    const data = JSON.stringify({
+      domain: { name: 'Tempo' },
+      message: { value: 'hello' },
+      primaryType: 'Message',
+      types: { Message: [{ name: 'value', type: 'string' }] },
+    })
+    await adapter.actions.signTypedData(
+      { address, data },
+      { method: 'eth_signTypedData_v4', params: [address, data] },
+    )
+
+    expect(provider.requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "eth_signTypedData_v4",
+          "params": [
+            "0x0000000000000000000000000000000000000001",
+            "{"domain":{"name":"Tempo"},"message":{"value":"hello"},"primaryType":"Message","types":{"Message":[{"name":"value","type":"string"}]}}",
+          ],
+        },
+      ]
+    `)
+  })
+
+  test('behavior: restored accounts must match persisted provider state', async () => {
+    const { adapter, store } = setup({ accounts: [] })
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      adapter.actions.signPersonalMessage(
+        { address, data: '0x68656c6c6f' },
+        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+      ),
+    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: No Privy account connected.]')
+
+    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: missing restored signer clears all provider accounts', async () => {
+    const { adapter, store } = setup()
+    store.setState({ accounts: [{ address }, { address: other }], activeAccount: 1 })
+
+    await expect(
+      adapter.actions.signPersonalMessage(
+        { address: other, data: '0x68656c6c6f' },
+        { method: 'personal_sign', params: ['0x68656c6c6f', other] },
+      ),
+    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: No Privy account connected.]')
+
+    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: restore supports React authenticated user shapes', async () => {
+    const { adapter, client, provider, store } = setup({ user_shape: 'react' })
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await adapter.actions.signPersonalMessage(
+      { address, data: '0x68656c6c6f' },
+      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+    )
+
+    expect(client.providerCalls.map((wallet) => wallet.address)).toMatchInlineSnapshot(`
+      [
+        "0x0000000000000000000000000000000000000001",
+      ]
+    `)
+    expect(provider.requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "personal_sign",
+          "params": [
+            "0x68656c6c6f",
+            "0x0000000000000000000000000000000000000001",
+          ],
+        },
+      ]
+    `)
+  })
+
+  test('behavior: Privy session errors clear provider accounts', async () => {
+    const { adapter, store } = setup({
+      requestError: { code: 'attempted_rpc_call_before_logged_in', message: 'Not logged in' },
+    })
+    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      adapter.actions.signPersonalMessage(
+        { address, data: '0x68656c6c6f' },
+        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+      ),
+    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: Privy session disconnected.]')
+
+    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('error: raw signing is required for digest signatures', async () => {
+    const { adapter } = setup({ rawSigning: false })
+
+    await expect(
+      adapter.actions.createAccount(
+        { digest: '0x1234', name: 'Ada' },
+        { method: 'wallet_connect', params: undefined },
+      ),
+    ).rejects.toMatchInlineSnapshot(
+      '[Provider.UnsupportedMethodError: Privy adapter requires raw secp256k1 hash signing via `secp256k1_sign` for Tempo transactions and access keys.]',
+    )
+  })
+
+  test('default: disconnect logs out the current Privy user and clears provider state', async () => {
+    const { adapter, client, store } = setup()
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await adapter.actions.disconnect!()
+
+    expect(client.logoutCalls).toMatchInlineSnapshot(`
+      [
+        {
+          "userId": "user_1",
+        },
+      ]
+    `)
+    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('default: disconnect supports React client logout shapes', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: 1, storage })
+    const provider = createProvider()
+    let logoutCalls = 0
+    const client = {
+      async getAuthenticatedUser() {
+        return { id: 'user_1' }
+      },
+      logout() {
+        logoutCalls++
+      },
+    }
+    const adapter = privy({
+      client,
+      createAccount: async () => ({ address, provider }),
+      loadAccounts: async () => [{ address, provider }],
+    })({
+      getAccount: (() => {
+        throw new Error('not implemented')
+      }) as never,
+      getClient: (() => ({ chain: { id: 1 } })) as never,
+      storage,
+      store,
+    })
+
+    await adapter.actions.disconnect!()
+
+    expect(logoutCalls).toMatchInlineSnapshot(`1`)
+  })
+})
+
+function setup(options: setup.Options = {}) {
+  const storage = Storage.memory()
+  const store = Store.create({ chainId: 1, storage })
+  const provider = createProvider(options)
+  const accounts = options.accounts ?? [{ address, provider }]
+  const client = createClient({ accounts, user_shape: options.user_shape })
+  const adapter = privy({
+    client,
+    createAccount: async () => ({ address, provider }),
+    loadAccounts: async () => {
+      client.loadCalls++
+      return accounts
+    },
+  })({
+    getAccount: (() => {
+      throw new Error('not implemented')
+    }) as never,
+    getClient: (() => ({ chain: { id: 1 } })) as never,
+    storage,
+    store,
+  })
+  return { adapter, client, provider, store }
+}
+
+declare namespace setup {
+  type Options = {
+    accounts?: readonly privy.WalletAccount[] | undefined
+    rawSigning?: boolean | undefined
+    requestError?: unknown
+    user_shape?: 'core' | 'react' | undefined
+  }
+}
+
+function createProvider(options: setup.Options = {}) {
+  const provider = {
+    requests: [] as { method: string; params?: unknown[] | undefined }[],
+    signPayloads: [] as Hex.Hex[],
+    async request(parameters: { method: string; params?: unknown[] | undefined }) {
+      if (options.requestError) throw options.requestError
+      provider.requests.push(parameters)
+
+      if (parameters.method === 'secp256k1_sign') {
+        if (options.rawSigning === false) throw { code: 4200, message: 'Unsupported method' }
+        const payload = parameters.params?.[0]
+        if (typeof payload === 'string') provider.signPayloads.push(payload as Hex.Hex)
+        return signature
+      }
+
+      if (parameters.method === 'personal_sign') return signature
+      if (parameters.method === 'eth_signTypedData_v4') return signature
+      throw { code: 4200, message: 'Unsupported method' }
+    },
+  } satisfies privy.EthereumProvider & {
+    requests: { method: string; params?: unknown[] | undefined }[]
+    signPayloads: Hex.Hex[]
+  }
+
+  return provider
+}
+
+function createClient(options: createClient.Options = {}) {
+  const { accounts = [], user_shape = 'core' } = options
+  const linked = accounts.map((account, index) =>
+    linkedAccount({ address: account.address, index, user_shape }),
+  )
+  const client = {
+    initCalls: 0,
+    loadCalls: 0,
+    logoutCalls: [] as { userId: string }[],
+    providerCalls: [] as privy.EmbeddedWallet[],
+    auth: {
+      logout(parameters: { userId: string }) {
+        client.logoutCalls.push(parameters)
+      },
+    },
+    embeddedWallet: {
+      async getProvider(wallet: privy.EmbeddedWallet) {
+        client.providerCalls.push(wallet)
+        const account = accounts.find((account) => account.address === wallet.address)
+        if (!account) throw { code: 'embedded_wallet_does_not_exist' }
+        return account.provider
+      },
+    },
+    initialize() {
+      client.initCalls++
+    },
+    ...(user_shape === 'react'
+      ? {
+          async getAuthenticatedUser() {
+            return { id: 'user_1', linkedAccounts: linked }
+          },
+          logout() {},
+        }
+      : {
+          user: {
+            async get() {
+              return { user: { id: 'user_1', linked_accounts: linked } }
+            },
+          },
+        }),
+  } satisfies privy.Client & {
+    initCalls: number
+    loadCalls: number
+    logoutCalls: { userId: string }[]
+    providerCalls: privy.EmbeddedWallet[]
+  }
+
+  return client
+}
+
+declare namespace createClient {
+  type Options = {
+    accounts?: readonly privy.WalletAccount[] | undefined
+    user_shape?: 'core' | 'react' | undefined
+  }
+}
+
+function linkedAccount(parameters: {
+  address: string
+  index: number
+  user_shape: 'core' | 'react'
+}): privy.LinkedAccount {
+  const { address, index, user_shape } = parameters
+  if (user_shape === 'react')
+    return {
+      address,
+      chainType: 'ethereum',
+      connectorType: 'embedded',
+      recoveryMethod: 'privy',
+      type: 'wallet',
+      walletClientType: 'privy',
+      walletIndex: index,
+    }
+
+  return {
+    address,
+    chain_type: 'ethereum',
+    connector_type: 'embedded',
+    recovery_method: 'privy',
+    type: 'wallet',
+    wallet_client_type: 'privy',
+    wallet_index: index,
+  }
+}

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -152,6 +152,54 @@ describe('privy', () => {
     `)
   })
 
+  test('default: restore can use an app-provided silent account loader', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: 1, storage })
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+    const provider = createProvider()
+    const client = createClient({ accounts: [], embeddedWallet: false })
+    let restoreCalls = 0
+    let loadCalls = 0
+    const adapter = privy({
+      client,
+      createAccount: async () => ({ address, provider }),
+      loadAccounts: async () => {
+        loadCalls++
+        return []
+      },
+      restoreAccounts: async () => {
+        restoreCalls++
+        return [{ address, provider }]
+      },
+    })({
+      getAccount: (() => {
+        throw new Error('not implemented')
+      }) as never,
+      getClient: (() => ({ chain: { id: 1 } })) as never,
+      storage,
+      store,
+    })
+
+    await adapter.actions.signPersonalMessage(
+      { address, data: '0x68656c6c6f' },
+      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+    )
+
+    expect(loadCalls).toMatchInlineSnapshot(`0`)
+    expect(restoreCalls).toMatchInlineSnapshot(`1`)
+    expect(provider.requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "personal_sign",
+          "params": [
+            "0x68656c6c6f",
+            "0x0000000000000000000000000000000000000001",
+          ],
+        },
+      ]
+    `)
+  })
+
   test('default: signTypedData forwards to the EIP-1193 provider', async () => {
     const { adapter, provider } = setup()
     await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
@@ -252,6 +300,19 @@ describe('privy', () => {
     expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
   })
 
+  test('behavior: createAccount requires the callback to leave a valid Privy session', async () => {
+    const { adapter, store } = setup({ accessToken: null })
+
+    await expect(
+      adapter.actions.createAccount(
+        { digest: '0x1234', name: 'Ada' },
+        { method: 'wallet_connect', params: undefined },
+      ),
+    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: Privy session disconnected.]')
+
+    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
   test('error: raw signing is required for digest signatures', async () => {
     const { adapter } = setup({ rawSigning: false })
 
@@ -279,6 +340,38 @@ describe('privy', () => {
       ]
     `)
     expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('default: disconnect supports no-argument Core logout shapes', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: 1, storage })
+    let logoutCalls = 0
+    const client = {
+      auth: {
+        logout() {
+          logoutCalls++
+        },
+      },
+      async getAccessToken() {
+        return 'token'
+      },
+    }
+    const adapter = privy({
+      client,
+      createAccount: async () => ({ address, provider: createProvider() }),
+      loadAccounts: async () => [],
+    })({
+      getAccount: (() => {
+        throw new Error('not implemented')
+      }) as never,
+      getClient: (() => ({ chain: { id: 1 } })) as never,
+      storage,
+      store,
+    })
+
+    await adapter.actions.disconnect!()
+
+    expect(logoutCalls).toMatchInlineSnapshot(`1`)
   })
 
   test('default: disconnect supports React client logout shapes', async () => {
@@ -318,7 +411,11 @@ function setup(options: setup.Options = {}) {
   const store = Store.create({ chainId: 1, storage })
   const provider = createProvider(options)
   const accounts = options.accounts ?? [{ address, provider }]
-  const client = createClient({ accounts, user_shape: options.user_shape })
+  const client = createClient({
+    accessToken: options.accessToken,
+    accounts,
+    user_shape: options.user_shape,
+  })
   const adapter = privy({
     client,
     createAccount: async () => ({ address, provider }),
@@ -339,6 +436,7 @@ function setup(options: setup.Options = {}) {
 
 declare namespace setup {
   type Options = {
+    accessToken?: string | null | undefined
     accounts?: readonly privy.WalletAccount[] | undefined
     rawSigning?: boolean | undefined
     requestError?: unknown
@@ -374,7 +472,7 @@ function createProvider(options: setup.Options = {}) {
 }
 
 function createClient(options: createClient.Options = {}) {
-  const { accounts = [], user_shape = 'core' } = options
+  const { accessToken, accounts = [], embeddedWallet = true, user_shape = 'core' } = options
   const linked = accounts.map((account, index) =>
     linkedAccount({ address: account.address, index, user_shape }),
   )
@@ -384,18 +482,29 @@ function createClient(options: createClient.Options = {}) {
     logoutCalls: [] as { userId: string }[],
     providerCalls: [] as privy.EmbeddedWallet[],
     auth: {
-      logout(parameters: { userId: string }) {
-        client.logoutCalls.push(parameters)
+      logout(parameters?: { userId?: string | undefined } | undefined) {
+        if (parameters?.userId) client.logoutCalls.push({ userId: parameters.userId })
       },
     },
-    embeddedWallet: {
-      async getProvider(wallet: privy.EmbeddedWallet) {
-        client.providerCalls.push(wallet)
-        const account = accounts.find((account) => account.address === wallet.address)
-        if (!account) throw { code: 'embedded_wallet_does_not_exist' }
-        return account.provider
-      },
-    },
+    ...(embeddedWallet
+      ? {
+          embeddedWallet: {
+            async getProvider(wallet: privy.EmbeddedWallet) {
+              client.providerCalls.push(wallet)
+              const account = accounts.find((account) => account.address === wallet.address)
+              if (!account) throw { code: 'embedded_wallet_does_not_exist' }
+              return account.provider
+            },
+          },
+        }
+      : {}),
+    ...(accessToken !== undefined
+      ? {
+          async getAccessToken() {
+            return accessToken
+          },
+        }
+      : {}),
     initialize() {
       client.initCalls++
     },
@@ -425,7 +534,9 @@ function createClient(options: createClient.Options = {}) {
 
 declare namespace createClient {
   type Options = {
+    accessToken?: string | null | undefined
     accounts?: readonly privy.WalletAccount[] | undefined
+    embeddedWallet?: boolean | undefined
     user_shape?: 'core' | 'react' | undefined
   }
 }

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -53,15 +53,9 @@ describe('privy', () => {
 
     expect(client.initCalls).toMatchInlineSnapshot(`1`)
     expect(client.loadCalls).toMatchInlineSnapshot(`1`)
-    expect(provider.requests).toMatchInlineSnapshot(`
+    expect(provider.signPayloads).toMatchInlineSnapshot(`
       [
-        {
-          "method": "personal_sign",
-          "params": [
-            "0x68656c6c6f",
-            "0x0000000000000000000000000000000000000001",
-          ],
-        },
+        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
       ]
     `)
     expect(result).toMatchInlineSnapshot(
@@ -187,20 +181,14 @@ describe('privy', () => {
 
     expect(loadCalls).toMatchInlineSnapshot(`0`)
     expect(restoreCalls).toMatchInlineSnapshot(`1`)
-    expect(provider.requests).toMatchInlineSnapshot(`
+    expect(provider.signPayloads).toMatchInlineSnapshot(`
       [
-        {
-          "method": "personal_sign",
-          "params": [
-            "0x68656c6c6f",
-            "0x0000000000000000000000000000000000000001",
-          ],
-        },
+        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
       ]
     `)
   })
 
-  test('default: signTypedData forwards to the EIP-1193 provider', async () => {
+  test('default: signTypedData hashes typed data before raw signing', async () => {
     const { adapter, provider } = setup()
     await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
 
@@ -215,15 +203,9 @@ describe('privy', () => {
       { method: 'eth_signTypedData_v4', params: [address, data] },
     )
 
-    expect(provider.requests).toMatchInlineSnapshot(`
+    expect(provider.signPayloads).toMatchInlineSnapshot(`
       [
-        {
-          "method": "eth_signTypedData_v4",
-          "params": [
-            "0x0000000000000000000000000000000000000001",
-            "{"domain":{"name":"Tempo"},"message":{"value":"hello"},"primaryType":"Message","types":{"Message":[{"name":"value","type":"string"}]}}",
-          ],
-        },
+        "0x000c5fe9b9bfeb5fbf1e40fa0dd7fe5e1c9896e4ecb892bd20f162e3ea66278a",
       ]
     `)
   })
@@ -270,15 +252,9 @@ describe('privy', () => {
         "0x0000000000000000000000000000000000000001",
       ]
     `)
-    expect(provider.requests).toMatchInlineSnapshot(`
+    expect(provider.signPayloads).toMatchInlineSnapshot(`
       [
-        {
-          "method": "personal_sign",
-          "params": [
-            "0x68656c6c6f",
-            "0x0000000000000000000000000000000000000001",
-          ],
-        },
+        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
       ]
     `)
   })

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -146,48 +146,6 @@ describe('privy', () => {
     `)
   })
 
-  test('default: restore can use an app-provided silent account loader', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: 1, storage })
-    store.setState({ accounts: [{ address }], activeAccount: 0 })
-    const provider = createProvider()
-    const client = createClient({ accounts: [] })
-    let restoreCalls = 0
-    let loadCalls = 0
-    const adapter = privy({
-      client,
-      createAccount: async () => ({ address, provider }),
-      loadAccounts: async () => {
-        loadCalls++
-        return []
-      },
-      restoreAccounts: async () => {
-        restoreCalls++
-        return [{ address, provider }]
-      },
-    })({
-      getAccount: (() => {
-        throw new Error('not implemented')
-      }) as never,
-      getClient: (() => ({ chain: { id: 1 } })) as never,
-      storage,
-      store,
-    })
-
-    await adapter.actions.signPersonalMessage(
-      { address, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-    )
-
-    expect(loadCalls).toMatchInlineSnapshot(`0`)
-    expect(restoreCalls).toMatchInlineSnapshot(`1`)
-    expect(provider.signPayloads).toMatchInlineSnapshot(`
-      [
-        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
-      ]
-    `)
-  })
-
   test('default: signTypedData hashes typed data before raw signing', async () => {
     const { adapter, provider } = setup()
     await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -151,7 +151,7 @@ describe('privy', () => {
     const store = Store.create({ chainId: 1, storage })
     store.setState({ accounts: [{ address }], activeAccount: 0 })
     const provider = createProvider()
-    const client = createClient({ accounts: [], embeddedWallet: false })
+    const client = createClient({ accounts: [] })
     let restoreCalls = 0
     let loadCalls = 0
     const adapter = privy({
@@ -238,27 +238,6 @@ describe('privy', () => {
     expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
   })
 
-  test('behavior: restore supports React authenticated user shapes', async () => {
-    const { adapter, client, provider, store } = setup({ user_shape: 'react' })
-    store.setState({ accounts: [{ address }], activeAccount: 0 })
-
-    await adapter.actions.signPersonalMessage(
-      { address, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-    )
-
-    expect(client.providerCalls.map((wallet) => wallet.address)).toMatchInlineSnapshot(`
-      [
-        "0x0000000000000000000000000000000000000001",
-      ]
-    `)
-    expect(provider.signPayloads).toMatchInlineSnapshot(`
-      [
-        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
-      ]
-    `)
-  })
-
   test('behavior: Privy session errors clear provider accounts', async () => {
     const { adapter, store } = setup({
       requestError: { code: 'attempted_rpc_call_before_logged_in', message: 'Not logged in' },
@@ -331,6 +310,16 @@ describe('privy', () => {
       async getAccessToken() {
         return 'token'
       },
+      embeddedWallet: {
+        async getProvider() {
+          return createProvider()
+        },
+      },
+      user: {
+        async get() {
+          return { user: { id: 'user_1' } }
+        },
+      },
     }
     const adapter = privy({
       client,
@@ -350,36 +339,6 @@ describe('privy', () => {
     expect(logoutCalls).toMatchInlineSnapshot(`1`)
   })
 
-  test('default: disconnect supports React client logout shapes', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: 1, storage })
-    const provider = createProvider()
-    let logoutCalls = 0
-    const client = {
-      async getAuthenticatedUser() {
-        return { id: 'user_1' }
-      },
-      logout() {
-        logoutCalls++
-      },
-    }
-    const adapter = privy({
-      client,
-      createAccount: async () => ({ address, provider }),
-      loadAccounts: async () => [{ address, provider }],
-    })({
-      getAccount: (() => {
-        throw new Error('not implemented')
-      }) as never,
-      getClient: (() => ({ chain: { id: 1 } })) as never,
-      storage,
-      store,
-    })
-
-    await adapter.actions.disconnect!()
-
-    expect(logoutCalls).toMatchInlineSnapshot(`1`)
-  })
 })
 
 function setup(options: setup.Options = {}) {
@@ -390,7 +349,6 @@ function setup(options: setup.Options = {}) {
   const client = createClient({
     accessToken: options.accessToken,
     accounts,
-    user_shape: options.user_shape,
   })
   const adapter = privy({
     client,
@@ -416,7 +374,6 @@ declare namespace setup {
     accounts?: readonly privy.WalletAccount[] | undefined
     rawSigning?: boolean | undefined
     requestError?: unknown
-    user_shape?: 'core' | 'react' | undefined
   }
 }
 
@@ -448,9 +405,9 @@ function createProvider(options: setup.Options = {}) {
 }
 
 function createClient(options: createClient.Options = {}) {
-  const { accessToken, accounts = [], embeddedWallet = true, user_shape = 'core' } = options
+  const { accessToken = 'token', accounts = [] } = options
   const linked = accounts.map((account, index) =>
-    linkedAccount({ address: account.address, index, user_shape }),
+    linkedAccount({ address: account.address, index }),
   )
   const client = {
     initCalls: 0,
@@ -458,46 +415,29 @@ function createClient(options: createClient.Options = {}) {
     logoutCalls: [] as { userId: string }[],
     providerCalls: [] as privy.EmbeddedWallet[],
     auth: {
-      logout(parameters?: { userId?: string | undefined } | undefined) {
+      logout(parameters?: { userId: string } | undefined) {
         if (parameters?.userId) client.logoutCalls.push({ userId: parameters.userId })
       },
     },
-    ...(embeddedWallet
-      ? {
-          embeddedWallet: {
-            async getProvider(wallet: privy.EmbeddedWallet) {
-              client.providerCalls.push(wallet)
-              const account = accounts.find((account) => account.address === wallet.address)
-              if (!account) throw { code: 'embedded_wallet_does_not_exist' }
-              return account.provider
-            },
-          },
-        }
-      : {}),
-    ...(accessToken !== undefined
-      ? {
-          async getAccessToken() {
-            return accessToken
-          },
-        }
-      : {}),
+    embeddedWallet: {
+      async getProvider(wallet: privy.EmbeddedWallet) {
+        client.providerCalls.push(wallet)
+        const account = accounts.find((account) => account.address === wallet.address)
+        if (!account) throw { code: 'embedded_wallet_does_not_exist' }
+        return account.provider
+      },
+    },
+    async getAccessToken() {
+      return accessToken
+    },
     initialize() {
       client.initCalls++
     },
-    ...(user_shape === 'react'
-      ? {
-          async getAuthenticatedUser() {
-            return { id: 'user_1', linkedAccounts: linked }
-          },
-          logout() {},
-        }
-      : {
-          user: {
-            async get() {
-              return { user: { id: 'user_1', linked_accounts: linked } }
-            },
-          },
-        }),
+    user: {
+      async get() {
+        return { user: { id: 'user_1', linked_accounts: linked } }
+      },
+    },
   } satisfies privy.Client & {
     initCalls: number
     loadCalls: number
@@ -512,28 +452,11 @@ declare namespace createClient {
   type Options = {
     accessToken?: string | null | undefined
     accounts?: readonly privy.WalletAccount[] | undefined
-    embeddedWallet?: boolean | undefined
-    user_shape?: 'core' | 'react' | undefined
   }
 }
 
-function linkedAccount(parameters: {
-  address: string
-  index: number
-  user_shape: 'core' | 'react'
-}): privy.LinkedAccount {
-  const { address, index, user_shape } = parameters
-  if (user_shape === 'react')
-    return {
-      address,
-      chainType: 'ethereum',
-      connectorType: 'embedded',
-      recoveryMethod: 'privy',
-      type: 'wallet',
-      walletClientType: 'privy',
-      walletIndex: index,
-    }
-
+function linkedAccount(parameters: { address: string; index: number }): privy.LinkedAccount {
+  const { address, index } = parameters
   return {
     address,
     chain_type: 'ethereum',

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -113,19 +113,9 @@ export function privy<const client extends privy.Client>(
     }
 
     async function getUser(client: client) {
-      if (client.user?.get)
-        return await client.user
-          .get()
-          .then((result) => result.user ?? undefined)
-          .catch((error) => {
-            if (!isSessionError(error)) throw error
-            return undefined
-          })
-
-      if (!client.getAuthenticatedUser) return undefined
-      return await client
-        .getAuthenticatedUser()
-        .then((user) => user ?? undefined)
+      return await client.user
+        .get()
+        .then((result) => result.user)
         .catch((error) => {
           if (!isSessionError(error)) throw error
           return undefined
@@ -133,17 +123,13 @@ export function privy<const client extends privy.Client>(
     }
 
     async function hasSession(client: client) {
-      if (client.getAccessToken)
-        return await client
-          .getAccessToken()
-          .then((token) => !!token)
-          .catch((error) => {
-            if (!isSessionError(error)) throw error
-            return false
-          })
-
-      if (!client.user?.get && !client.getAuthenticatedUser) return undefined
-      return !!(await getUser(client))
+      return await client
+        .getAccessToken()
+        .then((token) => !!token)
+        .catch((error) => {
+          if (!isSessionError(error)) throw error
+          return false
+        })
     }
 
     async function requireSession(client: client) {
@@ -156,7 +142,7 @@ export function privy<const client extends privy.Client>(
     }
 
     function linkedAccounts(user: privy.User) {
-      return user.linked_accounts ?? user.linkedAccounts ?? []
+      return user.linked_accounts ?? []
     }
 
     function embeddedWallets(user: privy.User) {
@@ -167,43 +153,29 @@ export function privy<const client extends privy.Client>(
     }
 
     function toEmbeddedWallet(account: privy.LinkedAccount): privy.EmbeddedWallet | undefined {
-      const chain_type = account.chain_type ?? account.chainType
-      const connector_type = account.connector_type ?? account.connectorType
-      const wallet_client_type = account.wallet_client_type ?? account.walletClientType
       if (
         account.type !== 'wallet' ||
         typeof account.address !== 'string' ||
-        chain_type !== 'ethereum' ||
-        connector_type !== 'embedded' ||
-        wallet_client_type !== 'privy'
+        account.chain_type !== 'ethereum' ||
+        account.connector_type !== 'embedded' ||
+        account.wallet_client_type !== 'privy'
       )
         return undefined
 
-      const recovery_method = account.recovery_method ?? account.recoveryMethod
-      const wallet_index = account.wallet_index ?? account.walletIndex ?? 0
+      const wallet_index = account.wallet_index ?? 0
       return {
         ...account,
         address: account.address,
         chain_type: 'ethereum',
-        chainType: 'ethereum',
         connector_type: 'embedded',
-        connectorType: 'embedded',
         type: 'wallet',
         wallet_client_type: 'privy',
-        walletClientType: 'privy',
         wallet_index,
-        walletIndex: wallet_index,
-        ...(recovery_method ? { recovery_method, recoveryMethod: recovery_method } : {}),
       }
     }
 
     async function providerFor(client: client, wallet: privy.EmbeddedWallet) {
-      if (client.embeddedWallet?.getProvider) return await client.embeddedWallet.getProvider(wallet)
-
-      throw new ox_Provider.UnsupportedMethodError({
-        message:
-          'Privy adapter restore requires `restoreAccounts` or `embeddedWallet.getProvider` on the Privy client.',
-      })
+      return await client.embeddedWallet.getProvider(wallet)
     }
 
     async function restoreAccounts() {
@@ -734,11 +706,7 @@ export function privy<const client extends privy.Client>(
         async disconnect() {
           const client = await getPrivyClient()
           const user = await getUser(client)
-          if (client.auth?.logout) {
-            if (user && client.auth.logout.length > 0) await client.auth.logout({ userId: user.id })
-            else await client.auth.logout()
-          }
-          else if (client.logout) await client.logout()
+          await client.auth.logout(user ? { userId: user.id } : undefined)
           clear()
         },
       },
@@ -749,7 +717,7 @@ export function privy<const client extends privy.Client>(
 export declare namespace privy {
   /** Options for {@link privy}. */
   type Options<client extends Client = Client> = {
-    /** Existing Privy Core client. Instantiate once per app, or pass the provider-owned client from Privy React when available. */
+    /** Existing Privy Core client. Instantiate once per app, or pass the Core client returned by Privy React when available. */
     client: client
     /** Creates/registers a Privy-backed wallet account. UI is allowed. */
     createAccount: (parameters: {
@@ -787,43 +755,31 @@ export declare namespace privy {
 
   /** Minimal structural Privy client surface used by the adapter. */
   type Client = {
-    /** Auth namespace used for disconnect when available. */
-    auth?:
-      | {
-          /** Clears the current Privy session for the given user. */
-          logout: (parameters?: { userId?: string | undefined } | undefined) => Promise<void> | void
-        }
-      | undefined
-    /** Embedded wallet namespace used for silent restore when available. */
-    embeddedWallet?:
-      | {
-          /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
-          getProvider?:
-            | ((
-                wallet: EmbeddedWallet,
-                recoveryPassword?: string | undefined,
-                recoveryAccessToken?: string | undefined,
-                recoverySecretOverride?: string | undefined,
-                recoveryKey?: string | undefined,
-              ) => Promise<EthereumProvider>)
-            | undefined
-        }
-      | undefined
-    /** Returns the current Privy user on React client shapes when available. */
-    getAuthenticatedUser?: (() => Promise<User | null | undefined>) | undefined
+    /** Auth namespace used for disconnect. */
+    auth: {
+      /** Clears the current Privy session for the given user. */
+      logout: (parameters?: { userId: string } | undefined) => Promise<void> | void
+    }
+    /** Embedded wallet namespace used for silent restore. */
+    embeddedWallet: {
+      /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
+      getProvider: (
+        wallet: EmbeddedWallet,
+        recoveryPassword?: string | undefined,
+        recoveryAccessToken?: string | undefined,
+        recoverySecretOverride?: string | undefined,
+        recoveryKey?: string | undefined,
+      ) => Promise<EthereumProvider>
+    }
     /** Returns the current access token when available, or null if no session exists. */
-    getAccessToken?: (() => Promise<string | null | undefined>) | undefined
+    getAccessToken: () => Promise<string | null>
     /** Initializes the client. Called once by the adapter when available. */
     initialize?: (() => Promise<void> | void) | undefined
-    /** Clears the current Privy session on React client shapes when available. */
-    logout?: (() => Promise<void> | void) | undefined
-    /** User namespace used for disconnect when available. */
-    user?:
-      | {
-          /** Returns the current Privy user, if any. */
-          get: () => Promise<{ user?: User | null | undefined }>
-        }
-      | undefined
+    /** User namespace used for restore and disconnect. */
+    user: {
+      /** Returns the current Privy user, if any. */
+      get: () => Promise<{ user: User }>
+    }
   }
 
   /** Minimal Privy user shape used by the adapter. */
@@ -832,8 +788,6 @@ export declare namespace privy {
     id: string
     /** Privy Core linked accounts. */
     linked_accounts?: readonly LinkedAccount[] | undefined
-    /** Privy React linked accounts. */
-    linkedAccounts?: readonly LinkedAccount[] | undefined
   }
 
   /** Minimal Privy linked account shape used during silent restore. */
@@ -842,26 +796,16 @@ export declare namespace privy {
     address?: string | undefined
     /** Privy Core chain type. */
     chain_type?: string | undefined
-    /** Privy React chain type. */
-    chainType?: string | undefined
     /** Privy Core connector type. */
     connector_type?: string | undefined
-    /** Privy React connector type. */
-    connectorType?: string | undefined
     /** Privy Core recovery method. */
     recovery_method?: string | undefined
-    /** Privy React recovery method. */
-    recoveryMethod?: string | undefined
     /** Linked account type. */
     type?: string | undefined
     /** Privy Core wallet client type. */
     wallet_client_type?: string | undefined
-    /** Privy React wallet client type. */
-    walletClientType?: string | undefined
     /** Privy Core HD wallet index. */
     wallet_index?: number | null | undefined
-    /** Privy React HD wallet index. */
-    walletIndex?: number | null | undefined
   }
 
   /** Minimal Privy embedded Ethereum wallet shape used during silent restore. */
@@ -870,22 +814,14 @@ export declare namespace privy {
     address: string
     /** Privy Core chain type. */
     chain_type: 'ethereum'
-    /** Privy React chain type. */
-    chainType: 'ethereum'
     /** Privy Core connector type. */
     connector_type: 'embedded'
-    /** Privy React connector type. */
-    connectorType: 'embedded'
     /** Linked account type. */
     type: 'wallet'
     /** Privy Core wallet client type. */
     wallet_client_type: 'privy'
-    /** Privy React wallet client type. */
-    walletClientType: 'privy'
     /** Privy Core HD wallet index. */
     wallet_index: number
-    /** Privy React HD wallet index. */
-    walletIndex: number
   }
 
   /** Minimal Privy-backed account returned by app-owned callbacks. */

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -178,7 +178,7 @@ export function privy<const client extends privy.Client>(
       return await client.embeddedWallet.getProvider(wallet)
     }
 
-    async function restoreAccounts() {
+    async function restoreWalletAccounts() {
       const client = await getPrivyClient()
       await requireSession(client)
       const user = await getUser(client)
@@ -186,8 +186,6 @@ export function privy<const client extends privy.Client>(
         throw new ox_Provider.DisconnectedError({
           message: 'Privy session disconnected.',
         })
-
-      if (options.restoreAccounts) return await options.restoreAccounts({ client, user })
 
       return await Promise.all(
         embeddedWallets(user).map(async (wallet) => ({
@@ -214,7 +212,7 @@ export function privy<const client extends privy.Client>(
       }
 
       restore_promise = (async () => {
-        const loaded = await restoreAccounts().catch((error) => {
+        const loaded = await restoreWalletAccounts().catch((error) => {
           if (!isSessionError(error) && !(error instanceof ox_Provider.DisconnectedError))
             throw error
           clear()
@@ -734,18 +732,6 @@ export declare namespace privy {
       client: client
       /** Provider load-accounts parameters. */
       parameters?: Adapter.loadAccounts.Parameters | undefined
-    }) => Promise<readonly WalletAccount[]>
-    /**
-     * Loads accounts from the current Privy session without showing UI.
-     *
-     * Use this with Privy Core clients that require app-owned entropy or secure-context
-     * handling before an embedded wallet provider can be rebuilt.
-     */
-    restoreAccounts?: (parameters: {
-      /** Initialized Privy client. */
-      client: client
-      /** Current authenticated Privy user. */
-      user: User
     }) => Promise<readonly WalletAccount[]>
     /** Display name of the provider. @default "Privy" */
     name?: string | undefined

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -7,7 +7,7 @@ import {
   WebCryptoP256,
 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { isAddressEqual, keccak256 } from 'viem'
+import { hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
 import type { Address } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
 import type { Account as TempoAccount } from 'viem/tempo'
@@ -359,10 +359,15 @@ export function privy<const client extends privy.Client>(
       walletAccount: privy.WalletAccount
     }) {
       const { message, walletAccount } = parameters
-      return await requestHex(walletAccount, {
-        method: 'personal_sign',
-        params: [message, core_Address.from(walletAccount.address)],
-      })
+      return await signPayload({ payload: hashMessage(message), walletAccount })
+    }
+
+    async function signRawPersonalMessage(parameters: {
+      data: Hex.Hex
+      walletAccount: privy.WalletAccount
+    }) {
+      const { data, walletAccount } = parameters
+      return await signPayload({ payload: hashMessage({ raw: data }), walletAccount })
     }
 
     async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
@@ -628,8 +633,8 @@ export function privy<const client extends privy.Client>(
         },
         async signPersonalMessage(parameters) {
           const account = await accountForSigning(parameters.address)
-          return await signPersonalMessage({
-            message: parameters.data,
+          return await signRawPersonalMessage({
+            data: parameters.data,
             walletAccount: account,
           })
         },
@@ -653,9 +658,15 @@ export function privy<const client extends privy.Client>(
         },
         async signTypedData(parameters) {
           const account = await accountForSigning(parameters.address)
-          return await requestHex(account, {
-            method: 'eth_signTypedData_v4',
-            params: [core_Address.from(account.address), parameters.data],
+          const typedData = JSON.parse(parameters.data) as {
+            domain: Record<string, unknown>
+            message: Record<string, unknown>
+            primaryType: string
+            types: Record<string, unknown>
+          }
+          return await signPayload({
+            payload: hashTypedData(typedData as never),
+            walletAccount: account,
           })
         },
         async sendTransaction(parameters) {

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -132,6 +132,29 @@ export function privy<const client extends privy.Client>(
         })
     }
 
+    async function hasSession(client: client) {
+      if (client.getAccessToken)
+        return await client
+          .getAccessToken()
+          .then((token) => !!token)
+          .catch((error) => {
+            if (!isSessionError(error)) throw error
+            return false
+          })
+
+      if (!client.user?.get && !client.getAuthenticatedUser) return undefined
+      return !!(await getUser(client))
+    }
+
+    async function requireSession(client: client) {
+      const session = await hasSession(client)
+      if (session !== false) return
+      clear()
+      throw new ox_Provider.DisconnectedError({
+        message: 'Privy session disconnected.',
+      })
+    }
+
     function linkedAccounts(user: privy.User) {
       return user.linked_accounts ?? user.linkedAccounts ?? []
     }
@@ -177,26 +200,22 @@ export function privy<const client extends privy.Client>(
     async function providerFor(client: client, wallet: privy.EmbeddedWallet) {
       if (client.embeddedWallet?.getProvider) return await client.embeddedWallet.getProvider(wallet)
 
-      if (client.embeddedWallet?.getEthereumProvider)
-        return await client.embeddedWallet.getEthereumProvider({
-          entropyId: wallet.address,
-          entropyIdVerifier: 'ethereum-address-verifier',
-          wallet,
-        })
-
       throw new ox_Provider.UnsupportedMethodError({
         message:
-          'Privy adapter restore requires `embeddedWallet.getProvider` or `embeddedWallet.getEthereumProvider` on the Privy client.',
+          'Privy adapter restore requires `restoreAccounts` or `embeddedWallet.getProvider` on the Privy client.',
       })
     }
 
     async function restoreAccounts() {
       const client = await getPrivyClient()
+      await requireSession(client)
       const user = await getUser(client)
       if (!user)
         throw new ox_Provider.DisconnectedError({
           message: 'Privy session disconnected.',
         })
+
+      if (options.restoreAccounts) return await options.restoreAccounts({ client, user })
 
       return await Promise.all(
         embeddedWallets(user).map(async (wallet) => ({
@@ -238,7 +257,7 @@ export function privy<const client extends privy.Client>(
           .filter((account): account is privy.WalletAccount => !!account)
 
         const matched = (() => {
-          if (!address) return restored.length > 0
+          if (!address) return restored.length > 0 && restored.length === persisted.length
           return restored.some((account) =>
             isAddressEqual(core_Address.from(account.address), address),
           )
@@ -515,6 +534,8 @@ export function privy<const client extends privy.Client>(
       return typeof value === 'object' && value !== null
     }
 
+    void restore().catch(() => undefined)
+
     return {
       actions: {
         async createAccount(parameters) {
@@ -527,6 +548,7 @@ export function privy<const client extends privy.Client>(
 
           const client = await getPrivyClient()
           const account = await options.createAccount({ client, parameters })
+          await requireSession(client)
           cache([account])
           restore_promise = undefined
 
@@ -565,6 +587,7 @@ export function privy<const client extends privy.Client>(
 
           const client = await getPrivyClient()
           const accounts = await options.loadAccounts({ client, parameters })
+          await requireSession(client)
           cache(accounts)
           restore_promise = undefined
 
@@ -700,7 +723,10 @@ export function privy<const client extends privy.Client>(
         async disconnect() {
           const client = await getPrivyClient()
           const user = await getUser(client)
-          if (user && client.auth?.logout) await client.auth.logout({ userId: user.id })
+          if (client.auth?.logout) {
+            if (user && client.auth.logout.length > 0) await client.auth.logout({ userId: user.id })
+            else await client.auth.logout()
+          }
           else if (client.logout) await client.logout()
           clear()
         },
@@ -730,6 +756,18 @@ export declare namespace privy {
       /** Provider load-accounts parameters. */
       parameters?: Adapter.loadAccounts.Parameters | undefined
     }) => Promise<readonly WalletAccount[]>
+    /**
+     * Loads accounts from the current Privy session without showing UI.
+     *
+     * Use this with Privy Core clients that require app-owned entropy or secure-context
+     * handling before an embedded wallet provider can be rebuilt.
+     */
+    restoreAccounts?: (parameters: {
+      /** Initialized Privy client. */
+      client: client
+      /** Current authenticated Privy user. */
+      user: User
+    }) => Promise<readonly WalletAccount[]>
     /** Display name of the provider. @default "Privy" */
     name?: string | undefined
     /** Reverse DNS identifier. @default "io.privy" */
@@ -742,31 +780,12 @@ export declare namespace privy {
     auth?:
       | {
           /** Clears the current Privy session for the given user. */
-          logout: (parameters: { userId: string }) => Promise<void> | void
+          logout: (parameters?: { userId?: string | undefined } | undefined) => Promise<void> | void
         }
       | undefined
     /** Embedded wallet namespace used for silent restore when available. */
     embeddedWallet?:
       | {
-          /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
-          getEthereumProvider?:
-            | ((parameters: {
-                /** Wallet account returned by the current Privy user. */
-                wallet: EmbeddedWallet
-                /** Embedded wallet entropy id. Privy uses the EVM address for Ethereum wallets. */
-                entropyId: string
-                /** Verifier for the entropy id. */
-                entropyIdVerifier: 'ethereum-address-verifier'
-                /** Optional user recovery access token. */
-                recoveryAccessToken?: string | undefined
-                /** Optional user recovery encryption key. */
-                recoveryKey?: string | undefined
-                /** Optional user recovery password. */
-                recoveryPassword?: string | undefined
-                /** Optional user recovery secret override. */
-                recoverySecretOverride?: string | undefined
-              }) => Promise<EthereumProvider>)
-            | undefined
           /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
           getProvider?:
             | ((
@@ -781,6 +800,8 @@ export declare namespace privy {
       | undefined
     /** Returns the current Privy user on React client shapes when available. */
     getAuthenticatedUser?: (() => Promise<User | null | undefined>) | undefined
+    /** Returns the current access token when available, or null if no session exists. */
+    getAccessToken?: (() => Promise<string | null | undefined>) | undefined
     /** Initializes the client. Called once by the adapter when available. */
     initialize?: (() => Promise<void> | void) | undefined
     /** Clears the current Privy session on React client shapes when available. */

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -1,0 +1,872 @@
+import {
+  Address as core_Address,
+  Hex,
+  Provider as ox_Provider,
+  PublicKey,
+  Signature,
+  WebCryptoP256,
+} from 'ox'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { isAddressEqual, keccak256 } from 'viem'
+import type { Address } from 'viem/accounts'
+import { prepareTransactionRequest } from 'viem/actions'
+import type { Account as TempoAccount } from 'viem/tempo'
+import { Transaction as TempoTransaction } from 'viem/tempo'
+
+import * as AccessKey from '../AccessKey.js'
+import * as Adapter from '../Adapter.js'
+import * as Store from '../Store.js'
+
+const privySessionErrorCodes = new Set([
+  'attempted_rpc_call_before_logged_in',
+  'attempted_to_read_storage_before_client_initialized',
+  'embedded_wallet_before_logged_in',
+  'embedded_wallet_does_not_exist',
+  'embedded_wallet_request_error',
+  'missing_auth_token',
+  'missing_privy_token',
+  'oauth_session_failed',
+  'oauth_session_timeout',
+  'session_expired',
+  'unauthenticated',
+  'unauthorized',
+])
+
+/**
+ * Creates a Privy adapter backed by an app-provided Privy client and embedded EVM wallet provider.
+ *
+ * The adapter owns Accounts state, access-key authorization, Tempo transaction
+ * preparation, raw hash signing, and broadcasting. Apps keep ownership of Privy
+ * auth UI, wallet creation, wallet selection, and secure-context recovery in
+ * `createAccount` and `loadAccounts`.
+ *
+ * @example
+ * ```ts
+ * import Privy, { LocalStorage } from '@privy-io/js-sdk-core'
+ * import { Provider } from 'accounts'
+ * import { privy } from 'accounts/privy'
+ *
+ * const client = new Privy({
+ *   appId,
+ *   clientId,
+ *   storage: new LocalStorage(),
+ * })
+ *
+ * const provider = Provider.create({
+ *   adapter: privy({
+ *     client,
+ *     createAccount: async ({ client, parameters }) => {
+ *       await openSignupUi(parameters)
+ *       return await getPrivyWalletAccount(client)
+ *     },
+ *     loadAccounts: async ({ client }) => {
+ *       await openLoginUi()
+ *       return await getPrivyWalletAccounts(client)
+ *     },
+ *   }),
+ * })
+ * ```
+ */
+export function privy<const client extends privy.Client>(
+  options: privy.Options<client>,
+): Adapter.Adapter {
+  const { icon, name = 'Privy', rdns = 'io.privy' } = options
+
+  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+    let client_promise: Promise<client> | undefined
+    let restore_promise: Promise<void> | undefined
+    let walletAccounts: readonly privy.WalletAccount[] = []
+
+    async function getPrivyClient() {
+      client_promise ??= (async () => {
+        const { client } = options
+        await client.initialize?.()
+        return client
+      })()
+      return await client_promise
+    }
+
+    function toStoreAccount(account: privy.WalletAccount, label?: string | undefined) {
+      return {
+        address: core_Address.from(account.address),
+        ...(label ? { label } : {}),
+      }
+    }
+
+    function cache(accounts: readonly privy.WalletAccount[]) {
+      walletAccounts = accounts.map((account) => {
+        core_Address.from(account.address)
+        return account
+      })
+    }
+
+    function clear() {
+      restore_promise = undefined
+      walletAccounts = []
+      store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
+    }
+
+    function accountByAddress(address: Address) {
+      return walletAccounts.find((account) =>
+        isAddressEqual(core_Address.from(account.address), address),
+      )
+    }
+
+    async function getUser(client: client) {
+      if (client.user?.get)
+        return await client.user
+          .get()
+          .then((result) => result.user ?? undefined)
+          .catch((error) => {
+            if (!isSessionError(error)) throw error
+            return undefined
+          })
+
+      if (!client.getAuthenticatedUser) return undefined
+      return await client
+        .getAuthenticatedUser()
+        .then((user) => user ?? undefined)
+        .catch((error) => {
+          if (!isSessionError(error)) throw error
+          return undefined
+        })
+    }
+
+    function linkedAccounts(user: privy.User) {
+      return user.linked_accounts ?? user.linkedAccounts ?? []
+    }
+
+    function embeddedWallets(user: privy.User) {
+      return linkedAccounts(user)
+        .map(toEmbeddedWallet)
+        .filter((account): account is privy.EmbeddedWallet => !!account)
+        .sort((a, b) => a.wallet_index - b.wallet_index)
+    }
+
+    function toEmbeddedWallet(account: privy.LinkedAccount): privy.EmbeddedWallet | undefined {
+      const chain_type = account.chain_type ?? account.chainType
+      const connector_type = account.connector_type ?? account.connectorType
+      const wallet_client_type = account.wallet_client_type ?? account.walletClientType
+      if (
+        account.type !== 'wallet' ||
+        typeof account.address !== 'string' ||
+        chain_type !== 'ethereum' ||
+        connector_type !== 'embedded' ||
+        wallet_client_type !== 'privy'
+      )
+        return undefined
+
+      const recovery_method = account.recovery_method ?? account.recoveryMethod
+      const wallet_index = account.wallet_index ?? account.walletIndex ?? 0
+      return {
+        ...account,
+        address: account.address,
+        chain_type: 'ethereum',
+        chainType: 'ethereum',
+        connector_type: 'embedded',
+        connectorType: 'embedded',
+        type: 'wallet',
+        wallet_client_type: 'privy',
+        walletClientType: 'privy',
+        wallet_index,
+        walletIndex: wallet_index,
+        ...(recovery_method ? { recovery_method, recoveryMethod: recovery_method } : {}),
+      }
+    }
+
+    async function providerFor(client: client, wallet: privy.EmbeddedWallet) {
+      if (client.embeddedWallet?.getProvider) return await client.embeddedWallet.getProvider(wallet)
+
+      if (client.embeddedWallet?.getEthereumProvider)
+        return await client.embeddedWallet.getEthereumProvider({
+          entropyId: wallet.address,
+          entropyIdVerifier: 'ethereum-address-verifier',
+          wallet,
+        })
+
+      throw new ox_Provider.UnsupportedMethodError({
+        message:
+          'Privy adapter restore requires `embeddedWallet.getProvider` or `embeddedWallet.getEthereumProvider` on the Privy client.',
+      })
+    }
+
+    async function restoreAccounts() {
+      const client = await getPrivyClient()
+      const user = await getUser(client)
+      if (!user)
+        throw new ox_Provider.DisconnectedError({
+          message: 'Privy session disconnected.',
+        })
+
+      return await Promise.all(
+        embeddedWallets(user).map(async (wallet) => ({
+          address: wallet.address,
+          provider: await providerFor(client, wallet),
+        })),
+      )
+    }
+
+    async function restore(address?: Address | undefined) {
+      await Store.waitForHydration(store)
+      const state = store.getState()
+      const persisted = state.accounts
+      if (persisted.length === 0) return
+      if (restore_promise) {
+        await restore_promise
+        if (address && !accountByAddress(address)) {
+          clear()
+          throw new ox_Provider.DisconnectedError({
+            message: 'No Privy account connected.',
+          })
+        }
+        return
+      }
+
+      restore_promise = (async () => {
+        const loaded = await restoreAccounts().catch((error) => {
+          if (!isSessionError(error) && !(error instanceof ox_Provider.DisconnectedError))
+            throw error
+          clear()
+          throw new ox_Provider.DisconnectedError({
+            message: 'Privy session disconnected.',
+          })
+        })
+        cache(loaded)
+
+        const restored = persisted
+          .map((account) => accountByAddress(account.address))
+          .filter((account): account is privy.WalletAccount => !!account)
+
+        const matched = (() => {
+          if (!address) return restored.length > 0
+          return restored.some((account) =>
+            isAddressEqual(core_Address.from(account.address), address),
+          )
+        })()
+
+        if (!matched) {
+          clear()
+          throw new ox_Provider.DisconnectedError({
+            message: 'No Privy account connected.',
+          })
+        }
+
+        walletAccounts = restored
+        store.setState({
+          accounts: restored.map((account) => toStoreAccount(account)),
+          activeAccount: Math.min(state.activeAccount, restored.length - 1),
+        })
+      })()
+
+      try {
+        await restore_promise
+      } finally {
+        restore_promise = undefined
+      }
+    }
+
+    async function accountForSigning(address: Address | undefined) {
+      await Store.waitForHydration(store)
+      const state = store.getState()
+      const address_ = address ?? state.accounts[state.activeAccount]?.address
+      if (!address_) throw new ox_Provider.DisconnectedError({ message: 'No accounts connected.' })
+
+      const account = accountByAddress(address_)
+      if (account) return account
+
+      const persisted = state.accounts.some((account) => isAddressEqual(account.address, address_))
+      await restore(persisted ? address_ : undefined)
+
+      const restored = accountByAddress(address_)
+      if (restored) return restored
+
+      if (walletAccounts.length === 0)
+        throw new ox_Provider.DisconnectedError({
+          message: 'No Privy account connected.',
+        })
+
+      throw new ox_Provider.UnauthorizedError({ message: `Account "${address_}" not found.` })
+    }
+
+    async function requestHex(
+      account: privy.WalletAccount,
+      request: { method: string; params?: unknown[] | undefined },
+      options: { rawSigning?: boolean | undefined } = {},
+    ): Promise<Hex.Hex> {
+      const result = await account.provider.request(request).catch((error) => {
+        if (options.rawSigning && isUnsupportedError(error)) throw unsupportedRawSigningError()
+        if (!isSessionError(error)) throw error
+        clear()
+        throw new ox_Provider.DisconnectedError({ message: 'Privy session disconnected.' })
+      })
+
+      if (typeof result !== 'string') {
+        if (options.rawSigning) throw unsupportedRawSigningError()
+        throw new ox_Provider.ProviderRpcError(
+          -32603,
+          'Privy provider returned a non-hex signature.',
+        )
+      }
+
+      try {
+        Hex.assert(result)
+        return result
+      } catch {
+        if (options.rawSigning) throw unsupportedRawSigningError()
+        throw new ox_Provider.ProviderRpcError(
+          -32603,
+          'Privy provider returned a non-hex signature.',
+        )
+      }
+    }
+
+    async function signPayload(parameters: {
+      payload: Hex.Hex
+      walletAccount: privy.WalletAccount
+    }) {
+      const { payload, walletAccount } = parameters
+      return await requestHex(
+        walletAccount,
+        {
+          method: 'secp256k1_sign',
+          params: [payload],
+        },
+        { rawSigning: true },
+      )
+    }
+
+    async function signPersonalMessage(parameters: {
+      message: string
+      walletAccount: privy.WalletAccount
+    }) {
+      const { message, walletAccount } = parameters
+      return await requestHex(walletAccount, {
+        method: 'personal_sign',
+        params: [message, core_Address.from(walletAccount.address)],
+      })
+    }
+
+    async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
+      const { expiry, limits, scopes } = options
+      const chainId = options.chainId ?? getClient().chain.id
+
+      if (options.publicKey || options.address) {
+        const address =
+          options.address ?? core_Address.fromPublicKey(PublicKey.from(options.publicKey!))
+        const keyAuthorization = KeyAuthorization.from({
+          address,
+          chainId: BigInt(chainId),
+          expiry,
+          limits,
+          scopes,
+          type: options.keyType ?? 'secp256k1',
+        })
+        return { keyAuthorization }
+      }
+
+      const keyPair = await WebCryptoP256.createKeyPair()
+      const address = core_Address.fromPublicKey(PublicKey.from(keyPair.publicKey))
+      const keyAuthorization = KeyAuthorization.from({
+        address,
+        chainId: BigInt(chainId),
+        expiry,
+        limits,
+        scopes,
+        type: 'p256',
+      })
+      return { keyAuthorization, keyPair }
+    }
+
+    async function signKeyAuthorization(
+      account: privy.WalletAccount,
+      prepared: Awaited<ReturnType<typeof prepareKeyAuthorization>>,
+      options: {
+        signature?: Hex.Hex | undefined
+      } = {},
+    ) {
+      const digest = KeyAuthorization.getSignPayload(prepared.keyAuthorization)
+      const signature =
+        options.signature ?? (await signPayload({ payload: digest, walletAccount: account }))
+      const keyAuthorization = KeyAuthorization.from(prepared.keyAuthorization, {
+        signature: SignatureEnvelope.from(signature),
+      })
+
+      AccessKey.save({
+        address: core_Address.from(account.address),
+        keyAuthorization,
+        ...(prepared.keyPair ? { keyPair: prepared.keyPair } : {}),
+        store,
+      })
+
+      return KeyAuthorization.toRpc(keyAuthorization)
+    }
+
+    async function withAccessKey<result>(
+      fn: (
+        account: TempoAccount.Account,
+        keyAuthorization?: KeyAuthorization.Signed,
+      ) => Promise<result>,
+    ) {
+      const account = (() => {
+        try {
+          return getAccount({ signable: true })
+        } catch {
+          return undefined
+        }
+      })()
+      if (!account || account.source !== 'accessKey') return undefined
+
+      const keyAuthorization = AccessKey.getPending(account, { store })
+      try {
+        const result = await fn(account, keyAuthorization ?? undefined)
+        AccessKey.removePending(account, { store })
+        return result
+      } catch {
+        AccessKey.remove(account, { store })
+        return undefined
+      }
+    }
+
+    async function signTransaction(parameters: Adapter.signTransaction.Parameters) {
+      const account = await accountForSigning(parameters.from)
+      const { feePayer, ...rest } = parameters
+      const viemClient = getClient({
+        feePayer: feePayer === true ? undefined : feePayer,
+      })
+      const prepared = await prepareTransactionRequest(viemClient, {
+        account: core_Address.from(account.address),
+        ...rest,
+        ...(feePayer ? { feePayer: true } : {}),
+        type: 'tempo',
+      } as never)
+      const presign = (() => {
+        if ('feePayerSignature' in prepared && prepared.feePayerSignature)
+          return { ...prepared, feePayerSignature: null }
+        return prepared
+      })()
+      const unsignedTransaction = await TempoTransaction.serialize(presign as never)
+
+      const signature = await signPayload({
+        payload: keccak256(unsignedTransaction),
+        walletAccount: account,
+      })
+      return await TempoTransaction.serialize(
+        prepared as never,
+        SignatureEnvelope.from(Signature.fromHex(signature)) as never,
+      )
+    }
+
+    function isSessionError(error: unknown) {
+      const code = getErrorCode(error)
+      if (typeof code === 'string') {
+        const normalized = code.toLowerCase()
+        if (privySessionErrorCodes.has(normalized)) return true
+        if (normalized.includes('before_logged_in')) return true
+        if (normalized.includes('session')) return true
+      }
+
+      const message = getErrorMessage(error).toLowerCase()
+      return (
+        message.includes('missing privy token') ||
+        message.includes('must be logged in') ||
+        message.includes('not authenticated') ||
+        message.includes('not logged in') ||
+        message.includes('session expired')
+      )
+    }
+
+    function isUnsupportedError(error: unknown) {
+      const code = getErrorCode(error)
+      if (code === 4200 || code === -32601) return true
+      if (typeof code === 'string' && code.toLowerCase().includes('unsupported')) return true
+
+      const message = getErrorMessage(error).toLowerCase()
+      return message.includes('unsupported') || message.includes('method not found')
+    }
+
+    function unsupportedRawSigningError() {
+      return new ox_Provider.UnsupportedMethodError({
+        message:
+          'Privy adapter requires raw secp256k1 hash signing via `secp256k1_sign` for Tempo transactions and access keys.',
+      })
+    }
+
+    function getErrorCode(error: unknown): string | number | undefined {
+      if (!isObject(error)) return undefined
+      const { cause, code } = error
+      if (typeof code === 'string' || typeof code === 'number') return code
+      return getErrorCode(cause)
+    }
+
+    function getErrorMessage(error: unknown): string {
+      if (error instanceof Error) return error.message
+      if (!isObject(error)) return ''
+      const { cause, error: error_, message } = error
+      const own = (() => {
+        if (typeof message === 'string') return message
+        if (typeof error_ === 'string') return error_
+        return ''
+      })()
+      const caused = getErrorMessage(cause)
+      return caused ? `${own} ${caused}` : own
+    }
+
+    function isObject(value: unknown): value is Record<string, unknown> {
+      return typeof value === 'object' && value !== null
+    }
+
+    return {
+      actions: {
+        async createAccount(parameters) {
+          const { authorizeAccessKey, personalSign } = parameters
+          if (personalSign && parameters.digest)
+            throw new ox_Provider.ProviderRpcError(
+              -32602,
+              '`digest` and `personalSign` cannot both be set on `wallet_connect`.',
+            )
+
+          const client = await getPrivyClient()
+          const account = await options.createAccount({ client, parameters })
+          cache([account])
+          restore_promise = undefined
+
+          const keyAuthorization = authorizeAccessKey
+            ? await signKeyAuthorization(
+                account,
+                await prepareKeyAuthorization(authorizeAccessKey),
+                { signature: authorizeAccessKey.signature },
+              )
+            : undefined
+
+          return {
+            accounts: [toStoreAccount(account, parameters.name)],
+            ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
+            ...(keyAuthorization ? { keyAuthorization } : {}),
+            signature: await (async () => {
+              if (personalSign)
+                return signPersonalMessage({
+                  message: personalSign.message,
+                  walletAccount: account,
+                })
+              if (parameters.digest)
+                return signPayload({ payload: parameters.digest, walletAccount: account })
+              return undefined
+            })(),
+          }
+        },
+        async loadAccounts(parameters) {
+          const { authorizeAccessKey, personalSign } =
+            parameters ?? ({} as Adapter.loadAccounts.Parameters)
+          if (personalSign && parameters?.digest)
+            throw new ox_Provider.ProviderRpcError(
+              -32602,
+              '`digest` and `personalSign` cannot both be set on `wallet_connect`.',
+            )
+
+          const client = await getPrivyClient()
+          const accounts = await options.loadAccounts({ client, parameters })
+          cache(accounts)
+          restore_promise = undefined
+
+          const account = walletAccounts[0]
+          const keyAuthorization =
+            authorizeAccessKey && account
+              ? await signKeyAuthorization(
+                  account,
+                  await prepareKeyAuthorization(authorizeAccessKey),
+                  { signature: authorizeAccessKey.signature },
+                )
+              : undefined
+
+          return {
+            accounts: walletAccounts.map((account) => toStoreAccount(account)),
+            ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
+            ...(keyAuthorization ? { keyAuthorization } : {}),
+            signature: await (async () => {
+              if (!account) return undefined
+              if (personalSign)
+                return signPersonalMessage({
+                  message: personalSign.message,
+                  walletAccount: account,
+                })
+              if (parameters?.digest)
+                return signPayload({ payload: parameters.digest, walletAccount: account })
+              return undefined
+            })(),
+          }
+        },
+        async authorizeAccessKey(parameters) {
+          const account = await accountForSigning(undefined)
+          const prepared = await prepareKeyAuthorization(parameters)
+          const keyAuthorization = await signKeyAuthorization(account, prepared, {
+            signature: parameters.signature,
+          })
+          return { keyAuthorization, rootAddress: core_Address.from(account.address) }
+        },
+        async signPersonalMessage(parameters) {
+          const account = await accountForSigning(parameters.address)
+          return await signPersonalMessage({
+            message: parameters.data,
+            walletAccount: account,
+          })
+        },
+        async signTransaction(parameters) {
+          const result = await withAccessKey(async (account, keyAuthorization) => {
+            const { feePayer, ...rest } = parameters
+            const viemClient = getClient({
+              feePayer: feePayer === true ? undefined : feePayer,
+            })
+            const prepared = await prepareTransactionRequest(viemClient, {
+              account,
+              ...rest,
+              ...(feePayer ? { feePayer: true } : {}),
+              keyAuthorization,
+              type: 'tempo',
+            } as never)
+            return await account.signTransaction(prepared as never)
+          })
+          if (result !== undefined) return result
+          return await signTransaction(parameters)
+        },
+        async signTypedData(parameters) {
+          const account = await accountForSigning(parameters.address)
+          return await requestHex(account, {
+            method: 'eth_signTypedData_v4',
+            params: [core_Address.from(account.address), parameters.data],
+          })
+        },
+        async sendTransaction(parameters) {
+          const result = await withAccessKey(async (account, keyAuthorization) => {
+            const { feePayer, ...rest } = parameters
+            const viemClient = getClient({
+              chainId: parameters.chainId,
+              feePayer: feePayer === true ? undefined : feePayer,
+            })
+            const prepared = await prepareTransactionRequest(viemClient, {
+              account,
+              ...rest,
+              ...(feePayer ? { feePayer: true } : {}),
+              keyAuthorization,
+              type: 'tempo',
+            } as never)
+            const signed = await account.signTransaction(prepared as never)
+            return await viemClient.request({
+              method: 'eth_sendRawTransaction' as never,
+              params: [signed],
+            })
+          })
+          if (result !== undefined) return result
+          const signed = await signTransaction(parameters)
+          const viemClient = getClient({
+            chainId: parameters.chainId,
+            feePayer: parameters.feePayer === true ? undefined : parameters.feePayer,
+          })
+          return await viemClient.request({
+            method: 'eth_sendRawTransaction' as never,
+            params: [signed],
+          })
+        },
+        async sendTransactionSync(parameters) {
+          const result = await withAccessKey(async (account, keyAuthorization) => {
+            const { feePayer, ...rest } = parameters
+            const viemClient = getClient({
+              chainId: parameters.chainId,
+              feePayer: feePayer === true ? undefined : feePayer,
+            })
+            const prepared = await prepareTransactionRequest(viemClient, {
+              account,
+              ...rest,
+              ...(feePayer ? { feePayer: true } : {}),
+              keyAuthorization,
+              type: 'tempo',
+            } as never)
+            const signed = await account.signTransaction(prepared as never)
+            return await viemClient.request({
+              method: 'eth_sendRawTransactionSync' as never,
+              params: [signed],
+            })
+          })
+          if (result !== undefined) return result
+          const signed = await signTransaction(parameters)
+          const viemClient = getClient({
+            chainId: parameters.chainId,
+            feePayer: parameters.feePayer === true ? undefined : parameters.feePayer,
+          })
+          return await viemClient.request({
+            method: 'eth_sendRawTransactionSync' as never,
+            params: [signed],
+          })
+        },
+        async disconnect() {
+          const client = await getPrivyClient()
+          const user = await getUser(client)
+          if (user && client.auth?.logout) await client.auth.logout({ userId: user.id })
+          else if (client.logout) await client.logout()
+          clear()
+        },
+      },
+    }
+  })
+}
+
+export declare namespace privy {
+  /** Options for {@link privy}. */
+  type Options<client extends Client = Client> = {
+    /** Existing Privy Core client. Instantiate once per app, or pass the provider-owned client from Privy React when available. */
+    client: client
+    /** Creates/registers a Privy-backed wallet account. UI is allowed. */
+    createAccount: (parameters: {
+      /** Initialized Privy client. */
+      client: client
+      /** Provider create-account parameters. */
+      parameters: Adapter.createAccount.Parameters
+    }) => Promise<WalletAccount>
+    /** Data URI of the provider icon. @default Black 1×1 SVG. */
+    icon?: `data:image/${string}` | undefined
+    /** Loads/logs into existing Privy-backed wallet accounts. UI is allowed. */
+    loadAccounts: (parameters: {
+      /** Initialized Privy client. */
+      client: client
+      /** Provider load-accounts parameters. */
+      parameters?: Adapter.loadAccounts.Parameters | undefined
+    }) => Promise<readonly WalletAccount[]>
+    /** Display name of the provider. @default "Privy" */
+    name?: string | undefined
+    /** Reverse DNS identifier. @default "io.privy" */
+    rdns?: string | undefined
+  }
+
+  /** Minimal structural Privy client surface used by the adapter. */
+  type Client = {
+    /** Auth namespace used for disconnect when available. */
+    auth?:
+      | {
+          /** Clears the current Privy session for the given user. */
+          logout: (parameters: { userId: string }) => Promise<void> | void
+        }
+      | undefined
+    /** Embedded wallet namespace used for silent restore when available. */
+    embeddedWallet?:
+      | {
+          /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
+          getEthereumProvider?:
+            | ((parameters: {
+                /** Wallet account returned by the current Privy user. */
+                wallet: EmbeddedWallet
+                /** Embedded wallet entropy id. Privy uses the EVM address for Ethereum wallets. */
+                entropyId: string
+                /** Verifier for the entropy id. */
+                entropyIdVerifier: 'ethereum-address-verifier'
+                /** Optional user recovery access token. */
+                recoveryAccessToken?: string | undefined
+                /** Optional user recovery encryption key. */
+                recoveryKey?: string | undefined
+                /** Optional user recovery password. */
+                recoveryPassword?: string | undefined
+                /** Optional user recovery secret override. */
+                recoverySecretOverride?: string | undefined
+              }) => Promise<EthereumProvider>)
+            | undefined
+          /** Returns an EIP-1193 provider for a Privy embedded Ethereum wallet. */
+          getProvider?:
+            | ((
+                wallet: EmbeddedWallet,
+                recoveryPassword?: string | undefined,
+                recoveryAccessToken?: string | undefined,
+                recoverySecretOverride?: string | undefined,
+                recoveryKey?: string | undefined,
+              ) => Promise<EthereumProvider>)
+            | undefined
+        }
+      | undefined
+    /** Returns the current Privy user on React client shapes when available. */
+    getAuthenticatedUser?: (() => Promise<User | null | undefined>) | undefined
+    /** Initializes the client. Called once by the adapter when available. */
+    initialize?: (() => Promise<void> | void) | undefined
+    /** Clears the current Privy session on React client shapes when available. */
+    logout?: (() => Promise<void> | void) | undefined
+    /** User namespace used for disconnect when available. */
+    user?:
+      | {
+          /** Returns the current Privy user, if any. */
+          get: () => Promise<{ user?: User | null | undefined }>
+        }
+      | undefined
+  }
+
+  /** Minimal Privy user shape used by the adapter. */
+  type User = {
+    /** Privy user id. */
+    id: string
+    /** Privy Core linked accounts. */
+    linked_accounts?: readonly LinkedAccount[] | undefined
+    /** Privy React linked accounts. */
+    linkedAccounts?: readonly LinkedAccount[] | undefined
+  }
+
+  /** Minimal Privy linked account shape used during silent restore. */
+  type LinkedAccount = {
+    /** Wallet address when the linked account is a wallet. */
+    address?: string | undefined
+    /** Privy Core chain type. */
+    chain_type?: string | undefined
+    /** Privy React chain type. */
+    chainType?: string | undefined
+    /** Privy Core connector type. */
+    connector_type?: string | undefined
+    /** Privy React connector type. */
+    connectorType?: string | undefined
+    /** Privy Core recovery method. */
+    recovery_method?: string | undefined
+    /** Privy React recovery method. */
+    recoveryMethod?: string | undefined
+    /** Linked account type. */
+    type?: string | undefined
+    /** Privy Core wallet client type. */
+    wallet_client_type?: string | undefined
+    /** Privy React wallet client type. */
+    walletClientType?: string | undefined
+    /** Privy Core HD wallet index. */
+    wallet_index?: number | null | undefined
+    /** Privy React HD wallet index. */
+    walletIndex?: number | null | undefined
+  }
+
+  /** Minimal Privy embedded Ethereum wallet shape used during silent restore. */
+  type EmbeddedWallet = LinkedAccount & {
+    /** EVM address for the embedded wallet. */
+    address: string
+    /** Privy Core chain type. */
+    chain_type: 'ethereum'
+    /** Privy React chain type. */
+    chainType: 'ethereum'
+    /** Privy Core connector type. */
+    connector_type: 'embedded'
+    /** Privy React connector type. */
+    connectorType: 'embedded'
+    /** Linked account type. */
+    type: 'wallet'
+    /** Privy Core wallet client type. */
+    wallet_client_type: 'privy'
+    /** Privy React wallet client type. */
+    walletClientType: 'privy'
+    /** Privy Core HD wallet index. */
+    wallet_index: number
+    /** Privy React HD wallet index. */
+    walletIndex: number
+  }
+
+  /** Minimal Privy-backed account returned by app-owned callbacks. */
+  type WalletAccount = {
+    /** EVM address for the Privy wallet. */
+    address: string
+    /** EIP-1193 provider returned by Privy for the selected wallet. */
+    provider: EthereumProvider
+  }
+
+  /** Minimal EIP-1193 provider surface used by the adapter. */
+  type EthereumProvider = {
+    /** Sends a JSON-RPC request to the Privy wallet provider. */
+    request: (parameters: { method: string; params?: unknown[] | undefined }) => Promise<unknown>
+  }
+}

--- a/src/privy/index.ts
+++ b/src/privy/index.ts
@@ -1,0 +1,1 @@
+export { privy } from '../core/adapters/privy.js'


### PR DESCRIPTION
## Summary
Add a Privy adapter for the Accounts SDK.

## Motivation
Apps using Privy embedded Ethereum wallets need an Accounts adapter that can restore sessions, create accounts, request accounts, sign messages, and send transactions through Privy’s client/provider APIs.

## Changes
- Added `src/core/adapters/privy.ts` with Privy client types and adapter behavior.
- Exported the adapter from `src/privy/index.ts` and package exports.
- Added runtime and type coverage in `src/core/adapters/privy.test.ts` and `src/core/adapters/privy.test-d.ts`.
- Added a changeset for the new adapter.

## Testing
- `./node_modules/.bin/vp test src/core/adapters/privy.test.ts`
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`