### PR TITLE
fix(turnkey): simplify loadAccounts and createAccount in turnkey adapter

### DIFF
--- a/.changeset/simplified-turnkey-callbacks.md
+++ b/.changeset/simplified-turnkey-callbacks.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Simplified loadAccounts and createAccount in turnkey adapter.

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -1,6 +1,5 @@
 import { TurnkeyClient, generateWalletAccountsFromAddressFormat } from '@turnkey/core'
 import type { CreateSubOrgParams } from '@turnkey/core'
-import type { TurnkeyClientMethods } from '@turnkey/core'
 import {
   type Dialog as DialogNs,
   WebAuthnCeremony,
@@ -21,11 +20,7 @@ export type AdapterType = 'secp256k1' | 'webAuthn' | 'turnkey' | 'tempoWallet' |
 export type Env = 'mainnet' | 'testnet' | 'devnet'
 export type DialogMode = 'iframe' | 'popup'
 export type ProviderValue = ReturnType<typeof Provider.create>
-type TurnkeyPlaygroundClient = turnkey.Client &
-  TurnkeyEmailOtpClient & {
-    createWallet: TurnkeyClientMethods['createWallet']
-  }
-const turnkeyEthereumAddressFormat = 'ADDRESS_FORMAT_ETHEREUM'
+type TurnkeyPlaygroundClient = turnkey.Client & TurnkeyEmailOtpClient
 
 export const env: Env = (() => {
   const param = new URLSearchParams(window.location.search).get('env')
@@ -112,25 +107,15 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
         async loadAccounts({ client }) {
           await requestTurnkeyEmailOtp({
             client,
-            createSubOrgParams: createTurnkeySubOrgParams(),
+            createSubOrgParams: {
+              customWallet: {
+                walletName: 'Tempo Playground',
+                walletAccounts: generateWalletAccountsFromAddressFormat({
+                  addresses: ['ADDRESS_FORMAT_ETHEREUM'],
+                }),
+              },
+            } satisfies CreateSubOrgParams,
           })
-
-          const existing = (await client.fetchWallets())
-            .flatMap((wallet) => wallet.accounts)
-            .filter((account) => account.addressFormat === turnkeyEthereumAddressFormat)
-          if (existing.length > 0) return existing
-
-          await client.createWallet({
-            walletName: 'Tempo Playground',
-            accounts: [turnkeyEthereumAddressFormat],
-          })
-
-          const created = (await client.fetchWallets())
-            .flatMap((wallet) => wallet.accounts)
-            .filter((account) => account.addressFormat === turnkeyEthereumAddressFormat)
-          if (created.length > 0) return created
-
-          throw new Error('No Turnkey Ethereum account found after creating a wallet.')
         },
       }),
       mpp: true,
@@ -176,18 +161,6 @@ function getTurnkeyAdapterClient() {
   })
 
   return turnkeyClient as TurnkeyPlaygroundClient
-}
-
-function createTurnkeySubOrgParams(name?: string | undefined) {
-  return {
-    ...(name ? { userName: name } : {}),
-    customWallet: {
-      walletName: 'Tempo Playground',
-      walletAccounts: generateWalletAccountsFromAddressFormat({
-        addresses: [turnkeyEthereumAddressFormat],
-      }),
-    },
-  } satisfies CreateSubOrgParams
 }
 
 export function switchTheme(

--- a/site/src/pages/docs/adapters/turnkey.mdx
+++ b/site/src/pages/docs/adapters/turnkey.mdx
@@ -22,18 +22,28 @@ TODO
 ## Usage
 
 ```tsx
-import { TurnkeyClient } from '@turnkey/core'
+import { TurnkeyClient, generateWalletAccountsFromAddressFormat } from '@turnkey/core'
 import { Provider, turnkey } from 'accounts'
 
 const provider = Provider.create({
   adapter: turnkey({
     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
+    createAccount: async ({ client, parameters }) => {
+      await client.signUpWithPasskey({
+        passkeyDisplayName: parameters.name,
+        createSubOrgParams: {
+          userName: parameters.name,
+          customWallet: {
+            walletName: 'FooBar',
+            walletAccounts: generateWalletAccountsFromAddressFormat({
+              addresses: ['ADDRESS_FORMAT_ETHEREUM'],
+            }),
+          },
+        },
+      })
+    },
     loadAccounts: async ({ client }) => {
-      const session = await client.getSession()
-      if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
-      return (await client.fetchWallets())
-        .flatMap((wallet) => wallet.accounts)
-        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')
+      await client.loginWithPasskey()
     },
   }),
 })

--- a/site/src/pages/docs/api/turnkey.mdx
+++ b/site/src/pages/docs/api/turnkey.mdx
@@ -12,18 +12,28 @@ The adapter owns silent reconnect, session-expiry cleanup, and provider signing 
 ## Usage
 
 ```ts
-import { TurnkeyClient } from '@turnkey/core'
+import { TurnkeyClient, generateWalletAccountsFromAddressFormat } from '@turnkey/core'
 import { Provider, turnkey } from 'accounts'
 
 const provider = Provider.create({
   adapter: turnkey({
     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
+    createAccount: async ({ client, parameters }) => {
+      await client.signUpWithPasskey({
+        passkeyDisplayName: parameters.name,
+        createSubOrgParams: {
+          userName: parameters.name,
+          customWallet: {
+            walletName: 'FooBar',
+            walletAccounts: generateWalletAccountsFromAddressFormat({
+              addresses: ['ADDRESS_FORMAT_ETHEREUM'],
+            }),
+          },
+        },
+      })
+    },
     loadAccounts: async ({ client }) => {
-      const session = await client.getSession()
-      if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
-      return (await client.fetchWallets())
-        .flatMap((wallet) => wallet.accounts)
-        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')
+      await client.loginWithPasskey()
     },
   }),
 })
@@ -71,12 +81,14 @@ const provider = Provider.create({
 
 ### loadAccounts
 
-- **Type:** `(params: { client; parameters? }) => Promise<readonly turnkey.WalletAccount[]>`
+- **Type:** `(params: { client; parameters? }) => Promise<readonly Address[] | void>`
 - **Required**
 
 Loads/logs into existing Turnkey wallet accounts. UI is allowed (e.g. passkey prompts to start a new session).
 
-Receives the initialized Turnkey `client` and the optional provider load-accounts `parameters` (e.g. `authorizeAccessKey`, `digest`, `personalSign`, `selectAccount`). Must return all Ethereum-format Turnkey wallet accounts that should be exposed to the provider.
+Receives the initialized Turnkey `client` and the optional provider load-accounts `parameters` (e.g. `authorizeAccessKey`, `digest`, `personalSign`, `selectAccount`). After this callback completes, the adapter calls `client.fetchWallets()` and exposes fetched Ethereum accounts.
+
+By default all the user's Ethereum accounts will be connected. Return `Address[]` to select and order the fetched accounts. The first returned address is active by default, matching `eth_requestAccounts`.
 
 When `createAccount` is omitted, register requests call `loadAccounts` too. This fits email and social auth flows where the same Turnkey ceremony can sign in an existing user or create one.
 
@@ -87,26 +99,11 @@ const provider = Provider.create({
   adapter: turnkey({
     client,
     loadAccounts: async ({ client }) => { // [!code focus]
-      const session = await client.getSession() // [!code focus]
-      if (!session || session.expiry * 1000 <= Date.now()) // [!code focus]
-        await client.loginWithPasskey() // [!code focus]
-      return (await client.fetchWallets()) // [!code focus]
-        .flatMap((wallet) => wallet.accounts) // [!code focus]
-        .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM') // [!code focus]
+      await client.loginWithPasskey() // [!code focus]
     }, // [!code focus]
   }),
 })
 ```
-
-### createAccount
-
-- **Type:** `(params: { client; parameters }) => Promise<turnkey.WalletAccount>`
-- **Optional**
-- **Default:** `loadAccounts`
-
-Creates/registers a Turnkey wallet account when registration needs a separate flow.
-
-Receives the initialized Turnkey `client` and the provider create-account `parameters` (display name, optional `digest`, `personalSign`, `userId`, etc.). Must return a single Ethereum-format Turnkey wallet account.
 
 ```ts
 import { Provider, turnkey } from 'accounts'
@@ -114,13 +111,46 @@ import { Provider, turnkey } from 'accounts'
 const provider = Provider.create({
   adapter: turnkey({
     client,
+    loadAccounts: async ({ client }) => {
+      await client.loginWithPasskey()
+      return [selectedAddress] // [!code focus]
+    },
+  }),
+})
+```
+
+### createAccount
+
+- **Type:** `(params: { client; parameters }) => Promise<readonly Address[] | void>`
+- **Optional**
+- **Default:** `loadAccounts`
+
+Creates/registers a Turnkey wallet account when registration needs a separate flow.
+
+Receives the initialized Turnkey `client` and the provider create-account `parameters` (display name, optional `digest`, `personalSign`, `userId`, etc.). After this callback completes, the adapter calls `client.fetchWallets()` and exposes fetched Ethereum accounts.
+
+Like `loadAccounts`, by default all the user's Ethereum accounts will be connected. Return `Address[]` to choose the returned accounts. The first address is active by default.
+
+```ts
+import { generateWalletAccountsFromAddressFormat } from '@turnkey/core'
+import { Provider, turnkey } from 'accounts'
+
+const provider = Provider.create({
+  adapter: turnkey({
+    client,
     createAccount: async ({ client, parameters }) => { // [!code focus]
       await client.signUpWithPasskey({ // [!code focus]
-        createSubOrgParams: { userName: parameters.name }, // [!code focus]
+        passkeyDisplayName: parameters.name, // [!code focus]
+        createSubOrgParams: { // [!code focus]
+          userName: parameters.name, // [!code focus]
+          customWallet: { // [!code focus]
+            walletName: 'FooBar', // [!code focus]
+            walletAccounts: generateWalletAccountsFromAddressFormat({ // [!code focus]
+              addresses: ['ADDRESS_FORMAT_ETHEREUM'], // [!code focus]
+            }), // [!code focus]
+          }, // [!code focus]
+        }, // [!code focus]
       }) // [!code focus]
-      return (await client.fetchWallets()) // [!code focus]
-        .flatMap((wallet) => wallet.accounts) // [!code focus]
-        .find((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')! // [!code focus]
     }, // [!code focus]
     loadAccounts: async ({ client }) => { /* ... */ },
   }),

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -1,12 +1,16 @@
-import { Hex } from 'ox'
+import { Hex, PublicKey } from 'ox'
+import type { Address } from 'viem/accounts'
 import { describe, expect, test } from 'vp/test'
 
+import { accounts } from '../../../test/config.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
 import { turnkey } from './turnkey.js'
 
-const address = '0x0000000000000000000000000000000000000001'
-const other = '0x0000000000000000000000000000000000000002'
+const account = accounts[0]
+const account_2 = accounts[1]
+const address = account.address
+const other = account_2.address
 
 describe('turnkey', () => {
   test('default: createAccount delegates registration and signs the requested digest', async () => {
@@ -27,7 +31,7 @@ describe('turnkey', () => {
       {
         "accounts": [
           {
-            "address": "0x0000000000000000000000000000000000000001",
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             "label": "Ada",
           },
         ],
@@ -50,7 +54,38 @@ describe('turnkey', () => {
       {
         "accounts": [
           {
-            "address": "0x0000000000000000000000000000000000000001",
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "label": "Ada",
+          },
+        ],
+        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
+      }
+    `)
+  })
+
+  test('default: createAccount can select the active fetched wallet account', async () => {
+    const { adapter, client } = setup({ createAddresses: [other] })
+    client.wallets = [
+      {
+        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
+      },
+    ]
+
+    const result = await adapter.actions.createAccount(
+      { digest: '0x1234', name: 'Ada' },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(client.signWith).toMatchInlineSnapshot(`
+      [
+        "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
             "label": "Ada",
           },
         ],
@@ -71,11 +106,111 @@ describe('turnkey', () => {
     expect(client.loadCalls).toMatchInlineSnapshot(`1`)
     expect(client.signWith).toMatchInlineSnapshot(`
       [
-        "0x0000000000000000000000000000000000000001",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       ]
     `)
     expect(result).toMatchInlineSnapshot(
       `"0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
+    )
+  })
+
+  test('default: loadAccounts can select and order fetched wallet accounts', async () => {
+    const { adapter, client } = setup({ loadAddresses: [other, address] })
+    client.wallets = [
+      {
+        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
+      },
+    ]
+
+    const result = await adapter.actions.loadAccounts(
+      { digest: '0x1234' },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(client.signWith).toMatchInlineSnapshot(`
+      [
+        "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+          },
+          {
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          },
+        ],
+        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
+      }
+    `)
+  })
+
+  test('default: signs transactions with a hydrated Tempo account', async () => {
+    const { adapter, client } = setup()
+
+    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    const result = await adapter.actions.signTransaction(
+      {
+        chainId: 1,
+        from: address,
+        gas: 21_000n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        nonce: 0,
+        to: other,
+        value: 1n,
+      },
+      { method: 'eth_signTransaction', params: [{ from: address }] },
+    )
+
+    expect(client.signWith).toMatchInlineSnapshot(`
+      [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ]
+    `)
+    expect(client.signPayloads).toMatchInlineSnapshot(`
+      [
+        "0x1d573a406538a466857ad6ac07f34eac6ede297aba6e85116a1e9a7cda46d9f2",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(
+      `"0x76f86a010101825208d8d7948c8d35429f74ec245f8ef2f4fd1e551cff97d6500180c0808080808080c0b841000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
+    )
+  })
+
+  test('default: accepts prefixed Turnkey public keys', async () => {
+    const { adapter, client } = setup()
+    const walletAccount = toWalletAccount(account)
+    client.wallets = [
+      {
+        accounts: [
+          {
+            ...walletAccount,
+            publicKey: `0x${walletAccount.publicKey}`,
+          },
+        ],
+      },
+    ]
+
+    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    const result = await adapter.actions.signTransaction(
+      {
+        chainId: 1,
+        from: address,
+        gas: 21_000n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        nonce: 0,
+        to: other,
+        value: 1n,
+      },
+      { method: 'eth_signTransaction', params: [{ from: address }] },
+    )
+
+    expect(result).toMatchInlineSnapshot(
+      `"0x76f86a010101825208d8d7948c8d35429f74ec245f8ef2f4fd1e551cff97d6500180c0808080808080c0b841000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
     )
   })
 
@@ -95,20 +230,20 @@ describe('turnkey', () => {
 
     expect(client.signPayloads).toMatchInlineSnapshot(`
       [
-        "0x219d0ef7a59d2a40d6ff9e115e32fb6b53eb7fa518ea3364b7b806990fad3944",
+        "0xea47721547363fc82a5dca62b4544e4718d861b3df10bfac65d30102594b5c26",
       ]
     `)
     expect(result).toMatchInlineSnapshot(`
       {
         "accounts": [
           {
-            "address": "0x0000000000000000000000000000000000000001",
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
           },
         ],
         "keyAuthorization": {
           "chainId": "0x1",
           "expiry": "0x7b",
-          "keyId": "0x0000000000000000000000000000000000000002",
+          "keyId": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
           "keyType": "secp256k1",
           "limits": undefined,
           "signature": {
@@ -142,7 +277,7 @@ describe('turnkey', () => {
         "keyAuthorization": {
           "chainId": "0x1",
           "expiry": "0x7b",
-          "keyId": "0x0000000000000000000000000000000000000002",
+          "keyId": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
           "keyType": "secp256k1",
           "limits": undefined,
           "signature": {
@@ -152,7 +287,7 @@ describe('turnkey', () => {
             "yParity": "0x0",
           },
         },
-        "rootAddress": "0x0000000000000000000000000000000000000001",
+        "rootAddress": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       }
     `)
   })
@@ -188,10 +323,7 @@ describe('turnkey', () => {
     const { adapter, client, store } = setup()
     client.wallets = [
       {
-        accounts: [
-          { address, addressFormat: 'ADDRESS_FORMAT_ETHEREUM' },
-          { address: other, addressFormat: 'ADDRESS_FORMAT_ETHEREUM' },
-        ],
+        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
       },
     ]
     store.setState({ accounts: [{ address: other }], activeAccount: 0 })
@@ -203,13 +335,13 @@ describe('turnkey', () => {
 
     expect(client.signWith).toMatchInlineSnapshot(`
       [
-        "0x0000000000000000000000000000000000000002",
+        "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
       ]
     `)
     expect(store.getState().accounts).toMatchInlineSnapshot(`
       [
         {
-          "address": "0x0000000000000000000000000000000000000002",
+          "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
         },
       ]
     `)
@@ -223,6 +355,7 @@ describe('turnkey', () => {
           {
             address,
             addressFormat: 'ADDRESS_FORMAT_SUI',
+            publicKey: toWalletAccount(account).publicKey,
           },
         ],
       },
@@ -280,7 +413,41 @@ describe('turnkey', () => {
         { method: 'personal_sign', params: ['0x68656c6c6f', other] },
       ),
     ).rejects.toMatchInlineSnapshot(
-      '[Provider.UnauthorizedError: Account "0x0000000000000000000000000000000000000002" not found.]',
+      `[Provider.UnauthorizedError: Account "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650" not found.]`,
+    )
+  })
+
+  test('error: rejects a Turnkey wallet account with mismatched address and public key', async () => {
+    const { adapter, client, store } = setup()
+    client.wallets = [
+      {
+        accounts: [
+          {
+            ...toWalletAccount(account_2),
+            address,
+          },
+        ],
+      },
+    ]
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      adapter.actions.signTransaction(
+        { from: address },
+        { method: 'eth_signTransaction', params: [{ from: address }] },
+      ),
+    ).rejects.toMatchInlineSnapshot(
+      `[RpcResponse.InternalError: Turnkey account publicKey does not match address "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".]`,
+    )
+  })
+
+  test('error: rejects a selected address missing from fetched wallet accounts', async () => {
+    const { adapter } = setup({ loadAddresses: [other] })
+
+    await expect(
+      adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined }),
+    ).rejects.toMatchInlineSnapshot(
+      `[RpcResponse.InternalError: Turnkey callback returned address "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650" that was not found in fetched wallet accounts.]`,
     )
   })
 })
@@ -296,12 +463,12 @@ function setup(options: setup.Options = {}) {
       : {
           createAccount: async () => {
             client.createCalls++
-            return { address }
+            return options.createAddresses
           },
         }),
     loadAccounts: async () => {
       client.loadCalls++
-      return [{ address }]
+      return options.loadAddresses
     },
   })({
     getAccount: (() => {
@@ -317,13 +484,17 @@ function setup(options: setup.Options = {}) {
 declare namespace setup {
   type Options = {
     createAccount?: boolean | undefined
+    createAddresses?: readonly Address[] | undefined
+    loadAddresses?: readonly Address[] | undefined
     session?: turnkey.Session | null | undefined
     signError?: unknown
   }
 }
 
 function createClient(options: setup.Options = {}) {
-  type WalletShape = { accounts: { address: string; addressFormat: string }[] }
+  type WalletShape = {
+    accounts: { address: string; addressFormat?: string | undefined; publicKey: string }[]
+  }
   const state = {
     createCalls: 0,
     fetchCalls: 0,
@@ -331,9 +502,7 @@ function createClient(options: setup.Options = {}) {
     loadCalls: 0,
     signPayloads: [] as Hex.Hex[],
     signWith: [] as string[],
-    wallets: [
-      { accounts: [{ address, addressFormat: 'ADDRESS_FORMAT_ETHEREUM' }] },
-    ] as WalletShape[],
+    wallets: [{ accounts: [toWalletAccount(account)] }] as WalletShape[],
   }
   const client = {
     get fetchCalls() {
@@ -401,4 +570,12 @@ function createClient(options: setup.Options = {}) {
   }
 
   return client
+}
+
+function toWalletAccount(account: (typeof accounts)[number]): turnkey.WalletAccount {
+  return {
+    address: account.address,
+    addressFormat: 'ADDRESS_FORMAT_ETHEREUM',
+    publicKey: PublicKey.toHex(PublicKey.compress(PublicKey.from(account.publicKey))).slice(2),
+  }
 }

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -1,10 +1,17 @@
-import { Address as core_Address, Hex, Provider as ox_Provider, Signature } from 'ox'
+import {
+  Address as core_Address,
+  Bytes,
+  Hex,
+  Provider as ox_Provider,
+  PublicKey,
+  RpcResponse,
+  Secp256k1,
+} from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
+import { hashMessage, hashTypedData, isAddressEqual } from 'viem'
 import type { Address } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
-import type { Account as TempoAccount } from 'viem/tempo'
-import { Transaction as TempoTransaction } from 'viem/tempo'
+import { Account as TempoAccount } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
@@ -25,23 +32,34 @@ const turnkeySessionErrorCodes = new Set([
  * Creates a Turnkey adapter backed by `@turnkey/core` client sessions and Ethereum wallet accounts.
  *
  * The adapter owns silent reconnect, session-expiry cleanup, and provider signing actions.
- * Apps provide the UI-bearing login or sign-up flow through `loadAccounts`. Provide
+ * Apps provide the UI-bearing login or sign-up flow through `loadAccounts`. The adapter
+ * fetches Ethereum wallet accounts from Turnkey after the flow completes. Provide
  * `createAccount` only when registration needs a distinct Turnkey flow.
  *
  * @example
  * ```ts
- * import { TurnkeyClient } from '@turnkey/core'
+ * import { TurnkeyClient, generateWalletAccountsFromAddressFormat } from '@turnkey/core'
  * import { Provider, turnkey } from 'accounts'
  *
  * const provider = Provider.create({
  *   adapter: turnkey({
  *     client: new TurnkeyClient({ organizationId, authProxyConfigId }),
+ *     createAccount: async ({ client, parameters }) => {
+ *       await client.signUpWithPasskey({
+ *         passkeyDisplayName: parameters.name,
+ *         createSubOrgParams: {
+ *           userName: parameters.name,
+ *           customWallet: {
+ *             walletName: 'FooBar',
+ *             walletAccounts: generateWalletAccountsFromAddressFormat({
+ *               addresses: ['ADDRESS_FORMAT_ETHEREUM'],
+ *             }),
+ *           },
+ *         },
+ *       })
+ *     },
  *     loadAccounts: async ({ client }) => {
- *       const session = await client.getSession()
- *       if (!session || session.expiry * 1000 <= Date.now()) await client.loginWithPasskey()
- *       return (await client.fetchWallets())
- *         .flatMap((wallet) => wallet.accounts)
- *         .filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM')
+ *       await client.loginWithPasskey()
  *     },
  *   }),
  * })
@@ -72,6 +90,68 @@ export function turnkey<const client extends turnkey.Client>(
         address: core_Address.from(account.address),
         ...(label ? { label } : {}),
       }
+    }
+
+    function toTempoAccount(account: turnkey.WalletAccount): TempoAccount.Account {
+      const publicKey = toPublicKey(account)
+      assertAddress(account, publicKey)
+
+      const sign = async (parameters: { hash: Hex.Hex }) =>
+        await signPayload({
+          payload: parameters.hash,
+          turnkeyClient: await getTurnkeyClient(),
+          walletAccount: account,
+        })
+
+      return TempoAccount.from({
+        keyType: 'secp256k1',
+        publicKey,
+        sign,
+      })
+    }
+
+    function toPublicKey(account: turnkey.WalletAccount) {
+      const publicKey = account.publicKey.startsWith('0x')
+        ? account.publicKey
+        : `0x${account.publicKey}`
+      Hex.assert(publicKey, { strict: true })
+      return PublicKey.from(Secp256k1.noble.ProjectivePoint.fromHex(Bytes.fromHex(publicKey)))
+    }
+
+    function assertAddress(account: turnkey.WalletAccount, publicKey: PublicKey.PublicKey) {
+      const address = core_Address.from(account.address)
+      const address_publicKey = core_Address.fromPublicKey(publicKey)
+      if (isAddressEqual(address, address_publicKey)) return
+
+      throw new RpcResponse.InternalError({
+        message: `Turnkey account publicKey does not match address "${address}".`,
+      })
+    }
+
+    async function fetchWalletAccounts(): Promise<readonly turnkey.WalletAccount[]> {
+      const turnkeyClient = await getTurnkeyClient()
+      return (await turnkeyClient.fetchWallets()).flatMap((wallet) =>
+        wallet.accounts.filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM'),
+      )
+    }
+
+    function selectWalletAccounts(
+      accounts: readonly turnkey.WalletAccount[],
+      addresses: turnkey.AccountSelection,
+    ) {
+      if (!addresses) return accounts
+
+      return addresses.map((address) => {
+        const address_ = core_Address.from(address)
+        const account = accounts.find((account) =>
+          isAddressEqual(core_Address.from(account.address), address_),
+        )
+        if (account) return account
+
+        throw new RpcResponse.InternalError({
+          message: `Turnkey callback returned address "${address_}" that was not found in fetched wallet accounts.`,
+        })
+      })
     }
 
     function clear() {
@@ -116,10 +196,7 @@ export function turnkey<const client extends turnkey.Client>(
         const session = await getValidSession()
         if (!session) return
 
-        const turnkeyClient = await getTurnkeyClient()
-        const restored = (await turnkeyClient.fetchWallets()).flatMap((wallet) =>
-          wallet.accounts.filter((account) => account.addressFormat === 'ADDRESS_FORMAT_ETHEREUM'),
-        )
+        const restored = await fetchWalletAccounts()
         walletAccounts = persisted
           .map((account) =>
             restored.find((walletAccount) =>
@@ -270,35 +347,19 @@ export function turnkey<const client extends turnkey.Client>(
     }
 
     async function signTransaction(parameters: Adapter.signTransaction.Parameters) {
-      const turnkeyClient = await getTurnkeyClient()
-      const account = await accountForSigning(parameters.from)
+      const account = toTempoAccount(await accountForSigning(parameters.from))
       const { feePayer, ...rest } = parameters
       const viemClient = getClient({
         chainId: parameters.chainId,
         feePayer: feePayer === true ? undefined : feePayer,
       })
       const prepared = await prepareTransactionRequest(viemClient, {
-        account: core_Address.from(account.address),
+        account,
         ...rest,
         ...(feePayer ? { feePayer: true } : {}),
         type: 'tempo',
       } as never)
-      const presign = (() => {
-        if ('feePayerSignature' in prepared && prepared.feePayerSignature)
-          return { ...prepared, feePayerSignature: null }
-        return prepared
-      })()
-      const unsignedTransaction = await TempoTransaction.serialize(presign as never)
-
-      const signature = await signPayload({
-        payload: keccak256(unsignedTransaction),
-        turnkeyClient,
-        walletAccount: account,
-      })
-      return await TempoTransaction.serialize(
-        prepared as never,
-        SignatureEnvelope.from(Signature.fromHex(signature)) as never,
-      )
+      return await account.signTransaction(prepared as never)
     }
 
     function isSessionError(error: unknown) {
@@ -341,8 +402,8 @@ export function turnkey<const client extends turnkey.Client>(
             )
 
           const turnkeyClient = await getTurnkeyClient()
-          const accounts = options.createAccount
-            ? [await options.createAccount({ client: turnkeyClient, parameters })]
+          const addresses = options.createAccount
+            ? await options.createAccount({ client: turnkeyClient, parameters })
             : await options.loadAccounts({
                 client: turnkeyClient,
                 parameters: {
@@ -352,7 +413,7 @@ export function turnkey<const client extends turnkey.Client>(
                 },
               })
           await requireSession()
-          walletAccounts = accounts
+          walletAccounts = selectWalletAccounts(await fetchWalletAccounts(), addresses)
           restore_promise = undefined
 
           const digest = personalSign ? hashMessage(personalSign.message) : parameters.digest
@@ -393,8 +454,9 @@ export function turnkey<const client extends turnkey.Client>(
             )
 
           const turnkeyClient = await getTurnkeyClient()
-          walletAccounts = await options.loadAccounts({ client: turnkeyClient, parameters })
+          const addresses = await options.loadAccounts({ client: turnkeyClient, parameters })
           await requireSession()
+          walletAccounts = selectWalletAccounts(await fetchWalletAccounts(), addresses)
           restore_promise = undefined
 
           const digest = personalSign ? hashMessage(personalSign.message) : parameters?.digest
@@ -558,24 +620,30 @@ export declare namespace turnkey {
   type Options<client extends Client = Client> = {
     /** Existing Turnkey client, such as `TurnkeyClient` from `@turnkey/core`. */
     client: client
-    /** Creates/registers a Turnkey wallet account. UI is allowed. Defaults to `loadAccounts`. */
+    /**
+     * Creates/registers a Turnkey wallet account. UI is allowed. Defaults to `loadAccounts`.
+     * May return selected addresses; the first address is treated as active by default.
+     */
     createAccount?:
       | ((parameters: {
           /** Initialized Turnkey client. */
           client: client
           /** Provider create-account parameters. */
           parameters: Adapter.createAccount.Parameters
-        }) => Promise<WalletAccount>)
+        }) => Promise<AccountSelection>)
       | undefined
     /** Data URI of the provider icon. @default Black 1×1 SVG. */
     icon?: `data:image/${string}` | undefined
-    /** Loads/logs into existing Turnkey wallet accounts. UI is allowed. */
+    /**
+     * Loads/logs into existing Turnkey wallet accounts. UI is allowed. May return selected
+     * addresses; the first address is treated as active by default.
+     */
     loadAccounts: (parameters: {
       /** Initialized Turnkey client. */
       client: client
       /** Provider load-accounts parameters. */
       parameters?: Adapter.loadAccounts.Parameters | undefined
-    }) => Promise<readonly WalletAccount[]>
+    }) => Promise<AccountSelection>
     /** Display name of the provider. @default "Turnkey" */
     name?: string | undefined
     /** Reverse DNS identifier. @default "com.turnkey" */
@@ -583,6 +651,13 @@ export declare namespace turnkey {
     /** Milliseconds before Turnkey session expiry to proactively disconnect. @default 10000 */
     sessionSkewMs?: number | undefined
   }
+
+  /**
+   * Optional selected addresses returned from a Turnkey login/sign-up callback.
+   * When omitted, all fetched Turnkey Ethereum accounts are used. When provided,
+   * fetched accounts are ordered to match this list, and the first address is active by default.
+   */
+  type AccountSelection = readonly Address[] | void
 
   /** Minimal structural Turnkey client surface used by the adapter. */
   type Client = {
@@ -613,12 +688,14 @@ export declare namespace turnkey {
     accounts: readonly WalletAccount[]
   }
 
-  /** Minimal structural Turnkey wallet account used by the adapter. */
+  /** Minimal structural Turnkey wallet account fetched by the adapter. */
   type WalletAccount = {
     /** EVM address for the Turnkey wallet account. */
     address: string
     /** Turnkey Ethereum address format. */
     addressFormat?: 'ADDRESS_FORMAT_ETHEREUM' | undefined
+    /** Raw compressed secp256k1 public key for the Turnkey wallet account. */
+    publicKey: string
   }
 
   /** Signature parts returned by Turnkey raw-payload signing. */


### PR DESCRIPTION
## Summary
Simplify the `turnkey` adapter API by handling wallet resolution internally.

## Motivation
Apps should not need to fetch Turnkey wallets or return Turnkey wallet account objects from `loadAccounts` / `createAccount`. The adapter can own wallet fetching, public key hydration, and signing setup while app code only drives auth and optionally selects addresses.

## Changes
- Build a `TempoAccount` from fetched Turnkey wallet accounts in `src/core/adapters/turnkey.ts`
- Fetch and hydrate Turnkey Ethereum wallet accounts inside the adapter after login/sign-up callbacks
- Let `loadAccounts` / `createAccount` optionally return selected addresses; the first address is active by default
- Update the web playground and Turnkey docs examples, including default wallet creation on sign-up
- Add a patch changeset for the Turnkey adapter API simplification

## Testing
- `./node_modules/.bin/vp test src/core/adapters/turnkey.test.ts` — 18 passed
- `./node_modules/.bin/tsc -b --noEmit` — passed
- `./node_modules/.bin/tsc --noEmit` in `playgrounds/web` — passed
- `./node_modules/.bin/vp fmt src/core/adapters/turnkey.ts site/src/pages/docs/api/turnkey.mdx site/src/pages/docs/adapters/turnkey.mdx` — passed
- `git diff --check` — passed