### PR TITLE
refactor: rename `dangerous_secp256k1` adapter to `secp256k1`

### DIFF
--- a/.changeset/rename-secp256k1-adapter.md
+++ b/.changeset/rename-secp256k1-adapter.md
@@ -1,0 +1,10 @@
+---
+'accounts': patch
+---
+
+Renamed the `dangerous_secp256k1` adapter to `secp256k1`. The old name is preserved as a deprecated alias so existing imports keep working.
+
+```diff
+- import { dangerous_secp256k1 } from 'accounts'
++ import { secp256k1 } from 'accounts'
+```

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -132,7 +132,7 @@ export type Instance = {
    * wallet host's own Provider runs the orchestration instead of racing
    * the dapp-side Provider for the challenge.
    *
-   * Wallet-host adapters (`local`, `webAuthn`, `dangerous_secp256k1`)
+   * Wallet-host adapters (`local`, `webAuthn`, `secp256k1`)
    * leave this unset.
    */
   forwardsAuth?: boolean | undefined

--- a/src/core/adapters/secp256k1.test.ts
+++ b/src/core/adapters/secp256k1.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, test } from 'vp/test'
 import { accounts, privateKeys } from '../../../test/config.js'
 import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
-import { dangerous_secp256k1 } from './dangerous_secp256k1.js'
+import { secp256k1 } from './secp256k1.js'
 
-describe('dangerous_secp256k1', () => {
+describe('secp256k1', () => {
   test('behavior: privateKey option pins the connected account', async () => {
     const account = accounts[1]!
     const provider = Provider.create({
-      adapter: dangerous_secp256k1({ privateKey: privateKeys[1]! }),
-      storage: Storage.memory({ key: 'dangerous-secp256k1-private-key' }),
+      adapter: secp256k1({ privateKey: privateKeys[1]! }),
+      storage: Storage.memory({ key: 'secp256k1-private-key' }),
     })
 
     const result = await provider.request({ method: 'wallet_connect' })

--- a/src/core/adapters/secp256k1.ts
+++ b/src/core/adapters/secp256k1.ts
@@ -5,23 +5,35 @@ import * as Adapter from '../Adapter.js'
 import { local } from './local.js'
 
 /**
- * Creates a secp256k1 adapter that generates random private keys and persists them to storage.
+ * Creates a secp256k1 adapter that signs in-process with a `secp256k1` private key.
  *
- * ⚠️ **Dangerous**: Private keys are stored in plaintext via the provider's storage adapter
- * (e.g. localStorage, cookies). Use only for development, testing, or when the threat model allows it.
+ * If `privateKey` is provided, the adapter pins that key as the signer (useful
+ * for server-side use, where the key is supplied by the host environment).
  *
- * Wraps the {@link local} adapter with automatic key generation.
+ * If `privateKey` is omitted, the adapter generates a random key on first
+ * connect and persists it via the provider's storage adapter (e.g.
+ * `localStorage`, cookies). Storing keys in browser storage in plaintext is
+ * dangerous — only use the unpinned form for development, testing, or when the
+ * threat model allows it.
+ *
+ * Wraps the {@link local} adapter.
  *
  * @example
  * ```ts
- * import { dangerous_secp256k1, Provider } from 'accounts'
+ * import { secp256k1, Provider } from 'accounts'
  *
+ * // Server-side (pinned key):
  * const provider = Provider.create({
- *   adapter: dangerous_secp256k1(),
+ *   adapter: secp256k1({ privateKey: process.env.PRIVATE_KEY }),
+ * })
+ *
+ * // Client-side (random key, persisted to storage):
+ * const provider = Provider.create({
+ *   adapter: secp256k1(),
  * })
  * ```
  */
-export function dangerous_secp256k1(options: dangerous_secp256k1.Options = {}): Adapter.Adapter {
+export function secp256k1(options: secp256k1.Options = {}): Adapter.Adapter {
   const { icon, name, privateKey, rdns } = options
   const fixed = privateKey
     ? {
@@ -52,7 +64,7 @@ export function dangerous_secp256k1(options: dangerous_secp256k1.Options = {}): 
   })
 }
 
-export declare namespace dangerous_secp256k1 {
+export declare namespace secp256k1 {
   type Options = {
     /** Data URI of the provider icon. @default Black 1×1 SVG. */
     icon?: `data:image/${string}` | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,8 @@ export { dialog, dialog as tempoWallet } from './core/adapters/dialog.js'
 export { local } from './core/adapters/local.js'
 export { turnkey } from './core/adapters/turnkey.js'
 export { webAuthn } from './core/adapters/webAuthn.js'
-export { dangerous_secp256k1 } from './core/adapters/dangerous_secp256k1.js'
+export {
+  secp256k1,
+  /** @deprecated Use `secp256k1` instead. */
+  secp256k1 as dangerous_secp256k1,
+} from './core/adapters/secp256k1.js'

--- a/test/adapters.ts
+++ b/test/adapters.ts
@@ -1,5 +1,5 @@
-import { dangerous_secp256k1 } from '../src/core/adapters/dangerous_secp256k1.js'
 import { local as core_local } from '../src/core/adapters/local.js'
+import { secp256k1 as core_secp256k1 } from '../src/core/adapters/secp256k1.js'
 import { webAuthn as core_webAuthn } from '../src/core/adapters/webAuthn.js'
 import type * as Store from '../src/core/Store.js'
 import * as WebAuthnCeremony from '../src/core/WebAuthnCeremony.js'
@@ -25,9 +25,9 @@ export function headlessWebAuthn() {
   })
 }
 
-/** Creates a `dangerous_secp256k1` adapter for testing. */
+/** Creates a `secp256k1` adapter for testing. */
 export function secp256k1() {
-  return dangerous_secp256k1()
+  return core_secp256k1()
 }
 
 /** Creates a WebAuthn adapter backed by a server-side ceremony via {@link WebAuthnCeremony.server}. */


### PR DESCRIPTION
Renamed the `dangerous_secp256k1` adapter to `secp256k1`. The `dangerous_` prefix was browser-centric (warning about persisting random keys to `localStorage`), but the adapter is the natural primitive for server-side use where the host supplies a fixed `privateKey` and storage is irrelevant.

The old name is preserved as a deprecated alias from `accounts`, so existing imports keep working.

```diff
- import { dangerous_secp256k1 } from 'accounts'
+ import { secp256k1 } from 'accounts'
```
