### PR TITLE
fix(types): resolve typecheck errors in tests and `vocs.config`

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -2,7 +2,8 @@ import { defineConfig, McpSource } from 'vocs/config'
 
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
-  if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL
+  if (process.env.VITE_BASE_URL && URL.canParse(process.env.VITE_BASE_URL))
+    return process.env.VITE_BASE_URL
   if (process.env.VERCEL_ENV === 'production')
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   return ''

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -292,27 +292,55 @@ declare namespace setup {
 }
 
 function createClient(options: setup.Options = {}) {
-  const client = {
+  type WalletShape = { accounts: { address: string; addressFormat: string }[] }
+  const state = {
     fetchCalls: 0,
     initCalls: 0,
     loadCalls: 0,
     signPayloads: [] as Hex.Hex[],
     signWith: [] as string[],
-    wallets: [{ accounts: [{ address, addressFormat: 'ADDRESS_FORMAT_ETHEREUM' }] }],
-    async fetchWallets() {
-      client.fetchCalls++
-      return client.wallets
+    wallets: [
+      { accounts: [{ address, addressFormat: 'ADDRESS_FORMAT_ETHEREUM' }] },
+    ] as WalletShape[],
+  }
+  const client = {
+    get fetchCalls() {
+      return state.fetchCalls
     },
-    async getSession() {
-      return options.session === undefined
+    get initCalls() {
+      return state.initCalls
+    },
+    get loadCalls() {
+      return state.loadCalls
+    },
+    set loadCalls(value: number) {
+      state.loadCalls = value
+    },
+    get signPayloads() {
+      return state.signPayloads
+    },
+    get signWith() {
+      return state.signWith
+    },
+    get wallets() {
+      return state.wallets
+    },
+    set wallets(value: WalletShape[]) {
+      state.wallets = value
+    },
+    fetchWallets: async () => {
+      state.fetchCalls++
+      return state.wallets as readonly turnkey.Wallet[]
+    },
+    getSession: async () =>
+      options.session === undefined
         ? { expiry: Math.floor(Date.now() / 1000) + 60 }
-        : options.session
-    },
+        : options.session,
     httpClient: {
-      async signRawPayload(parameters: turnkey.SignRawPayloadParameters) {
+      signRawPayload: async (parameters: turnkey.SignRawPayloadParameters) => {
         if (options.signError) throw options.signError
-        client.signPayloads.push(parameters.payload)
-        client.signWith.push(parameters.signWith)
+        state.signPayloads.push(parameters.payload)
+        state.signWith.push(parameters.signWith)
         return {
           r: Hex.padLeft('0x11', 32),
           s: Hex.padLeft('0x22', 32),
@@ -320,17 +348,17 @@ function createClient(options: setup.Options = {}) {
         }
       },
     },
-    init() {
-      client.initCalls++
+    init: () => {
+      state.initCalls++
     },
-    logout() {},
+    logout: () => {},
   } satisfies turnkey.Client & {
     fetchCalls: number
     initCalls: number
     loadCalls: number
     signPayloads: Hex.Hex[]
     signWith: string[]
-    wallets: turnkey.Wallet[]
+    wallets: WalletShape[]
   }
 
   return client

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -355,7 +355,7 @@ describe('behavior: with feePayer.feeToken', () => {
     const { transaction } = await fillTransaction(client, {
       account: userAccount.address,
       calls: [transferCall()],
-      feePayer: false,
+      feePayer: false as never,
       feeToken: addresses.alphaUsd as Address,
     })
     expect(transaction.feeToken?.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())


### PR DESCRIPTION
Fixed three `pnpm check:types` failures.

`site/vocs.config.ts` now guards `process.env.VITE_BASE_URL` before passing it to `URL.canParse`, satisfying its `string | URL` parameter type.

`src/core/adapters/turnkey.test.ts` `createClient` was self-referencing inside its initializer, which tripped TS7022. Mutable counters and arrays now live on a separate `state` object so the methods can mutate them without recursive inference, and the `satisfies turnkey.Client` constraint is preserved.

`src/server/internal/handlers/relay.test.ts` opt-out test passes `feePayer: false as never` to match the runtime `parameters.feePayer !== false` check that's not exposed in viem's `feePayer?: Account | true | undefined` type.
