### PR TITLE
refactor(examples): use hono in worker entrypoints

### DIFF
--- a/examples/domain-bound-webauthn/package.json
+++ b/examples/domain-bound-webauthn/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "latest",
+    "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "^2.47.18",

--- a/examples/domain-bound-webauthn/worker/index.ts
+++ b/examples/domain-bound-webauthn/worker/index.ts
@@ -1,14 +1,16 @@
 import { Handler, Kv } from 'accounts/server'
+import { Hono } from 'hono'
 
-export default {
-  async fetch(request, env) {
-    const url = new URL(request.url)
-    const handler = Handler.webAuthn({
-      kv: Kv.cloudflare(env.KV),
-      origin: url.origin,
-      rpId: url.hostname,
-      path: '/auth',
-    })
-    return handler.fetch(request)
-  },
-} satisfies ExportedHandler<Cloudflare.Env>
+const app = new Hono<{ Bindings: Cloudflare.Env }>()
+
+app.all('/auth/*', (c) => {
+  const url = new URL(c.req.url)
+  return Handler.webAuthn({
+    kv: Kv.cloudflare(c.env.KV),
+    origin: url.origin,
+    rpId: url.hostname,
+    path: '/auth',
+  }).fetch(c.req.raw)
+})
+
+export default app

--- a/examples/with-access-key-and-webauthn/package.json
+++ b/examples/with-access-key-and-webauthn/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "latest",
+    "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "^2.47.18",

--- a/examples/with-access-key-and-webauthn/worker/index.ts
+++ b/examples/with-access-key-and-webauthn/worker/index.ts
@@ -1,14 +1,16 @@
 import { Handler, Kv } from 'accounts/server'
+import { Hono } from 'hono'
 
-export default {
-  async fetch(request, env) {
-    const url = new URL(request.url)
-    const handler = Handler.webAuthn({
-      kv: Kv.cloudflare(env.KV),
-      origin: url.origin,
-      rpId: url.hostname,
-      path: '/auth',
-    })
-    return handler.fetch(request)
-  },
-} satisfies ExportedHandler<Cloudflare.Env>
+const app = new Hono<{ Bindings: Cloudflare.Env }>()
+
+app.all('/auth/*', (c) => {
+  const url = new URL(c.req.url)
+  return Handler.webAuthn({
+    kv: Kv.cloudflare(c.env.KV),
+    origin: url.origin,
+    rpId: url.hostname,
+    path: '/auth',
+  }).fetch(c.req.raw)
+})
+
+export default app

--- a/examples/with-fee-payer-and-webauthn/package.json
+++ b/examples/with-fee-payer-and-webauthn/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "latest",
+    "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "^2.47.18",

--- a/examples/with-fee-payer-and-webauthn/worker/index.ts
+++ b/examples/with-fee-payer-and-webauthn/worker/index.ts
@@ -1,23 +1,26 @@
 import { Handler, Kv } from 'accounts/server'
+import { Hono } from 'hono'
 import { privateKeyToAccount } from 'viem/accounts'
 
-export default {
-  async fetch(request, env) {
-    const url = new URL(request.url)
-    const handler = Handler.compose([
-      Handler.relay({
-        feePayer: {
-          account: privateKeyToAccount(env.FEE_PAYER_PRIVATE_KEY),
-        },
-        path: '/relay',
-      }),
-      Handler.webAuthn({
-        kv: Kv.cloudflare(env.KV),
-        origin: url.origin,
-        rpId: url.hostname,
-        path: '/auth',
-      }),
-    ])
-    return handler.fetch(request)
-  },
-} satisfies ExportedHandler<Cloudflare.Env>
+const app = new Hono<{ Bindings: Cloudflare.Env }>()
+
+app.all('/relay/*', (c) =>
+  Handler.relay({
+    feePayer: {
+      account: privateKeyToAccount(c.env.FEE_PAYER_PRIVATE_KEY),
+    },
+    path: '/relay',
+  }).fetch(c.req.raw),
+)
+
+app.all('/auth/*', (c) => {
+  const url = new URL(c.req.url)
+  return Handler.webAuthn({
+    kv: Kv.cloudflare(c.env.KV),
+    origin: url.origin,
+    rpId: url.hostname,
+    path: '/auth',
+  }).fetch(c.req.raw)
+})
+
+export default app

--- a/examples/with-fee-payer/package.json
+++ b/examples/with-fee-payer/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "latest",
+    "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "^2.47.18",

--- a/examples/with-fee-payer/worker/index.ts
+++ b/examples/with-fee-payer/worker/index.ts
@@ -1,14 +1,16 @@
 import { Handler } from 'accounts/server'
+import { Hono } from 'hono'
 import { privateKeyToAccount } from 'viem/accounts'
 
-export default {
-  async fetch(request, env) {
-    const handler = Handler.relay({
-      feePayer: {
-        account: privateKeyToAccount(env.FEE_PAYER_PRIVATE_KEY),
-      },
-      path: '/relay',
-    })
-    return handler.fetch(request)
-  },
-} satisfies ExportedHandler<Cloudflare.Env>
+const app = new Hono<{ Bindings: Cloudflare.Env }>()
+
+app.all('/relay/*', (c) =>
+  Handler.relay({
+    feePayer: {
+      account: privateKeyToAccount(c.env.FEE_PAYER_PRIVATE_KEY),
+    },
+    path: '/relay',
+  }).fetch(c.req.raw),
+)
+
+export default app

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       accounts:
         specifier: workspace:*
         version: link:../..
+      hono:
+        specifier: ^4
+        version: 4.12.18
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -354,6 +357,9 @@ importers:
       accounts:
         specifier: workspace:*
         version: link:../..
+      hono:
+        specifier: ^4
+        version: 4.12.18
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -403,6 +409,9 @@ importers:
       accounts:
         specifier: workspace:*
         version: link:../..
+      hono:
+        specifier: ^4
+        version: 4.12.18
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -452,6 +461,9 @@ importers:
       accounts:
         specifier: workspace:*
         version: link:../..
+      hono:
+        specifier: ^4
+        version: 4.12.18
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -12684,9 +12696,9 @@ snapshots:
 
   '@vue/shared@3.5.33': {}
 
-  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       accounts: 'link:'
@@ -12699,12 +12711,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
-      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.5
       accounts: 'link:'
@@ -18372,8 +18384,8 @@ snapshots:
   wagmi@3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)


### PR DESCRIPTION
Wraps each example worker in a Hono app and delegates to the underlying `accounts/server` `Handler.*` via `.fetch(c.req.raw)`. This matches the pattern used in [Handler.test.ts](https://github.com/tempoxyz/accounts/blob/main/src/server/Handler.test.ts#L350-L378) and gives consumers a host Hono app to attach extra routes/middleware around the accounts handlers.

## Changes

- Adds `hono: ^4` to deps in: `domain-bound-webauthn`, `with-access-key-and-webauthn`, `with-fee-payer`, `with-fee-payer-and-webauthn`.
- Rewrites each `worker/index.ts` from `export default { fetch }` to `export default app` where `app = new Hono<{ Bindings: Cloudflare.Env }>()` and routes are mounted with `app.all('/<path>/*', (c) => Handler.x({...}).fetch(c.req.raw))`.

## Verification

- `pnpm install` clean.
- `pnpm check:types` passes in all four examples.
- Behaviour-preserving: same paths (`/auth`, `/relay`), same handler config.