### PR TITLE
fix(examples): use catalog viem

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -13,7 +13,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -11,7 +11,7 @@
     "accounts": "latest",
     "incur": "latest",
     "ox": "~0.14.18",
-    "viem": "^2.47.18"
+    "viem": "catalog:"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/examples/domain-bound-webauthn/package.json
+++ b/examples/domain-bound-webauthn/package.json
@@ -16,7 +16,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/examples/with-access-key-and-webauthn/package.json
+++ b/examples/with-access-key-and-webauthn/package.json
@@ -16,7 +16,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/examples/with-access-key/package.json
+++ b/examples/with-access-key/package.json
@@ -14,7 +14,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/examples/with-fee-payer-and-webauthn/package.json
+++ b/examples/with-fee-payer-and-webauthn/package.json
@@ -16,7 +16,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/examples/with-fee-payer/package.json
+++ b/examples/with-fee-payer/package.json
@@ -16,7 +16,7 @@
     "accounts": "latest",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.47.18",
+    "viem": "catalog:",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 4.3.6
       zustand:
         specifier: ^5.0.12
-        version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+        version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -141,7 +141,7 @@ importers:
         version: 5.2.0(vite@8.0.10)
       '@wagmi/core':
         specifier: ^3.4.10
-        version: 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.3.6))
+        version: 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.3.6))
       elysia:
         specifier: ^1.4.28
         version: 1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -209,11 +209,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -246,8 +246,8 @@ importers:
         specifier: ~0.14.18
         version: 0.14.18(typescript@5.9.3)(zod@4.4.3)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: latest
@@ -274,11 +274,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -323,11 +323,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -363,11 +363,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -412,11 +412,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -461,11 +461,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.47.18
-        version: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -12718,14 +12718,6 @@ snapshots:
 
   '@vue/shared@3.5.33': {}
 
-  '@wagmi/connectors@8.0.13(@wagmi/core@3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.11(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))':
-    dependencies:
-      '@wagmi/core': 3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
-      viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
-    optionalDependencies:
-      accounts: 'link:'
-      typescript: 5.9.3
-
   '@wagmi/connectors@8.0.13(@wagmi/core@3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       '@wagmi/core': 3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3))
@@ -12741,30 +12733,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.3.6)
-      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
-    optionalDependencies:
-      '@tanstack/query-core': 5.100.5
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.5
-      accounts: 'link:'
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -18444,29 +18420,6 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3)):
-    dependencies:
-      '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.13(@wagmi/core@3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.11(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.11(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
-      react: 19.2.5
-      use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@base-org/account'
-      - '@coinbase/wallet-sdk'
-      - '@metamask/connect-evm'
-      - '@safe-global/safe-apps-provider'
-      - '@safe-global/safe-apps-sdk'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@walletconnect/ethereum-provider'
-      - accounts
-      - immer
-      - porto
-
   wagmi@3.6.14(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@0e282d6(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.5(react@19.2.5)
@@ -18774,18 +18727,11 @@ snapshots:
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
 
-  zustand@5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
+  zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5)):
     optionalDependencies:
       '@types/react': 19.2.14
       immer: 11.1.4
       react: 19.2.5
-      use-sync-external-store: 1.6.0(react@19.2.5)
-
-  zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
-    optionalDependencies:
-      '@types/react': 19.2.14
-      immer: 11.1.4
-      react: 19.2.5
-      use-sync-external-store: 1.6.0(react@19.2.5)
+      use-sync-external-store: 1.4.0(react@19.2.5)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
Align examples on the workspace catalog viem dependency.

## Motivation
Examples type-check against local accounts source, which uses the workspace catalog viem build. Installing a separate registry viem copy makes TypeScript compare incompatible viem Client and Account types.

## Changes
- Change example package manifests from registry viem ranges to catalog:.
- Update pnpm-lock.yaml so wagmi and example imports resolve through the catalog viem build.

## Testing
- CI=true pnpm check:types