### PR TITLE
docs: add reference pages for `Rpc`, `Schema`, and `TrustedHosts`

### DIFF
--- a/site/src/pages/docs/api/rpc.mdx
+++ b/site/src/pages/docs/api/rpc.mdx
@@ -1,0 +1,177 @@
+---
+title: Rpc
+description: Per-method Zod schemas and shared building blocks for the Accounts JSON-RPC surface.
+---
+
+# `Rpc`
+
+A namespace of Zod schemas describing every JSON-RPC method the [`Provider`](/docs/api/provider) handles, alongside the shared building blocks (logs, receipts, key authorizations, transaction requests) those methods compose from.
+
+Each RPC method is exposed as its own sub-namespace with a `schema` (a [`Schema.Item`](/docs/api/schema#item)) and `Encoded` / `Decoded` types describing the wire and runtime shapes. The aggregated schema is re-exported as [`Schema.schema`](/docs/api/schema#schema) for use with [`Provider`](/docs/api/provider).
+
+For end-user JSON-RPC documentation (parameters, return values, examples), see the [JSON-RPC reference](/docs/rpc/wallet_connect).
+
+## Usage
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const item = Rpc.eth_chainId.schema
+
+type Decoded = Rpc.wallet_connect.Decoded
+```
+
+## Method Namespaces
+
+Each method namespace exposes a uniform shape:
+
+```ts
+namespace eth_accounts {
+  /** Zod schema for the method (a `Schema.Item`). */
+  const schema: Schema.Item
+  /** Wire-format type — raw JSON-RPC `{ method, params, returns }`. */
+  type Encoded
+  /** Decoded type — the runtime shape after codec transforms. */
+  type Decoded
+}
+```
+
+The full list of method namespaces is:
+
+- `eth_accounts`
+- `eth_chainId`
+- `eth_fillTransaction`
+- `eth_requestAccounts`
+- `eth_sendTransaction`
+- `eth_sendTransactionSync`
+- `eth_signTransaction`
+- `eth_signTypedData_v4`
+- `personal_sign`
+- `wallet_authorizeAccessKey`
+- `wallet_connect`
+- `wallet_deposit`
+- `wallet_depositZone`
+- `wallet_disconnect`
+- `wallet_getBalances`
+- `wallet_getCallsStatus`
+- `wallet_getCapabilities`
+- `wallet_revokeAccessKey`
+- `wallet_send`
+- `wallet_sendCalls`
+- `wallet_swap`
+- `wallet_switchEthereumChain`
+- `wallet_withdrawZone`
+
+Two additional `_strict` variants narrow the validation rules used inside the [`Provider`](/docs/api/provider) request pipeline:
+
+- `wallet_authorizeAccessKey_strict`
+- `wallet_connect_strict`
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const { schema } = Rpc.wallet_sendCalls // [!code focus]
+
+type Encoded = Rpc.wallet_sendCalls.Encoded // [!code focus]
+type Decoded = Rpc.wallet_sendCalls.Decoded // [!code focus]
+```
+
+## Shared Schemas
+
+Building-block Zod schemas reused across the per-method definitions.
+
+### call
+
+- **Type:** `z.ZodMiniObject`
+
+Single-call shape (`{ to?, data?, value? }`) used inside `wallet_sendCalls` and friends.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.call // [!code focus]
+```
+
+### keyAuthorization
+
+- **Type:** `z.ZodMiniObject`
+
+TIP-20 key authorization payload (`{ address, chainId, expiry, keyId, keyType, limits?, signature }`).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.keyAuthorization // [!code focus]
+```
+
+### keyType
+
+- **Type:** `z.ZodMiniUnion<['secp256k1', 'p256', 'webAuthn']>`
+
+Supported access key types.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.keyType // [!code focus]
+```
+
+### log
+
+- **Type:** `z.ZodMiniObject`
+
+EVM log shape included in transaction receipts.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.log // [!code focus]
+```
+
+### receipt
+
+- **Type:** `z.ZodMiniObject`
+
+Transaction receipt shape returned by [`eth_sendTransactionSync`](/docs/rpc/eth_sendTransactionSync).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.receipt // [!code focus]
+```
+
+### signatureEnvelope
+
+- **Type:** `z.ZodMiniType<SignatureEnvelope.SignatureEnvelopeRpc>`
+
+Signature envelope payload (passes through unchanged via `z.custom`).
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.signatureEnvelope // [!code focus]
+```
+
+### transactionRequest
+
+- **Type:** `z.ZodMiniObject`
+
+Transaction request shape accepted by `eth_sendTransaction`, `eth_fillTransaction`, and `eth_signTransaction`.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const schema = Rpc.transactionRequest // [!code focus]
+```
+
+### strictParameters
+
+- **Type:** `Record<string, z.ZodMiniType>`
+
+Lookup of stricter parameter schemas (currently `wallet_authorizeAccessKey` and `wallet_connect`) used internally by [`Provider`](/docs/api/provider) to narrow validation beyond the wire-compatible default.
+
+```ts twoslash
+import { Rpc } from 'accounts'
+
+const strict = Rpc.strictParameters // [!code focus]
+```

--- a/site/src/pages/docs/api/schema.mdx
+++ b/site/src/pages/docs/api/schema.mdx
@@ -1,0 +1,156 @@
+---
+title: Schema
+description: Zod-based JSON-RPC schema definitions for the Accounts provider.
+---
+
+# `Schema`
+
+Zod schemas describing every JSON-RPC method the [`Provider`](/docs/api/provider) handles, plus helpers for defining and combining schema items and translating them into [Ox](https://oxlib.sh) and [Viem](https://viem.sh)-compatible RPC schemas.
+
+A `Schema` is a `readonly Item[]`. Each `Item` is a `{ method, params, returns }` triple of Zod schemas. The package ships a `Schema.schema` containing every provider-handled method, derived from [`Rpc`](/docs/api/rpc).
+
+## Usage
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const item = Schema.defineItem({
+  method: Schema.schema[0].method,
+  params: Schema.schema[0].params,
+  returns: Schema.schema[0].returns,
+})
+```
+
+## Functions
+
+### defineItem
+
+- **Type:** `<const item extends Schema.Item>(item: item) => item`
+
+Defines a single JSON-RPC method schema item, preserving the literal types of `method`, `params`, and `returns`.
+
+```ts twoslash
+import { Rpc, Schema } from 'accounts'
+
+const item = Schema.defineItem({ // [!code focus]
+  method: Rpc.eth_chainId.schema.method, // [!code focus]
+  params: undefined, // [!code focus]
+  returns: Rpc.eth_chainId.schema.returns, // [!code focus]
+}) // [!code focus]
+```
+
+### from
+
+- **Type:** `<const schema extends Schema.Schema>(schema: schema) => schema`
+
+Creates a `Schema` from a tuple of items. The identity function exists to anchor the inferred tuple type.
+
+```ts twoslash
+import { Rpc, Schema } from 'accounts'
+
+const schema = Schema.from([ // [!code focus]
+  Rpc.eth_accounts.schema, // [!code focus]
+  Rpc.eth_chainId.schema, // [!code focus]
+]) // [!code focus]
+```
+
+## Properties
+
+### schema
+
+- **Type:** `Schema`
+
+Every provider-handled JSON-RPC method, derived from [`Rpc`](/docs/api/rpc). This is the canonical schema used by `Provider`.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const items = Schema.schema // [!code focus]
+```
+
+### Request
+
+- **Type:** `z.ZodMiniType<Schema.Request, ToRequestInput<typeof schema>>`
+
+Discriminated union (on `method`) of every provider-handled RPC request. Use it to validate incoming `{ method, params }` payloads.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const result = Schema.Request.safeParse({ // [!code focus]
+  method: 'eth_chainId', // [!code focus]
+}) // [!code focus]
+```
+
+### ox
+
+- **Type:** `RpcSchema<Schema.Ox>`
+
+[Ox](https://oxlib.sh)-compatible RPC schema union for the provider, suitable for `RpcSchema.from<Schema.Ox>(){:js}`-style consumers.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const ox = Schema.ox // [!code focus]
+```
+
+### viem
+
+- **Type:** `RpcSchema<Schema.Viem>`
+
+[Viem](https://viem.sh)-compatible RPC schema tuple for the provider, suitable for typing `Client`s and `Transport`s.
+
+```ts twoslash
+import { Schema } from 'accounts'
+
+const viem = Schema.viem // [!code focus]
+```
+
+## Types
+
+### Item
+
+- **Type:**
+
+```ts
+type Item = {
+  /** Method name as a Zod literal. */
+  method: z.ZodMiniLiteral<string>
+  /** Parameters schema, or `undefined` if the method takes no params. */
+  params: z.ZodMiniType | undefined
+  /** Return type schema, or `undefined` if the method returns nothing. */
+  returns: z.ZodMiniType | undefined
+}
+```
+
+A single JSON-RPC method definition.
+
+### Schema
+
+- **Type:** `readonly Item[]`
+
+An array of JSON-RPC method definitions.
+
+### Encoded
+
+- **Type:** `Encoded<item extends Item>`
+
+Wire-format type for a schema item — raw JSON-RPC `{ method, params, returns }` before any codec transforms are applied (hex strings, etc.).
+
+### Decoded
+
+- **Type:** `Decoded<item extends Item>`
+
+Decoded type for a schema item — the runtime shape returned after codec transforms are applied.
+
+### ToOx
+
+- **Type:** `ToOx<schema extends Schema>`
+
+Transforms a `Schema` into an Ox-compatible `RpcSchema.Generic` union over the wire/encoded form.
+
+### ToViem
+
+- **Type:** `ToViem<schema extends Schema>`
+
+Transforms a `Schema` into a Viem-compatible `RpcSchema` tuple over the wire/encoded form.

--- a/site/src/pages/docs/api/trustedHosts.mdx
+++ b/site/src/pages/docs/api/trustedHosts.mdx
@@ -1,0 +1,67 @@
+---
+title: TrustedHosts
+description: Trusted host mappings and matching helpers for dialog adapters.
+---
+
+# `TrustedHosts`
+
+Built-in mappings of dialog hosts (e.g. `tempo.xyz`) to the third-party origins they trust to embed them, plus helpers to test a hostname against a trusted-host list.
+
+The `dialog` adapter consults these mappings to decide whether the calling page is allowed to embed the dialog. Patterns starting with `*.` match any subdomain suffix (e.g. `*.workers.dev` matches `foo.workers.dev`).
+
+## Usage
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz']!
+
+const ok = TrustedHosts.match(trusted, 'app.tempo.xyz')
+```
+
+## Properties
+
+### hosts
+
+- **Type:** `Record<string, readonly string[]>`
+
+Trusted host mappings. Each key is a dialog host, and its value is the list of third-party origins that the dialog trusts to embed it. Supports wildcard patterns (e.g. `*.workers.dev`).
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz'] // [!code focus]
+```
+
+## Functions
+
+### match
+
+- **Type:** `(trustedHosts: readonly string[], hostname: string, source?: string) => boolean`
+
+Returns `true` if `hostname` matches any pattern in `trustedHosts`, or (when `source` is provided) if `hostname` shares the same registrable domain ("eTLD+1") as `source`.
+
+Patterns starting with `*.` match any subdomain suffix (e.g. `*.workers.dev` matches `foo.workers.dev`).
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const trusted = TrustedHosts.hosts['tempo.xyz']!
+
+const ok = TrustedHosts.match(trusted, 'app.tempo.xyz') // [!code focus]
+```
+
+### sameRegistrableDomain
+
+- **Type:** `(a: string, b: string) => boolean`
+
+Returns `true` if `a` and `b` share the same registrable domain ("eTLD+1").
+
+```ts twoslash
+import { TrustedHosts } from 'accounts'
+
+const ok = TrustedHosts.sameRegistrableDomain( // [!code focus]
+  'app.tempo.xyz', // [!code focus]
+  'docs.tempo.xyz', // [!code focus]
+) // [!code focus]
+```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -110,8 +110,8 @@ const config: Config = defineConfig({
               },
               { text: 'Expiry', link: '/docs/api/expiry' },
               { text: 'Provider', link: '/docs/api/provider' },
-              { text: 'Rpc 🚧', disabled: true },
-              { text: 'Schema 🚧', disabled: true },
+              { text: 'Rpc', link: '/docs/api/rpc' },
+              { text: 'Schema', link: '/docs/api/schema' },
               {
                 text: 'Storage',
                 collapsed: true,
@@ -124,7 +124,7 @@ const config: Config = defineConfig({
                   { text: '.memory 🚧', disabled: true },
                 ],
               },
-              { text: 'TrustedHosts 🚧', disabled: true },
+              { text: 'TrustedHosts', link: '/docs/api/trustedHosts' },
               {
                 text: 'WebAuthnCeremony',
                 collapsed: true,
@@ -170,11 +170,12 @@ const config: Config = defineConfig({
             text: 'Remote',
             collapsed: true,
             items: [
-              { text: '.create 🚧', disabled: true },
-              { text: '.useEnsureVisibility 🚧', disabled: true },
-              { text: '.useState 🚧', disabled: true },
-              { text: '.useTheme 🚧', disabled: true },
-              { text: '.validateSearch 🚧', disabled: true },
+              { text: 'Overview', link: '/docs/api/remote' },
+              { text: '.create', link: '/docs/api/remote.create' },
+              { text: '.useEnsureVisibility', link: '/docs/api/remote.useEnsureVisibility' },
+              { text: '.useState', link: '/docs/api/remote.useState' },
+              { text: '.useTheme', link: '/docs/api/remote.useTheme' },
+              { text: '.validateSearch', link: '/docs/api/remote.validateSearch' },
             ],
           },
           {


### PR DESCRIPTION
Adds reference documentation pages for the `Rpc`, `Schema`, and `TrustedHosts` namespaces under `accounts`. The `Rpc` page covers the per-method schema namespaces and the shared building-block schemas (`call`, `keyAuthorization`, `keyType`, `log`, `receipt`, `signatureEnvelope`, `transactionRequest`, `strictParameters`). The `Schema` page documents `from`, `defineItem`, the canonical `schema`/`Request` exports, and the Ox/Viem-compatible mappings. The `TrustedHosts` page documents the trusted-host mappings plus `match` and `sameRegistrableDomain`.

Previously-disabled sidebar entries for `Rpc`, `Schema`, and `TrustedHosts` are now enabled in `site/vocs.config.ts`.
