### PR TITLE
fix: restore public key access authorization

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -344,6 +344,30 @@ describe('prepare', () => {
     `)
   })
 
+  test('behavior: prepares external key authorization from public key', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const account = TempoAccount.fromWebCryptoP256(keyPair)
+
+    const result = await AccessKey.prepare({
+      chainId: 123n,
+      expiry: 456,
+      keyType: 'p256',
+      publicKey: account.publicKey,
+    })
+
+    expect(result.keyPair).toBeUndefined()
+    expect(result.keyAuthorization).toMatchInlineSnapshot(`
+      {
+        "address": "${account.address.toLowerCase()}",
+        "chainId": 123n,
+        "expiry": 456,
+        "limits": undefined,
+        "scopes": undefined,
+        "type": "p256",
+      }
+    `)
+  })
+
   test('behavior: defaults external key type to secp256k1', async () => {
     const result = await AccessKey.prepare({
       address: accounts[1]!.address,

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -90,11 +90,11 @@ export declare namespace generate {
 
 /** Prepares an unsigned key authorization and local key material when needed. */
 export async function prepare(options: prepare.Options): Promise<prepare.ReturnType> {
-  const { address, chainId, expiry, keyType, limits, scopes } = options
+  const { address, chainId, expiry, keyType, limits, publicKey, scopes } = options
 
-  if (address) {
+  if (address || publicKey) {
     const keyAuthorization = KeyAuthorization.from({
-      address,
+      address: address ?? Address.fromPublicKey(PublicKey.from(publicKey!)),
       chainId: BigInt(chainId),
       expiry,
       limits,
@@ -119,7 +119,7 @@ export async function prepare(options: prepare.Options): Promise<prepare.ReturnT
 export declare namespace prepare {
   /** Options for {@link prepare}. */
   type Options = {
-    /** External access key address. When omitted, a local P256 key is generated. */
+    /** External access key address. Alternative to `publicKey`. */
     address?: Address.Address | undefined
     /** Chain ID the key authorization is scoped to. */
     chainId: bigint | number
@@ -129,6 +129,8 @@ export declare namespace prepare {
     keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
     /** TIP-20 spending limits for this key. */
     limits?: readonly KeyAuthorization.TokenLimit[] | undefined
+    /** External public key to derive the access key address from. */
+    publicKey?: Hex.Hex | undefined
     /** Call scopes restricting which contracts/selectors this key can call. */
     scopes?: readonly KeyAuthorization.Scope[] | undefined
   }


### PR DESCRIPTION
## Summary
Restore `publicKey` as an external access-key authorization input.

## Motivation
PR #397 removed `publicKey` handling from `AccessKey.prepare(...)`, so callers that supplied only an external public key fell through to local P256 key generation and received an authorization for the wrong key.

## Changes
- Derive the access-key address from `publicKey` in `src/core/AccessKey.ts` when no `address` is provided.
- Restore `publicKey` on `prepare.Options` so the helper matches the adapter/RPC contract.
- Add regression coverage in `src/core/AccessKey.test.ts` for `publicKey` without `address`.

## Testing
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts` — 39 tests passed
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit --pretty false` — passed with no output
- `git commit -m "fix: restore public key access authorization"` — pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; passed with 2 existing warnings