### PR TITLE
feat(provider): rename wallet_send to wallet_transfer with editable discriminator

### DIFF
--- a/.changeset/wallet-transfer-editable.md
+++ b/.changeset/wallet-transfer-editable.md
@@ -1,0 +1,16 @@
+---
+'accounts': minor
+---
+
+**Breaking:** Renamed `wallet_send` to `wallet_transfer`. The method now defaults to "read-only" mode. 
+
+For previous behavior, pass `editable: true` to open the editable flow.
+
+```diff
+provider.request({
+- method: 'wallet_send',
+- params: [{ token: '0x...' }],
++ method: 'wallet_transfer',
++ params: [{ editable: true, token: '0x...' }],
+})
+```

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -109,7 +109,7 @@ export function App() {
 
           <PlaygroundSection id="transactions" title="Transactions">
             <Transactions />
-            <WalletSend />
+            <WalletTransfer />
             <WalletSwap />
             <WalletDepositZone />
             <WalletWithdrawZone />
@@ -349,7 +349,7 @@ function WalletDeposit() {
   )
 }
 
-function WalletSend() {
+function WalletTransfer() {
   const [result, error, execute] = useRequest()
   const [feePayerMode, setFeePayerMode] = useState<'wallet' | 'playground' | 'disabled'>('wallet')
 
@@ -360,14 +360,14 @@ function WalletSend() {
   })()
 
   return (
-    <Method method="wallet_send" result={result} error={error}>
+    <Method method="wallet_transfer" result={result} error={error}>
       <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
         <legend>Fee Payer</legend>
         {(['wallet', 'playground', 'disabled'] as const).map((mode) => (
           <label key={mode} style={{ marginRight: 12 }}>
             <input
               type="radio"
-              name="walletSendFeePayerMode"
+              name="WalletTransferFeePayerMode"
               value={mode}
               checked={feePayerMode === mode}
               onChange={() => setFeePayerMode(mode)}
@@ -376,35 +376,15 @@ function WalletSend() {
           </label>
         ))}
       </fieldset>
+
+      <h5 style={{ flexBasis: '100%', fontSize: 11, margin: '8px 0 4px', width: '100%' }}>
+        Read-only
+      </h5>
       <Button
         onClick={() =>
           execute(() =>
             provider.request({
-              method: 'wallet_send',
-              params: [{ ...feePayerParam }],
-            }),
-          )
-        }
-      >
-        Send
-      </Button>
-      <Button
-        onClick={() =>
-          execute(() =>
-            provider.request({
-              method: 'wallet_send',
-              params: [{ token: tokens.pathUSD, ...feePayerParam }],
-            }),
-          )
-        }
-      >
-        Send pathUSD
-      </Button>
-      <Button
-        onClick={() =>
-          execute(() =>
-            provider.request({
-              method: 'wallet_send',
+              method: 'wallet_transfer',
               params: [
                 {
                   amount: '1',
@@ -423,7 +403,7 @@ function WalletSend() {
         onClick={() =>
           execute(() =>
             provider.request({
-              method: 'wallet_send',
+              method: 'wallet_transfer',
               params: [
                 {
                   amount: '1',
@@ -444,10 +424,103 @@ function WalletSend() {
         onClick={() =>
           execute(() =>
             provider.request({
-              method: 'wallet_send',
+              method: 'wallet_transfer',
               params: [
                 {
                   amount: '1',
+                  // Hex-encoded UTF-8 memo (max 32 bytes). Wallet rejects
+                  // with InvalidParamsError if the token is not TIP-20.
+                  memo: Hex.fromString('invoice #4821'),
+                  to: '0x0000000000000000000000000000000000000001',
+                  token: 'pathUSD',
+                  ...feePayerParam,
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Send $1 with memo
+      </Button>
+
+      <h5 style={{ flexBasis: '100%', fontSize: 11, margin: '8px 0 4px', width: '100%' }}>
+        Editable
+      </h5>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_transfer',
+              params: [{ editable: true, ...feePayerParam }],
+            }),
+          )
+        }
+      >
+        Send
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_transfer',
+              params: [{ editable: true, token: tokens.pathUSD, ...feePayerParam }],
+            }),
+          )
+        }
+      >
+        Send pathUSD
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_transfer',
+              params: [
+                {
+                  amount: '1',
+                  editable: true,
+                  to: '0x0000000000000000000000000000000000000001',
+                  token: tokens.pathUSD,
+                  ...feePayerParam,
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Send $1 pathUSD
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_transfer',
+              params: [
+                {
+                  amount: '1',
+                  editable: true,
+                  // Resolved against the wallet's curated tokenlist
+                  // (case-insensitive). `pathusd` is also accepted.
+                  token: 'pathUSD',
+                  to: '0x0000000000000000000000000000000000000001',
+                  ...feePayerParam,
+                },
+              ],
+            }),
+          )
+        }
+      >
+        Send $1 pathUSD (symbol)
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_transfer',
+              params: [
+                {
+                  amount: '1',
+                  editable: true,
                   // 32-byte UTF-8 memo attached to the TIP-20 transfer.
                   // The wallet rejects with `InvalidParamsError` if the
                   // selected token is not TIP-20.

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -222,7 +222,8 @@ export function selectAccount(
   for (const key of accessKeys) {
     if (key.access.toLowerCase() !== address.toLowerCase()) continue
     if (key.chainId !== chainId) continue
-    if (!('keyPair' in key && !!key.keyPair) && !('privateKey' in key && !!key.privateKey)) continue
+    if (!('keyPair' in key && !!key.keyPair) && !('privateKey' in key && !!key.privateKey))
+      continue
 
     if (key.expiry && key.expiry < Date.now() / 1000) {
       accessKeys_next = accessKeys_next.filter((a) => a !== key)

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -75,11 +75,11 @@ export type Instance = {
         ) => Promise<void>)
       | undefined
     /** Open the send-token flow. */
-    send?:
+    transfer?:
       | ((
-          params: send.Parameters,
-          request: EncodedRequest<Rpc.wallet_send.Encoded>,
-        ) => Promise<send.ReturnType>)
+          params: transfer.Parameters,
+          request: EncodedRequest<Rpc.wallet_transfer.Encoded>,
+        ) => Promise<transfer.ReturnType>)
       | undefined
     /** Open the swap flow. */
     swap?:
@@ -330,9 +330,9 @@ export declare namespace revokeAccessKey {
   }
 }
 
-export declare namespace send {
-  type Parameters = ActionRequest<typeof Rpc.wallet_send.schema>
-  type ReturnType = Rpc.wallet_send.Encoded['returns']
+export declare namespace transfer {
+  type Parameters = ActionRequest<typeof Rpc.wallet_transfer.schema>
+  type ReturnType = Rpc.wallet_transfer.Encoded['returns']
 }
 
 /** Parameters and return type for the `wallet_swap` action. */

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1101,24 +1101,25 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
     })
   })
 
-  describe('wallet_send', () => {
-    test('error: throws UnsupportedMethodError when adapter has no send action', async () => {
+  describe('wallet_transfer', () => {
+    test('error: throws UnsupportedMethodError when adapter has no transfer action', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       await connect(provider)
 
       await expect(
         provider.request({
-          method: 'wallet_send',
+          method: 'wallet_transfer',
           params: [
             {
               amount: '1',
+              editable: true,
               to: '0x0000000000000000000000000000000000000001',
               token: Addresses.pathUsd,
             },
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `[Provider.UnsupportedMethodError: \`send\` not supported by adapter.]`,
+        `[Provider.UnsupportedMethodError: \`transfer\` not supported by adapter.]`,
       )
     })
   })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -2,7 +2,7 @@ import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { http, type Chain, type Client as ViemClient, type Transport } from 'viem'
+import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import { parseSiweMessage } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
@@ -17,6 +17,7 @@ import { withDedupe } from './internal/withDedupe.js'
 import * as Schema from './Schema.js'
 import * as Storage from './Storage.js'
 import * as Store from './Store.js'
+import * as Tokenlist from './Tokenlist.js'
 import * as Request from './zod/request.js'
 import * as Rpc from './zod/rpc.js'
 
@@ -244,10 +245,12 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const { to, data, ...rest } = decoded
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
+                    const state = store.getState()
                     return (await actions.sendTransaction(
                       {
                         ...rest,
-                        chainId: decoded.chainId ?? store.getState().chainId,
+                        chainId: decoded.chainId ?? state.chainId,
+                        from: decoded.from ?? state.accounts[state.activeAccount]?.address,
                         ...(calls ? { calls } : {}),
                         feePayer: resolveFeePayer(decoded.feePayer),
                       },
@@ -337,10 +340,12 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const { to, data, ...rest } = decoded
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
+                    const state = store.getState()
                     return (await actions.signTransaction(
                       {
                         ...rest,
-                        chainId: decoded.chainId ?? store.getState().chainId,
+                        chainId: decoded.chainId ?? state.chainId,
+                        from: decoded.from ?? state.accounts[state.activeAccount]?.address,
                         ...(calls ? { calls } : {}),
                         feePayer: resolveFeePayer(decoded.feePayer),
                       },
@@ -354,10 +359,12 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const { to, data, ...rest } = decoded
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
+                    const state = store.getState()
                     return (await actions.sendTransactionSync(
                       {
                         ...rest,
-                        chainId: decoded.chainId ?? store.getState().chainId,
+                        chainId: decoded.chainId ?? state.chainId,
+                        from: decoded.from ?? state.accounts[state.activeAccount]?.address,
                         ...(calls ? { calls } : {}),
                         feePayer: resolveFeePayer(decoded.feePayer),
                       },
@@ -397,10 +404,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const feePayer = resolveFeePayer(
                       capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
                     )
+                    const state = store.getState()
                     const txRequest = {
                       calls,
                       chainId,
-                      from,
+                      from: from ?? state.accounts[state.activeAccount]?.address,
                       ...(feePayer ? { feePayer } : {}),
                     }
                     if (!sync) {
@@ -790,23 +798,104 @@ export function create(options: create.Options = {}): create.ReturnType {
                     )) satisfies Rpc.wallet_deposit.Encoded['returns']
                   }
 
-                  case 'wallet_send': {
+                  case 'wallet_transfer': {
                     assertConnected()
-                    if (!actions.send)
-                      throw new ox_Provider.UnsupportedMethodError({
-                        message: '`send` not supported by adapter.',
+                    // Default to the editable variant when params are
+                    // omitted — programmatic mode requires `amount`,
+                    // `to`, and `token`, so an empty call only makes
+                    // sense as "open the wallet send UI".
+                    const decoded = request._decoded.params?.[0] ?? { editable: true as const }
+
+                    // Editable variant: forward to the wallet host UI.
+                    if (decoded.editable === true) {
+                      if (!actions.transfer)
+                        throw new ox_Provider.UnsupportedMethodError({
+                          message: '`transfer` not supported by adapter.',
+                        })
+                      const parameters = {
+                        ...decoded,
+                        ...(typeof decoded.feePayer !== 'undefined'
+                          ? { feePayer: resolveFeePayer(decoded.feePayer) }
+                          : {}),
+                      } as Adapter.transfer.Parameters
+                      return (await actions.transfer(
+                        parameters,
+                        request,
+                      )) satisfies Rpc.wallet_transfer.Encoded['returns']
+                    }
+
+                    // Programmatic variant (default): skip the wallet UI,
+                    // build the TIP-20 `transfer` call inline, and route
+                    // through `eth_sendTransactionSync` (which uses an
+                    // access key when one matches, falling back to the
+                    // dialog otherwise).
+                    const { amount, feePayer, from, memo, to, token } = decoded
+                    const state = store.getState()
+                    const chainId = decoded.chainId ?? state.chainId
+                    const resolvedFeePayer = resolveFeePayer(feePayer)
+
+                    const client = getClient({
+                      chainId,
+                      feePayer:
+                        typeof resolvedFeePayer === 'string' ? resolvedFeePayer : undefined,
+                    })
+                    const { address: tokenAddress, decimals } = await (async () => {
+                      if (Address.validate(token)) {
+                        const metadata = await Actions.token.getMetadata(client, {
+                          token,
+                        })
+                        return { address: token, decimals: metadata.decimals }
+                      }
+                      const resolved = await Tokenlist.resolveSymbol({
+                        chainId: client.chain.id,
+                        symbol: token,
                       })
-                    const decoded = request._decoded.params?.[0] ?? {}
-                    const parameters = {
-                      ...decoded,
-                      ...(typeof decoded.feePayer !== 'undefined'
-                        ? { feePayer: resolveFeePayer(decoded.feePayer) }
-                        : {}),
-                    } as Adapter.send.Parameters
-                    return (await actions.send(
-                      parameters,
-                      request,
-                    )) satisfies Rpc.wallet_send.Encoded['returns']
+                      if (!resolved)
+                        throw new ox_Provider.ProviderRpcError(
+                          -32602,
+                          `Unknown token symbol "${token}".`,
+                        )
+                      return { address: resolved.address, decimals: resolved.decimals }
+                    })()
+                    const amountUnits = parseUnits(amount, decimals)
+
+                    // The signer is the active account (or its access
+                    // key). `from` here is the TIP-20 source for
+                    // `transferFrom` semantics, so we only forward it
+                    // when the caller explicitly set it to a different
+                    // address — otherwise `Actions.token.transfer.call`
+                    // emits `transferFrom` (different selector) instead
+                    // of plain `transfer`, breaking access-key scope
+                    // matching.
+                    const signerAddress = state.accounts[state.activeAccount]?.address
+                    const sourceFrom =
+                      from &&
+                      signerAddress &&
+                      from.toLowerCase() !== signerAddress.toLowerCase()
+                        ? from
+                        : undefined
+                    const call = Actions.token.transfer.call({
+                      amount: amountUnits,
+                      ...(sourceFrom ? { from: sourceFrom } : {}),
+                      memo,
+                      to,
+                      token: tokenAddress,
+                    })
+
+                    const txRequest = {
+                      calls: [call],
+                      chainId,
+                      from: signerAddress,
+                      ...(resolvedFeePayer !== undefined ? { feePayer: resolvedFeePayer } : {}),
+                    }
+                    const receipt = await actions.sendTransactionSync(txRequest, {
+                      method: 'eth_sendTransactionSync',
+                      params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
+                    })
+                    return {
+                      chainId: Hex.fromNumber(chainId),
+                      receipt,
+                    } satisfies Rpc.wallet_transfer.Encoded['returns']
                   }
 
                   case 'wallet_swap': {
@@ -1053,12 +1142,16 @@ export declare namespace mpp {
  * (notably Cloudflare Workers) expose a non-writable, non-configurable
  * `fetch` that throws when `Mppx.create({ polyfill: true })` tries to
  * replace it.
+ *
+ * Tries an actual no-op self-reassignment because some runtimes report a
+ * writable descriptor but still throw at assignment time (e.g. Workers
+ * dev runner via Durable Objects).
  */
 function isFetchWritable(): boolean {
   try {
-    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch')
-    if (!descriptor) return true
-    return Boolean(descriptor.writable || descriptor.set)
+    const original = globalThis.fetch
+    globalThis.fetch = original
+    return true
   } catch {
     return false
   }

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -121,9 +121,9 @@ describe('Encoded', () => {
     }>()
   })
 
-  test('wallet_send', () => {
-    expectTypeOf<Rpc.wallet_send.Encoded>().toMatchTypeOf<{
-      method: 'wallet_send'
+  test('wallet_transfer', () => {
+    expectTypeOf<Rpc.wallet_transfer.Encoded>().toMatchTypeOf<{
+      method: 'wallet_transfer'
       params:
         | readonly [
             {
@@ -222,7 +222,7 @@ describe('Request', () => {
       | 'wallet_depositZone'
       | 'wallet_getBalances'
       | 'wallet_revokeAccessKey'
-      | 'wallet_send'
+      | 'wallet_transfer'
       | 'wallet_swap'
       | 'wallet_withdrawZone'
     >()

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -94,7 +94,7 @@ export const schema = from([
   Rpc.wallet_getCallsStatus.schema,
   Rpc.wallet_getCapabilities.schema,
   Rpc.wallet_revokeAccessKey.schema,
-  Rpc.wallet_send.schema,
+  Rpc.wallet_transfer.schema,
   Rpc.wallet_sendCalls.schema,
   Rpc.wallet_swap.schema,
   Rpc.wallet_switchEthereumChain.schema,

--- a/src/core/Tokenlist.ts
+++ b/src/core/Tokenlist.ts
@@ -1,0 +1,91 @@
+import type { Address } from 'ox'
+
+/** Default base URL for the curated tempo tokenlist. */
+const defaultBaseUrl = 'https://tokenlist.tempo.xyz'
+
+/** A single tokenlist entry. */
+export type Token = {
+  /** Token contract address. */
+  address: Address.Address
+  /** Token decimals. */
+  decimals: number
+  /** Token logo URI. */
+  logoUri?: string | undefined
+  /** Token name. */
+  name: string
+  /** Token symbol. */
+  symbol: string
+}
+
+/** Cache keyed by `${baseUrl}|${chainId}` so concurrent callers share a single fetch. */
+const cache = new Map<string, Promise<readonly Token[]>>()
+
+/**
+ * Fetches the curated tokenlist for a given Tempo chain. Concurrent calls
+ * for the same chain share a single in-flight request, and successful
+ * responses are cached for the lifetime of the process.
+ *
+ * Returns an empty list on any non-OK response so callers can fall back
+ * to chain-supplied behavior rather than treating a fetch failure as fatal.
+ */
+export async function fetch(options: fetch.Options): Promise<readonly Token[]> {
+  const { chainId, baseUrl = defaultBaseUrl } = options
+  const key = `${baseUrl}|${chainId}`
+  const existing = cache.get(key)
+  if (existing) return existing
+  const pending = (async () => {
+    try {
+      const response = await globalThis.fetch(`${baseUrl}/list/${chainId}`)
+      if (!response.ok) return []
+      const data = (await response.json()) as {
+        tokens: readonly (Token & { logoURI?: string })[]
+      }
+      return data.tokens.map(({ logoURI, ...token }) => ({
+        ...token,
+        logoUri: token.logoUri ?? logoURI,
+      }))
+    } catch {
+      return []
+    }
+  })()
+  cache.set(key, pending)
+  // Drop failed/empty results so the next caller retries.
+  pending.then((tokens) => {
+    if (tokens.length === 0) cache.delete(key)
+  })
+  return pending
+}
+
+export declare namespace fetch {
+  /** Options for {@link fetch}. */
+  type Options = {
+    /** Chain id to fetch the tokenlist for. */
+    chainId: number
+    /**
+     * Base URL of the tokenlist service.
+     * @default 'https://tokenlist.tempo.xyz'
+     */
+    baseUrl?: string | undefined
+  }
+}
+
+/**
+ * Resolves a token symbol (case-insensitive) against the curated tokenlist
+ * for a given chain. Returns the token entry, or `undefined` if no match.
+ */
+export async function resolveSymbol(
+  options: resolveSymbol.Options,
+): Promise<Token | undefined> {
+  const { symbol, ...rest } = options
+  const tokens = await fetch(rest)
+  const lowered = symbol.toLowerCase()
+  return tokens.find((token) => token.symbol.toLowerCase() === lowered)
+}
+
+export declare namespace resolveSymbol {
+  /** Options for {@link resolveSymbol}. */
+  type Options = fetch.Options & {
+    /** Symbol to look up (case-insensitive). */
+    symbol: string
+  }
+}

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -409,10 +409,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           return await provider.request(request)
         },
 
-        async send(params, request) {
+        async transfer(params, request) {
           return await provider.request({
             ...request,
-            params: [z.encode(Rpc.wallet_send.parameters, params)] as const,
+            params: [z.encode(Rpc.wallet_transfer.parameters, params)] as const,
           })
         },
 

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -612,35 +612,85 @@ export namespace wallet_getCallsStatus {
   export type Decoded = Schema.Decoded<typeof schema>
 }
 
-export namespace wallet_send {
-  /** Parameters object for `wallet_send`. */
-  export const parameters = z.object({
-    /** Human-readable amount to pre-fill (e.g. "1.5"). */
-    amount: z.optional(z.string()),
-    /**
-     * Fee payer override. `false` to disable the wallet's default fee
-     * payer, a URL string to use a custom fee payer service.
-     */
-    feePayer: z.optional(z.union([z.boolean(), z.string()])),
-    /**
-     * UTF-8 memo (max 32 bytes) to attach to the transfer. Wallet
-     * rejects the request if the selected token does not support
-     * memos (non-TIP-20).
-     */
-    memo: z.optional(z.string()),
-    /** Recipient address to pre-fill. */
-    to: z.optional(u.address()),
-    /**
-     * Token to pre-fill, accepted as either a contract address or a
-     * curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`).
-     * Symbols are resolved against the curated tokenlist on the active
-     * chain. Omit to let the user choose.
-     */
-    token: z.optional(z.union([u.address(), z.string()])),
-  })
+export namespace wallet_transfer {
+  /**
+   * Parameters for `wallet_transfer`.
+   *
+   * Discriminated on `editable`:
+   *
+   * - omitted or `false` (default): programmatic. `amount` is a
+   *   human-readable string (e.g. `"1.5"`), `to` and `token` are
+   *   required, no UI is shown. Uses an access key when one matches,
+   *   otherwise falls back to a confirm dialog.
+   * - `true`: editable. Wallet shows a UI with optional fields
+   *   pre-filled; the user confirms or edits before signing.
+   */
+  export const parameters = z.discriminatedUnion('editable', [
+    z.object({
+      /** Human-readable amount to transfer (e.g. `"1.5"`). */
+      amount: z.string(),
+      /** Chain id. Defaults to the active chain. */
+      chainId: z.optional(u.number()),
+      /** Skip the wallet UI and sign programmatically. @default false */
+      editable: z.optional(z.literal(false)),
+      /**
+       * Fee payer override. `false` to disable the wallet's default fee
+       * payer, a URL string to use a custom fee payer service.
+       */
+      feePayer: z.optional(z.union([z.boolean(), z.string()])),
+      /**
+       * Address to transfer tokens from. Defaults to the active account.
+       * When set to a different address, the call uses `transferFrom` and
+       * requires the active account to have an allowance from `from`.
+       */
+      from: z.optional(u.address()),
+      /**
+       * UTF-8 memo to attach to the transfer (max 32 bytes when encoded
+       * as UTF-8). Sent via `transferWithMemo` / `transferFromWithMemo`.
+       */
+      memo: z.optional(u.hex()),
+      /** Recipient address. */
+      to: u.address(),
+      /**
+       * Token to transfer, accepted as either a contract address or a
+       * curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`).
+       * Symbols are resolved against the curated tokenlist on the active
+       * chain.
+       */
+      token: z.union([u.address(), z.string()]),
+    }),
+    z.object({
+      /** Human-readable amount to pre-fill (e.g. `"1.5"`). */
+      amount: z.optional(z.string()),
+      /** Chain id. Defaults to the active chain. */
+      chainId: z.optional(u.number()),
+      /** Show the wallet UI for the user to confirm or edit. */
+      editable: z.literal(true),
+      /**
+       * Fee payer override. `false` to disable the wallet's default fee
+       * payer, a URL string to use a custom fee payer service.
+       */
+      feePayer: z.optional(z.union([z.boolean(), z.string()])),
+      /**
+       * UTF-8 memo (max 32 bytes) to attach to the transfer. Wallet
+       * rejects the request if the selected token does not support
+       * memos (non-TIP-20).
+       */
+      memo: z.optional(z.string()),
+      /** Recipient address to pre-fill. */
+      to: z.optional(u.address()),
+      /**
+       * Token to pre-fill, accepted as either a contract address or a
+       * curated tokenlist symbol (case-insensitive, e.g. `"pathUsd"`).
+       * Symbols are resolved against the curated tokenlist on the active
+       * chain. Omit to let the user choose.
+       */
+      token: z.optional(z.union([u.address(), z.string()])),
+    }),
+  ])
 
   export const schema = Schema.defineItem({
-    method: z.literal('wallet_send'),
+    method: z.literal('wallet_transfer'),
     params: z.optional(z.readonly(z.tuple([parameters]))),
     returns: z.object({
       /** Chain id the send is to. */


### PR DESCRIPTION
## Summary

Consolidates editable and programmatic transfer flows under a single `wallet_transfer` method, discriminated on the `editable` field.

- **Programmatic (default):** signs without UI, requires `amount`/`to`/`token`. Uses an access key when one matches; otherwise falls back to a confirm dialog. `amount` is a human-readable string (e.g. `'1.5'`).
- **Editable (`editable: true`):** opens the wallet send UI with optional pre-filled fields.

Adds a new `Tokenlist` module that resolves curated token symbols and per-token decimals against `https://tokenlist.tempo.xyz` (in-flight requests are deduped, empty responses are not cached).

Renames the adapter action `send` -> `transfer` for consistency with the new method name.

## Migration

```diff
provider.request({
- method: 'wallet_send',
- params: [{ token: '0x...' }],
+ method: 'wallet_transfer',
+ params: [{ editable: true, token: '0x...' }],
})
```

For programmatic transfers, omit `editable` (or set `editable: false`) and provide `amount`/`to`/`token`:

```ts
provider.request({
  method: 'wallet_transfer',
  params: [{ amount: '1', to: '0x...', token: 'pathUSD' }],
})
```