### PR TITLE
ci: ignore `GHSA-rmmr-r34h-pfm5` in `pnpm audit`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+auditConfig:
+  ignoreGhsas:
+    - GHSA-rmmr-r34h-pfm5 # affected versions have been removed from npm.
+
 allowBuilds:
   bufferutil: true
   cloudflared: true


### PR DESCRIPTION
Ignores `GHSA-rmmr-r34h-pfm5` in `pnpm audit` so CI passes again. The advisory flagged `@tanstack/history` as malware, but our pinned version (`1.161.6`, pulled in transitively by `ref-impls/dialog` via `@tanstack/react-router`) is not affected.

Fixes the failing audit step on https://github.com/tempoxyz/accounts/actions/runs/25710376101.
