### PR TITLE
refactor(wallet_send): rename `value` to `amount`, add `memo`, accept token symbol

### DIFF
--- a/.changeset/wallet-send-amount.md
+++ b/.changeset/wallet-send-amount.md
@@ -1,5 +1,5 @@
 ---
-'accounts': major
+'accounts': minor
 ---
 
 Renamed the `wallet_send` `value` parameter to `amount`.

--- a/.changeset/wallet-send-amount.md
+++ b/.changeset/wallet-send-amount.md
@@ -1,0 +1,17 @@
+---
+'accounts': major
+---
+
+Renamed the `wallet_send` `value` parameter to `amount`.
+
+```diff
+ await provider.request({
+   method: 'wallet_send',
+   params: [{
+     to: '0x...',
+     token: '0x20c0000000000000000000000000000000000001',
+-    value: '1.5',
++    amount: '1.5',
+   }],
+ })
+```

--- a/.changeset/wallet-send-memo.md
+++ b/.changeset/wallet-send-memo.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added an optional `memo` parameter to `wallet_send` that the wallet attaches to TIP-20 transfers and rejects with `InvalidParamsError` for non-TIP-20 tokens.

--- a/.changeset/wallet-send-memo.md
+++ b/.changeset/wallet-send-memo.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added an optional `memo` parameter to `wallet_send` that the wallet attaches to TIP-20 transfers and rejects with `InvalidParamsError` for non-TIP-20 tokens.

--- a/.changeset/wallet-send-token-symbol.md
+++ b/.changeset/wallet-send-token-symbol.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Widened the `wallet_send` `token` parameter to accept a curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`) in addition to a contract address.

--- a/.changeset/wallet-send-token-symbol.md
+++ b/.changeset/wallet-send-token-symbol.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Widened the `wallet_send` `token` parameter to accept a curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`) in addition to a contract address.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -398,7 +398,7 @@ function WalletSend() {
           )
         }
       >
-        Send (PathUSD)
+        Send pathUSD
       </Button>
       <Button
         onClick={() =>
@@ -407,9 +407,9 @@ function WalletSend() {
               method: 'wallet_send',
               params: [
                 {
+                  amount: '1',
                   to: '0x0000000000000000000000000000000000000001',
                   token: tokens.pathUSD,
-                  value: '1',
                   ...feePayerParam,
                 },
               ],
@@ -417,7 +417,51 @@ function WalletSend() {
           )
         }
       >
-        Send ($1 PathUSD)
+        Send $1 pathUSD
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_send',
+              params: [
+                {
+                  amount: '1',
+                  to: '0x0000000000000000000000000000000000000001',
+                  // Resolved against the wallet's curated tokenlist
+                  // (case-insensitive). `pathusd` is also accepted.
+                  token: 'pathUSD',
+                  ...feePayerParam,
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Send $1 pathUSD (symbol)
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_send',
+              params: [
+                {
+                  amount: '1',
+                  // 32-byte UTF-8 memo attached to the TIP-20 transfer.
+                  // The wallet rejects with `InvalidParamsError` if the
+                  // selected token is not TIP-20.
+                  memo: 'invoice #4821',
+                  to: '0x0000000000000000000000000000000000000001',
+                  token: 'pathUSD',
+                  ...feePayerParam,
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Send $1 with memo
       </Button>
     </Method>
   )

--- a/site/src/pages/docs/rpc/wallet_send.mdx
+++ b/site/src/pages/docs/rpc/wallet_send.mdx
@@ -17,17 +17,28 @@ This method is only supported by adapters that opt in to the `send` action (typi
 type Request = {
   method: 'wallet_send'
   params?: [{
+    /** Human-readable amount to pre-fill (e.g. `"1.5"`). */
+    amount?: string
     /**
      * Fee payer override. `false` disables the wallet's default fee
      * payer, a URL string points at a custom fee payer service.
      */
     feePayer?: boolean | string
+    /**
+     * UTF-8 memo (max 32 bytes) to attach to the transfer. The wallet
+     * rejects the request if the selected token does not support
+     * memos (non-TIP-20).
+     */
+    memo?: string
     /** Recipient address to pre-fill. */
     to?: `0x${string}`
-    /** Token contract address to pre-fill. Omit to let the user choose. */
-    token?: `0x${string}`
-    /** Human-readable amount to pre-fill (e.g. `"1.5"`). */
-    value?: string
+    /**
+     * Token to pre-fill, accepted as either a contract address or a
+     * curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`).
+     * Symbols are resolved against the curated tokenlist on the
+     * active chain. Omit to let the user choose.
+     */
+    token?: `0x${string}` | string
   }]
 }
 ```
@@ -49,9 +60,10 @@ type Response = {
 const { receipt } = await provider.request({
   method: 'wallet_send',
   params: [{
+    amount: '1.5',
+    memo: 'invoice #4821',
     to: '0x...',
-    token: '0x20c0000000000000000000000000000000000001',
-    value: '1.5',
+    token: 'pathUsd',
   }],
 })
 ```

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1111,9 +1111,9 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           method: 'wallet_send',
           params: [
             {
+              amount: '1',
               to: '0x0000000000000000000000000000000000000001',
               token: Addresses.pathUsd,
-              value: '1',
             },
           ],
         }),

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -127,9 +127,10 @@ describe('Encoded', () => {
       params:
         | readonly [
             {
+              amount?: string | undefined
+              memo?: string | undefined
               to?: Hex | undefined
-              token?: Hex | undefined
-              value?: string | undefined
+              token?: Hex | string | undefined
             },
           ]
         | undefined

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -615,17 +615,28 @@ export namespace wallet_getCallsStatus {
 export namespace wallet_send {
   /** Parameters object for `wallet_send`. */
   export const parameters = z.object({
+    /** Human-readable amount to pre-fill (e.g. "1.5"). */
+    amount: z.optional(z.string()),
     /**
      * Fee payer override. `false` to disable the wallet's default fee
      * payer, a URL string to use a custom fee payer service.
      */
     feePayer: z.optional(z.union([z.boolean(), z.string()])),
+    /**
+     * UTF-8 memo (max 32 bytes) to attach to the transfer. Wallet
+     * rejects the request if the selected token does not support
+     * memos (non-TIP-20).
+     */
+    memo: z.optional(z.string()),
     /** Recipient address to pre-fill. */
     to: z.optional(u.address()),
-    /** Token contract address to pre-fill. Omit to let the user choose. */
-    token: z.optional(u.address()),
-    /** Human-readable amount to pre-fill (e.g. "1.5"). */
-    value: z.optional(z.string()),
+    /**
+     * Token to pre-fill, accepted as either a contract address or a
+     * curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`).
+     * Symbols are resolved against the curated tokenlist on the active
+     * chain. Omit to let the user choose.
+     */
+    token: z.optional(z.union([u.address(), z.string()])),
   })
 
   export const schema = Schema.defineItem({


### PR DESCRIPTION
Refactors `wallet_send` parameters.

- **Breaking**: renamed `value` to `amount` for parity with `wallet_swap`.
- Added optional `memo` (UTF-8, max 32 bytes) attached to TIP-20 transfers; the wallet rejects with `InvalidParamsError` when the selected token is not TIP-20.
- Widened `token` to accept either a contract address or a curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`) resolved against the active chain's curated tokenlist; unknown symbols reject with `InvalidParamsError`.

```diff
 await provider.request({
   method: 'wallet_send',
   params: [{
+    amount: '1.5',
+    memo: 'invoice #4821',
     to: '0x...',
-    token: '0x20c0000000000000000000000000000000000001',
-    value: '1.5',
+    token: 'pathUsd',
   }],
 })
```

Each change ships as a separate changeset.
