### PR TITLE
feat: default turnkey registration to loadAccounts

### DIFF
--- a/.changeset/turnkey-load-accounts-registration.md
+++ b/.changeset/turnkey-load-accounts-registration.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Made `turnkey` `createAccount` optional and default registration requests to `loadAccounts`.

--- a/playgrounds/web/src/TurnkeyEmailOtp.tsx
+++ b/playgrounds/web/src/TurnkeyEmailOtp.tsx
@@ -28,8 +28,6 @@ export function TurnkeyEmailOtp() {
 
   if (!request) return null
 
-  const label = request.mode === 'register' ? 'Register' : 'Continue'
-
   function cancel(event: MouseEvent<HTMLDivElement>) {
     if (pending || event.target !== event.currentTarget) return
     rejectTurnkeyEmailOtp(new Error('Turnkey email OTP cancelled.'))
@@ -76,34 +74,13 @@ export function TurnkeyEmailOtp() {
       setError(undefined)
       setPending(true)
 
-      if (request.mode === 'login') {
-        await request.client.completeOtp({
-          contact: email_,
-          ...(request.createSubOrgParams ? { createSubOrgParams: request.createSubOrgParams } : {}),
-          otpCode: code_,
-          otpId,
-          otpType: OtpType.Email,
-        })
-      } else {
-        const publicKey = await request.client.createApiKeyPair()
-        const verified = await request.client.verifyOtp({
-          contact: email_,
-          otpCode: code_,
-          otpId,
-          otpType: OtpType.Email,
-          publicKey,
-        })
-
-        if (verified.subOrganizationId)
-          throw new Error('A Turnkey account already exists for that email.')
-        await request.client.signUpWithOtp({
-          contact: email_,
-          ...(request.createSubOrgParams ? { createSubOrgParams: request.createSubOrgParams } : {}),
-          otpType: OtpType.Email,
-          publicKey,
-          verificationToken: verified.verificationToken,
-        })
-      }
+      await request.client.completeOtp({
+        contact: email_,
+        ...(request.createSubOrgParams ? { createSubOrgParams: request.createSubOrgParams } : {}),
+        otpCode: code_,
+        otpId,
+        otpType: OtpType.Email,
+      })
 
       resolveTurnkeyEmailOtp()
     } catch (error) {
@@ -117,7 +94,7 @@ export function TurnkeyEmailOtp() {
     <div className="turnkey-otp-backdrop" onClick={cancel} role="presentation">
       <section aria-label="Turnkey email OTP" className="turnkey-otp-panel">
         <header className="turnkey-otp-header">
-          <h2>{label} with Turnkey</h2>
+          <h2>Continue with Turnkey</h2>
         </header>
 
         {!otpId ? (

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -109,24 +109,28 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
     return Provider.create({
       adapter: turnkey({
         client,
-        async createAccount({ client, parameters }) {
-          const client_ = client as TurnkeyPlaygroundClient
-          await requestTurnkeyEmailOtp({
-            client: client_,
-            createSubOrgParams: createTurnkeySubOrgParams(parameters.name),
-            mode: 'register',
-          })
-          const account = (await getOrCreateEthereumAccounts(client_))[0]
-          return account
-        },
         async loadAccounts({ client }) {
-          const client_ = client as TurnkeyPlaygroundClient
           await requestTurnkeyEmailOtp({
-            client: client_,
+            client,
             createSubOrgParams: createTurnkeySubOrgParams(),
-            mode: 'login',
           })
-          return await getOrCreateEthereumAccounts(client_)
+
+          const existing = (await client.fetchWallets())
+            .flatMap((wallet) => wallet.accounts)
+            .filter((account) => account.addressFormat === turnkeyEthereumAddressFormat)
+          if (existing.length > 0) return existing
+
+          await client.createWallet({
+            walletName: 'Tempo Playground',
+            accounts: [turnkeyEthereumAddressFormat],
+          })
+
+          const created = (await client.fetchWallets())
+            .flatMap((wallet) => wallet.accounts)
+            .filter((account) => account.addressFormat === turnkeyEthereumAddressFormat)
+          if (created.length > 0) return created
+
+          throw new Error('No Turnkey Ethereum account found after creating a wallet.')
         },
       }),
       mpp: true,
@@ -184,27 +188,6 @@ function createTurnkeySubOrgParams(name?: string | undefined) {
       }),
     },
   } satisfies CreateSubOrgParams
-}
-
-async function getEthereumAccounts(client: TurnkeyPlaygroundClient) {
-  return (await client.fetchWallets())
-    .flatMap((wallet) => wallet.accounts)
-    .filter((account) => account.addressFormat === turnkeyEthereumAddressFormat)
-}
-
-async function getOrCreateEthereumAccounts(client: TurnkeyPlaygroundClient) {
-  const existing = await getEthereumAccounts(client)
-  if (existing.length > 0) return existing
-
-  await client.createWallet({
-    walletName: 'Tempo Playground',
-    accounts: [turnkeyEthereumAddressFormat],
-  })
-
-  const created = await getEthereumAccounts(client)
-  if (created.length > 0) return created
-
-  throw new Error('No Turnkey Ethereum account found after creating a wallet.')
 }
 
 export function switchTheme(

--- a/playgrounds/web/src/turnkeyOtpStore.ts
+++ b/playgrounds/web/src/turnkeyOtpStore.ts
@@ -1,31 +1,20 @@
 import type { CreateSubOrgParams, TurnkeyClientMethods } from '@turnkey/core'
 import { useSyncExternalStore } from 'react'
 
-/** Turnkey email OTP flow mode requested by the playground adapter. */
-export type TurnkeyEmailOtpMode = 'login' | 'register'
-
 /** Minimal Turnkey client surface used by the playground email OTP UI. */
 export type TurnkeyEmailOtpClient = {
   /** Completes OTP auth, logging in or registering when needed. */
   completeOtp: TurnkeyClientMethods['completeOtp']
-  /** Creates a session key pair used by OTP verification and auth. */
-  createApiKeyPair: TurnkeyClientMethods['createApiKeyPair']
   /** Sends an OTP code to an email address. */
   initOtp: TurnkeyClientMethods['initOtp']
-  /** Registers with a verified OTP token. */
-  signUpWithOtp: TurnkeyClientMethods['signUpWithOtp']
-  /** Verifies an OTP code. */
-  verifyOtp: TurnkeyClientMethods['verifyOtp']
 }
 
 /** Options for requesting an email OTP auth ceremony. */
 export type TurnkeyEmailOtpOptions = {
   /** Turnkey client that will perform OTP requests. */
   client: TurnkeyEmailOtpClient
-  /** Optional sub-organization params used for registration. */
+  /** Optional sub-organization params used when Turnkey creates a new account. */
   createSubOrgParams?: CreateSubOrgParams | undefined
-  /** Explicit auth mode requested by the adapter. */
-  mode: TurnkeyEmailOtpMode
 }
 
 /** Active email OTP request rendered by the playground UI. */

--- a/site/src/pages/docs/adapters/turnkey.mdx
+++ b/site/src/pages/docs/adapters/turnkey.mdx
@@ -7,7 +7,7 @@ import { Cards, Card } from 'vocs'
 
 # Turnkey Adapter
 
-The Turnkey adapter is for apps that want Turnkey to own key custody and authentication while plugging into Tempo account features. Your app keeps the registration and login UX (passkey prompts, OTP, etc.); the adapter handles silent reconnect, session expiry, and provider signing.
+The Turnkey adapter is for apps that want Turnkey to own key custody and authentication while plugging into Tempo account features. Your app keeps the login or sign-up UX (passkey prompts, OTP, etc.); the adapter handles silent reconnect, session expiry, and provider signing.
 
 Use it when you want:
 
@@ -28,14 +28,6 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
-    createAccount: async ({ client, parameters }) => {
-      await client.signUpWithPasskey({
-        createSubOrgParams: { userName: parameters.name },
-      })
-      return (await client.fetchWallets())
-        .flatMap((wallet) => wallet.accounts)
-        .find((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')!
-    },
     loadAccounts: async ({ client }) => {
       const session = await client.getSession()
       if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()

--- a/site/src/pages/docs/api/turnkey.mdx
+++ b/site/src/pages/docs/api/turnkey.mdx
@@ -7,7 +7,7 @@ description: Adapter backed by Turnkey client sessions.
 
 Creates a Turnkey adapter backed by `@turnkey/core` client sessions and Ethereum wallet accounts.
 
-The adapter owns silent reconnect, session-expiry cleanup, and provider signing actions. Apps provide the UI-bearing registration and login flows through [`createAccount`](#createaccount) and [`loadAccounts`](#loadaccounts).
+The adapter owns silent reconnect, session-expiry cleanup, and provider signing actions. Apps usually provide one UI-bearing login or sign-up flow through [`loadAccounts`](#loadaccounts). Use [`createAccount`](#createaccount) only when registration needs a distinct Turnkey flow.
 
 ## Usage
 
@@ -18,14 +18,6 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
-    createAccount: async ({ client, parameters }) => {
-      await client.signUpWithPasskey({
-        createSubOrgParams: { userName: parameters.name },
-      })
-      return (await client.fetchWallets())
-        .flatMap((wallet) => wallet.accounts)
-        .find((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')!
-    },
     loadAccounts: async ({ client }) => {
       const session = await client.getSession()
       if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
@@ -53,8 +45,55 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client: new TurnkeyClient({ organizationId, authProxyConfigId }), // [!code focus]
-    createAccount: async ({ client, parameters }) => { /* ... */ },
     loadAccounts: async ({ client }) => { /* ... */ },
+  }),
+})
+```
+
+### icon
+
+- **Type:** `` `data:image/${string}` ``
+- **Optional**
+
+Data URI of the provider icon.
+
+```ts
+import { Provider, turnkey } from 'accounts'
+
+const provider = Provider.create({
+  adapter: turnkey({
+    client,
+    loadAccounts: async () => { /* ... */ },
+    icon: 'data:image/svg+xml,...', // [!code focus]
+  }),
+})
+```
+
+### loadAccounts
+
+- **Type:** `(params: { client; parameters? }) => Promise<readonly turnkey.WalletAccount[]>`
+- **Required**
+
+Loads/logs into existing Turnkey wallet accounts. UI is allowed (e.g. passkey prompts to start a new session).
+
+Receives the initialized Turnkey `client` and the optional provider load-accounts `parameters` (e.g. `authorizeAccessKey`, `digest`, `personalSign`, `selectAccount`). Must return all Ethereum-format Turnkey wallet accounts that should be exposed to the provider.
+
+When `createAccount` is omitted, register requests call `loadAccounts` too. This fits email and social auth flows where the same Turnkey ceremony can sign in an existing user or create one.
+
+```ts
+import { Provider, turnkey } from 'accounts'
+
+const provider = Provider.create({
+  adapter: turnkey({
+    client,
+    loadAccounts: async ({ client }) => { // [!code focus]
+      const session = await client.getSession() // [!code focus]
+      if (!session || session.expiry * 1000 <= Date.now()) // [!code focus]
+        await client.loginWithPasskey() // [!code focus]
+      return (await client.fetchWallets()) // [!code focus]
+        .flatMap((wallet) => wallet.accounts) // [!code focus]
+        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM') // [!code focus]
+    }, // [!code focus]
   }),
 })
 ```
@@ -62,9 +101,10 @@ const provider = Provider.create({
 ### createAccount
 
 - **Type:** `(params: { client; parameters }) => Promise<turnkey.WalletAccount>`
-- **Required**
+- **Optional**
+- **Default:** `loadAccounts`
 
-Creates/registers a Turnkey wallet account. UI is allowed (e.g. passkey prompts).
+Creates/registers a Turnkey wallet account when registration needs a separate flow.
 
 Receives the initialized Turnkey `client` and the provider create-account `parameters` (display name, optional `digest`, `personalSign`, `userId`, etc.). Must return a single Ethereum-format Turnkey wallet account.
 
@@ -87,54 +127,6 @@ const provider = Provider.create({
 })
 ```
 
-### icon
-
-- **Type:** `` `data:image/${string}` ``
-- **Optional**
-
-Data URI of the provider icon.
-
-```ts
-import { Provider, turnkey } from 'accounts'
-
-const provider = Provider.create({
-  adapter: turnkey({
-    client,
-    createAccount: async () => { /* ... */ },
-    loadAccounts: async () => { /* ... */ },
-    icon: 'data:image/svg+xml,...', // [!code focus]
-  }),
-})
-```
-
-### loadAccounts
-
-- **Type:** `(params: { client; parameters? }) => Promise<readonly turnkey.WalletAccount[]>`
-- **Required**
-
-Loads/logs into existing Turnkey wallet accounts. UI is allowed (e.g. passkey prompts to start a new session).
-
-Receives the initialized Turnkey `client` and the optional provider load-accounts `parameters` (e.g. `authorizeAccessKey`, `digest`, `personalSign`, `selectAccount`). Must return all Ethereum-format Turnkey wallet accounts that should be exposed to the provider.
-
-```ts
-import { Provider, turnkey } from 'accounts'
-
-const provider = Provider.create({
-  adapter: turnkey({
-    client,
-    createAccount: async () => { /* ... */ },
-    loadAccounts: async ({ client }) => { // [!code focus]
-      const session = await client.getSession() // [!code focus]
-      if (!session || session.expiry * 1000 <= Date.now()) // [!code focus]
-        await client.loginWithPasskey() // [!code focus]
-      return (await client.fetchWallets()) // [!code focus]
-        .flatMap((wallet) => wallet.accounts) // [!code focus]
-        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM') // [!code focus]
-    }, // [!code focus]
-  }),
-})
-```
-
 ### name
 
 - **Type:** `string`
@@ -148,7 +140,6 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client,
-    createAccount: async () => { /* ... */ },
     loadAccounts: async () => { /* ... */ },
     name: 'My Wallet', // [!code focus]
   }),
@@ -168,7 +159,6 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client,
-    createAccount: async () => { /* ... */ },
     loadAccounts: async () => { /* ... */ },
     rdns: 'com.example.wallet', // [!code focus]
   }),
@@ -188,7 +178,6 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client,
-    createAccount: async () => { /* ... */ },
     loadAccounts: async () => { /* ... */ },
     sessionSkewMs: 30_000, // [!code focus]
   }),

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -36,6 +36,29 @@ describe('turnkey', () => {
     `)
   })
 
+  test('default: createAccount falls back to loadAccounts', async () => {
+    const { adapter, client } = setup({ createAccount: false })
+
+    const result = await adapter.actions.createAccount(
+      { digest: '0x1234', name: 'Ada' },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(client.createCalls).toMatchInlineSnapshot(`0`)
+    expect(client.loadCalls).toMatchInlineSnapshot(`1`)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+            "label": "Ada",
+          },
+        ],
+        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
+      }
+    `)
+  })
+
   test('default: loadAccounts delegates login and caches wallet accounts for signing', async () => {
     const { adapter, client } = setup()
 
@@ -268,7 +291,14 @@ function setup(options: setup.Options = {}) {
   const client = createClient(options)
   const adapter = turnkey({
     client,
-    createAccount: async () => ({ address }),
+    ...(options.createAccount === false
+      ? {}
+      : {
+          createAccount: async () => {
+            client.createCalls++
+            return { address }
+          },
+        }),
     loadAccounts: async () => {
       client.loadCalls++
       return [{ address }]
@@ -286,6 +316,7 @@ function setup(options: setup.Options = {}) {
 
 declare namespace setup {
   type Options = {
+    createAccount?: boolean | undefined
     session?: turnkey.Session | null | undefined
     signError?: unknown
   }
@@ -294,6 +325,7 @@ declare namespace setup {
 function createClient(options: setup.Options = {}) {
   type WalletShape = { accounts: { address: string; addressFormat: string }[] }
   const state = {
+    createCalls: 0,
     fetchCalls: 0,
     initCalls: 0,
     loadCalls: 0,
@@ -306,6 +338,12 @@ function createClient(options: setup.Options = {}) {
   const client = {
     get fetchCalls() {
       return state.fetchCalls
+    },
+    get createCalls() {
+      return state.createCalls
+    },
+    set createCalls(value: number) {
+      state.createCalls = value
     },
     get initCalls() {
       return state.initCalls
@@ -353,6 +391,7 @@ function createClient(options: setup.Options = {}) {
     },
     logout: () => {},
   } satisfies turnkey.Client & {
+    createCalls: number
     fetchCalls: number
     initCalls: number
     loadCalls: number

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -25,8 +25,8 @@ const turnkeySessionErrorCodes = new Set([
  * Creates a Turnkey adapter backed by `@turnkey/core` client sessions and Ethereum wallet accounts.
  *
  * The adapter owns silent reconnect, session-expiry cleanup, and provider signing actions.
- * Apps provide the UI-bearing registration and login flows through `createAccount` and
- * `loadAccounts`.
+ * Apps provide the UI-bearing login or sign-up flow through `loadAccounts`. Provide
+ * `createAccount` only when registration needs a distinct Turnkey flow.
  *
  * @example
  * ```ts
@@ -36,14 +36,6 @@ const turnkeySessionErrorCodes = new Set([
  * const provider = Provider.create({
  *   adapter: turnkey({
  *     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
- *     createAccount: async ({ client, parameters }) => {
- *       await client.signUpWithPasskey({
- *         createSubOrgParams: { userName: parameters.name },
- *       })
- *       return (await client.fetchWallets())
- *         .flatMap((wallet) => wallet.accounts)
- *         .find((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')!
- *     },
  *     loadAccounts: async ({ client }) => {
  *       const session = await client.getSession()
  *       if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
@@ -55,16 +47,18 @@ const turnkeySessionErrorCodes = new Set([
  * })
  * ```
  */
-export function turnkey(options: turnkey.Options): Adapter.Adapter {
+export function turnkey<const client extends turnkey.Client>(
+  options: turnkey.Options<client>,
+): Adapter.Adapter {
   const { icon, name = 'Turnkey', rdns = 'com.turnkey', sessionSkewMs = 10_000 } = options
 
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
-    let turnkeyClient_promise: Promise<turnkey.Client> | undefined
+    let turnkeyClient_promise: Promise<client> | undefined
     let expiry_timeout: ReturnType<typeof setTimeout> | undefined
     let restore_promise: Promise<void> | undefined
     let walletAccounts: readonly turnkey.WalletAccount[] = []
 
-    async function getTurnkeyClient() {
+    async function getTurnkeyClient(): Promise<client> {
       turnkeyClient_promise ??= (async () => {
         const { client } = options
         await client.init?.()
@@ -344,31 +338,46 @@ export function turnkey(options: turnkey.Options): Adapter.Adapter {
             )
 
           const turnkeyClient = await getTurnkeyClient()
-          const account = await options.createAccount({ client: turnkeyClient, parameters })
+          const accounts = options.createAccount
+            ? [await options.createAccount({ client: turnkeyClient, parameters })]
+            : await options.loadAccounts({
+                client: turnkeyClient,
+                parameters: {
+                  authorizeAccessKey,
+                  digest: parameters.digest,
+                  ...(personalSign ? { personalSign } : {}),
+                },
+              })
           await requireSession()
-          walletAccounts = [account]
+          walletAccounts = accounts
           restore_promise = undefined
 
           const digest = personalSign ? hashMessage(personalSign.message) : parameters.digest
+          const account = walletAccounts[0]
           const keyAuthorization = authorizeAccessKey
-            ? await signKeyAuthorization(
-                account,
-                await prepareKeyAuthorization(authorizeAccessKey),
-                { signature: authorizeAccessKey.signature },
-              )
+            ? account
+              ? await signKeyAuthorization(
+                  account,
+                  await prepareKeyAuthorization(authorizeAccessKey),
+                  { signature: authorizeAccessKey.signature },
+                )
+              : undefined
             : undefined
 
           return {
-            accounts: [toStoreAccount(account, parameters.name)],
+            accounts: walletAccounts.map((account, index) =>
+              toStoreAccount(account, index === 0 ? parameters.name : undefined),
+            ),
             ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
             ...(keyAuthorization ? { keyAuthorization } : {}),
-            signature: digest
-              ? await signPayload({
-                  payload: digest,
-                  turnkeyClient,
-                  walletAccount: account,
-                })
-              : undefined,
+            signature:
+              digest && account
+                ? await signPayload({
+                    payload: digest,
+                    turnkeyClient,
+                    walletAccount: account,
+                  })
+                : undefined,
           }
         },
         async loadAccounts(parameters) {
@@ -542,22 +551,24 @@ export function turnkey(options: turnkey.Options): Adapter.Adapter {
 
 export declare namespace turnkey {
   /** Options for {@link turnkey}. */
-  type Options = {
+  type Options<client extends Client = Client> = {
     /** Existing Turnkey client, such as `TurnkeyClient` from `@turnkey/core`. */
-    client: Client
-    /** Creates/registers a Turnkey wallet account. UI is allowed. */
-    createAccount: (parameters: {
-      /** Initialized Turnkey client. */
-      client: Client
-      /** Provider create-account parameters. */
-      parameters: Adapter.createAccount.Parameters
-    }) => Promise<WalletAccount>
+    client: client
+    /** Creates/registers a Turnkey wallet account. UI is allowed. Defaults to `loadAccounts`. */
+    createAccount?:
+      | ((parameters: {
+          /** Initialized Turnkey client. */
+          client: client
+          /** Provider create-account parameters. */
+          parameters: Adapter.createAccount.Parameters
+        }) => Promise<WalletAccount>)
+      | undefined
     /** Data URI of the provider icon. @default Black 1×1 SVG. */
     icon?: `data:image/${string}` | undefined
     /** Loads/logs into existing Turnkey wallet accounts. UI is allowed. */
     loadAccounts: (parameters: {
       /** Initialized Turnkey client. */
-      client: Client
+      client: client
       /** Provider load-accounts parameters. */
       parameters?: Adapter.loadAccounts.Parameters | undefined
     }) => Promise<readonly WalletAccount[]>


### PR DESCRIPTION
## Summary
Make the Turnkey adapter use `loadAccounts` as the default registration path.

## Motivation
Most Turnkey email and social auth flows use one sign-up-or-login ceremony. `createAccount` should be an escape hatch for integrations that need a separate registration path.

## Changes
- Make `turnkey.Options.createAccount` optional in `src/core/adapters/turnkey.ts`
- Route `actions.createAccount` through `loadAccounts` when no explicit `createAccount` hook is configured
- Collapse the web playground Turnkey OTP flow onto `completeOtp` in `playgrounds/web/src/*`
- Update Turnkey adapter docs to present `loadAccounts` as the normal integration point

## Testing
- `./node_modules/.bin/vp test src/core/adapters/turnkey.test.ts` — 12 tests passed
- `pnpm check:types` — passed
- `pnpm --filter './playgrounds/web' check:types` — passed
- `git diff --check` — passed
- pre-commit `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test` — passed with existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`