### PR TITLE
fix: preserve access key `publicKey` and propagate `keyType` for fill

### DIFF
--- a/.changeset/account-keytype-on-jsonrpc.md
+++ b/.changeset/account-keytype-on-jsonrpc.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Carried `keyType` through on non-signable json-rpc accounts so the viem/tempo transaction formatter can derive the correct `keyType`/`keyData` placeholder bytes during `eth_fillTransaction` gas estimation (notably for WebAuthn EOAs).

--- a/.changeset/preserve-access-key-publickey.md
+++ b/.changeset/preserve-access-key-publickey.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed `local` and `turnkey` adapters dropping `publicKey` when preparing key authorizations, which caused the wallet to sign authorizations for a freshly-generated address instead of the caller-supplied one.

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -95,7 +95,12 @@ export function hydrate(
   options: hydrate.Options = {},
 ): TempoAccount.Account | JsonRpcAccount {
   const { signable = false } = options
-  if (!signable) return { address: account.address, type: 'json-rpc' }
+  if (!signable)
+    return {
+      address: account.address,
+      type: 'json-rpc',
+      ...(account.keyType ? { keyType: account.keyType } : {}),
+    } as JsonRpcAccount
   if ('sign' in account && typeof account.sign === 'function')
     return account as TempoAccount.Account
   if (!account.keyType)

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -32,13 +32,14 @@ export function local(options: local.Options): Adapter.Adapter {
      * Resolves access key params into an unsigned key authorization.
      */
     async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
-      const { address, expiry, keyType, limits, scopes } = options
+      const { address, expiry, keyType, limits, publicKey, scopes } = options
       return await AccessKey.prepare({
         address,
         chainId: options.chainId ?? getClient().chain.id,
         expiry,
         keyType,
         limits,
+        publicKey,
         scopes,
       })
     }

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -197,13 +197,14 @@ export function turnkey<const client extends turnkey.Client>(
     }
 
     async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
-      const { address, expiry, keyType, limits, scopes } = options
+      const { address, expiry, keyType, limits, publicKey, scopes } = options
       return await AccessKey.prepare({
         address,
         chainId: options.chainId ?? getClient().chain.id,
         expiry,
         keyType,
         limits,
+        publicKey,
         scopes,
       })
     }


### PR DESCRIPTION
Two related access-key fixes that surfaced when sending the first transaction after `wallet_connect` with `authorizeAccessKey` via the dialog adapter.

`local` and `turnkey` adapters were dropping `publicKey` when destructuring `prepareKeyAuthorization` options (regression from `cba589b`). When the dialog adapter generates the access key on the dapp side and forwards `{ publicKey, ... }`, the host fell through to `AccessKey.prepare`'s "no address/publicKey" branch, generated a fresh `keyPair`, and signed the authorization for an unrelated address.

The dapp later signed transactions with its actual access key, but the on-chain authorization pointed at a different address -- so the relay rejected the first transaction with `KeyNotFound`.

`Account.hydrate` also now carries `keyType` through on the non-signable json-rpc account. The viem/tempo formatter reads `account.keyType` to inject the correct `keyType`/`keyData` placeholder bytes during `eth_fillTransaction` gas estimation, which matters for WebAuthn EOAs whose dummy signature is ~1400 bytes.
