### PR TITLE
refactor: name store persistence boundary

### DIFF
--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -81,6 +81,196 @@ describe('create', () => {
   })
 })
 
+describe('serialize', () => {
+  test('default: returns the persisted refresh snapshot', () => {
+    const result = Store.serialize({
+      accessKeys: [
+        {
+          access: '0x0000000000000000000000000000000000000001',
+          address: '0x0000000000000000000000000000000000000099',
+          keyType: 'secp256k1',
+          privateKey: '0x1234',
+        },
+      ],
+      accounts: [
+        { address: '0x0000000000000000000000000000000000000001' },
+        { address: '0x0000000000000000000000000000000000000002' },
+      ],
+      activeAccount: 1,
+      auth: { logout: 'https://example.com/logout' },
+      chainId: 123,
+      requestQueue: [
+        {
+          request: { method: 'eth_accounts' } as never,
+          status: 'pending',
+        },
+      ],
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [
+          {
+            "access": "0x0000000000000000000000000000000000000001",
+            "address": "0x0000000000000000000000000000000000000099",
+            "keyType": "secp256k1",
+            "privateKey": "0x1234",
+          },
+        ],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+          },
+        ],
+        "activeAccount": 1,
+        "auth": {
+          "logout": "https://example.com/logout",
+        },
+        "chainId": 123,
+      }
+    `)
+  })
+
+  test('behavior: limits persisted accounts', () => {
+    const result = Store.serialize(
+      {
+        accessKeys: [],
+        accounts: [
+          { address: '0x0000000000000000000000000000000000000001' },
+          { address: '0x0000000000000000000000000000000000000002' },
+        ],
+        activeAccount: 0,
+        chainId: 123,
+        requestQueue: [],
+      },
+      { maxAccounts: 1 },
+    )
+
+    expect(result.accounts).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x0000000000000000000000000000000000000001",
+        },
+      ]
+    `)
+  })
+
+  test('behavior: skips access keys when credential persistence is disabled', () => {
+    const result = Store.serialize(
+      {
+        accessKeys: [
+          {
+            access: '0x0000000000000000000000000000000000000001',
+            address: '0x0000000000000000000000000000000000000099',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: 123,
+        requestQueue: [],
+      },
+      { persistCredentials: false },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 123,
+      }
+    `)
+  })
+})
+
+describe('hydrate', () => {
+  test('behavior: restores persisted state with runtime-only request queue', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [
+        {
+          request: { method: 'eth_accounts' } as never,
+          status: 'pending',
+        },
+      ],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        chainId: 456,
+      },
+      current,
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [
+          {
+            "request": {
+              "method": "eth_accounts",
+            },
+            "status": "pending",
+          },
+        ],
+      }
+    `)
+  })
+
+  test('behavior: preserves in-memory account credentials when persisted accounts are redacted', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          keyType: 'secp256k1',
+          privateKey: '0x1234',
+        },
+      ],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        chainId: 456,
+      },
+      current,
+    )
+
+    expect(result.accounts).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x0000000000000000000000000000000000000001",
+          "keyType": "secp256k1",
+          "privateKey": "0x1234",
+        },
+      ]
+    `)
+  })
+})
+
 describe('persistence', () => {
   test('default: persists accounts, activeAccount, and chainId to storage', async () => {
     const storage = Storage.memory()

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -38,10 +38,27 @@ export type State = {
   requestQueue: readonly QueuedRequest[]
 }
 
+/** Provider state persisted as a refresh snapshot. */
+export type Persisted = {
+  /** Stored access keys. */
+  accessKeys?: readonly AccessKey[] | undefined
+  /** Connected accounts. */
+  accounts?: readonly Account[] | undefined
+  /** Index of the active account. */
+  activeAccount?: number | undefined
+  /**
+   * Absolutized Server Authentication endpoints from the most recent
+   * `wallet_connect` (or the Provider's `auth` option).
+   */
+  auth?: State['auth'] | undefined
+  /** Active chain ID. */
+  chainId?: number | undefined
+}
+
 /** Zustand vanilla store with `subscribeWithSelector` and `persist` middleware. */
 export type Store = Mutate<
   StoreApi<State>,
-  [['zustand/subscribeWithSelector', never], ['zustand/persist', State]]
+  [['zustand/subscribeWithSelector', never], ['zustand/persist', Persisted]]
 >
 
 /** Options for {@link create}. */
@@ -89,7 +106,7 @@ export function create(options: Options): Store {
 
   return createStore(
     subscribeWithSelector(
-      persist<State>(
+      persist<State, [], [], Persisted>(
         () => ({
           accessKeys: [],
           accounts: [],
@@ -98,43 +115,70 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge(persisted, current) {
-            const state = persisted as State
-            return {
-              ...state,
-              ...current,
-              // Preserve in-memory credentials when persisted accounts only have addresses.
-              accounts:
-                state.accounts?.map((persisted) => {
-                  const account = current.accounts.find(
-                    (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
-                  )
-                  return account ?? persisted
-                }) ?? current.accounts,
-              accessKeys: state.accessKeys ?? current.accessKeys,
-              chainId: state.chainId ?? current.chainId,
-            }
-          },
+          merge: hydrate,
           name: 'store',
-          partialize: (state) => {
-            const accounts =
-              maxAccounts && state.accounts.length > maxAccounts
-                ? state.accounts.slice(0, maxAccounts)
-                : state.accounts
-            return {
-              accounts,
-              activeAccount: state.activeAccount,
-              ...(persistCredentials ? { accessKeys: state.accessKeys } : {}),
-              ...(state.auth ? { auth: state.auth } : {}),
-              chainId: state.chainId,
-            } as unknown as State
-          },
+          partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
           version: 0,
         },
       ),
     ),
   )
+}
+
+/** Converts runtime provider state into the persisted refresh snapshot. */
+export function serialize(state: State, options: serialize.Options = {}): Persisted {
+  const { maxAccounts, persistCredentials = true } = options
+  const accounts =
+    maxAccounts && state.accounts.length > maxAccounts
+      ? state.accounts.slice(0, maxAccounts)
+      : state.accounts
+  return {
+    accounts,
+    activeAccount: state.activeAccount,
+    ...(persistCredentials ? { accessKeys: state.accessKeys } : {}),
+    ...(state.auth ? { auth: state.auth } : {}),
+    chainId: state.chainId,
+  }
+}
+
+export declare namespace serialize {
+  /** Options for {@link serialize}. */
+  type Options = {
+    /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded. */
+    maxAccounts?: number | undefined
+    /** Whether to persist credentials and access keys to storage. @default true */
+    persistCredentials?: boolean | undefined
+  }
+}
+
+/** Restores runtime provider state from a persisted refresh snapshot. */
+export function hydrate(persisted: unknown, current: State): State {
+  return normalize(persisted, current)
+}
+
+/** Normalizes a persisted refresh snapshot using the current runtime state as fallback. */
+export function normalize(persisted: unknown, current: State): State {
+  const state = stateFromPersisted(persisted)
+  return {
+    ...state,
+    ...current,
+    // Preserve in-memory credentials when persisted accounts only have addresses.
+    accounts:
+      state.accounts?.map((persisted) => {
+        const account = current.accounts.find(
+          (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
+        )
+        return account ?? persisted
+      }) ?? current.accounts,
+    accessKeys: state.accessKeys ?? current.accessKeys,
+    chainId: state.chainId ?? current.chainId,
+  }
+}
+
+function stateFromPersisted(persisted: unknown): Partial<Persisted> {
+  if (!persisted || typeof persisted !== 'object') return {}
+  return persisted as Partial<Persisted>
 }
 
 /**

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -154,12 +154,7 @@ export declare namespace serialize {
 
 /** Restores runtime provider state from a persisted refresh snapshot. */
 export function hydrate(persisted: unknown, current: State): State {
-  return normalize(persisted, current)
-}
-
-/** Normalizes a persisted refresh snapshot using the current runtime state as fallback. */
-export function normalize(persisted: unknown, current: State): State {
-  const state = stateFromPersisted(persisted)
+  const state = persisted && typeof persisted === 'object' ? (persisted as Partial<Persisted>) : {}
   return {
     ...state,
     ...current,
@@ -174,11 +169,6 @@ export function normalize(persisted: unknown, current: State): State {
     accessKeys: state.accessKeys ?? current.accessKeys,
     chainId: state.chainId ?? current.chainId,
   }
-}
-
-function stateFromPersisted(persisted: unknown): Partial<Persisted> {
-  if (!persisted || typeof persisted !== 'object') return {}
-  return persisted as Partial<Persisted>
 }
 
 /**


### PR DESCRIPTION
## Summary
Name the Store runtime/persistence boundary without changing persistence behavior.

## Motivation
`src/core/Store.ts` uses one Zustand store for runtime provider state, but only a subset of that state is written to storage and restored after refresh. Keeping that projection inline inside `partialize` and `merge` made the persisted shape look like full runtime state, even though fields like `requestQueue` are runtime-only.

This change gives the persisted refresh snapshot its own type and named conversion functions so the storage boundary is explicit and testable.

## Changes
- Add `Store.Persisted` alongside runtime `Store.State` in `src/core/Store.ts`.
- Move persisted snapshot creation into `Store.serialize(...)`.
- Move restore behavior into `Store.hydrate(...)`.
- Add focused `src/core/Store.test.ts` coverage for the named persistence functions.

## Testing
- `pnpm install`
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit --pretty false`
- `./node_modules/.bin/vp test src/core/Store.test.ts`
- `./node_modules/.bin/vp lint --fix --ignore-pattern package.json src/core/Store.ts src/core/Store.test.ts`
- pre-commit hook: `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`

Pre-commit reported two existing warnings outside this PR: `site/src/pages.gen.ts` unused `GetConfigResponse`, and `src/server/internal/handlers/exchange.test.ts` unused `address`.