### PR TITLE
test: avoid provider fee payer nonce replays

### DIFF
--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -29,11 +29,15 @@ const adapters = [
 ] as const
 
 describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
-  const transferCall = Actions.token.transfer.call({
-    to: '0x0000000000000000000000000000000000000001',
-    token: Addresses.pathUsd,
-    amount: parseUnits('1', 6),
-  })
+  function transfer(amount: string) {
+    return Actions.token.transfer.call({
+      to: '0x0000000000000000000000000000000000000001',
+      token: Addresses.pathUsd,
+      amount: parseUnits(amount, 6),
+    })
+  }
+
+  const transferCall = transfer('1')
 
   /** Connects via login (or register if login returns no accounts), returns the active account address. */
   async function connect(provider: ReturnType<typeof Provider.create>) {
@@ -2183,6 +2187,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.01')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2252,6 +2257,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.02')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2293,6 +2299,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.03')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2315,6 +2322,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.04')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2358,6 +2366,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.05')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2419,6 +2428,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.06')
 
       const hash = await provider.request({
         method: 'eth_sendTransaction',
@@ -2478,6 +2488,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.07')
 
       const result = await provider.request({
         method: 'wallet_sendCalls',
@@ -2506,6 +2517,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.08')
 
       const result = await provider.request({
         method: 'wallet_sendCalls',
@@ -2534,6 +2546,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const connected = await connect(provider)
       await fund(connected)
+      const transferCall = transfer('1.09')
 
       const result = await provider.request({
         method: 'wallet_sendCalls',


### PR DESCRIPTION
## Summary
Make provider fee-payer transaction tests use distinct transfer calldata.

## Motivation
The localnet CI job in run 25828839346 failed with ExpiringNonceReplay when repeated fee-payer tests sent identical raw transactions in the same expiring nonce window.

## Changes
- Add a small transfer-call helper in src/core/Provider.test.ts
- Use distinct transfer amounts for fee-payer eth_sendTransaction and wallet_sendCalls broadcast cases
- Keep each transfer below the per-test funded PathUSD balance

## Testing
CI=true VITE_NODE_TAG=latest ./node_modules/.bin/node ./node_modules/vp/bin/vp test src/core/Provider.test.ts --bail=1

252 tests passed.