### PR TITLE
chore: bump turnkey adapter changeset to patch

### DIFF
--- a/.changeset/silent-turnkeys-kick.md
+++ b/.changeset/silent-turnkeys-kick.md
@@ -1,5 +1,5 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
 Added a Turnkey adapter for connecting and signing with app-provided Turnkey wallet accounts.


### PR DESCRIPTION
The Turnkey adapter is additive but ships alongside other patch-level changes in this release; bumping the changeset down to `patch` keeps the next version a patch.
