### PR TITLE
fix: log getAccount failures in dialog withAccessKey

### DIFF
--- a/.changeset/dialog-access-key-calls.md
+++ b/.changeset/dialog-access-key-calls.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed the dialog adapter to forward transaction calls to access key selection, so scoped access keys are used for silent signing instead of falling through to the passkey dialog.

--- a/.changeset/dialog-access-key-logging.md
+++ b/.changeset/dialog-access-key-logging.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Improved console logging in the dialog adapter's access key fallback path so errors are always visible in the console when a silent sign attempt fails.

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -171,7 +171,8 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         return result
       } catch (err) {
         if (AccessKey.invalidate(account, err, { store }))
-          console.warn('[accounts] silent sign with access key failed, removing key:', err)
+          console.warn('[accounts] access key invalidated, falling through to dialog:', err)
+        else console.warn('[accounts] access key sign failed, falling through to dialog:', err)
         return undefined
       }
     }

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -158,7 +158,8 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       const account = (() => {
         try {
           return getAccount({ address: options.from, calls: options.calls, signable: true })
-        } catch {
+        } catch (err) {
+          console.warn('[accounts] getAccount failed in withAccessKey:', err)
           return undefined
         }
       })()


### PR DESCRIPTION
When `getAccount` throws inside `withAccessKey` (e.g. scope mismatch, no account found), the error was silently swallowed. Now it's logged to the console so the exact failure reason is visible when debugging why the access key path fell through to the passkey dialog.