### PR TITLE
feat(examples): add with-auth example using Handler.auth + tempoWallet

### DIFF
--- a/.changeset/kv-durable-object-namespace-type.md
+++ b/.changeset/kv-durable-object-namespace-type.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Relaxed the `id` parameter on `Kv.durableObject.Namespace.get` from `unknown` to `any` so Cloudflare's `DurableObjectNamespace<T>` is structurally assignable without an intermediate cast at the call site.

--- a/.changeset/with-auth-example.md
+++ b/.changeset/with-auth-example.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Defaulted `Handler.auth({ trustProxy })` to `true` on Cloudflare Workers and appended a `trustProxy` / `origin` hint to "domain mismatch" / "uri mismatch" errors raised from `wallet_connect`.

--- a/.changeset/with-auth-example.md
+++ b/.changeset/with-auth-example.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Defaulted `Handler.auth({ trustProxy })` to `true` on Cloudflare Workers and appended a `trustProxy` / `origin` hint to "domain mismatch" / "uri mismatch" errors raised from `wallet_connect`.

--- a/examples/with-auth/.env.example
+++ b/examples/with-auth/.env.example
@@ -1,0 +1,2 @@
+# No environment variables required for the with-auth example.
+# Handler.auth uses an in-memory session store by default.

--- a/examples/with-auth/.env.example
+++ b/examples/with-auth/.env.example
@@ -1,2 +1,0 @@
-# No environment variables required for the with-auth example.
-# Handler.auth uses an in-memory session store by default.

--- a/examples/with-auth/.gitignore
+++ b/examples/with-auth/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.local
+.wrangler
+.dev.vars*
+.env
+worker-configuration.d.ts

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -19,9 +19,3 @@ A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connectio
 is created automatically during development so the wallet iframe can reach the
 local auth endpoint (required due to Chrome's
 [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) policy).
-
-> [!NOTE]
-> In production, set `tempoWallet({ auth: '/auth' })` to your deployed worker
-> URL — no tunnel needed. The default `Handler.auth` session store is
-> in-memory; use [`Kv.durableObject`](https://docs.tempo.xyz/accounts/server/kv.durableObject)
-> for production deployments on Cloudflare Workers.

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -1,0 +1,27 @@
+# With Auth Example
+
+Demonstrates server-side session authentication using `Handler.auth` from
+`accounts/server` and the `auth` capability on `tempoWallet`.
+
+The wallet signs a SIWE-style challenge during `wallet_connect`, the worker
+verifies it, and the SDK is issued a `Set-Cookie` session that authenticates
+follow-up requests like `GET /me`.
+
+## Setup
+
+```bash
+npx gitpick tempoxyz/accounts/examples/with-auth
+npm i
+npm dev
+```
+
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/)
+is created automatically during development so the wallet iframe can reach the
+local auth endpoint (required due to Chrome's
+[Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) policy).
+
+> [!NOTE]
+> In production, set `tempoWallet({ auth: '/auth' })` to your deployed worker
+> URL — no tunnel needed. The default `Handler.auth` session store is
+> in-memory; use [`Kv.durableObject`](https://docs.tempo.xyz/accounts/server/kv.durableObject)
+> for production deployments on Cloudflare Workers.

--- a/examples/with-auth/env.d.ts
+++ b/examples/with-auth/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite-plugin-cloudflare-tunnel/virtual" />
+
+declare namespace Cloudflare {
+  interface Env {}
+}

--- a/examples/with-auth/index.html
+++ b/examples/with-auth/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wagmi + Tempo Wallet — Server Auth</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "with-auth-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "check:types": "tsc -b --noEmit",
+    "dev": "vp dev",
+    "gen:types": "wrangler types",
+    "postinstall": "[ -f .env ] || cp .env.example .env && pnpm gen:types",
+    "build": "tsc -b && vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "latest",
+    "accounts": "latest",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "viem": "^2.47.18",
+    "wagmi": "latest"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "catalog:",
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "latest",
+    "typescript": "~5.9.3",
+    "vite-plugin-cloudflare-tunnel": "^1.0.12",
+    "vite-plus": "latest",
+    "wrangler": "^4.82.2"
+  }
+}

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "latest",
+    "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "^2.47.18",

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "[ -f .env ] || cp .env.example .env && pnpm gen:types",
+    "postinstall": "pnpm gen:types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },

--- a/examples/with-auth/src/App.tsx
+++ b/examples/with-auth/src/App.tsx
@@ -82,9 +82,11 @@ function ServerAuth() {
     <div>
       <p>
         The wallet signs a SIWE challenge during connect (because{' '}
-        <code>tempoWallet({'{'} auth {'}'})</code> is set). The server issues an{' '}
-        <code>accounts_auth</code> session cookie, which authenticates calls to{' '}
-        <code>GET /me</code>. <strong>Disconnect</strong> calls{' '}
+        <code>
+          tempoWallet({'{'} auth {'}'})
+        </code>{' '}
+        is set). The server issues an <code>accounts_auth</code> session cookie, which authenticates
+        calls to <code>GET /me</code>. <strong>Disconnect</strong> calls{' '}
         <code>POST /auth/logout</code> automatically.
       </p>
       <div style={{ display: 'flex', gap: 8 }}>

--- a/examples/with-auth/src/App.tsx
+++ b/examples/with-auth/src/App.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { stringify } from 'viem'
+import { useConnect, useConnection, useConnectors, useDisconnect } from 'wagmi'
+
+export default function App() {
+  const { address, chainId, status } = useConnection()
+  return (
+    <div>
+      <h1>Wagmi + Tempo Wallet (with Server Auth)</h1>
+
+      <h2>Connection</h2>
+      <pre>
+        {stringify({ address: address ?? null, chainId: chainId ?? null, status }, null, 2)}
+      </pre>
+
+      <h2>Connect</h2>
+      <Connect />
+
+      <h2>Server Authentication</h2>
+      <ServerAuth />
+    </div>
+  )
+}
+
+function Connect() {
+  const { mutate: connect, status, error } = useConnect()
+  const { mutate: disconnect } = useDisconnect()
+  const { address } = useConnection()
+  const connectors = useConnectors()
+  const connector = connectors[0]
+
+  if (!connector) return null
+
+  return (
+    <div>
+      {address ? (
+        <button type="button" onClick={() => disconnect()}>
+          Disconnect
+        </button>
+      ) : (
+        <button type="button" onClick={() => connect({ connector })}>
+          Login
+        </button>
+      )}
+      <div>{status}</div>
+      {error && <pre style={{ color: 'red' }}>{error.message}</pre>}
+    </div>
+  )
+}
+
+function ServerAuth() {
+  type State =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'success'; data: unknown }
+    | { status: 'error'; status_code: number; error: string }
+
+  const { address } = useConnection()
+  const [me, setMe] = useState<State>({ status: 'idle' })
+
+  async function fetchMe() {
+    setMe({ status: 'loading' })
+    try {
+      const res = await fetch('/me', { credentials: 'include' })
+      const data = await res.json()
+      if (!res.ok)
+        return setMe({ status: 'error', status_code: res.status, error: stringify(data) })
+      setMe({ status: 'success', data })
+    } catch (error) {
+      setMe({ status: 'error', status_code: 0, error: (error as Error).message })
+    }
+  }
+
+  // Re-fetch the session whenever the connected address changes
+  // (login → 200 with new address; disconnect → 401 because
+  // `wallet_disconnect` already POSTed to `/auth/logout` for us).
+  useEffect(() => {
+    fetchMe()
+  }, [address])
+
+  return (
+    <div>
+      <p>
+        The wallet signs a SIWE challenge during connect (because{' '}
+        <code>tempoWallet({'{'} auth {'}'})</code> is set). The server issues an{' '}
+        <code>accounts_auth</code> session cookie, which authenticates calls to{' '}
+        <code>GET /me</code>. <strong>Disconnect</strong> calls{' '}
+        <code>POST /auth/logout</code> automatically.
+      </p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={fetchMe} disabled={me.status === 'loading'}>
+          GET /me
+        </button>
+      </div>
+      {me.status === 'success' && <pre>{stringify(me.data, null, 2)}</pre>}
+      {me.status === 'error' && (
+        <pre style={{ color: 'red' }}>
+          {me.status_code} {me.error}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/examples/with-auth/src/config.ts
+++ b/examples/with-auth/src/config.ts
@@ -2,7 +2,7 @@ import { createConfig, http } from 'wagmi'
 import { tempo, tempoModerato } from 'wagmi/chains'
 import { tempoWallet } from 'wagmi/connectors'
 
-const authUrl = await (async () => {
+const auth = await (async () => {
   if (import.meta.env.MODE === 'development') {
     const { getTunnelUrl } = await import('virtual:vite-plugin-cloudflare-tunnel')
     return `${getTunnelUrl()}/auth`
@@ -12,7 +12,7 @@ const authUrl = await (async () => {
 
 export const config = createConfig({
   chains: [tempoModerato, tempo],
-  connectors: [tempoWallet({ auth: authUrl })],
+  connectors: [tempoWallet({ auth })],
   multiInjectedProviderDiscovery: false,
   transports: {
     [tempo.id]: http(),

--- a/examples/with-auth/src/config.ts
+++ b/examples/with-auth/src/config.ts
@@ -1,0 +1,27 @@
+import { createConfig, http } from 'wagmi'
+import { tempo, tempoModerato } from 'wagmi/chains'
+import { tempoWallet } from 'wagmi/connectors'
+
+const authUrl = await (async () => {
+  if (import.meta.env.MODE === 'development') {
+    const { getTunnelUrl } = await import('virtual:vite-plugin-cloudflare-tunnel')
+    return `${getTunnelUrl()}/auth`
+  }
+  return '/auth'
+})()
+
+export const config = createConfig({
+  chains: [tempo, tempoModerato],
+  connectors: [tempoWallet({ testnet: true, auth: authUrl })],
+  multiInjectedProviderDiscovery: false,
+  transports: {
+    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
+  },
+})
+
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}

--- a/examples/with-auth/src/config.ts
+++ b/examples/with-auth/src/config.ts
@@ -11,8 +11,8 @@ const authUrl = await (async () => {
 })()
 
 export const config = createConfig({
-  chains: [tempo, tempoModerato],
-  connectors: [tempoWallet({ testnet: true, auth: authUrl })],
+  chains: [tempoModerato, tempo],
+  connectors: [tempoWallet({ auth: authUrl })],
   multiInjectedProviderDiscovery: false,
   transports: {
     [tempo.id]: http(),

--- a/examples/with-auth/src/main.tsx
+++ b/examples/with-auth/src/main.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { WagmiProvider } from 'wagmi'
+
+import App from './App.js'
+import { config } from './config.js'
+
+const queryClient = new QueryClient()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </WagmiProvider>
+  </StrictMode>,
+)

--- a/examples/with-auth/tsconfig.app.json
+++ b/examples/with-auth/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vp/client"],
+    "skipLibCheck": true,
+    "customConditions": ["src"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src", "worker", "env.d.ts", "worker-configuration.d.ts"]
+}

--- a/examples/with-auth/tsconfig.json
+++ b/examples/with-auth/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/examples/with-auth/tsconfig.node.json
+++ b/examples/with-auth/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/with-auth/vite.config.ts
+++ b/examples/with-auth/vite.config.ts
@@ -1,0 +1,18 @@
+import { cloudflare } from '@cloudflare/vite-plugin'
+import react from '@vitejs/plugin-react'
+import tunnel from 'vite-plugin-cloudflare-tunnel'
+import { defineConfig } from 'vp'
+
+export default defineConfig({
+  plugins: [react(), cloudflare(), tunnel()],
+  server: {
+    // Use a fixed, less-common port. The cloudflare tunnel plugin's
+    // port-conflict fallback leaves `globalState.tunnelUrl` undefined,
+    // which breaks the `auth` URL on first load.
+    port: 5180,
+    strictPort: true,
+    cors: {
+      origin: '*',
+    },
+  },
+})

--- a/examples/with-auth/worker/index.ts
+++ b/examples/with-auth/worker/index.ts
@@ -1,22 +1,33 @@
-import { Handler } from 'accounts/server'
+import { Handler, Kv } from 'accounts/server'
+import { env } from 'cloudflare:workers'
+import { Hono } from 'hono'
+
+// Re-export the reference Durable Object class so wrangler can wire it up.
+export const NonceStorage = Kv.NonceStorage
 
 // `trustProxy` defaults to `true` on Cloudflare Workers because the runtime
 // is always edge-fronted (Cloudflare Tunnel in dev, Cloudflare's edge in
 // prod sets `x-forwarded-proto: https`).
-const auth = Handler.auth({ path: '/auth' })
+//
+// `Kv.durableObject(env.NONCE_DO)` gives the auth handler a linearizable
+// store for one-time-consume SIWE challenge nonces and issued sessions
+// across concurrent worker instances.
+const auth = Handler.auth({
+  path: '/auth',
+  store: Kv.durableObject(env.NONCE_DO),
+})
 
-export default {
-  async fetch(request) {
-    const url = new URL(request.url)
+const app = new Hono()
 
-    // Reads the SIWE-issued session and returns the connected address.
-    // Demonstrates how an authenticated endpoint consumes Handler.auth.
-    if (url.pathname === '/me') {
-      const session = await auth.getSession(request)
-      if (!session) return Response.json({ error: 'unauthenticated' }, { status: 401 })
-      return Response.json({ address: session.address, chainId: session.chainId })
-    }
+app.all('/auth', (c) => auth.fetch(c.req.raw))
+app.all('/auth/*', (c) => auth.fetch(c.req.raw))
 
-    return auth.fetch(request)
-  },
-} satisfies ExportedHandler<Cloudflare.Env>
+// Reads the SIWE-issued session and returns the connected address.
+// Demonstrates how an authenticated endpoint consumes Handler.auth.
+app.get('/me', async (c) => {
+  const session = await auth.getSession(c.req.raw)
+  if (!session) return c.json({ error: 'unauthenticated' }, 401)
+  return c.json({ address: session.address, chainId: session.chainId })
+})
+
+export default app

--- a/examples/with-auth/worker/index.ts
+++ b/examples/with-auth/worker/index.ts
@@ -1,0 +1,22 @@
+import { Handler } from 'accounts/server'
+
+// `trustProxy` defaults to `true` on Cloudflare Workers because the runtime
+// is always edge-fronted (Cloudflare Tunnel in dev, Cloudflare's edge in
+// prod sets `x-forwarded-proto: https`).
+const auth = Handler.auth({ path: '/auth' })
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url)
+
+    // Reads the SIWE-issued session and returns the connected address.
+    // Demonstrates how an authenticated endpoint consumes Handler.auth.
+    if (url.pathname === '/me') {
+      const session = await auth.getSession(request)
+      if (!session) return Response.json({ error: 'unauthenticated' }, { status: 401 })
+      return Response.json({ address: session.address, chainId: session.chainId })
+    }
+
+    return auth.fetch(request)
+  },
+} satisfies ExportedHandler<Cloudflare.Env>

--- a/examples/with-auth/wrangler.jsonc
+++ b/examples/with-auth/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "with-auth",
+  "compatibility_date": "2026-03-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
+  "assets": {
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/auth", "/auth/*", "/me"],
+  },
+}

--- a/examples/with-auth/wrangler.jsonc
+++ b/examples/with-auth/wrangler.jsonc
@@ -8,4 +8,8 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/auth", "/auth/*", "/me"],
   },
+  "durable_objects": {
+    "bindings": [{ "name": "NONCE_DO", "class_name": "NonceStorage" }],
+  },
+  "migrations": [{ "tag": "v1", "new_classes": ["NonceStorage"] }],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       accounts:
         specifier: workspace:*
         version: link:../..
+      hono:
+        specifier: ^4
+        version: 4.12.18
       react:
         specifier: ^19.2.5
         version: 19.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 5.2.0(vite@8.0.10)
       '@wagmi/core':
         specifier: ^3.4.10
-        version: 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
+        version: 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       elysia:
         specifier: ^1.4.28
         version: 1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -187,7 +187,7 @@ importers:
         version: vite-plus@0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
       wagmi:
         specifier: ^3.6.12
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       zile:
         specifier: ^0.0.25
         version: 0.0.25(typescript@5.9.3)
@@ -211,7 +211,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -227,7 +227,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: latest
-        version: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-mkcert:
         specifier: ^2.0.0
         version: 2.0.0(vite@8.0.10)
@@ -276,7 +276,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -325,7 +325,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -344,7 +344,7 @@ importers:
         version: 2.0.0(vite@8.0.10)
       vite-plus:
         specifier: ~0.1.18
-        version: 0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+        version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
 
   examples/with-access-key-and-webauthn:
     dependencies:
@@ -365,7 +365,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -395,6 +395,55 @@ importers:
         specifier: ^4.85.0
         version: 4.85.0
 
+  examples/with-auth:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: latest
+        version: 5.100.10(react@19.2.5)
+      accounts:
+        specifier: workspace:*
+        version: link:../..
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      viem:
+        specifier: ^2.48.8
+        version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
+      wagmi:
+        specifier: latest
+        version: 3.6.14(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 'catalog:'
+        version: 1.33.2(vite@8.0.10)(workerd@1.20260424.1)(wrangler@4.85.0)
+      '@types/node':
+        specifier: latest
+        version: 25.7.0
+      '@types/react':
+        specifier: latest
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: latest
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: latest
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite-plugin-cloudflare-tunnel:
+        specifier: ^1.0.12
+        version: 1.0.12(vite@8.0.10)
+      vite-plus:
+        specifier: ~0.1.18
+        version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+      wrangler:
+        specifier: ^4.85.0
+        version: 4.85.0
+
   examples/with-fee-payer:
     dependencies:
       '@tanstack/react-query':
@@ -414,7 +463,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -463,7 +512,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -564,7 +613,7 @@ importers:
         version: 2.48.8(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -644,7 +693,7 @@ importers:
         version: 23.0.1(@svgr/core@8.1.0(typescript@5.9.3))(@vue/compiler-sfc@3.5.33)
       vp:
         specifier: npm:vite-plus@~0.1.18
-        version: vite-plus@0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+        version: vite-plus@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
       wrangler:
         specifier: ^4.85.0
         version: 4.85.0
@@ -714,7 +763,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@tanstack/router-plugin':
         specifier: ^1.167.20
@@ -733,7 +782,7 @@ importers:
         version: 5.9.3
       vp:
         specifier: npm:vite-plus@~0.1.18
-        version: vite-plus@0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+        version: vite-plus@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
 
   site:
     dependencies:
@@ -781,7 +830,7 @@ importers:
         version: https://pkg.pr.new/wevm/vocs@dc18ab3(patch_hash=0749dd43af96e1423a849f589c6b765ac71042c00b84c5d521e0af05bf159b6e)(@cfworker/json-schema@4.1.1)(@tanstack/react-router@1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(@vue/compiler-sfc@3.5.33)(mermaid@11.15.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.10)(waku@1.0.0-alpha.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(babel-plugin-react-compiler@1.0.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
       waku:
         specifier: 1.0.0-alpha.10
         version: 1.0.0-alpha.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(babel-plugin-react-compiler@1.0.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -3538,8 +3587,16 @@ packages:
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/query-core@5.100.10':
+    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
+
   '@tanstack/query-core@5.100.5':
     resolution: {integrity: sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==}
+
+  '@tanstack/react-query@5.100.10':
+    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
+    peerDependencies:
+      react: ^19.2.5
 
   '@tanstack/react-query@5.100.5':
     resolution: {integrity: sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==}
@@ -3850,6 +3907,9 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/node@25.7.0':
+    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -4165,8 +4225,57 @@ packages:
       typescript:
         optional: true
 
+  '@wagmi/connectors@8.0.13':
+    resolution: {integrity: sha512-uRWutZygoX5K1Vk4svKeMxmyeTEjdZn8f/+EDKQEQaFMvy6yMVlLpy5DKFK0NRjtTIinRrqVccDqJQYCcC62hw==}
+    peerDependencies:
+      '@base-org/account': ^2.5.1
+      '@coinbase/wallet-sdk': ^4.3.6
+      '@metamask/connect-evm': ^1.0.0
+      '@safe-global/safe-apps-provider': ~0.18.6
+      '@safe-global/safe-apps-sdk': ^9.1.0
+      '@wagmi/core': 3.4.11
+      '@walletconnect/ethereum-provider': ^2.21.1
+      accounts: workspace:*
+      porto: ~0.2.35
+      typescript: '>=5.7.3'
+      viem: ^2.48.8
+    peerDependenciesMeta:
+      '@base-org/account':
+        optional: true
+      '@coinbase/wallet-sdk':
+        optional: true
+      '@metamask/connect-evm':
+        optional: true
+      '@safe-global/safe-apps-provider':
+        optional: true
+      '@safe-global/safe-apps-sdk':
+        optional: true
+      '@walletconnect/ethereum-provider':
+        optional: true
+      accounts:
+        optional: true
+      porto:
+        optional: true
+      typescript:
+        optional: true
+
   '@wagmi/core@3.4.10':
     resolution: {integrity: sha512-WDgJ/IRCBF3PI/JHfa9fubIms+xz4SlmLNoLdFYzEONrbaDWxtoN3L4GuW5FOG8yH+eNB5nSp7yYZP5cEgIqSQ==}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      accounts: workspace:*
+      typescript: '>=5.7.3'
+      viem: ^2.48.8
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+      accounts:
+        optional: true
+      typescript:
+        optional: true
+
+  '@wagmi/core@3.4.11':
+    resolution: {integrity: sha512-dmrZr0fKxCmG3pyWO9//oYtE5cgWRrgaQjC0+jX6IiuufE4MSW7gSL2MKdK8bvT3jg4Ra8cdRIJpveHJSHKdNw==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       accounts: workspace:*
@@ -8366,6 +8475,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici-types@7.21.0:
+    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
@@ -8730,6 +8842,17 @@ packages:
 
   wagmi@3.6.12:
     resolution: {integrity: sha512-EivDCxZmVde4nUF+Bhc+VZGcly6fM71QpHMDv76s7+iR+oBDqHi8+LJApaB6TxtcxJciHLbAkcplrzRNEqlgmg==}
+    peerDependencies:
+      '@tanstack/react-query': '>=5.0.0'
+      react: ^19.2.5
+      typescript: '>=5.7.3'
+      viem: ^2.48.8
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  wagmi@3.6.14:
+    resolution: {integrity: sha512-kHRaaD9DeFaUN6WcVMEKApTwVwImt0fGINh04Z4WYXLJhkb0rBxG4js+3t8EzXsV/veec5dV90j7jfGwjGSsqQ==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.5
@@ -9775,7 +9898,7 @@ snapshots:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
       miniflare: 4.20260424.0
       unenv: 2.0.0-rc.24
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       wrangler: 4.85.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -11613,7 +11736,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -11832,7 +11955,7 @@ snapshots:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@takumi-rs/core-darwin-arm64@0.62.8':
     optional: true
@@ -11881,7 +12004,14 @@ snapshots:
 
   '@tanstack/history@1.161.6': {}
 
+  '@tanstack/query-core@5.100.10': {}
+
   '@tanstack/query-core@5.100.5': {}
+
+  '@tanstack/react-query@5.100.10(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.10
+      react: 19.2.5
 
   '@tanstack/react-query@5.100.5(react@19.2.5)':
     dependencies:
@@ -11948,7 +12078,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       webpack: 5.106.2(esbuild@0.27.7)
     transitivePeerDependencies:
       - supports-color
@@ -11984,7 +12114,7 @@ snapshots:
 
   '@turnkey/api-key-stamper@0.6.3':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@turnkey/crypto': 2.8.12
       '@turnkey/encoding': 0.6.0
       sha256-uint8array: 0.10.7
@@ -12314,6 +12444,10 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/node@25.7.0':
+    dependencies:
+      undici-types: 7.21.0
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -12380,7 +12514,7 @@ snapshots:
       '@vitejs/devtools-rpc': 0.1.15(typescript@5.9.3)
       birpc: 4.0.0
       ohash: 2.0.11
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12474,7 +12608,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.1
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
       ws: 8.20.0
     transitivePeerDependencies:
@@ -12529,7 +12663,7 @@ snapshots:
   '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -12557,6 +12691,24 @@ snapshots:
       postcss: 8.5.14
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitejs/devtools': 0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.10)
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      publint: 0.3.18
+      terser: 5.46.2
+      tsx: 4.21.0
+      typescript: 5.9.3
+      yaml: 2.8.3
+
+  '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+    dependencies:
+      '@oxc-project/runtime': 0.124.0
+      '@oxc-project/types': 0.124.0
+      lightningcss: 1.32.0
+      postcss: 8.5.14
+    optionalDependencies:
+      '@types/node': 25.7.0
       '@vitejs/devtools': 0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.10)
       esbuild: 0.27.7
       fsevents: 2.3.3
@@ -12603,6 +12755,45 @@ snapshots:
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - yaml
+
+  '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.2
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      ws: 8.20.0
+    optionalDependencies:
+      '@types/node': 25.7.0
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -12684,29 +12875,37 @@ snapshots:
 
   '@vue/shared@3.5.33': {}
 
-  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       accounts: 'link:'
       typescript: 5.9.3
 
-  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       viem: 2.48.8(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.13(@wagmi/core@3.4.11(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      '@wagmi/core': 3.4.11(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
+    optionalDependencies:
+      accounts: 'link:'
+      typescript: 5.9.3
+
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
-      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
-      '@tanstack/query-core': 5.100.5
+      '@tanstack/query-core': 5.100.10
       accounts: 'link:'
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12715,14 +12914,14 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.48.8(typescript@5.9.3)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
-      '@tanstack/query-core': 5.100.5
+      '@tanstack/query-core': 5.100.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -12730,14 +12929,30 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.48.8(typescript@5.9.3)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
-      '@tanstack/query-core': 5.100.5
+      '@tanstack/query-core': 5.100.10
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.11(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.9.3)
+      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.100.10
+      accounts: 'link:'
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -15137,7 +15352,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -17963,6 +18178,8 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  undici-types@7.21.0: {}
+
   undici@7.24.8: {}
 
   undici@7.25.0: {}
@@ -18171,7 +18388,7 @@ snapshots:
     dependencies:
       cloudflared: 0.7.1
       dotenv: 16.6.1
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       zod: 4.3.6
 
   vite-plugin-mkcert@2.0.0(vite@8.0.10):
@@ -18179,7 +18396,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       supports-color: 10.2.2
       undici: 8.1.0
-      vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-plugin-wasm@3.6.0(vite@8.0.10):
     dependencies:
@@ -18232,6 +18449,53 @@ snapshots:
       - vite
       - yaml
 
+  vite-plus@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3):
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+      oxfmt: 0.45.0
+      oxlint: 1.60.0(oxlint-tsgolint@0.20.0)
+      oxlint-tsgolint: 0.20.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.18
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.18
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.18
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.18
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.18
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.18
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.18
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.18
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - vite
+      - yaml
+
   vite@8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -18241,6 +18505,23 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitejs/devtools': 0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.10)
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vite@8.0.10(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.7.0
       '@vitejs/devtools': 0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.10)
       esbuild: 0.27.7
       fsevents: 2.3.3
@@ -18369,11 +18650,11 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
+  wagmi@3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
-      '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@tanstack/react-query': 5.100.10(react@19.2.5)
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
@@ -18392,14 +18673,60 @@ snapshots:
       - immer
       - porto
 
-  wagmi@3.6.12(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)):
+  wagmi@3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
-      '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.5)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
+      '@tanstack/react-query': 5.100.10(react@19.2.5)
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.8(typescript@5.9.3)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+
+  wagmi@3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
+    dependencies:
+      '@tanstack/react-query': 5.100.5(react@19.2.5)
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.3.6)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+
+  wagmi@3.6.14(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)):
+    dependencies:
+      '@tanstack/react-query': 5.100.10(react@19.2.5)
+      '@wagmi/connectors': 8.0.13(@wagmi/core@3.4.11(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.11(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.8(typescript@5.9.3)(zod@4.4.3))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.48.8(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/site/src/pages/docs/server/handler.auth.mdx
+++ b/site/src/pages/docs/server/handler.auth.mdx
@@ -245,7 +245,7 @@ const handler = Handler.auth({
 ### trustProxy
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true` on Cloudflare Workers (always edge-fronted), `false` elsewhere.
 
 Honor `x-forwarded-proto` / `x-forwarded-host` to derive the public origin. Required when running behind a trusted reverse proxy that terminates TLS. When `false`, forwarded headers are ignored to prevent spoofing on deployments that expose the origin server directly. Ignored when [`origin`](#origin) is set.
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -911,9 +911,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     }
   }
 
-  if (options.mpp) {
-    const mppOptions = typeof options.mpp === 'object' ? options.mpp : {}
-    const { mode = 'push' } = mppOptions
+  const mpp = (() => {
+    if (options.mpp === false) return undefined
+    if (typeof options.mpp === 'object') return options.mpp
+    return {}
+  })()
+  if (mpp) {
+    const { mode = 'push' } = mpp
     Mppx.create({
       methods: [
         mppx_tempo({
@@ -967,9 +971,9 @@ export declare namespace create {
     /**
      * Enable Machine Payment Protocol (mppx) support.
      *
-     * Pass `true` to enable with defaults, or an options object to configure.
+     * Pass an options object to configure, or `false` to disable.
      *
-     * @default false
+     * @default true
      */
     mpp?: boolean | mpp.Options | undefined
     /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */
@@ -1140,6 +1144,16 @@ function assertSameAuthOrigin(auth: NonNullable<z.output<typeof Rpc.wallet_conne
 }
 
 /**
+ * Hint appended to "domain mismatch" / "uri mismatch" errors raised in
+ * {@link fetchAuthChallenge}. Most of the time these come from a server
+ * sitting behind a TLS-terminating proxy (Cloudflare Tunnel, ngrok, a
+ * CDN) that forwards `x-forwarded-proto` / `x-forwarded-host` headers the
+ * auth handler isn't honoring by default.
+ */
+const authOriginHint =
+  ' Hint: if the server is behind a reverse proxy or tunnel, set `Handler.auth({ trustProxy: true })` to honor `x-forwarded-*` headers, or pin the public origin with `Handler.auth({ origin: "https://app.example.com" })`.'
+
+/**
  * Fetches an auth challenge from the auth endpoint and validates that the
  * server-supplied message is bound to the auth endpoint's origin and the
  * requested chain.
@@ -1187,11 +1201,11 @@ async function fetchAuthChallenge(
     })
   if (parsed.domain !== expected.host)
     throw new RpcResponse.InvalidParamsError({
-      message: `Server Authentication challenge endpoint \`${url}\` returned a message bound to \`${parsed.domain}\` (expected \`${expected.host}\`).`,
+      message: `Server Authentication challenge endpoint \`${url}\` returned a message bound to \`${parsed.domain}\` (expected \`${expected.host}\`).${authOriginHint}`,
     })
   if (parsed.uri !== expected.origin)
     throw new RpcResponse.InvalidParamsError({
-      message: `Server Authentication challenge endpoint \`${url}\` returned a message with \`uri\` \`${parsed.uri}\` (expected \`${expected.origin}\`).`,
+      message: `Server Authentication challenge endpoint \`${url}\` returned a message with \`uri\` \`${parsed.uri}\` (expected \`${expected.origin}\`).${authOriginHint}`,
     })
   if (parsed.chainId !== chainId)
     throw new RpcResponse.InvalidParamsError({

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -161,10 +161,16 @@ export declare namespace durableObject {
   /**
    * Minimal shape of a Cloudflare Durable Object namespace binding.
    * Compatible with `DurableObjectNamespace` from `@cloudflare/workers-types`.
+   *
+   * `get`'s parameter is typed as `any` (rather than `unknown`) so the
+   * stricter `(id: DurableObjectId) => ...` signature on Cloudflare's
+   * `DurableObjectNamespace` is structurally assignable here without an
+   * intermediate cast on the caller.
    */
   type Namespace = {
     idFromName: (name: string) => unknown
-    get: (id: unknown) => { fetch: (input: string, init?: unknown) => Promise<Response> }
+    // biome-ignore lint/suspicious/noExplicitAny: contravariant id parameter — see JSDoc above.
+    get: (id: any) => { fetch: (input: string, init?: unknown) => Promise<Response> }
   }
   type Options = {
     /**

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -796,6 +796,40 @@ describe('origin / trustProxy', () => {
       `[Error: \`auth({ origin })\` must be a valid absolute URL. Got: not-a-url]`,
     )
   })
+
+  test('default trustProxy: true on Cloudflare Workers runtime', async () => {
+    // Spoof the Cloudflare Workers runtime marker.
+    const originalNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { userAgent: 'Cloudflare-Workers' },
+      configurable: true,
+    })
+    try {
+      const handler = auth()
+      const app = new Hono()
+      app.route('/', handler)
+
+      const res = await app.request('/challenge', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          host: 'internal.example',
+          'x-forwarded-host': 'app.example',
+          'x-forwarded-proto': 'https',
+        },
+        body: JSON.stringify({ chainId: 1 }),
+      })
+      const body = (await res.json()) as { message: string }
+      const parsed = parseSiweMessage(body.message)
+      expect(parsed.domain).toBe('app.example')
+      expect(parsed.uri).toBe('https://app.example')
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true,
+      })
+    }
+  })
 })
 
 describe('Handler.compose integration', () => {

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -126,7 +126,11 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     session = true,
     store = Kv.memory(),
     transport = http(),
-    trustProxy = false,
+    // Cloudflare Workers always run behind Cloudflare's edge proxy, which
+    // sets `x-forwarded-proto`/`x-forwarded-host`. Default `trustProxy` to
+    // `true` there so deployments work out of the box. Other runtimes keep
+    // the secure default of `false` (operator must opt in).
+    trustProxy = isCloudflareWorkers(),
     ttl: {
       challenge: challengeTtl = defaults.ttl.challenge,
       session: sessionTtl = defaults.ttl.session,
@@ -409,7 +413,7 @@ export declare namespace auth {
      * `false`, forwarded headers are ignored to prevent spoofing on
      * deployments that expose the origin server directly. Ignored when
      * `origin` is set.
-     * @default false
+     * @default `true` on Cloudflare Workers (always edge-fronted), `false` elsewhere.
      */
     trustProxy?: boolean | undefined
     /** TTLs in seconds. */
@@ -461,4 +465,16 @@ function resolveOrigin(
     protocol: reqUrl.protocol,
     host: headers.get('host') || reqUrl.host,
   }
+}
+
+/**
+ * Detects whether we're executing inside the Cloudflare Workers runtime,
+ * which is always edge-fronted and forwards `x-forwarded-*` headers from
+ * Cloudflare's proxy. Used to flip the default `trustProxy` to `true`.
+ */
+function isCloudflareWorkers(): boolean {
+  return (
+    typeof globalThis.navigator !== 'undefined' &&
+    globalThis.navigator.userAgent === 'Cloudflare-Workers'
+  )
 }


### PR DESCRIPTION
Forks `examples/basic` into `examples/with-auth`, demonstrating server-side SIWE authentication with `Handler.auth` from `accounts/server` and the `auth` capability on `tempoWallet`. The wallet signs a SIWE challenge during `wallet_connect`, the worker verifies it, and the SDK is issued an `accounts_auth` session cookie that authenticates follow-up requests like `GET /me`. `Disconnect` calls `POST /auth/logout` automatically via `wallet_disconnect`.

Also includes two SDK DX improvements:

- **`Handler.auth({ trustProxy })` defaults to `true` on Cloudflare Workers** — the runtime is always edge-fronted, and Cloudflare's edge / Cloudflare Tunnel always set `x-forwarded-proto` / `x-forwarded-host`. Other runtimes keep the secure default of `false`.
- **Better error hint on `domain` / `uri` mismatch** — when `wallet_connect` rejects an auth challenge because the SIWE message URI doesn't match the dapp origin, the error now points at `Handler.auth({ trustProxy: true })` or `Handler.auth({ origin: ... })` so server-behind-tunnel/proxy misconfigurations are easier to diagnose.

## Test plan

- `pnpm --filter with-auth-example check:types` ✅
- `pnpm --filter with-auth-example build` ✅
- `pnpm test run src/server/internal/handlers/auth.test.ts` (35/35 pass, +1 for CF Workers default) ✅
- Manual: \`pnpm --filter with-auth-example dev\` → connect via wallet → \`GET /me\` returns the connected address; \`Disconnect\` clears the session.

Amp-Thread-ID: https://ampcode.com/threads/T-019e2835-ac3d-7558-9475-832b7b35b820