### PR TITLE
fix(relay): actionable error when eth_signRawTransaction called without fee payer

### DIFF
--- a/.changeset/relay-sign-raw-error.md
+++ b/.changeset/relay-sign-raw-error.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `Handler.relay()` to return an actionable error when `eth_signRawTransaction` is called without a fee payer configured, instead of forwarding to the RPC node which returns an opaque "Method not found".

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -163,6 +163,29 @@ describe('default', () => {
     `)
   })
 
+  test('behavior: returns actionable error for eth_signRawTransaction without feePayer', async () => {
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_signRawTransaction',
+        params: ['0x00'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      id: number
+      jsonrpc: string
+      error: { code: number; message: string }
+    }
+    expect(body.error.code).toBe(-32601)
+    expect(body.error.message).toContain('fee payer')
+    expect(body.error.message).toContain('Handler.relay()')
+  })
+
   test('behavior: handles JSON-RPC batch requests', async () => {
     const response = await fetch(server.url, {
       method: 'POST',

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -496,6 +496,23 @@ export function relay(options: relay.Options = {}): Handler {
       case 'eth_sendRawTransactionSync': {
         try {
           if (!feePayerOptions) {
+            // For eth_sendRawTransaction(Sync), the RPC node can handle
+            // these natively. But eth_signRawTransaction is a signing
+            // method that only the relay can fulfill — forwarding it to
+            // the node will return an opaque "Method not found".
+            if (request.method === 'eth_signRawTransaction') {
+              return RpcResponse.from(
+                {
+                  error: {
+                    code: -32601,
+                    message:
+                      'eth_signRawTransaction requires a fee payer to be configured on the relay. ' +
+                      'Set the `feePayer` option in `Handler.relay()` to enable transaction sponsorship.',
+                  },
+                },
+                { request },
+              )
+            }
             const result = await client.request(request as never)
             return RpcResponse.from({ result }, { request })
           }

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -496,11 +496,10 @@ export function relay(options: relay.Options = {}): Handler {
       case 'eth_sendRawTransactionSync': {
         try {
           if (!feePayerOptions) {
-            // For eth_sendRawTransaction(Sync), the RPC node can handle
-            // these natively. But eth_signRawTransaction is a signing
-            // method that only the relay can fulfill — forwarding it to
-            // the node will return an opaque "Method not found".
-            if (request.method === 'eth_signRawTransaction') {
+            // eth_signRawTransaction is a signing method that only the
+            // relay can fulfill — forwarding it to the RPC node returns
+            // an opaque "Method not found". Return an actionable error.
+            if ((request as { method: string }).method === 'eth_signRawTransaction') {
               return RpcResponse.from(
                 {
                   error: {
@@ -509,8 +508,8 @@ export function relay(options: relay.Options = {}): Handler {
                       'eth_signRawTransaction requires a fee payer to be configured on the relay. ' +
                       'Set the `feePayer` option in `Handler.relay()` to enable transaction sponsorship.',
                   },
-                },
-                { request },
+                } as never,
+                { request } as never,
               )
             }
             const result = await client.request(request as never)


### PR DESCRIPTION
When `Handler.relay()` has no `feePayer` configured and receives `eth_signRawTransaction`, it previously forwarded the request to the RPC node which returned an opaque `Method not found` (`-32601`).

Now returns a clear error: `eth_signRawTransaction requires a fee payer to be configured on the relay.`

`eth_sendRawTransaction` and `eth_sendRawTransactionSync` still forward to the node as before since those are valid node methods.

Prompted by: @jxom