### PR TITLE
feat: default `mpp` to true in Provider.create

### DIFF
--- a/.changeset/default-mpp-true.md
+++ b/.changeset/default-mpp-true.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Changed the default value of `mpp` on `Provider.create` to `true`. Machine Payment Protocol (mppx) support is now enabled by default -- pass `mpp: false` to opt out.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -235,15 +235,15 @@ const provider = Provider.create({
 ### mpp
 
 - **Type:** `boolean | Provider.mpp.Options`
-- **Default:** `false`
+- **Default:** `true`
 
-Enable [Machine Payment Protocol](https://mpp.dev) (mppx) support. Pass `true` to enable with defaults, or an options object to configure.
+Enable [Machine Payment Protocol](https://mpp.dev) (mppx) support. Enabled by default — pass an options object to configure, or `false` to disable.
 
 ```ts twoslash
 import { Provider } from 'accounts'
 
 const provider = Provider.create({
-  mpp: true, // [!code focus]
+  mpp: false, // [!code focus]
 })
 ```
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -911,9 +911,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     }
   }
 
-  if (options.mpp) {
-    const mppOptions = typeof options.mpp === 'object' ? options.mpp : {}
-    const { mode = 'push' } = mppOptions
+  const mpp = (() => {
+    if (options.mpp === false) return undefined
+    if (typeof options.mpp === 'object') return options.mpp
+    return {}
+  })()
+  if (mpp) {
+    const { mode = 'push' } = mpp
     Mppx.create({
       methods: [
         mppx_tempo({
@@ -967,9 +971,9 @@ export declare namespace create {
     /**
      * Enable Machine Payment Protocol (mppx) support.
      *
-     * Pass `true` to enable with defaults, or an options object to configure.
+     * Pass an options object to configure, or `false` to disable.
      *
-     * @default false
+     * @default true
      */
     mpp?: boolean | mpp.Options | undefined
     /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */


### PR DESCRIPTION
Defaults `mpp` to `true` on `Provider.create` so Machine Payment Protocol (mppx) support is enabled out of the box. Pass `mpp: false` to opt out.

- `src/core/Provider.ts`: normalize `options.mpp` so `undefined` and `true` both enable mppx (`mode: 'push'`); only `false` disables. JSDoc default updated to `true`.
- `site/src/pages/docs/api/provider.mdx`: updated default + example to show opt-out.
- `.changeset/default-mpp-true.md`: minor changeset.

The CLI Provider keeps its own normalization, so `cli.Provider` defaults stay unchanged (off by default, `mode: 'pull'` when enabled).