### PR TITLE
fix(ci): avoid nested pnpm in example postinstalls

### DIFF
--- a/examples/domain-bound-webauthn/package.json
+++ b/examples/domain-bound-webauthn/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "pnpm gen:types",
+    "postinstall": "wrangler types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },

--- a/examples/with-access-key-and-webauthn/package.json
+++ b/examples/with-access-key-and-webauthn/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "pnpm gen:types",
+    "postinstall": "wrangler types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },

--- a/examples/with-fee-payer-and-webauthn/package.json
+++ b/examples/with-fee-payer-and-webauthn/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "[ -f .env ] || cp .env.example .env && pnpm gen:types",
+    "postinstall": "[ -f .env ] || cp .env.example .env && wrangler types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },

--- a/examples/with-fee-payer/package.json
+++ b/examples/with-fee-payer/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "[ -f .env ] || cp .env.example .env && pnpm gen:types",
+    "postinstall": "[ -f .env ] || cp .env.example .env && wrangler types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },


### PR DESCRIPTION
## Summary
Avoid nested pnpm calls from example postinstall scripts during CI typecheck.

## Motivation
`pnpm -r --if-present check:types` can trigger pnpm's dependency status check, which re-runs workspace postinstall scripts. The example postinstalls shelling back into `pnpm gen:types` can race with root `zile dev` linking and intermittently fail while parsing `package.json`.

## Changes
- Replace `pnpm gen:types` with `wrangler types` in WebAuthn example postinstall scripts.
- Keep `.env` bootstrap behavior for fee-payer examples.
- Leave explicit `gen:types` scripts in place for manual use.

## Testing
`pnpm -r --if-present check:types`

Passed. The lifecycle output showed the affected examples running `wrangler types` directly before typechecks completed.