### PR TITLE
fix: add changesets for dialog access key fix + improve error logging

### DIFF
--- a/.changeset/dialog-access-key-calls.md
+++ b/.changeset/dialog-access-key-calls.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed the dialog adapter to forward transaction calls to access key selection, so scoped access keys are used for silent signing instead of falling through to the passkey dialog.

--- a/.changeset/dialog-access-key-logging.md
+++ b/.changeset/dialog-access-key-logging.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Improved console logging in the dialog adapter's access key fallback path so errors are always visible in the console when a silent sign attempt fails.

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -171,7 +171,8 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         return result
       } catch (err) {
         if (AccessKey.invalidate(account, err, { store }))
-          console.warn('[accounts] silent sign with access key failed, removing key:', err)
+          console.warn('[accounts] access key invalidated, falling through to dialog:', err)
+        else console.warn('[accounts] access key sign failed, falling through to dialog:', err)
         return undefined
       }
     }


### PR DESCRIPTION
## Context

PR #401 fixed the dialog adapter's `withAccessKey` to forward `calls` to access key selection, but it shipped without a changeset — so no npm release was triggered and the fix isn't live in the deployed playground yet.

## Changes

1. **Changeset for #401** — triggers a patch release so the dialog access key fix is published  
2. **Better error logging** — when silent signing with an access key fails for a non-key reason (RPC error, gas estimation failure, etc.), the error is now always logged to the console. Previously it was swallowed silently, making it impossible to debug why the access key path fell through to the passkey dialog.

## Why the user still sees the passkey prompt

The fix from #401 is on `main` but no npm release was cut (no changeset). The playground builds from `workspace:*` so a Cloudflare deploy from HEAD should have the fix — but it's possible the user hit a cached deployment or the deploy hasn't propagated. This PR adds changesets to trigger a proper release.