### PR TITLE
feat: accept Node.js IncomingMessage in getSession

### DIFF
--- a/.changeset/getsession-node-compat.md
+++ b/.changeset/getsession-node-compat.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+Widened `getSession` to accept Node.js `http.IncomingMessage` in addition to Fetch API `Request`.

--- a/src/server/Handler.ts
+++ b/src/server/Handler.ts
@@ -5,6 +5,7 @@ import type { UnionToIntersection } from '../internal/types.js'
 import * as RequestListener from './internal/requestListener.js'
 
 export { auth } from './internal/handlers/auth.js'
+export { type SessionRequest } from './internal/handlers/session.js'
 export { codeAuth } from './internal/handlers/codeAuth.js'
 export { exchange } from './internal/handlers/exchange.js'
 export { relay } from './internal/handlers/relay.js'

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -317,8 +317,8 @@ export declare namespace auth {
   /** Return type of `auth()` — a `Handler` extended with `getSession`. */
   type ReturnType = Handler & { getSession: getSession }
 
-  /** Resolves the current session from a request's cookie. */
-  type getSession = (req: Request) => Promise<SessionPayload | undefined>
+  /** Resolves the current session from a request's cookie or bearer token. */
+  type getSession = (req: Session.SessionRequest) => Promise<SessionPayload | undefined>
 
   /**
    * Hook invoked after a SIWE signature is verified but before the

--- a/src/server/internal/handlers/session.test.ts
+++ b/src/server/internal/handlers/session.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vp/test'
+
+import {
+  bearerToken,
+  parseCookieValue,
+  type SessionRequest,
+  tokenFromRequest,
+} from './session.js'
+
+const cookieOptions = { cookie: true, cookieName: 'sid' } as const
+const noCookieOptions = { cookie: false, cookieName: 'sid' } as const
+
+// ---------------------------------------------------------------------------
+// bearerToken
+// ---------------------------------------------------------------------------
+
+describe('bearerToken', () => {
+  test('extracts token from valid Bearer header', () => {
+    expect(bearerToken('Bearer abc123')).toBe('abc123')
+  })
+
+  test('is case-insensitive on the scheme', () => {
+    expect(bearerToken('bearer abc123')).toBe('abc123')
+    expect(bearerToken('BEARER abc123')).toBe('abc123')
+  })
+
+  test('returns undefined for null', () => {
+    expect(bearerToken(null)).toBeUndefined()
+  })
+
+  test('returns undefined for non-Bearer scheme', () => {
+    expect(bearerToken('Basic abc123')).toBeUndefined()
+  })
+
+  test('returns undefined for empty token after Bearer', () => {
+    expect(bearerToken('Bearer ')).toBeUndefined()
+    expect(bearerToken('Bearer   ')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseCookieValue
+// ---------------------------------------------------------------------------
+
+describe('parseCookieValue', () => {
+  test('parses a single cookie', () => {
+    expect(parseCookieValue('sid=token123', 'sid')).toBe('token123')
+  })
+
+  test('parses from multiple cookies', () => {
+    expect(parseCookieValue('other=x; sid=token123; foo=bar', 'sid')).toBe('token123')
+  })
+
+  test('returns undefined when cookie is absent', () => {
+    expect(parseCookieValue('other=x; foo=bar', 'sid')).toBeUndefined()
+  })
+
+  test('decodes URI-encoded values', () => {
+    expect(parseCookieValue('sid=hello%20world', 'sid')).toBe('hello world')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenFromRequest — Fetch API Request
+// ---------------------------------------------------------------------------
+
+describe('tokenFromRequest (Fetch Request)', () => {
+  test('extracts bearer token from Authorization header', () => {
+    const req = new Request('http://localhost', {
+      headers: { authorization: 'Bearer fetch-token' },
+    })
+    expect(tokenFromRequest(req, cookieOptions)).toBe('fetch-token')
+  })
+
+  test('extracts cookie token', () => {
+    const req = new Request('http://localhost', {
+      headers: { cookie: 'sid=cookie-token' },
+    })
+    expect(tokenFromRequest(req, cookieOptions)).toBe('cookie-token')
+  })
+
+  test('prefers bearer over cookie', () => {
+    const req = new Request('http://localhost', {
+      headers: {
+        authorization: 'Bearer bearer-wins',
+        cookie: 'sid=cookie-loses',
+      },
+    })
+    expect(tokenFromRequest(req, cookieOptions)).toBe('bearer-wins')
+  })
+
+  test('ignores cookie when cookie option is false', () => {
+    const req = new Request('http://localhost', {
+      headers: { cookie: 'sid=ignored' },
+    })
+    expect(tokenFromRequest(req, noCookieOptions)).toBeUndefined()
+  })
+
+  test('returns undefined when no token is present', () => {
+    const req = new Request('http://localhost')
+    expect(tokenFromRequest(req, cookieOptions)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenFromRequest — Node.js IncomingMessage-shaped request
+// ---------------------------------------------------------------------------
+
+describe('tokenFromRequest (Node.js headers)', () => {
+  test('extracts bearer token from Authorization header', () => {
+    const req: SessionRequest = {
+      headers: { authorization: 'Bearer node-token' },
+    }
+    expect(tokenFromRequest(req, cookieOptions)).toBe('node-token')
+  })
+
+  test('extracts cookie token', () => {
+    const req: SessionRequest = {
+      headers: { cookie: 'sid=node-cookie' },
+    }
+    expect(tokenFromRequest(req, cookieOptions)).toBe('node-cookie')
+  })
+
+  test('prefers bearer over cookie', () => {
+    const req: SessionRequest = {
+      headers: {
+        authorization: 'Bearer bearer-wins',
+        cookie: 'sid=cookie-loses',
+      },
+    }
+    expect(tokenFromRequest(req, cookieOptions)).toBe('bearer-wins')
+  })
+
+  test('ignores cookie when cookie option is false', () => {
+    const req: SessionRequest = {
+      headers: { cookie: 'sid=ignored' },
+    }
+    expect(tokenFromRequest(req, noCookieOptions)).toBeUndefined()
+  })
+
+  test('returns undefined when no token is present', () => {
+    const req: SessionRequest = { headers: {} }
+    expect(tokenFromRequest(req, cookieOptions)).toBeUndefined()
+  })
+
+  test('handles undefined header values', () => {
+    const req: SessionRequest = {
+      headers: { authorization: undefined, cookie: 'sid=fallback' },
+    }
+    expect(tokenFromRequest(req, cookieOptions)).toBe('fallback')
+  })
+
+  test('handles array header values (multiple Set-Cookie style)', () => {
+    const req: SessionRequest = {
+      headers: { cookie: ['sid=from-array', 'other=x'] },
+    }
+    // Node joins array values with ", " — parseCookieValue handles this
+    expect(tokenFromRequest(req, cookieOptions)).toBe('from-array')
+  })
+})

--- a/src/server/internal/handlers/session.test.ts
+++ b/src/server/internal/handlers/session.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'vp/test'
+import * as Http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterAll, beforeAll, describe, expect, test } from 'vp/test'
 
+import * as Kv from '../../Kv.js'
+import { auth } from './auth.js'
 import {
   bearerToken,
   parseCookieValue,
@@ -9,10 +13,6 @@ import {
 
 const cookieOptions = { cookie: true, cookieName: 'sid' } as const
 const noCookieOptions = { cookie: false, cookieName: 'sid' } as const
-
-// ---------------------------------------------------------------------------
-// bearerToken
-// ---------------------------------------------------------------------------
 
 describe('bearerToken', () => {
   test('extracts token from valid Bearer header', () => {
@@ -38,10 +38,6 @@ describe('bearerToken', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// parseCookieValue
-// ---------------------------------------------------------------------------
-
 describe('parseCookieValue', () => {
   test('parses a single cookie', () => {
     expect(parseCookieValue('sid=token123', 'sid')).toBe('token123')
@@ -59,10 +55,6 @@ describe('parseCookieValue', () => {
     expect(parseCookieValue('sid=hello%20world', 'sid')).toBe('hello world')
   })
 })
-
-// ---------------------------------------------------------------------------
-// tokenFromRequest — Fetch API Request
-// ---------------------------------------------------------------------------
 
 describe('tokenFromRequest (Fetch Request)', () => {
   test('extracts bearer token from Authorization header', () => {
@@ -101,10 +93,6 @@ describe('tokenFromRequest (Fetch Request)', () => {
     expect(tokenFromRequest(req, cookieOptions)).toBeUndefined()
   })
 })
-
-// ---------------------------------------------------------------------------
-// tokenFromRequest — Node.js IncomingMessage-shaped request
-// ---------------------------------------------------------------------------
 
 describe('tokenFromRequest (Node.js headers)', () => {
   test('extracts bearer token from Authorization header', () => {
@@ -150,11 +138,85 @@ describe('tokenFromRequest (Node.js headers)', () => {
     expect(tokenFromRequest(req, cookieOptions)).toBe('fallback')
   })
 
-  test('handles array header values (multiple Set-Cookie style)', () => {
+  test('handles array header values', () => {
     const req: SessionRequest = {
       headers: { cookie: ['sid=from-array', 'other=x'] },
     }
-    // Node joins array values with ", " — parseCookieValue handles this
     expect(tokenFromRequest(req, cookieOptions)).toBe('from-array')
+  })
+})
+
+describe('getSession with http.IncomingMessage', () => {
+  const store = Kv.memory()
+  const handler = auth({ store, cookie: false })
+
+  let authServer: Http.Server
+  let authUrl: string
+  let appServer: Http.Server
+  let appUrl: string
+
+  beforeAll(async () => {
+    authServer = Http.createServer(handler.listener)
+    await new Promise<void>((resolve) => authServer.listen(0, resolve))
+    authUrl = `http://localhost:${(authServer.address() as AddressInfo).port}`
+
+    appServer = Http.createServer(async (req, res) => {
+      const session = await handler.getSession(req)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ session: session ?? null }))
+    })
+    await new Promise<void>((resolve) => appServer.listen(0, resolve))
+    appUrl = `http://localhost:${(appServer.address() as AddressInfo).port}`
+  })
+
+  afterAll(() => {
+    authServer.close()
+    appServer.close()
+  })
+
+  test('resolves session from bearer token on a real http.IncomingMessage', async () => {
+    const { privateKeyToAccount } = await import('viem/accounts')
+    const account = privateKeyToAccount(
+      '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    )
+
+    const challengeRes = await fetch(`${authUrl}/challenge`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chainId: 0 }),
+    })
+    expect(challengeRes.status).toBe(200)
+    const { message } = (await challengeRes.json()) as { message: string }
+
+    const signature = await account.signMessage({ message })
+    const verifyRes = await fetch(authUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        address: account.address,
+        message,
+        signature,
+        returnToken: true,
+      }),
+    })
+    expect(verifyRes.status).toBe(200)
+    const { token } = (await verifyRes.json()) as { token: string }
+    expect(token).toBeDefined()
+
+    const appRes = await fetch(appUrl, {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    const body = (await appRes.json()) as { session: { address: string; chainId: number } | null }
+
+    expect(body.session).toMatchObject({
+      address: account.address,
+      chainId: 0,
+    })
+  })
+
+  test('returns null for unauthenticated request', async () => {
+    const appRes = await fetch(appUrl)
+    const body = (await appRes.json()) as { session: unknown }
+    expect(body.session).toBeNull()
   })
 })

--- a/src/server/internal/handlers/session.ts
+++ b/src/server/internal/handlers/session.ts
@@ -61,11 +61,10 @@ export type SessionRequest =
  * where values may be `string | string[] | undefined`.
  */
 function getHeader(req: SessionRequest, name: string): string | null {
-  if ('get' in req.headers && typeof req.headers.get === 'function')
-    return req.headers.get(name)
+  if ('get' in req.headers && typeof req.headers.get === 'function') return req.headers.get(name)
   const value = (req.headers as Record<string, string | string[] | undefined>)[name]
   if (value === undefined) return null
-  return Array.isArray(value) ? value.join(', ') : value
+  return Array.isArray(value) ? value.join('; ') : value
 }
 
 /**

--- a/src/server/internal/handlers/session.ts
+++ b/src/server/internal/handlers/session.ts
@@ -43,13 +43,42 @@ export function parseCookieValue(header: string, name: string): string | undefin
 }
 
 /**
+ * Minimal request interface accepted by `tokenFromRequest` and
+ * `getSession`. Compatible with both the Fetch API `Request` and
+ * Node.js `http.IncomingMessage` so callers in Express, Fastify, or
+ * plain `http.createServer` don't need to construct a synthetic
+ * `Request` just to read a session.
+ */
+export type SessionRequest =
+  | Request
+  | {
+      headers: Record<string, string | string[] | undefined>
+    }
+
+/**
+ * Read a single header value from a `SessionRequest`. Handles both
+ * the Fetch API `Headers` (`.get()`) and the Node.js record shape
+ * where values may be `string | string[] | undefined`.
+ */
+function getHeader(req: SessionRequest, name: string): string | null {
+  if ('get' in req.headers && typeof req.headers.get === 'function')
+    return req.headers.get(name)
+  const value = (req.headers as Record<string, string | string[] | undefined>)[name]
+  if (value === undefined) return null
+  return Array.isArray(value) ? value.join(', ') : value
+}
+
+/**
  * Resolve the session token for a request. Prefers `Authorization: Bearer
  * <token>` over the cookie. When `cookie: false`, the cookie is ignored
  * even if present so callers cannot opt back into cookie mode by sending
  * a stale `Set-Cookie` value.
+ *
+ * Accepts both Fetch API `Request` and Node.js `IncomingMessage`-shaped
+ * objects (see {@link SessionRequest}).
  */
 export function tokenFromRequest(
-  req: Request,
+  req: SessionRequest,
   options: {
     /** Whether cookie issuance is enabled for this handler. */
     cookie: boolean
@@ -57,10 +86,10 @@ export function tokenFromRequest(
     cookieName: string
   },
 ): string | undefined {
-  const bearer = bearerToken(req.headers.get('authorization'))
+  const bearer = bearerToken(getHeader(req, 'authorization'))
   if (bearer) return bearer
   if (!options.cookie) return undefined
-  const cookieHeader = req.headers.get('cookie')
+  const cookieHeader = getHeader(req, 'cookie')
   return cookieHeader ? parseCookieValue(cookieHeader, options.cookieName) : undefined
 }
 

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -329,7 +329,7 @@ export declare namespace webAuthn {
   type ReturnType = Handler & { getSession: getSession }
 
   /** Resolves the current session from a request's cookie or bearer token. */
-  type getSession = (req: Request) => Promise<SessionPayload | undefined>
+  type getSession = (req: Session.SessionRequest) => Promise<SessionPayload | undefined>
 
   type Options = from.Options & {
     /**


### PR DESCRIPTION
Widened `getSession` (on both `Handler.auth` and `Handler.webAuthn`) to accept a Node.js `http.IncomingMessage` in addition to a Fetch API `Request`. This lets Express, Fastify, and plain `http.createServer` callers pass their native request objects directly without constructing a synthetic `Request`.

### Changes

- Added `SessionRequest` type union (`Request | { headers: Record<string, string | string[] | undefined> }`)
- Widened `tokenFromRequest` and `getSession` to accept `SessionRequest`
- Exported `SessionRequest` from `Handler` for consumer type annotations
- Added unit tests for `bearerToken`, `parseCookieValue`, and `tokenFromRequest` with both Fetch and Node.js header shapes
- Added integration tests using real `http.createServer` and `http.IncomingMessage`

Prompted by: @jxom