### PR TITLE
feat(webAuthn): accept `auth` option matching Provider `auth` capability

### DIFF
--- a/.changeset/webauthn-auth-option.md
+++ b/.changeset/webauthn-auth-option.md
@@ -1,0 +1,10 @@
+---
+'accounts': patch
+---
+
+Added `auth` option to the `webAuthn` adapter, mirroring the Provider `auth` capability shape (`string | { url, ... }`); the existing `authUrl` option is preserved as a deprecated alias.
+
+```diff
+- webAuthn({ authUrl: '/webauthn' })
++ webAuthn({ auth: '/webauthn' })
+```

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -66,7 +66,7 @@ Adapter to use for account management.
 import { Provider, webAuthn } from 'accounts'
 
 const provider = Provider.create({
-  adapter: webAuthn({ authUrl: '/auth' }), // [!code focus]
+  adapter: webAuthn({ auth: '/auth' }), // [!code focus]
 })
 ```
 

--- a/site/src/pages/docs/api/webAuthn.mdx
+++ b/site/src/pages/docs/api/webAuthn.mdx
@@ -13,22 +13,22 @@ Enables domain-bound passkey experiences by wrapping the `local` adapter with We
 import { webAuthn, Provider } from 'accounts'
 
 const provider = Provider.create({
-  adapter: webAuthn({ authUrl: '/auth' }),
+  adapter: webAuthn({ auth: '/auth' }),
 })
 ```
 
 ## Parameters
 
-`ceremony` and `authUrl` are mutually exclusive — the `Options` type is constrained as `OneOf<{ ceremony } | { authUrl }>`.
+`ceremony` and `auth` are mutually exclusive — the `Options` type is constrained as `OneOf<{ ceremony } | { auth }>`.
 
-### authUrl
+### auth
 
-- **Type:** `string`
+- **Type:** `string | { url?: string; challenge?: string; verify?: string; logout?: string; returnToken?: boolean }`
 - **Optional**
 
-URL of a [WebAuthn server handler](/docs/server/handler.webAuthn) (shorthand for `WebAuthnCeremony.server({ url }){:js}`).
+Server Authentication endpoint for WebAuthn ceremonies (shorthand for `WebAuthnCeremony.server({ url }){:js}`). Accepts the same shape as the [Provider `auth` capability](/docs/api/provider#auth) so the same value can be passed to both surfaces; the WebAuthn adapter only consumes the `url` field — SIWE-only fields (`challenge`, `verify`, `logout`, `returnToken`) are ignored by the ceremony.
 
-When supplied (and `ceremony` is omitted), the adapter falls back to `WebAuthnCeremony.server({ url: authUrl }){:js}`.
+When supplied (and `ceremony` is omitted), the adapter falls back to `WebAuthnCeremony.server({ url }){:js}`.
 
 :::warning
 Cannot be used with `ceremony`.
@@ -39,20 +39,28 @@ import { webAuthn, Provider } from 'accounts'
 
 const provider = Provider.create({
   adapter: webAuthn({
-    authUrl: '/auth', // [!code focus]
+    auth: '/auth', // [!code focus]
   }),
 })
 ```
 
+### authUrl
+
+- **Type:** `string`
+- **Optional**
+- **Deprecated** — use [`auth`](#auth) instead.
+
+URL of a [WebAuthn server handler](/docs/server/handler.webAuthn). Preserved as a backwards-compatible alias for `auth`. When both are supplied, `auth` wins.
+
 ### ceremony
 
 - **Type:** `WebAuthnCeremony`
-- **Default:** `WebAuthnCeremony.local({ storage }){:js}` when `authUrl` is also omitted, otherwise `WebAuthnCeremony.server({ url: authUrl }){:js}`.
+- **Default:** `WebAuthnCeremony.local({ storage }){:js}` when `auth` is also omitted, otherwise `WebAuthnCeremony.server({ url }){:js}`.
 
 Ceremony strategy for WebAuthn registration and authentication. [See more](/docs/api/webauthnceremony).
 
 :::warning
-Cannot be used with `authUrl`.
+Cannot be used with `auth`.
 :::
 
 ```ts twoslash
@@ -77,7 +85,7 @@ import { webAuthn, Provider } from 'accounts'
 
 const provider = Provider.create({
   adapter: webAuthn({
-    authUrl: '/auth',
+    auth: '/auth',
     icon: 'data:image/svg+xml,...', // [!code focus]
   }),
 })
@@ -95,7 +103,7 @@ import { webAuthn, Provider } from 'accounts'
 
 const provider = Provider.create({
   adapter: webAuthn({
-    authUrl: '/auth',
+    auth: '/auth',
     name: 'My Wallet', // [!code focus]
   }),
 })
@@ -113,7 +121,7 @@ import { webAuthn, Provider } from 'accounts'
 
 const provider = Provider.create({
   adapter: webAuthn({
-    authUrl: '/auth',
+    auth: '/auth',
     rdns: 'com.example.wallet', // [!code focus]
   }),
 })

--- a/site/src/pages/docs/api/webAuthn.mdx
+++ b/site/src/pages/docs/api/webAuthn.mdx
@@ -44,14 +44,6 @@ const provider = Provider.create({
 })
 ```
 
-### authUrl
-
-- **Type:** `string`
-- **Optional**
-- **Deprecated** — use [`auth`](#auth) instead.
-
-URL of a [WebAuthn server handler](/docs/server/handler.webAuthn). Preserved as a backwards-compatible alias for `auth`. When both are supplied, `auth` wins.
-
 ### ceremony
 
 - **Type:** `WebAuthnCeremony`

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -2,10 +2,12 @@ import { PublicKey, Signature } from 'ox'
 import { SignatureEnvelope } from 'ox/tempo'
 import { Account } from 'viem/tempo'
 import { Authentication, Registration } from 'webauthx/client'
+import type { z } from 'zod'
 
 import type { OneOf } from '../../internal/types.js'
 import * as Adapter from '../Adapter.js'
 import * as WebAuthnCeremony from '../WebAuthnCeremony.js'
+import * as Rpc from '../zod/rpc.js'
 import { local } from './local.js'
 
 /**
@@ -24,14 +26,19 @@ import { local } from './local.js'
  * ```
  */
 export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
-  const { authUrl, icon, name, rdns } = options
+  const { auth, authUrl, icon, name, rdns } = options
+
+  const url = (() => {
+    if (auth) return typeof auth === 'string' ? auth : auth.url
+    return authUrl
+  })()
 
   return Adapter.define({ icon, name, rdns }, (parameters) => {
     const { storage } = parameters
 
     const ceremony =
       options.ceremony ??
-      (authUrl ? WebAuthnCeremony.server({ url: authUrl }) : WebAuthnCeremony.local({ storage }))
+      (url ? WebAuthnCeremony.server({ url }) : WebAuthnCeremony.local({ storage }))
 
     const base = local({
       async createAccount(parameters) {
@@ -120,7 +127,15 @@ export declare namespace webAuthn {
         ceremony?: WebAuthnCeremony.WebAuthnCeremony | undefined
       }
     | {
-        /** URL of a WebAuthn handler (shorthand for `WebAuthnCeremony.server({ url })`). */
+        /**
+         * Server Authentication endpoint for WebAuthn ceremonies (shorthand for
+         * `WebAuthnCeremony.server({ url })`). Accepts the same shape as the
+         * Provider `auth` capability — only the `url` field is consumed here;
+         * other fields (`challenge`, `verify`, `logout`, `returnToken`) are
+         * SIWE-only and ignored by the WebAuthn ceremony.
+         */
+        auth?: z.input<typeof Rpc.wallet_connect.auth> | undefined
+        /** @deprecated Use `auth` instead. */
         authUrl?: string | undefined
       }
   > & {


### PR DESCRIPTION
Adds an `auth` option to the `webAuthn` adapter that accepts the same shape as the Provider `auth` capability (`string | { url, ... }`), so the same value can be passed to both surfaces.

The existing `authUrl` option is preserved as a deprecated alias and continues to work. When both are supplied, `auth` wins. The adapter only consumes the `url` field — SIWE-only fields like `challenge`, `verify`, `logout`, and `returnToken` are ignored by the WebAuthn ceremony.

```diff
- webAuthn({ authUrl: '/webauthn' })
+ webAuthn({ auth: '/webauthn' })
```

Updated [`docs/api/webAuthn`](https://github.com/tempoxyz/accounts/blob/feat/webauthn-auth-option/site/src/pages/docs/api/webAuthn.mdx) and the `Provider.adapter` example in [`docs/api/provider`](https://github.com/tempoxyz/accounts/blob/feat/webauthn-auth-option/site/src/pages/docs/api/provider.mdx). Wagmi-style docs and examples (`wagmi/tempo`-rooted snippets) still use `authUrl` because the external `@wagmi/core/tempo` `webAuthn` connector explicitly destructures `authUrl` and does not yet forward `auth` — a parallel change in `@wagmi/core` is needed for the new option to flow through wagmi-style usage.
