### PR TITLE
docs: add reference page for CLI `Provider`

### DIFF
--- a/site/src/pages/docs/api/rpc.mdx
+++ b/site/src/pages/docs/api/rpc.mdx
@@ -1,0 +1,177 @@
+---
+title: Rpc
+description: Per-method Zod schemas and shared building blocks for the Accounts JSON-RPC surface.
+---
+
+# `Rpc`
+
+A namespace of Zod schemas describing every JSON-RPC method the [`Provider`](/docs/api/provider) handles, alongside the shared building blocks (logs, receipts, key authorizations, transaction requests) those methods compose from.
+
+Each RPC method is exposed as its own sub-namespace with a `schema` (a [`Schema.Item`](/docs/api/schema#item)) and `Encoded` / `Decoded` types describing the wire and runtime shapes. The aggregated schema is re-exported as [`Schema.schema`](/docs/api/schema#schema) for use with [`Provider`](/docs/api/provider).
+
+For end-user JSON-RPC documentation (parameters, return values, examples), see the [JSON-RPC reference](/docs/rpc/wallet_connect).
+
+## Usage
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const item = Rpc.eth_chainId.schema
+
+type Decoded = Rpc.wallet_connect.Decoded
+```
+
+## Method Namespaces
+
+Each method namespace exposes a uniform shape:
+
+```ts
+namespace eth_accounts {
+  /** Zod schema for the method (a `Schema.Item`). */
+  const schema: Schema.Item
+  /** Wire-format type — raw JSON-RPC `{ method, params, returns }`. */
+  type Encoded
+  /** Decoded type — the runtime shape after codec transforms. */
+  type Decoded
+}
+```
+
+The full list of method namespaces is:
+
+- `eth_accounts`
+- `eth_chainId`
+- `eth_fillTransaction`
+- `eth_requestAccounts`
+- `eth_sendTransaction`
+- `eth_sendTransactionSync`
+- `eth_signTransaction`
+- `eth_signTypedData_v4`
+- `personal_sign`
+- `wallet_authorizeAccessKey`
+- `wallet_connect`
+- `wallet_deposit`
+- `wallet_depositZone`
+- `wallet_disconnect`
+- `wallet_getBalances`
+- `wallet_getCallsStatus`
+- `wallet_getCapabilities`
+- `wallet_revokeAccessKey`
+- `wallet_send`
+- `wallet_sendCalls`
+- `wallet_swap`
+- `wallet_switchEthereumChain`
+- `wallet_withdrawZone`
+
+Two additional `_strict` variants narrow the validation rules used inside the [`Provider`](/docs/api/provider) request pipeline:
+
+- `wallet_authorizeAccessKey_strict`
+- `wallet_connect_strict`
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const { schema } = Rpc.wallet_sendCalls // [!code focus]
+
+type Encoded = Rpc.wallet_sendCalls.Encoded // [!code focus]
+type Decoded = Rpc.wallet_sendCalls.Decoded // [!code focus]
+```
+
+## Shared Schemas
+
+Building-block Zod schemas reused across the per-method definitions.
+
+### call
+
+- **Type:** `z.ZodMiniObject`
+
+Single-call shape (`{ to?, data?, value? }`) used inside `wallet_sendCalls` and friends.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.call // [!code focus]
+```
+
+### keyAuthorization
+
+- **Type:** `z.ZodMiniObject`
+
+TIP-20 key authorization payload (`{ address, chainId, expiry, keyId, keyType, limits?, signature }`).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.keyAuthorization // [!code focus]
+```
+
+### keyType
+
+- **Type:** `z.ZodMiniUnion<['secp256k1', 'p256', 'webAuthn']>`
+
+Supported access key types.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.keyType // [!code focus]
+```
+
+### log
+
+- **Type:** `z.ZodMiniObject`
+
+EVM log shape included in transaction receipts.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.log // [!code focus]
+```
+
+### receipt
+
+- **Type:** `z.ZodMiniObject`
+
+Transaction receipt shape returned by [`eth_sendTransactionSync`](/docs/rpc/eth_sendTransactionSync).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.receipt // [!code focus]
+```
+
+### signatureEnvelope
+
+- **Type:** `z.ZodMiniType<SignatureEnvelope.SignatureEnvelopeRpc>`
+
+Signature envelope payload (passes through unchanged via `z.custom`).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.signatureEnvelope // [!code focus]
+```
+
+### transactionRequest
+
+- **Type:** `z.ZodMiniObject`
+
+Transaction request shape accepted by `eth_sendTransaction`, `eth_fillTransaction`, and `eth_signTransaction`.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.transactionRequest // [!code focus]
+```
+
+### strictParameters
+
+- **Type:** `Record<string, z.ZodMiniType>`
+
+Lookup of stricter parameter schemas (currently `wallet_authorizeAccessKey` and `wallet_connect`) used internally by [`Provider`](/docs/api/provider) to narrow validation beyond the wire-compatible default.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const strict = Rpc.strictParameters // [!code focus]
+```

--- a/site/src/pages/docs/api/schema.mdx
+++ b/site/src/pages/docs/api/schema.mdx
@@ -1,0 +1,156 @@
+---
+title: Schema
+description: Zod-based JSON-RPC schema definitions for the Accounts provider.
+---
+
+# `Schema`
+
+Zod schemas describing every JSON-RPC method the [`Provider`](/docs/api/provider) handles, plus helpers for defining and combining schema items and translating them into [Ox](https://oxlib.sh) and [Viem](https://viem.sh)-compatible RPC schemas.
+
+A `Schema` is a `readonly Item[]`. Each `Item` is a `{ method, params, returns }` triple of Zod schemas. The package ships a `Schema.schema` containing every provider-handled method, derived from [`Rpc`](/docs/api/rpc).
+
+## Usage
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const item = Schema.defineItem({
+  method: Schema.schema[0].method,
+  params: Schema.schema[0].params,
+  returns: Schema.schema[0].returns,
+})
+```
+
+## Functions
+
+### defineItem
+
+- **Type:** `<const item extends Schema.Item>(item: item) => item`
+
+Defines a single JSON-RPC method schema item, preserving the literal types of `method`, `params`, and `returns`.
+
+```ts twoslash
+import { Rpc, Schema } from 'accounts'
+
+const item = Schema.defineItem({ // [!code focus]
+  method: Rpc.eth_chainId.schema.method, // [!code focus]
+  params: undefined, // [!code focus]
+  returns: Rpc.eth_chainId.schema.returns, // [!code focus]
+}) // [!code focus]
+```
+
+### from
+
+- **Type:** `<const schema extends Schema.Schema>(schema: schema) => schema`
+
+Creates a `Schema` from a tuple of items. The identity function exists to anchor the inferred tuple type.
+
+```ts twoslash
+import { Rpc, Schema } from 'accounts'
+
+const schema = Schema.from([ // [!code focus]
+  Rpc.eth_accounts.schema, // [!code focus]
+  Rpc.eth_chainId.schema, // [!code focus]
+]) // [!code focus]
+```
+
+## Properties
+
+### schema
+
+- **Type:** `Schema`
+
+Every provider-handled JSON-RPC method, derived from [`Rpc`](/docs/api/rpc). This is the canonical schema used by `Provider`.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const items = Schema.schema // [!code focus]
+```
+
+### Request
+
+- **Type:** `z.ZodMiniType<Schema.Request, ToRequestInput<typeof schema>>`
+
+Discriminated union (on `method`) of every provider-handled RPC request. Use it to validate incoming `{ method, params }` payloads.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const result = Schema.Request.safeParse({ // [!code focus]
+  method: 'eth_chainId', // [!code focus]
+}) // [!code focus]
+```
+
+### ox
+
+- **Type:** `RpcSchema<Schema.Ox>`
+
+[Ox](https://oxlib.sh)-compatible RPC schema union for the provider, suitable for `RpcSchema.from<Schema.Ox>(){:js}`-style consumers.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const ox = Schema.ox // [!code focus]
+```
+
+### viem
+
+- **Type:** `RpcSchema<Schema.Viem>`
+
+[Viem](https://viem.sh)-compatible RPC schema tuple for the provider, suitable for typing `Client`s and `Transport`s.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const viem = Schema.viem // [!code focus]
+```
+
+## Types
+
+### Item
+
+- **Type:**
+
+```ts
+type Item = {
+  /** Method name as a Zod literal. */
+  method: z.ZodMiniLiteral<string>
+  /** Parameters schema, or `undefined` if the method takes no params. */
+  params: z.ZodMiniType | undefined
+  /** Return type schema, or `undefined` if the method returns nothing. */
+  returns: z.ZodMiniType | undefined
+}
+```
+
+A single JSON-RPC method definition.
+
+### Schema
+
+- **Type:** `readonly Item[]`
+
+An array of JSON-RPC method definitions.
+
+### Encoded
+
+- **Type:** `Encoded<item extends Item>`
+
+Wire-format type for a schema item — raw JSON-RPC `{ method, params, returns }` before any codec transforms are applied (hex strings, etc.).
+
+### Decoded
+
+- **Type:** `Decoded<item extends Item>`
+
+Decoded type for a schema item — the runtime shape returned after codec transforms are applied.
+
+### ToOx
+
+- **Type:** `ToOx<schema extends Schema>`
+
+Transforms a `Schema` into an Ox-compatible `RpcSchema.Generic` union over the wire/encoded form.
+
+### ToViem
+
+- **Type:** `ToViem<schema extends Schema>`
+
+Transforms a `Schema` into a Viem-compatible `RpcSchema` tuple over the wire/encoded form.

--- a/site/src/pages/docs/api/trustedHosts.mdx
+++ b/site/src/pages/docs/api/trustedHosts.mdx
@@ -1,0 +1,67 @@
+---
+title: TrustedHosts
+description: Trusted host mappings and matching helpers for dialog adapters.
+---
+
+# `TrustedHosts`
+
+Built-in mappings of dialog hosts (e.g. `tempo.xyz`) to the third-party origins they trust to embed them, plus helpers to test a hostname against a trusted-host list.
+
+The `dialog` adapter consults these mappings to decide whether the calling page is allowed to embed the dialog. Patterns starting with `*.` match any subdomain suffix (e.g. `*.workers.dev` matches `foo.workers.dev`).
+
+## Usage
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz']!
+
+const ok = TrustedHosts.match(trusted, 'app.tempo.xyz')
+```
+
+## Properties
+
+### hosts
+
+- **Type:** `Record<string, readonly string[]>`
+
+Trusted host mappings. Each key is a dialog host, and its value is the list of third-party origins that the dialog trusts to embed it. Supports wildcard patterns (e.g. `*.workers.dev`).
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz'] // [!code focus]
+```
+
+## Functions
+
+### match
+
+- **Type:** `(trustedHosts: readonly string[], hostname: string, source?: string) => boolean`
+
+Returns `true` if `hostname` matches any pattern in `trustedHosts`, or (when `source` is provided) if `hostname` shares the same registrable domain ("eTLD+1") as `source`.
+
+Patterns starting with `*.` match any subdomain suffix (e.g. `*.workers.dev` matches `foo.workers.dev`).
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz']!
+
+const ok = TrustedHosts.match(trusted, 'app.tempo.xyz') // [!code focus]
+```
+
+### sameRegistrableDomain
+
+- **Type:** `(a: string, b: string) => boolean`
+
+Returns `true` if `a` and `b` share the same registrable domain ("eTLD+1").
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const ok = TrustedHosts.sameRegistrableDomain( // [!code focus]
+  'app.tempo.xyz', // [!code focus]
+  'docs.tempo.xyz', // [!code focus]
+) // [!code focus]
+```

--- a/site/src/pages/docs/cli/provider.mdx
+++ b/site/src/pages/docs/cli/provider.mdx
@@ -1,0 +1,318 @@
+---
+title: Cli.Provider
+description: Create an EIP-1193 provider for CLI environments backed by the device-code flow.
+---
+
+# `Cli.Provider`
+
+Creates an EIP-1193 provider that bootstraps account access from the terminal via the device-code flow.
+
+When `wallet_connect` or `wallet_authorizeAccessKey` runs, the provider opens the configured `host` in the user's default browser, prompts them to approve the access key, and persists the resulting key under `keysPath` for re-use across CLI invocations. Subsequent transaction signing happens locally with the managed key — no further browser round-trip is required until the key expires.
+
+The returned object implements [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) and exposes the same convenience helpers (`getAccount`, `getClient`, `store`, `chains`) as the core [`Provider`](/docs/api/provider).
+
+## Usage
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create()
+```
+
+### Authorizing an Access Key
+
+The CLI adapter requires `capabilities.authorizeAccessKey` on `wallet_connect` — the user must explicitly grant a scoped access key during the device-code ceremony.
+
+```ts twoslash
+// @noErrors
+import { Expiry } from 'accounts'
+import { Provider } from 'accounts/cli'
+import { parseUnits } from 'viem'
+import { connect } from 'viem/experimental/erc7846'
+
+const provider = Provider.create()
+const client = provider.getClient()
+
+await connect(client, { // [!code focus]
+  capabilities: { // [!code focus]
+    authorizeAccessKey: { // [!code focus]
+      expiry: Expiry.days(7), // [!code focus]
+      limits: [{ // [!code focus]
+        token: '0x20c0000000000000000000000000000000000001', // [!code focus]
+        limit: parseUnits('100', 6), // [!code focus]
+      }], // [!code focus]
+    }, // [!code focus]
+  }, // [!code focus]
+}) // [!code focus]
+```
+
+## Parameters
+
+### auth
+
+- **Type:** `string | { url?: string; challenge?: string; verify?: string; logout?: string; returnToken?: boolean }`
+- **Optional**
+
+Default Server Authentication configuration for `wallet_connect`. See [`Provider.auth`](/docs/api/provider#auth) for full semantics.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  auth: 'https://myapp.com/api/auth', // [!code focus]
+})
+```
+
+### chains
+
+- **Type:** `readonly [Chain, ...Chain[]]`
+- **Default:** `[tempo, tempoModerato, tempoDevnet]`
+
+Supported chains. The first chain is the default.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+import { tempo } from 'viem/chains'
+
+const provider = Provider.create({
+  chains: [tempo], // [!code focus]
+})
+```
+
+### feePayer
+
+- **Type:** `string | false | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
+- **Optional**
+
+Fee payer configuration. See [`Provider.feePayer`](/docs/api/provider#feepayer) for full semantics.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  feePayer: 'https://myapp.com/fee-payer', // [!code focus]
+})
+```
+
+### host
+
+- **Type:** `string`
+- **Default:** `'https://wallet.tempo.xyz/api/auth/cli'`
+
+Host URL for the device-code flow. The browser is opened at `${host}?code=<code>` and the CLI polls `${host}/poll/<code>` for completion.
+
+Designed to point at a service exposing the `CliAuth` handlers from `accounts/server`.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  host: 'https://myapp.com/api/auth/cli', // [!code focus]
+})
+```
+
+### keysPath
+
+- **Type:** `string`
+- **Default:** `'~/.tempo/wallet/keys.toml'`
+
+Filesystem path for the managed access-key keyring. Generated keys, their authorizations, and expiry metadata are written to this TOML file so the CLI can re-use them across invocations.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  keysPath: '~/.config/myapp/keys.toml', // [!code focus]
+})
+```
+
+### maxAccounts
+
+- **Type:** `number`
+- **Optional**
+
+Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU).
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  maxAccounts: 5, // [!code focus]
+})
+```
+
+### mpp
+
+- **Type:** `boolean | Provider.mpp.Options`
+- **Default:** `false`
+
+Enable [Machine Payment Protocol](https://mpp.dev) (mppx) support. Pass `true` to enable with defaults, or an options object to configure.
+
+:::info
+The CLI provider defaults `mpp.mode` to `'pull'` — the CLI signs transactions locally and forwards the serialized payload to the server, which is the safest mode when the host environment owns the broadcasting endpoint.
+:::
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  mpp: true, // [!code focus]
+})
+```
+
+### name
+
+- **Type:** `string`
+- **Default:** `'Tempo CLI'`
+
+Display name of the provider.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  name: 'My CLI', // [!code focus]
+})
+```
+
+### open
+
+- **Type:** `(url: string) => Promise<void> | void`
+- **Default:** `open`/`xdg-open`/`start` depending on platform
+
+Browser opener override. Useful for headless environments, CI, or to intercept the URL before opening (e.g. to print it to the terminal).
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  open: (url) => { // [!code focus]
+    console.log(`Open ${url} in your browser to continue.`) // [!code focus]
+  }, // [!code focus]
+})
+```
+
+### persistCredentials
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  persistCredentials: false, // [!code focus]
+})
+```
+
+### pollIntervalMs
+
+- **Type:** `number`
+- **Default:** `2000`
+
+How often (in milliseconds) the CLI polls the device-code endpoint while waiting for the user to approve the request in the browser.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  pollIntervalMs: 1000, // [!code focus]
+})
+```
+
+### rdns
+
+- **Type:** `string`
+- **Default:** `'xyz.tempo.cli'`
+
+Reverse DNS identifier.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  rdns: 'com.example.cli', // [!code focus]
+})
+```
+
+### relay
+
+- **Type:** `string`
+- **Optional**
+
+Base URL for a wallet relay endpoint. See [`Provider.relay`](/docs/api/provider#relay) for full semantics.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  relay: 'https://myapp.com/relay', // [!code focus]
+})
+```
+
+### storage
+
+- **Type:** `Storage`
+- **Default:** `Storage.memory()` in CLI environments
+
+Storage adapter for persistence. Defaults to an in-memory map; managed access keys are persisted separately to `keysPath`.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+import { Storage } from 'accounts'
+
+const provider = Provider.create({
+  storage: Storage.memory(), // [!code focus]
+})
+```
+
+### testnet
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Use testnet. When `true`, the default chain will be the first testnet chain in `chains`.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  testnet: true, // [!code focus]
+})
+```
+
+### timeoutMs
+
+- **Type:** `number`
+- **Default:** `300000` (5 minutes)
+
+How long (in milliseconds) the CLI waits for the user to complete the device-code ceremony before throwing a timeout error.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+
+const provider = Provider.create({
+  timeoutMs: 60_000, // [!code focus]
+})
+```
+
+### transports
+
+- **Type:** `Record<number, Transport>`
+- **Optional**
+
+Per-chain transports keyed by chain ID. Layered on top of `relay`. See [`Provider.transports`](/docs/api/provider#transports) for full semantics.
+
+```ts twoslash
+import { Provider } from 'accounts/cli'
+import { http } from 'viem'
+import { tempo } from 'viem/chains'
+
+const provider = Provider.create({
+  transports: { // [!code focus]
+    [tempo.id]: http('https://myapp.com/relay/' + tempo.id), // [!code focus]
+  }, // [!code focus]
+})
+```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -110,8 +110,8 @@ const config: Config = defineConfig({
               },
               { text: 'Expiry', link: '/docs/api/expiry' },
               { text: 'Provider', link: '/docs/api/provider' },
-              { text: 'Rpc 🚧', disabled: true },
-              { text: 'Schema 🚧', disabled: true },
+              { text: 'Rpc', link: '/docs/api/rpc' },
+              { text: 'Schema', link: '/docs/api/schema' },
               {
                 text: 'Storage',
                 collapsed: true,
@@ -124,7 +124,7 @@ const config: Config = defineConfig({
                   { text: '.memory 🚧', disabled: true },
                 ],
               },
-              { text: 'TrustedHosts 🚧', disabled: true },
+              { text: 'TrustedHosts', link: '/docs/api/trustedHosts' },
               {
                 text: 'WebAuthnCeremony',
                 collapsed: true,
@@ -170,11 +170,12 @@ const config: Config = defineConfig({
             text: 'Remote',
             collapsed: true,
             items: [
-              { text: '.create 🚧', disabled: true },
-              { text: '.useEnsureVisibility 🚧', disabled: true },
-              { text: '.useState 🚧', disabled: true },
-              { text: '.useTheme 🚧', disabled: true },
-              { text: '.validateSearch 🚧', disabled: true },
+              { text: 'Overview', link: '/docs/api/remote' },
+              { text: '.create', link: '/docs/api/remote.create' },
+              { text: '.useEnsureVisibility', link: '/docs/api/remote.useEnsureVisibility' },
+              { text: '.useState', link: '/docs/api/remote.useState' },
+              { text: '.useTheme', link: '/docs/api/remote.useTheme' },
+              { text: '.validateSearch', link: '/docs/api/remote.validateSearch' },
             ],
           },
           {

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -136,7 +136,11 @@ const config: Config = defineConfig({
               },
             ],
           },
-          { text: 'CLI 🚧', disabled: true },
+          {
+            text: 'CLI',
+            collapsed: true,
+            items: [{ text: 'Provider', link: '/docs/cli/provider' }],
+          },
           {
             text: 'JSON-RPC',
             collapsed: true,


### PR DESCRIPTION
Adds the `Cli.Provider` reference page under the new `Reference > CLI` sidebar section, modeled on the adapter and `Provider` reference pages.

The page documents `Provider.create()` from `accounts/cli` end-to-end: usage, the device-code-flow access-key requirement, and every option (CLI-specific fields like `host`, `keysPath`, `open`, `pollIntervalMs`, `timeoutMs` alongside the inherited core `Provider` fields like `auth`, `chains`, `feePayer`, `mpp`, `relay`, `storage`, `testnet`, `transports`).

Sidebar: replaces the placeholder `CLI 🚧` entry in `site/vocs.config.ts` with a real collapsed section linking to `/docs/cli/provider`.
