### PR TITLE
refactor(provider): accept UTF-8 `memo` string in `wallet_transfer`

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -428,9 +428,9 @@ function WalletTransfer() {
               params: [
                 {
                   amount: '1',
-                  // Hex-encoded UTF-8 memo (max 32 bytes). Wallet rejects
-                  // with InvalidParamsError if the token is not TIP-20.
-                  memo: Hex.fromString('invoice #4821'),
+                  // UTF-8 memo (max 32 bytes). Wallet rejects with
+                  // InvalidParamsError if the token is not TIP-20.
+                  memo: 'invoice #4821',
                   to: '0x0000000000000000000000000000000000000001',
                   token: 'pathUSD',
                   ...feePayerParam,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -801,7 +801,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                   case 'wallet_transfer': {
                     assertConnected()
                     // Default to the editable variant when params are
-                    // omitted — programmatic mode requires `amount`,
+                    // omitted — Read-only mode requires `amount`,
                     // `to`, and `token`, so an empty call only makes
                     // sense as "open the wallet send UI".
                     const decoded = request._decoded.params?.[0] ?? { editable: true as const }
@@ -877,7 +877,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const call = Actions.token.transfer.call({
                       amount: amountUnits,
                       ...(sourceFrom ? { from: sourceFrom } : {}),
-                      memo,
+                      memo: memo ? Hex.fromString(memo) : undefined,
                       to,
                       token: tokenAddress,
                     })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -618,11 +618,12 @@ export namespace wallet_transfer {
    *
    * Discriminated on `editable`:
    *
-   * - omitted or `false` (default): programmatic. `amount` is a
+   * - omitted or `false` (default): Read-only. `amount` is a
    *   human-readable string (e.g. `"1.5"`), `to` and `token` are
-   *   required, no UI is shown. Uses an access key when one matches,
-   *   otherwise falls back to a confirm dialog.
-   * - `true`: editable. Wallet shows a UI with optional fields
+   *   required, no editable UI is shown. Uses an access key when one
+   *   matches (signs without UI), otherwise falls back to a confirm
+   *   dialog the user has to approve.
+   * - `true`: Editable. Wallet shows a UI with optional fields
    *   pre-filled; the user confirms or edits before signing.
    */
   export const parameters = z.discriminatedUnion('editable', [
@@ -631,7 +632,7 @@ export namespace wallet_transfer {
       amount: z.string(),
       /** Chain id. Defaults to the active chain. */
       chainId: z.optional(u.number()),
-      /** Skip the wallet UI and sign programmatically. @default false */
+      /** Skip the editable wallet UI (Read-only mode). @default false */
       editable: z.optional(z.literal(false)),
       /**
        * Fee payer override. `false` to disable the wallet's default fee
@@ -648,7 +649,7 @@ export namespace wallet_transfer {
        * UTF-8 memo to attach to the transfer (max 32 bytes when encoded
        * as UTF-8). Sent via `transferWithMemo` / `transferFromWithMemo`.
        */
-      memo: z.optional(u.hex()),
+      memo: z.optional(z.string()),
       /** Recipient address. */
       to: u.address(),
       /**


### PR DESCRIPTION
In Read-only mode, `memo` was previously typed as a hex string. Accept a UTF-8 string instead and convert to hex inside the Provider so callers don't have to round-trip through `Hex.fromString`.

Also aligns JSDoc and code comments to the "Read-only" / "Editable" terminology used in the [viem docs](https://github.com/wevm/viem/blob/main/site/pages/tempo/actions/wallet.transfer.mdx).

```diff
provider.request({
  method: 'wallet_transfer',
  params: [{
    amount: '1',
-   memo: Hex.fromString('invoice #4821'),
+   memo: 'invoice #4821',
    to: '0x...',
    token: 'pathUSD',
  }],
})
```