### PR TITLE
fix: pass calls to access key selection in dialog adapter

### DIFF
--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -149,6 +149,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
      * the dialog so the user can fund, approve, or retry.
      */
     async function withAccessKey<result>(
+      options: Pick<Adapter.sendTransaction.Parameters, 'calls' | 'from'>,
       fn: (
         account: TempoAccount.Account,
         keyAuthorization?: KeyAuthorization.Signed,
@@ -156,7 +157,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     ): Promise<result | undefined> {
       const account = (() => {
         try {
-          return getAccount({ signable: true })
+          return getAccount({ address: options.from, calls: options.calls, signable: true })
         } catch {
           return undefined
         }
@@ -287,7 +288,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         },
 
         async signTransaction(parameters, request) {
-          const result = await withAccessKey(async (account, keyAuthorization) => {
+          const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
               feePayer: (() => {
@@ -317,7 +318,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         },
 
         async sendTransaction(parameters, request) {
-          const result = await withAccessKey(async (account, keyAuthorization) => {
+          const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
               feePayer: (() => {
@@ -347,7 +348,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         },
 
         async sendTransactionSync(parameters, request) {
-          const result = await withAccessKey(async (account, keyAuthorization) => {
+          const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
               feePayer: (() => {


### PR DESCRIPTION
## Problem

The dialog adapter's `withAccessKey` was not forwarding `calls` and `from` to `getAccount`, so `AccessKey.select` (via `scopesMatch`) always returned `false` for scoped access keys — falling through to the passkey dialog.

This was introduced when `scopesMatch` was tightened in #383 to return `false` when `calls` is absent but the key has scopes. The local and turnkey adapters were updated to pass calls, but the dialog adapter was missed.

## Repro

1. Go to the playground
2. Sign in + authorize an access key with 100 PATHUSD and `transfer(address,uint256)` scope  
3. Send a 1 PATH transfer
4. **Expected:** access key signs silently
5. **Actual:** passkey prompt appears

## Fix

Pass `parameters` (which contains `calls` and `from`) from `sendTransaction`, `sendTransactionSync`, and `signTransaction` into `withAccessKey`, then forward them to `getAccount` so `scopesMatch` can check whether the access key's scopes cover the requested calls.