### PR TITLE
chore: rephrase changeset in past tense

### DIFF
--- a/.changeset/scoped-access-key-selection.md
+++ b/.changeset/scoped-access-key-selection.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Select scoped access keys only when the current transaction calls match the key scopes.
+Fixed scoped access key selection to only match keys whose scopes covered the current transaction calls.


### PR DESCRIPTION
Rephrased the `scoped-access-key-selection` changeset to past tense per project conventions.