### PR TITLE
docs: add reference pages for `Remote` namespace

### DIFF
--- a/site/src/pages/docs/api/remote.create.mdx
+++ b/site/src/pages/docs/api/remote.create.mdx
@@ -1,0 +1,217 @@
+---
+title: Remote.create
+description: Create a remote context bound to a Messenger and Provider.
+---
+
+# `Remote.create`
+
+Creates a remote context for the wallet's iframe/popup app. The context bundles a [`Messenger`](https://github.com/tempoxyz/accounts/blob/main/src/core/Messenger.ts) bridge to the host SDK, a [`Provider`](/docs/api/provider) used to actually execute approved requests, and a [Zustand](https://github.com/pmndrs/zustand) store of queued RPC requests.
+
+## Usage
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({
+  messenger,
+  provider,
+})
+
+remote.onUserRequest(({ account, request }) => {
+  if (!request) return
+  // Navigate to the request's approval UI...
+})
+
+remote.ready()
+```
+
+## Parameters
+
+### messenger
+
+- **Type:** `Messenger.Bridge`
+- **Required**
+
+Bridge messenger used to receive RPC requests from the host SDK and to send back responses, sync events, and mode switches.
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({
+  messenger, // [!code focus]
+  provider,
+})
+```
+
+### provider
+
+- **Type:** `Provider.Provider`
+- **Required**
+
+[`Provider`](/docs/api/provider) instance used to execute RPC requests once the user approves them.
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({
+  messenger,
+  provider, // [!code focus]
+})
+```
+
+### trustedHosts
+
+- **Type:** `readonly string[]`
+- **Default:** `[]`
+
+Hostnames trusted to render the wallet in an iframe. Forwarded to [`Messenger.ready`](https://github.com/tempoxyz/accounts/blob/main/src/core/Messenger.ts) and consulted by [`Remote.useEnsureVisibility`](/docs/api/remote.useEnsureVisibility) to decide whether occlusion monitoring is required.
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({
+  messenger,
+  provider,
+  trustedHosts: ['example.com', '*.example.com'], // [!code focus]
+})
+```
+
+## Returns
+
+`Remote.create` returns a `Remote` object with the following properties:
+
+### messenger
+
+- **Type:** `Messenger.Bridge`
+
+The messenger passed in via options.
+
+### provider
+
+- **Type:** `Provider.Provider`
+
+The provider passed in via options.
+
+### store
+
+- **Type:** `StoreApi<Remote.State>`
+
+Zustand store holding the remote context's state:
+
+```ts
+type State = {
+  /** Whether the dialog is rendered in an iframe or popup. */
+  mode: 'iframe' | 'popup' | undefined
+  /** Trusted host origin from MessageEvent. */
+  origin: string | undefined
+  /** Whether the dialog is ready to display content. */
+  ready: boolean
+  /** Queued RPC requests received from the host. */
+  requests: readonly Store.QueuedRequest[]
+}
+```
+
+### trustedHosts
+
+- **Type:** `readonly string[]`
+
+The trusted hosts list passed in via options (defaulted to `[]`).
+
+### onUserRequest
+
+- **Type:** `(cb: (payload: { account; origin; request }) => void | Promise<void>) => () => void`
+
+Subscribes to user-facing RPC requests. Syncs the host's active account/chain, updates the remote store, and invokes the callback with the first pending request -- or `null` when the queue is cleared, signalling the UI should close. Returns an unsubscribe function.
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({ messenger, provider })
+
+const unsubscribe = remote.onUserRequest(({ account, request }) => { // [!code focus]
+  if (!request) return // Queue cleared -- close the dialog. // [!code focus]
+  // Navigate to the per-method approval UI. // [!code focus]
+}) // [!code focus]
+```
+
+### onRequests
+
+- **Type:** `(cb: (requests, event, extra) => void) => () => void`
+
+Lower-level subscription that fires on every `rpc-requests` message and receives the full queued request list, the underlying `MessageEvent`, and the host's active account. Used internally by `onUserRequest`. Returns an unsubscribe function.
+
+### ready
+
+- **Type:** `(options?: { accounts?: readonly string[] } & Messenger.ReadyOptions) => void`
+
+Signals readiness to the host and begins accepting requests. Call this after the remote context is fully initialized. When `accounts` is provided, the wallet responds to SDK account-sync messages.
+
+```ts
+import { Remote } from 'accounts'
+
+const remote = Remote.create({ messenger, provider })
+
+remote.ready({ accounts: ['0x...'] }) // [!code focus]
+```
+
+### reject
+
+- **Type:** `(request: Store.QueuedRequest['request'], error?: ProviderRpcError | RpcResponse.BaseError) => void`
+
+Rejects a single RPC request. Defaults to `Provider.UserRejectedRequestError` when no `error` is provided.
+
+```ts
+remote.reject(request) // [!code focus]
+```
+
+### rejectAll
+
+- **Type:** `(error?: ProviderRpcError | RpcResponse.BaseError) => void`
+
+Rejects every pending RPC request. Typically wired to backdrop clicks and dialog dismissals.
+
+```ts
+remote.rejectAll() // [!code focus]
+```
+
+### respond
+
+- **Type:** `(request, options?: respond.Options) => Promise<unknown>`
+
+Responds to an RPC request. When `options.result` is provided, sends it directly. When `options.error` is provided, sends an error response. Otherwise, executes `provider.request(request)` and sends the result.
+
+```ts
+declare namespace respond {
+  type Options = {
+    /** Error to respond with (takes precedence over result). */
+    error?: { code: number; message: string } | undefined
+    /**
+     * Called when `provider.request()` throws. Return `true` to suppress the
+     * error response to the parent -- the dialog stays open and can show a
+     * recovery UI. The error is still re-thrown to the caller.
+     */
+    onError?: ((error: Error) => boolean | void) | undefined
+    /** Explicit result -- if omitted, calls `provider.request(request)`. */
+    result?: unknown | undefined
+    /** Transform the result before sending. */
+    selector?: ((result: any) => unknown) | undefined
+  }
+}
+```
+
+```ts
+// Defer to the bound provider. // [!code focus]
+await remote.respond(request) // [!code focus]
+
+// Send an explicit result. // [!code focus]
+await remote.respond(request, { result: '0x...' }) // [!code focus]
+
+// Send an explicit error. // [!code focus]
+await remote.respond(request, { // [!code focus]
+  error: { code: 4001, message: 'User rejected' }, // [!code focus]
+}) // [!code focus]
+```
+
+## SSR
+
+In SSR environments (no `window`), prefer `Remote.noop()` which returns an inert context whose methods are no-ops.

--- a/site/src/pages/docs/api/remote.mdx
+++ b/site/src/pages/docs/api/remote.mdx
@@ -1,0 +1,54 @@
+---
+title: Remote
+description: Bridge that runs inside the wallet's iframe/popup and serves RPC requests from the host SDK.
+---
+
+import { Cards, Card } from 'vocs'
+
+# `Remote`
+
+The `Remote` namespace is the **wallet-side** counterpart to the [`Provider`](/docs/api/provider). It runs inside the iframe or popup served by the wallet's auth app, receives RPC requests forwarded from the host SDK over [`Messenger`](https://github.com/tempoxyz/accounts/blob/main/src/core/Messenger.ts), and exposes a queue of pending requests for the UI to render approval surfaces against.
+
+A typical wallet app calls [`Remote.create`](/docs/api/remote.create) once at startup, subscribes to the request queue with `onUserRequest`, navigates to a per-method route, and either [`respond`](#respond) or [`reject`](#reject)s once the user has approved or cancelled.
+
+## Core
+
+<Cards>
+  <Card
+    description="Create a remote context bound to a Messenger and Provider"
+    icon="lucide:plug"
+    to="/docs/api/remote.create"
+    title=".create"
+  />
+  <Card
+    description="Validate an RPC request payload from URL search params"
+    icon="lucide:shield-check"
+    to="/docs/api/remote.validateSearch"
+    title=".validateSearch"
+  />
+</Cards>
+
+## React
+
+The React hooks live in the `accounts/react` entrypoint and are designed to be used from inside the wallet's auth app.
+
+<Cards>
+  <Card
+    description="Detect iframe occlusion and fall back to a popup"
+    icon="lucide:eye"
+    to="/docs/api/remote.useEnsureVisibility"
+    title=".useEnsureVisibility"
+  />
+  <Card
+    description="Subscribe to a remote context's state store"
+    icon="lucide:database"
+    to="/docs/api/remote.useState"
+    title=".useState"
+  />
+  <Card
+    description="Apply theme overrides from the host SDK"
+    icon="lucide:palette"
+    to="/docs/api/remote.useTheme"
+    title=".useTheme"
+  />
+</Cards>

--- a/site/src/pages/docs/api/remote.useEnsureVisibility.mdx
+++ b/site/src/pages/docs/api/remote.useEnsureVisibility.mdx
@@ -1,0 +1,90 @@
+---
+title: Remote.useEnsureVisibility
+description: React hook that monitors iframe visibility and falls back to a popup when occluded.
+---
+
+# `Remote.useEnsureVisibility`
+
+React hook that monitors element visibility using [IntersectionObserver v2](https://web.dev/articles/intersectionobserver-v2). When the wallet is rendered inside an iframe on an **untrusted host**, this hook detects occlusion / clickjacking attempts and exposes a `visible` flag plus an `invokePopup` action so the wallet can fall back to a popup.
+
+Imported from the `accounts/react` entrypoint.
+
+The hook is a no-op when the host is in [`remote.trustedHosts`](/docs/api/remote.create#trustedhosts), or when `enabled` is `false`. If IntersectionObserver v2 is not supported by the browser, `visible` is set to `false` so the wallet can immediately switch to a popup.
+
+## Usage
+
+```tsx
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+function EnsureVisibility(props: { children: React.ReactNode }) {
+  const mode = Remote.useState(remote, (s) => s.mode)
+  const { invokePopup, ref, visible } = Remote.useEnsureVisibility(remote, {
+    enabled: mode === 'iframe',
+  })
+
+  return (
+    <div ref={ref}>
+      {visible ? props.children : <button onClick={invokePopup}>Continue in new window</button>}
+    </div>
+  )
+}
+```
+
+## Parameters
+
+### remote
+
+- **Type:** `Remote.Remote`
+- **Required**
+
+The remote context returned from [`Remote.create`](/docs/api/remote.create). Used to read `trustedHosts` and to send the `switch-mode` message when `invokePopup` is called.
+
+```tsx
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+const { invokePopup, ref, visible } = Remote.useEnsureVisibility(
+  remote, // [!code focus]
+)
+```
+
+### options.enabled
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether visibility monitoring is enabled. Wire this to `mode === 'iframe'` so the hook is inert when the wallet is already rendered in a popup.
+
+```tsx
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+const mode = Remote.useState(remote, (s) => s.mode)
+const { invokePopup, ref, visible } = Remote.useEnsureVisibility(remote, {
+  enabled: mode === 'iframe', // [!code focus]
+})
+```
+
+## Returns
+
+### invokePopup
+
+- **Type:** `() => void`
+
+Sends a `switch-mode` message to the host SDK requesting it tear down the iframe and reopen the wallet in a popup.
+
+### ref
+
+- **Type:** `React.RefObject<HTMLDivElement | null>`
+
+Ref that must be attached to the element being monitored for occlusion.
+
+### visible
+
+- **Type:** `boolean`
+
+Whether the monitored element is currently fully visible. `true` while it has a clear viewport intersection of at least 99%; `false` when it is covered or when IntersectionObserver v2 is unavailable.

--- a/site/src/pages/docs/api/remote.useState.mdx
+++ b/site/src/pages/docs/api/remote.useState.mdx
@@ -1,0 +1,74 @@
+---
+title: Remote.useState
+description: React hook to subscribe to a remote context's state store.
+---
+
+# `Remote.useState`
+
+React hook that subscribes to the [`Remote`](/docs/api/remote.create) context's Zustand store. Re-renders whenever the selected slice changes.
+
+Imported from the `accounts/react` entrypoint.
+
+## Usage
+
+```ts
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+// Subscribe to the full state.
+const state = Remote.useState(remote)
+
+// Or subscribe to a slice via a selector.
+const ready = Remote.useState(remote, (s) => s.ready)
+```
+
+## Parameters
+
+### remote
+
+- **Type:** `Remote.Remote`
+- **Required**
+
+The remote context returned from [`Remote.create`](/docs/api/remote.create).
+
+```ts
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+const state = Remote.useState(remote) // [!code focus]
+```
+
+### selector
+
+- **Type:** `(state: Remote.State) => selected`
+- **Optional**
+
+Function that picks a slice from the store's state. The component only re-renders when the selected value changes (using `Object.is` equality).
+
+```ts
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+const ready = Remote.useState(remote, (s) => s.ready) // [!code focus]
+const mode = Remote.useState(remote, (s) => s.mode) // [!code focus]
+```
+
+## Returns
+
+The full `Remote.State` when no `selector` is provided, otherwise the selector's return value:
+
+```ts
+type State = {
+  /** Whether the dialog is rendered in an iframe or popup. */
+  mode: 'iframe' | 'popup' | undefined
+  /** Trusted host origin from MessageEvent. */
+  origin: string | undefined
+  /** Whether the dialog is ready to display content. */
+  ready: boolean
+  /** Queued RPC requests received from the host. */
+  requests: readonly Store.QueuedRequest[]
+}
+```

--- a/site/src/pages/docs/api/remote.useTheme.mdx
+++ b/site/src/pages/docs/api/remote.useTheme.mdx
@@ -1,0 +1,66 @@
+---
+title: Remote.useTheme
+description: React hook that applies theme overrides from URL search params and live messenger updates.
+---
+
+# `Remote.useTheme`
+
+React hook that applies theme overrides to the document root. On mount, it reads `accent`, `radius`, and `scheme` from the wallet app's URL search params and writes them to `<html>`. When a `remote` context is provided, it also subscribes to live `theme` messages from the host SDK and re-applies the latest values.
+
+The hook captures the original document attributes/styles on mount and restores them on unmount, so it is safe to use inside a route that may unmount and remount.
+
+Imported from the `accounts/react` entrypoint.
+
+## Usage
+
+```tsx
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+function App() {
+  Remote.useTheme(remote)
+  return <Outlet />
+}
+```
+
+## Parameters
+
+### remote
+
+- **Type:** `Remote.Remote | undefined`
+- **Optional**
+
+The remote context returned from [`Remote.create`](/docs/api/remote.create). When provided, the hook subscribes to live `theme` messages on the messenger so the wallet re-themes whenever the host SDK pushes an update.
+
+When omitted, only the initial URL-search-param theme is applied -- useful for SSR-rendered pages or static previews.
+
+```tsx
+import { Remote } from 'accounts/react'
+
+import { remote } from '../lib/config.js'
+
+Remote.useTheme(remote) // [!code focus]
+```
+
+## Theme values
+
+The following values are read from URL search params (and from `theme` messenger payloads) and applied to `<html>`:
+
+### accent
+
+- **Type:** `'neutral' | 'blue' | 'red' | 'amber' | 'green' | 'purple' | string`
+
+Sets the `data-theme-accent` attribute. When the value is not one of the named presets above, it is also written to the `--theme-accent` CSS custom property and `data-theme-accent` is set to `'custom'`.
+
+### radius
+
+- **Type:** `string`
+
+Sets the `data-theme-radius` attribute on `<html>` so theme CSS can pick up corner-radius variants.
+
+### scheme
+
+- **Type:** `string`
+
+Written to `document.documentElement.style.colorScheme` (e.g. `'light'`, `'dark'`).

--- a/site/src/pages/docs/api/remote.validateSearch.mdx
+++ b/site/src/pages/docs/api/remote.validateSearch.mdx
@@ -1,0 +1,101 @@
+---
+title: Remote.validateSearch
+description: Validate an RPC request payload from URL search params.
+---
+
+# `Remote.validateSearch`
+
+Validates an RPC request from URL search params against the wallet's [`Schema.Request`](https://github.com/tempoxyz/accounts/blob/main/src/core/Schema.ts) discriminated union.
+
+`Remote.validateSearch` parses `search` against the schema, asserts the decoded `method` matches the expected `method`, and enforces strict parameter schemas (e.g. required `limits`). On failure it rejects all pending requests via `remote.rejectAll(error)` and re-throws so the router can render its error boundary.
+
+Designed to be used from inside a TanStack Router (or similar) `validateSearch` callback so each per-method route gets a fully-typed, decoded request.
+
+## Usage
+
+```ts
+import { createFileRoute } from '@tanstack/react-router'
+import { Remote } from 'accounts'
+
+import { remote } from '../lib/config.js'
+
+export const Route = createFileRoute('/rpc/personal_sign')({
+  validateSearch: (search) =>
+    Remote.validateSearch(remote, search, { method: 'personal_sign' }),
+  component: Component,
+})
+```
+
+## Parameters
+
+### remote
+
+- **Type:** `Remote.Remote`
+- **Required**
+
+The remote context returned from [`Remote.create`](/docs/api/remote.create). Used to call `rejectAll(error)` when validation fails so the host SDK is notified before the router error boundary renders.
+
+```ts
+import { Remote } from 'accounts'
+
+import { remote } from '../lib/config.js'
+
+Remote.validateSearch(
+  remote, // [!code focus]
+  search,
+  { method: 'personal_sign' },
+)
+```
+
+### search
+
+- **Type:** `Record<string, unknown>`
+- **Required**
+
+Raw URL search params (including the encoded `_decoded`/`params`/`id` fields written by the host SDK).
+
+```ts
+import { Remote } from 'accounts'
+
+Remote.validateSearch(
+  remote,
+  search, // [!code focus]
+  { method: 'personal_sign' },
+)
+```
+
+### parameters.method
+
+- **Type:** `Schema.Request['method']`
+- **Required**
+
+Expected RPC method name. The decoded request's `method` must equal this value or an `InvalidParamsError` is thrown.
+
+```ts
+import { Remote } from 'accounts'
+
+Remote.validateSearch(remote, search, {
+  method: 'eth_sendTransaction', // [!code focus]
+})
+```
+
+## Returns
+
+The validated, decoded request payload -- a discriminated union member matching the requested `method`, augmented with:
+
+- `id: number` -- coerced from `search.id`.
+- `jsonrpc: '2.0'`.
+- `_decoded` -- the parsed `Schema.Request` member.
+- `_returnType` -- phantom marker for the route's return type.
+
+```ts
+type ReturnType<method extends Schema.Request['method']> = Extract<
+  Schema.Request,
+  { method: method }
+> & {
+  id: number
+  jsonrpc: '2.0'
+  _decoded: Extract<Schema.Request, { method: method }>
+  _returnType: unknown
+}
+```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -170,11 +170,12 @@ const config: Config = defineConfig({
             text: 'Remote',
             collapsed: true,
             items: [
-              { text: '.create 🚧', disabled: true },
-              { text: '.useEnsureVisibility 🚧', disabled: true },
-              { text: '.useState 🚧', disabled: true },
-              { text: '.useTheme 🚧', disabled: true },
-              { text: '.validateSearch 🚧', disabled: true },
+              { text: 'Overview', link: '/docs/api/remote' },
+              { text: '.create', link: '/docs/api/remote.create' },
+              { text: '.useEnsureVisibility', link: '/docs/api/remote.useEnsureVisibility' },
+              { text: '.useState', link: '/docs/api/remote.useState' },
+              { text: '.useTheme', link: '/docs/api/remote.useTheme' },
+              { text: '.validateSearch', link: '/docs/api/remote.validateSearch' },
             ],
           },
           {


### PR DESCRIPTION
Adds reference pages for the `Remote` namespace covering both the core wallet-side context (`accounts`) and the React hooks (`accounts/react`).

New pages: `Remote` overview, `.create`, `.validateSearch`, `.useEnsureVisibility`, `.useState`, `.useTheme`. Each member page follows the established style of `dialog.iframe.mdx` and `webauthnceremony.from.mdx`: front-matter, namespace-scoped heading, intro, `## Usage`, `## Parameters` with per-field `**Type:**` / required-or-optional / description / focused example, and `## Returns` where useful.

Sidebar `Remote` group in `site/vocs.config.ts` is enabled (overview + 5 members) and the local `tasks/reference-sidebar-audit.md` checklist is bumped accordingly.
