### PR TITLE
docs(site): add Turnkey and Secp256k1 adapter pages

### DIFF
--- a/site/src/pages.gen.ts
+++ b/site/src/pages.gen.ts
@@ -98,7 +98,9 @@ type Page =
 | { path: '/docs/api/webauthnceremony.server'; render: 'static' }
 | { path: '/docs/adapters/custom'; render: 'static' }
 | { path: '/docs/adapters'; render: 'static' }
+| { path: '/docs/adapters/secp256k1'; render: 'static' }
 | { path: '/docs/adapters/tempo-wallet'; render: 'static' }
+| { path: '/docs/adapters/turnkey'; render: 'static' }
 | { path: '/docs/adapters/webauthn'; render: 'static' };
 
 // prettier-ignore

--- a/site/src/pages/docs/adapters/index.mdx
+++ b/site/src/pages/docs/adapters/index.mdx
@@ -11,7 +11,9 @@ Adapters decide where keys live, who runs authentication, and how account reques
 | --- | --- | --- |
 | [Tempo Wallet](/docs/adapters/tempo-wallet) | Tempo Wallet | Apps that want a universal wallet without owning signing infrastructure. |
 | [WebAuthn](/docs/adapters/webauthn) | Your app origin | Teams that want domain-bound passkeys and Tempo account features. |
-| [Custom](/docs/adapters/custom) | Your infrastructure | Privy, AWS KMS, Turnkey, internal signers, and hosted wallet products. |
+| [Turnkey](/docs/adapters/turnkey) | Turnkey | Apps that want Turnkey to own key custody and authentication. |
+| [Secp256k1](/docs/adapters/secp256k1) | Your environment | Server-side signers with a pinned key, or development with a random in-storage key. |
+| [Custom](/docs/adapters/custom) | Your infrastructure | Privy, AWS KMS, internal signers, and hosted wallet products. |
 
 ```mermaid
 sequenceDiagram
@@ -32,5 +34,7 @@ sequenceDiagram
 
 - [Tempo Wallet](/docs/adapters/tempo-wallet)
 - [WebAuthn](/docs/adapters/webauthn)
+- [Turnkey](/docs/adapters/turnkey)
+- [Secp256k1](/docs/adapters/secp256k1)
 - [Custom adapter](/docs/adapters/custom)
 - [Adapter API reference](/docs/api/adapters)

--- a/site/src/pages/docs/adapters/secp256k1.mdx
+++ b/site/src/pages/docs/adapters/secp256k1.mdx
@@ -1,0 +1,38 @@
+---
+title: Secp256k1 Adapter
+description: Sign in-process with a `secp256k1` private key.
+---
+
+# Secp256k1 Adapter
+
+The `secp256k1` adapter signs in-process with a `secp256k1` private key. Use it when you have a key the host environment owns (server-side signers, fee payers, scripts) or when you need a quick development signer that persists a generated key in storage.
+
+Use it when you want:
+
+- A pinned private key supplied by your environment (e.g. server-side signers, scripted flows).
+- A development-only signer that generates and persists a random key in the provider's storage.
+- A lightweight signing layer without passkey or hosted wallet UX.
+
+:::warning
+Storing keys in browser storage in plaintext is dangerous — only use the unpinned form for development, testing, or when the threat model allows it.
+:::
+
+## Configure
+
+```ts twoslash
+import { Provider, secp256k1 } from 'accounts'
+
+const provider = Provider.create({
+  adapter: secp256k1({ privateKey: '0x...' }),
+})
+```
+
+## Human Pass Needed
+
+This page should be expanded with key-rotation guidance, server-side deployment patterns, and storage warnings for browser environments.
+
+## Next Steps
+
+- [Custom adapter](/docs/adapters/custom)
+- [`secp256k1` API reference](/docs/api/secp256k1)
+- [`local` API reference](/docs/api/local)

--- a/site/src/pages/docs/adapters/turnkey.mdx
+++ b/site/src/pages/docs/adapters/turnkey.mdx
@@ -1,0 +1,52 @@
+---
+title: Turnkey Adapter
+description: Use Turnkey-managed wallet accounts as the account signing adapter.
+---
+
+# Turnkey Adapter
+
+The Turnkey adapter is for apps that want Turnkey to own key custody and authentication while plugging into Tempo account features. Your app keeps the registration and login UX (passkey prompts, OTP, etc.); the adapter handles silent reconnect, session expiry, and provider signing.
+
+Use it when you want:
+
+- Turnkey to own key custody and policy.
+- Passkey or other Turnkey-supported authentication on your own organization.
+- Tempo account features without managing your own signer infrastructure.
+
+## Configure
+
+```tsx
+import { TurnkeyClient } from '@turnkey/core'
+import { Provider, turnkey } from 'accounts'
+
+const provider = Provider.create({
+  adapter: turnkey({
+    client: new TurnkeyClient({ organizationId, authProxyConfigId }),
+    createAccount: async ({ client, parameters }) => {
+      await client.signUpWithPasskey({
+        createSubOrgParams: { userName: parameters.name },
+      })
+      return (await client.fetchWallets())
+        .flatMap((wallet) => wallet.accounts)
+        .find((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')!
+    },
+    loadAccounts: async ({ client }) => {
+      const session = await client.getSession()
+      if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
+      return (await client.fetchWallets())
+        .flatMap((wallet) => wallet.accounts)
+        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')
+    },
+  }),
+})
+```
+
+## Human Pass Needed
+
+This page should be expanded with sub-org setup, session lifetime guidance, recovery flows, and production policy expectations.
+
+## Next Steps
+
+- [Bring Your Auth — Turnkey](/docs/enterprise/bring-your-auth/turnkey)
+- [Authentication](/docs/guides/authentication)
+- [`turnkey` API reference](/docs/api/turnkey)

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -61,6 +61,8 @@ const config: Config = defineConfig({
           { text: 'Overview', link: '/docs/adapters' },
           { text: 'Tempo Wallet', link: '/docs/adapters/tempo-wallet' },
           { text: 'WebAuthn', link: '/docs/adapters/webauthn' },
+          { text: 'Turnkey', link: '/docs/adapters/turnkey' },
+          { text: 'Secp256k1', link: '/docs/adapters/secp256k1' },
           { text: 'Custom', link: '/docs/adapters/custom' },
         ],
       },


### PR DESCRIPTION
Added `/docs/adapters/turnkey` and `/docs/adapters/secp256k1` pages alongside the existing Tempo Wallet, WebAuthn, and Custom adapter docs.

Updated the adapter overview table and the sidebar so both adapters are discoverable from the top-level Adapters section, in addition to the existing reference entries under `/docs/api/turnkey` and `/docs/api/secp256k1`.