### PR TITLE
fix(dialog): avoid root signer probe for access keys

### DIFF
--- a/.changeset/quiet-dialog-signing-fallback.md
+++ b/.changeset/quiet-dialog-signing-fallback.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Removed console warning from expected signing paths in dialog adapter.

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -424,7 +424,7 @@ describe('hydrate', () => {
   })
 })
 
-describe('select', () => {
+describe('selectAccount', () => {
   function setup(accessKeys: readonly Store.AccessKey[] = []) {
     const store = createStore()
     store.setState({ accessKeys })
@@ -443,9 +443,9 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
   test('behavior: skips access keys for another root address', async () => {
@@ -460,7 +460,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })
@@ -477,7 +477,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 42_431, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 42_431, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })
@@ -492,7 +492,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })
@@ -510,7 +510,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
     expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
@@ -529,9 +529,9 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
     expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
   })
 
@@ -553,9 +553,10 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
-    expect(result?.limits).toMatchInlineSnapshot(`
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
+    expect(store.getState().accessKeys[0]?.limits).toMatchInlineSnapshot(`
       [
         {
           "limit": 1000n,
@@ -577,14 +578,14 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({
+    const result = AccessKey.selectAccount({
       address: rootAddress,
       chainId: 1,
       store,
       calls: [{ to: '0x0000000000000000000000000000000000000abc', data: '0xa9059cbb' }],
     })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
   test('behavior: scoped access key selects when calls match', async () => {
@@ -601,14 +602,14 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({
+    const result = AccessKey.selectAccount({
       address: rootAddress,
       chainId: 1,
       store,
       calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
     })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
   test('behavior: scoped access key skips calls that do not match', async () => {
@@ -625,7 +626,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({
+    const result = AccessKey.selectAccount({
       address: rootAddress,
       chainId: 1,
       store,
@@ -649,14 +650,14 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({
+    const result = AccessKey.selectAccount({
       address: rootAddress,
       chainId: 1,
       store,
       calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
     })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
   test('behavior: scoped access key without selector allows any call to that address', async () => {
@@ -673,14 +674,14 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({
+    const result = AccessKey.selectAccount({
       address: rootAddress,
       chainId: 1,
       store,
       calls: [{ to: token, data: '0xdeadbeef' }],
     })
 
-    expect(result?.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000099"`)
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
   test('behavior: scoped access key skips when no calls are provided', async () => {
@@ -696,7 +697,7 @@ describe('select', () => {
       },
     ])
 
-    const result = AccessKey.select({ address: rootAddress, chainId: 1, store })
+    const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
   })

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -212,8 +212,10 @@ export function removePending(
   }))
 }
 
-/** Selects a locally-signable access key for a root account, removing expired keys. */
-export function select(options: select.Options): AccessKey | undefined {
+/** Selects and hydrates a locally-signable access key account for a root account. */
+export function selectAccount(
+  options: selectAccount.Options,
+): TempoAccount.AccessKeyAccount | undefined {
   const { address, calls, chainId, store } = options
   const { accessKeys } = store.getState()
   let accessKeys_next = accessKeys
@@ -228,13 +230,13 @@ export function select(options: select.Options): AccessKey | undefined {
       continue
     }
 
-    if (scopesMatch(key, { calls })) return key
+    if (scopesMatch(key, { calls })) return hydrate(key) as TempoAccount.AccessKeyAccount
   }
   return undefined
 }
 
-export declare namespace select {
-  /** Options for {@link select}. */
+export declare namespace selectAccount {
+  /** Options for {@link selectAccount}. */
   type Options = {
     /** Root account address. */
     address: Address.Address

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -49,13 +49,13 @@ export function find(options: find.Options): TempoAccount.Account | JsonRpcAccou
 
   // When accessKey is requested, prefer a locally-signable access key for this address.
   if (accessKey) {
-    const key = core_AccessKey.select({
+    const account = core_AccessKey.selectAccount({
       address: root.address,
       calls: options.calls,
       chainId: options.chainId ?? store.getState().chainId,
       store,
     })
-    if (key) return core_AccessKey.hydrate(key) as never
+    if (account) return account
   }
 
   return hydrate(root, { signable }) as never

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -1,0 +1,137 @@
+import { Provider as ox_Provider } from 'ox'
+import { tempoLocalnet } from 'viem/chains'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import * as AccessKey from '../AccessKey.js'
+import * as Dialog from '../Dialog.js'
+import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
+import { dialog } from './dialog.js'
+
+const address = '0x0000000000000000000000000000000000000001'
+const recipient = '0x0000000000000000000000000000000000000002'
+
+describe('dialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('behavior: sendTransaction signs locally when an access key is selected', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    const clientRequests: unknown[] = []
+    const signRequests: unknown[] = []
+    vi.spyOn(AccessKey, 'selectAccount').mockReturnValue({
+      accessKeyAddress: '0x0000000000000000000000000000000000000099',
+      address: '0x0000000000000000000000000000000000000099',
+      signTransaction: async (request: unknown) => {
+        signRequests.push(request)
+        return '0xsigned'
+      },
+      source: 'accessKey',
+      type: 'local',
+    } as never)
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () =>
+        ({
+          chain: { id: tempoLocalnet.id },
+          request: async (request: unknown) => {
+            clientRequests.push(request)
+            return '0xtransaction'
+          },
+        }) as never,
+      storage,
+      store,
+    })
+
+    const result = await adapter.actions.sendTransaction(
+      {
+        calls: [{ data: '0x12345678', to: recipient }],
+        chainId: 1,
+        from: address,
+        gas: 1n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        nonce: 0,
+      },
+      {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            calls: [{ data: '0x12345678' as const, to: recipient }],
+            chainId: '0x1' as const,
+            from: address,
+          },
+        ] as const,
+      },
+    )
+
+    expect(result).toMatchInlineSnapshot(`"0xtransaction"`)
+    expect(signRequests.length).toMatchInlineSnapshot(`1`)
+    expect(clientRequests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "eth_sendRawTransaction",
+          "params": [
+            "0xsigned",
+          ],
+        },
+      ]
+    `)
+    expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: sendTransaction falls through when no access key is selected', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    vi.spyOn(AccessKey, 'selectAccount').mockReturnValue(undefined)
+    const lookups: unknown[] = []
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: (options) => {
+        lookups.push(options)
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+    const request = {
+      method: 'eth_sendTransaction' as const,
+      params: [
+        {
+          calls: [{ data: '0x12345678' as const, to: recipient }],
+          chainId: '0x1' as const,
+          from: address,
+        },
+      ] as const,
+    }
+
+    const promise = adapter.actions.sendTransaction(
+      {
+        calls: [{ data: '0x12345678', to: recipient }],
+        chainId: 1,
+        from: address,
+      },
+      request,
+    )
+
+    await Promise.resolve()
+
+    const queued = store.getState().requestQueue[0]!
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: '0x1234',
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchInlineSnapshot(`"0x1234"`)
+    expect(lookups).toMatchInlineSnapshot(`[]`)
+  })
+})

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -155,21 +155,14 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         keyAuthorization?: KeyAuthorization.Signed,
       ) => Promise<result>,
     ): Promise<result | undefined> {
-      const account = (() => {
-        try {
-          return getAccount({
-            address: options.from,
-            calls: options.calls,
-            chainId: options.chainId,
-            signable: true,
-          })
-        } catch (err) {
-          console.warn('[accounts] getAccount failed in withAccessKey:', err)
-          return undefined
-        }
-      })()
+      if (!options.from || typeof options.chainId === 'undefined') return undefined
+      const account = AccessKey.selectAccount({
+        address: options.from,
+        calls: options.calls,
+        chainId: options.chainId,
+        store,
+      })
       if (!account) return undefined
-      if (account.source !== 'accessKey') return undefined
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {
         const result = await fn(account, keyAuthorization ?? undefined)


### PR DESCRIPTION
## Summary
Remove the expected `withAccessKey` warning from the dialog adapter fallback path.

## Motivation
`tempoWallet` only has a local signer when a stored access key matches the transaction. When no access key matches, the adapter should quietly fall through to the wallet dialog instead of probing the remote root account as a local signer and logging `Account ... cannot sign`.

## Changes
- Added `AccessKey.selectAccount(...)` in `src/core/AccessKey.ts` to select and hydrate local access-key signers.
- Updated `src/core/Account.ts` to use `selectAccount(...)` while preserving root-account fallback.
- Updated `src/core/adapters/dialog.ts` to use access-key-only selection for silent signing attempts.
- Added focused tests in `src/core/adapters/dialog.test.ts` and updated access-key selection tests.
- Added a patch changeset.

## Testing
- `pnpm test src/core/Account.test.ts src/core/AccessKey.test.ts src/core/adapters/dialog.test.ts` passed.
- `pnpm check:types` fails in `examples/cli` because the local install has duplicate `viem` type trees (`pkg.pr.new` and `2.48.11`), unrelated to this change.