### PR TITLE
fix(relay): forward `keyAuthorization` in RPC shape to `eth_fillTransaction`

### DIFF
--- a/.changeset/relay-key-authorization-shape.md
+++ b/.changeset/relay-key-authorization-shape.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed `Handler.relay` forwarding `keyAuthorization` to `eth_fillTransaction` in the internal envelope shape instead of the RPC shape the chain expects.

--- a/src/server/internal/handlers/utils.ts
+++ b/src/server/internal/handlers/utils.ts
@@ -43,14 +43,17 @@ export function normalizeFillTransactionRequest(
   return { ...rest, ...withKeyAuthorization, calls: [call] }
 }
 
+/**
+ * Forwards `keyAuthorization` to the chain in RPC shape. Pass-through
+ * when already RPC; convert via `KeyAuthorization.toRpc` when internal.
+ */
 function normalizeKeyAuthorization(value: unknown) {
   if (!value || typeof value !== 'object') return undefined
   const ka = value as Record<string, unknown>
   const signature = ka.signature as Record<string, unknown> | undefined
   if (!signature || typeof signature !== 'object') return undefined
   const isInternal = typeof signature.signature === 'object' && signature.signature !== null
-  if (isInternal) return undefined
-  return KeyAuthorization.fromRpc(value as never)
+  return isInternal ? KeyAuthorization.toRpc(value as never) : value
 }
 
 function normalizeFillValue(value: unknown) {


### PR DESCRIPTION
`Handler.relay` was forwarding `keyAuthorization` to `eth_fillTransaction` in ox's internal envelope shape (`{ address, type, scopes[], signature: { publicKey, signature, metadata } }`) instead of the RPC shape the chain understands (`{ keyId, keyType, allowedCalls[], signature: { r, s, pubKeyX, pubKeyY, ... } }`). The chain rejected those fills with `missing field 'r'`.

`normalizeKeyAuthorization` now passes RPC-shaped input through unchanged and only converts internal-shaped input back to RPC via `KeyAuthorization.toRpc`.
