### PR TITLE
fix: scope and select access keys by chain

### DIFF
--- a/.changeset/chain-scoped-access-keys.md
+++ b/.changeset/chain-scoped-access-keys.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed access keys selection to include chain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - **CLI auth device codes are raw in protocol** — store, return, and query device codes as raw 8-character values (for example `ABCDEFGH`). Only apply hyphen formatting (`ABCD-EFGH`) when rendering for humans.
 - **Keep CLI protocol looseness scoped** — if the CLI bootstrap/device-code flow needs a more permissive request shape than the shared SDK RPC contract, keep that looseness in the CLI/server-specific surface (for example `src/server/CliAuth.ts` and CLI adapter handling). Do not widen `src/core/zod/rpc.ts` or shared `wallet_authorizeAccessKey` semantics unless the change is explicitly intended SDK-wide.
 - **Preserve WebAuthn signature-envelope magic when verifying RPC payloads** — `SignatureEnvelope.serialize(SignatureEnvelope.fromRpc(signature))` must pass `{ magic: true }` for `webAuthn` signatures, but not for secp256k1/p256 signatures. `viem/tempo` uses the magic suffix to route stateless verification through `SignatureEnvelope.verify(...)`.
+- **Access keys are chain-scoped** — store and select locally managed access keys by the `chainId` from their signed key authorization. Do not use an access key authorized on one chain for another chain; fall back to root signing or reauthorization instead.
 
 ## Type Conventions
 

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -49,6 +49,7 @@ describe('save', () => {
     expect(accessKeys.length).toMatchInlineSnapshot(`1`)
     expect(accessKeys[0]!.address).toBe(accessKey.address)
     expect(accessKeys[0]!.access).toBe(rootAddress)
+    expect(accessKeys[0]!.chainId).toMatchInlineSnapshot(`1`)
     expect(accessKeys[0]!.keyType).toMatchInlineSnapshot(`"p256"`)
     expect(accessKeys[0]!.keyAuthorization).toBe(keyAuthorization)
   })
@@ -385,6 +386,7 @@ describe('hydrate', () => {
     const result = AccessKey.hydrate({
       access: rootAddress,
       address: '0x0000000000000000000000000000000000000099',
+      chainId: 1,
       keyPair,
       keyType: 'webCrypto',
     })
@@ -398,6 +400,7 @@ describe('hydrate', () => {
     const result = AccessKey.hydrate({
       access: rootAddress,
       address: accounts[1]!.address,
+      chainId: 1,
       keyType: 'secp256k1',
       privateKey: privateKeys[1],
     })
@@ -412,6 +415,7 @@ describe('hydrate', () => {
       AccessKey.hydrate({
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyType: 'p256',
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -433,12 +437,13 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
   })
@@ -449,12 +454,30 @@ describe('select', () => {
       {
         access: accounts[1]!.address,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('behavior: skips access keys for another chain', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+      },
+    ])
+
+    const result = AccessKey.select({ address: rootAddress, chainId: 42_431, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })
@@ -464,11 +487,12 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyType: 'p256',
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })
@@ -480,12 +504,13 @@ describe('select', () => {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
         expiry: Math.floor(Date.now() / 1000) - 3600,
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
     expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
@@ -498,12 +523,13 @@ describe('select', () => {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
         expiry: Math.floor(Date.now() / 1000) + 3600,
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
     expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
@@ -515,6 +541,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         limits: [
@@ -526,7 +553,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result?.limits).toMatchInlineSnapshot(`
       [
@@ -544,6 +571,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
       },
@@ -551,6 +579,7 @@ describe('select', () => {
 
     const result = AccessKey.select({
       address: rootAddress,
+      chainId: 1,
       store,
       calls: [{ to: '0x0000000000000000000000000000000000000abc', data: '0xa9059cbb' }],
     })
@@ -565,6 +594,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         scopes: [{ address: token, selector: '0xa9059cbb' }],
@@ -573,6 +603,7 @@ describe('select', () => {
 
     const result = AccessKey.select({
       address: rootAddress,
+      chainId: 1,
       store,
       calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
     })
@@ -587,6 +618,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         scopes: [{ address: token, selector: '0xa9059cbb' }],
@@ -595,6 +627,7 @@ describe('select', () => {
 
     const result = AccessKey.select({
       address: rootAddress,
+      chainId: 1,
       store,
       calls: [{ to: '0x0000000000000000000000000000000000000def', data: '0xdeadbeef' }],
     })
@@ -609,6 +642,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         scopes: [{ address: token, selector: 'transfer(address,uint256)' }],
@@ -617,6 +651,7 @@ describe('select', () => {
 
     const result = AccessKey.select({
       address: rootAddress,
+      chainId: 1,
       store,
       calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
     })
@@ -631,6 +666,7 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         scopes: [{ address: token }],
@@ -639,6 +675,7 @@ describe('select', () => {
 
     const result = AccessKey.select({
       address: rootAddress,
+      chainId: 1,
       store,
       calls: [{ to: token, data: '0xdeadbeef' }],
     })
@@ -652,13 +689,14 @@ describe('select', () => {
       {
         access: rootAddress,
         address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
         keyPair,
         keyType: 'webCrypto',
         scopes: [{ address: '0x0000000000000000000000000000000000000abc' }],
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, store })
+    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -22,6 +22,8 @@ export type AccessKey = {
   address: Address.Address
   /** Owner of the access key. */
   access: Address.Address
+  /** Chain ID this access key authorization is scoped to. */
+  chainId: number
   /** Unix timestamp when the access key expires. */
   expiry?: number | undefined
   /** Signed key authorization to attach to the first transaction. Consumed on use. */
@@ -212,11 +214,12 @@ export function removePending(
 
 /** Selects a locally-signable access key for a root account, removing expired keys. */
 export function select(options: select.Options): AccessKey | undefined {
-  const { address, calls, store } = options
+  const { address, calls, chainId, store } = options
   const { accessKeys } = store.getState()
   let accessKeys_next = accessKeys
   for (const key of accessKeys) {
     if (key.access.toLowerCase() !== address.toLowerCase()) continue
+    if (key.chainId !== chainId) continue
     if (!('keyPair' in key && !!key.keyPair) && !('privateKey' in key && !!key.privateKey)) continue
 
     if (key.expiry && key.expiry < Date.now() / 1000) {
@@ -237,6 +240,8 @@ export declare namespace select {
     address: Address.Address
     /** Calls to match against access key scopes. */
     calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
     /** Reactive state store. */
     store: Store.Store
   }
@@ -298,6 +303,7 @@ export function save(options: save.Options): void {
   const base = {
     address: keyAuthorization.address,
     access: address,
+    chainId: Number(keyAuthorization.chainId),
     expiry: keyAuthorization.expiry ?? undefined,
     keyAuthorization,
     keyType: keyAuthorization.type,

--- a/src/core/Account.test.ts
+++ b/src/core/Account.test.ts
@@ -153,13 +153,14 @@ describe('find', () => {
         {
           address: '0x0000000000000000000000000000000000000099',
           access: accounts[0].address,
+          chainId: tempoLocalnet.id,
           keyType: 'webCrypto',
           keyPair,
         },
       ],
     )
 
-    const result = Account.find({ store, signable: true })
+    const result = Account.find({ chainId: tempoLocalnet.id, store, signable: true })
 
     expect(result.source).toMatchInlineSnapshot(`"accessKey"`)
   })
@@ -172,6 +173,7 @@ describe('find', () => {
         {
           address: '0x0000000000000000000000000000000000000099',
           access: accounts[0].address,
+          chainId: tempoLocalnet.id,
           keyType: 'webCrypto',
           keyPair,
         },

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -49,7 +49,12 @@ export function find(options: find.Options): TempoAccount.Account | JsonRpcAccou
 
   // When accessKey is requested, prefer a locally-signable access key for this address.
   if (accessKey) {
-    const key = core_AccessKey.select({ address: root.address, calls: options.calls, store })
+    const key = core_AccessKey.select({
+      address: root.address,
+      calls: options.calls,
+      chainId: options.chainId ?? store.getState().chainId,
+      store,
+    })
     if (key) return core_AccessKey.hydrate(key) as never
   }
 
@@ -64,6 +69,8 @@ export declare namespace find {
     address?: Address | undefined
     /** Calls to match against access key scopes. When provided, access keys whose scopes don't cover these calls are skipped. */
     calls?: readonly { to?: Address | undefined; data?: Hex | undefined }[] | undefined
+    /** Chain ID the access key must be authorized on. Defaults to the active chain. */
+    chainId?: number | undefined
     /** Whether to hydrate signing capability. @default false */
     signable?: boolean | undefined
     /** Reactive state store. */

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -300,6 +300,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                           return getAccount({
                             address: parameters.from,
                             calls,
+                            chainId: parameters.chainId ?? store.getState().chainId,
                             signable: true,
                           })
                         } catch {

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -88,6 +88,7 @@ describe('serialize', () => {
         {
           access: '0x0000000000000000000000000000000000000001',
           address: '0x0000000000000000000000000000000000000099',
+          chainId: 123,
           keyType: 'secp256k1',
           privateKey: '0x1234',
         },
@@ -113,6 +114,7 @@ describe('serialize', () => {
           {
             "access": "0x0000000000000000000000000000000000000001",
             "address": "0x0000000000000000000000000000000000000099",
+            "chainId": 123,
             "keyType": "secp256k1",
             "privateKey": "0x1234",
           },
@@ -165,6 +167,7 @@ describe('serialize', () => {
           {
             access: '0x0000000000000000000000000000000000000001',
             address: '0x0000000000000000000000000000000000000099',
+            chainId: 123,
             keyType: 'secp256k1',
             privateKey: '0x1234',
           },
@@ -269,6 +272,32 @@ describe('hydrate', () => {
       ]
     `)
   })
+
+  test('behavior: drops legacy access key without chain context', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accessKeys: [
+          {
+            access: '0x0000000000000000000000000000000000000001',
+            address: '0x0000000000000000000000000000000000000099',
+            keyType: 'webCrypto',
+            keyPair: {} as any,
+          },
+        ],
+      },
+      current,
+    )
+
+    expect(result.accessKeys).toMatchInlineSnapshot(`[]`)
+  })
 })
 
 describe('persistence', () => {
@@ -339,6 +368,7 @@ describe('persistence', () => {
         {
           address: '0x0000000000000000000000000000000000000099',
           access: '0x0000000000000000000000000000000000000001',
+          chainId: 123,
           keyType: 'webCrypto',
           keyPair: {} as any,
         },
@@ -351,6 +381,7 @@ describe('persistence', () => {
         {
           "access": "0x0000000000000000000000000000000000000001",
           "address": "0x0000000000000000000000000000000000000099",
+          "chainId": 123,
           "keyPair": {},
           "keyType": "webCrypto",
         },
@@ -370,6 +401,7 @@ describe('persistence', () => {
         {
           address: '0x0000000000000000000000000000000000000099',
           access: '0x0000000000000000000000000000000000000001',
+          chainId: 123,
           expiry: 9999999999,
           limits: [{ token: '0x0000000000000000000000000000000000000abc', limit: 500n }],
           keyType: 'webCrypto',
@@ -386,6 +418,7 @@ describe('persistence', () => {
         {
           "access": "0x0000000000000000000000000000000000000001",
           "address": "0x0000000000000000000000000000000000000099",
+          "chainId": 123,
           "expiry": 9999999999,
           "keyPair": {},
           "keyType": "webCrypto",
@@ -411,6 +444,7 @@ describe('persistence', () => {
         {
           address: '0x0000000000000000000000000000000000000099',
           access: '0x0000000000000000000000000000000000000001',
+          chainId: 123,
           keyType: 'webCrypto',
           keyPair: {} as any,
         },

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -42,7 +42,7 @@ export type State = {
 /** Provider state persisted as a refresh snapshot. */
 export type Persisted = {
   /** Stored access keys. */
-  accessKeys?: readonly AccessKey[] | undefined
+  accessKeys?: readonly unknown[] | undefined
   /** Connected accounts. */
   accounts?: readonly Account[] | undefined
   /** Index of the active account. */
@@ -167,9 +167,31 @@ export function hydrate(persisted: unknown, current: State): State {
         )
         return account ?? persisted
       }) ?? current.accounts,
-    accessKeys: state.accessKeys ?? current.accessKeys,
+    accessKeys: normalizeAccessKeys(state.accessKeys) ?? current.accessKeys,
     chainId: state.chainId ?? current.chainId,
   }
+}
+
+function normalizeAccessKeys(accessKeys: Persisted['accessKeys']) {
+  if (!accessKeys) return undefined
+  return accessKeys.filter((key): key is AccessKey => {
+    if (!key || typeof key !== 'object') return false
+    const value = key as {
+      access?: unknown
+      address?: unknown
+      chainId?: unknown
+      keyType?: unknown
+    }
+    return (
+      typeof value.access === 'string' &&
+      typeof value.address === 'string' &&
+      typeof value.chainId === 'number' &&
+      (value.keyType === 'secp256k1' ||
+        value.keyType === 'p256' ||
+        value.keyType === 'webAuthn' ||
+        value.keyType === 'webCrypto')
+    )
+  })
 }
 
 /**

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -149,7 +149,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
      * the dialog so the user can fund, approve, or retry.
      */
     async function withAccessKey<result>(
-      options: Pick<Adapter.sendTransaction.Parameters, 'calls' | 'from'>,
+      options: Pick<Adapter.sendTransaction.Parameters, 'calls' | 'chainId' | 'from'>,
       fn: (
         account: TempoAccount.Account,
         keyAuthorization?: KeyAuthorization.Signed,
@@ -157,7 +157,12 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     ): Promise<result | undefined> {
       const account = (() => {
         try {
-          return getAccount({ address: options.from, calls: options.calls, signable: true })
+          return getAccount({
+            address: options.from,
+            calls: options.calls,
+            chainId: options.chainId,
+            signable: true,
+          })
         } catch (err) {
           console.warn('[accounts] getAccount failed in withAccessKey:', err)
           return undefined
@@ -293,6 +298,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
+              chainId: parameters.chainId,
               feePayer: (() => {
                 if (feePayer === false) return false
                 if (typeof feePayer === 'string') return feePayer
@@ -323,6 +329,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
+              chainId: parameters.chainId,
               feePayer: (() => {
                 if (feePayer === false) return false
                 if (typeof feePayer === 'string') return feePayer
@@ -353,6 +360,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const result = await withAccessKey(parameters, async (account, keyAuthorization) => {
             const { feePayer, ...rest } = parameters
             const client = getClient({
+              chainId: parameters.chainId,
               feePayer: (() => {
                 if (feePayer === false) return false
                 if (typeof feePayer === 'string') return feePayer

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -70,7 +70,7 @@ export function local(options: local.Options): Adapter.Adapter {
     }
 
     async function withAccessKey<result>(
-      options: Pick<Account.find.Options, 'address' | 'calls'>,
+      options: Pick<Account.find.Options, 'address' | 'calls' | 'chainId'>,
       fn: (
         account: TempoAccount.Account,
         keyAuthorization?: KeyAuthorization.Signed,
@@ -244,6 +244,7 @@ export function local(options: local.Options): Adapter.Adapter {
         async signTransaction(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
+            chainId: parameters.chainId,
             feePayer: (() => {
               if (feePayer === false) return false
               if (typeof feePayer === 'string') return feePayer
@@ -251,7 +252,7 @@ export function local(options: local.Options): Adapter.Adapter {
             })(),
           })
           const { account, prepared } = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => ({
               account,
               prepared: await prepareTransactionRequest(client, {
@@ -278,6 +279,7 @@ export function local(options: local.Options): Adapter.Adapter {
         async sendTransaction(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
+            chainId: parameters.chainId,
             feePayer: (() => {
               if (feePayer === false) return false
               if (typeof feePayer === 'string') return feePayer
@@ -285,7 +287,7 @@ export function local(options: local.Options): Adapter.Adapter {
             })(),
           })
           const { account, prepared } = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => ({
               account,
               prepared: await prepareTransactionRequest(client, {
@@ -306,6 +308,7 @@ export function local(options: local.Options): Adapter.Adapter {
         async sendTransactionSync(parameters) {
           const { feePayer, ...rest } = parameters
           const client = getClient({
+            chainId: parameters.chainId,
             feePayer: (() => {
               if (feePayer === false) return false
               if (typeof feePayer === 'string') return feePayer
@@ -313,7 +316,7 @@ export function local(options: local.Options): Adapter.Adapter {
             })(),
           })
           const { account, prepared } = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => ({
               account,
               prepared: await prepareTransactionRequest(client, {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -241,6 +241,7 @@ export function turnkey<const client extends turnkey.Client>(
       options: {
         address?: Address | undefined
         calls?: Adapter.signTransaction.Parameters['calls']
+        chainId?: number | undefined
       },
       fn: (
         account: TempoAccount.Account,
@@ -272,6 +273,7 @@ export function turnkey<const client extends turnkey.Client>(
       const account = await accountForSigning(parameters.from)
       const { feePayer, ...rest } = parameters
       const viemClient = getClient({
+        chainId: parameters.chainId,
         feePayer: feePayer === true ? undefined : feePayer,
       })
       const prepared = await prepareTransactionRequest(viemClient, {
@@ -438,10 +440,11 @@ export function turnkey<const client extends turnkey.Client>(
         },
         async signTransaction(parameters) {
           const result = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => {
               const { feePayer, ...rest } = parameters
               const viemClient = getClient({
+                chainId: parameters.chainId,
                 feePayer: feePayer === true ? undefined : feePayer,
               })
               const prepared = await prepareTransactionRequest(viemClient, {
@@ -474,7 +477,7 @@ export function turnkey<const client extends turnkey.Client>(
         },
         async sendTransaction(parameters) {
           const result = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => {
               const { feePayer, ...rest } = parameters
               const viemClient = getClient({
@@ -508,7 +511,7 @@ export function turnkey<const client extends turnkey.Client>(
         },
         async sendTransactionSync(parameters) {
           const result = await withAccessKey(
-            { address: parameters.from, calls: parameters.calls },
+            { address: parameters.from, calls: parameters.calls, chainId: parameters.chainId },
             async (account, keyAuthorization) => {
               const { feePayer, ...rest } = parameters
               const viemClient = getClient({


### PR DESCRIPTION
## Summary
Scope locally stored access keys to the chain that authorized them.

## Motivation
Switching from mainnet to moderato could reuse a mainnet access key locally, causing moderato gas estimation to fail with keychain or key authorization chain mismatch errors.

## Changes
- Store `chainId` on `src/core/AccessKey.ts` entries when saving key authorizations.
- Require `chainId` when selecting access keys, and pass transaction `chainId` through `src/core/Account.ts` and local/dialog/Turnkey signing paths.
- Normalize persisted access keys during `src/core/Store.ts` hydration and drop invalid entries without numeric `chainId`.

## Testing
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts`
- `VITE_RPC_PORT=18545 ./node_modules/.bin/vp test src/core/Store.test.ts`
- `VITE_RPC_PORT=18545 ./node_modules/.bin/vp test src/core/Provider.test.ts -t "eth_fillTransaction"`