### PR TITLE
feat(examples): add with-transfers example

### DIFF
--- a/examples/with-transfers/.env.example
+++ b/examples/with-transfers/.env.example
@@ -1,0 +1,7 @@
+# Identifier for the MPP realm — included in the `WWW-Authenticate` challenge
+# header so clients can scope credentials per server.
+MPP_REALM=with-transfers
+
+# Server-side secret used to sign MPP challenges. Generate a strong random
+# value in production (e.g. `openssl rand -hex 32`).
+MPP_SECRET_KEY=dev-secret-key-change-me-in-production

--- a/examples/with-transfers/.gitignore
+++ b/examples/with-transfers/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.local
+.wrangler
+.dev.vars*
+.env
+worker-configuration.d.ts

--- a/examples/with-transfers/README.md
+++ b/examples/with-transfers/README.md
@@ -1,0 +1,59 @@
+# Transfers Example
+
+Two ways to transfer from a Tempo account using the Accounts SDK:
+
+| Category                       | Mechanism                       | What it does                                                                                                       |
+| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **User-initiated transfers**   | `wallet_send` RPC from the page | Client signs and broadcasts a stablecoin transfer directly from the user account.                                  |
+| **Server-initiated transfers** | `GET /api/transfer`             | Server responds with HTTP `402 Payment Required`; the SDK auto-fulfills the challenge and retries the request.     |
+
+## Setup
+
+```bash
+npx gitpick tempoxyz/accounts/examples/with-transfers
+cp .env.example .env
+npm i
+npm dev
+```
+
+Sign in with a Tempo Wallet account on testnet, click **Fund Account** to mint
+some pathUSD, then try each transfer button.
+
+## How it works
+
+### User-initiated transfers
+
+The page sends a `wallet_send` RPC request to the connected account, which
+signs and broadcasts a stablecoin transfer:
+
+```http
+→ wallet_send { amount: "1", to: "0x…", token: "pathusd" }
+← { receipt: { transactionHash: "0x…", … } }
+```
+
+See `src/App.tsx` for the client-side implementation.
+
+### Server-initiated transfers
+
+`GET /api/transfer` responds with HTTP `402 Payment Required` and a challenge
+describing the amount, currency, and recipient. The Accounts SDK automatically
+intercepts the 402 response, signs and broadcasts a pathUSD transfer with the
+connected account, and retries the original request with the credential
+attached — no extra client-side wiring required.
+
+```http
+GET /api/transfer
+
+→ 402 Payment Required
+  WWW-Authenticate: Payment id="…", method="tempo", intent="charge", …
+
+→ (SDK signs and broadcasts the transfer, then retries)
+
+GET /api/transfer
+  Authorization: Payment …
+
+→ 200 OK
+  { "fortune": "Your code will compile on the first try." }
+```
+
+See `worker/index.ts` for the server-side implementation.

--- a/examples/with-transfers/env.d.ts
+++ b/examples/with-transfers/env.d.ts
@@ -1,0 +1,6 @@
+declare namespace Cloudflare {
+  interface Env {
+    MPP_REALM: string
+    MPP_SECRET_KEY: string
+  }
+}

--- a/examples/with-transfers/index.html
+++ b/examples/with-transfers/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Transfers Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/with-transfers/package.json
+++ b/examples/with-transfers/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "with-transfers",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "check:types": "tsc -b --noEmit",
+    "dev": "vp dev",
+    "gen:types": "wrangler types",
+    "postinstall": "wrangler types",
+    "build": "tsc -b && vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.97.0",
+    "accounts": "latest",
+    "hono": "^4.12.18",
+    "mppx": "^0.6.19",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "viem": "latest",
+    "wagmi": "latest"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "~1.33.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "typescript": "^5.9.3",
+    "vite-plus": "~0.1.18",
+    "wrangler": "^4.85.0"
+  }
+}

--- a/examples/with-transfers/src/App.tsx
+++ b/examples/with-transfers/src/App.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { formatUnits, stringify } from 'viem'
+import { useConnect, useConnection, useConnectors, useDisconnect } from 'wagmi'
+import { tempoModerato } from 'wagmi/chains'
+import { Hooks } from 'wagmi/tempo'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+
+export default function App() {
+  const { address, status } = useConnection()
+  return (
+    <div>
+      <h1>Transfers Example</h1>
+      <p>
+        Demonstrates two ways to transfer from a connected Tempo account: a{' '}
+        <strong>user-initiated transfer</strong> via a <code>wallet_send</code> RPC request from the
+        browser, and a <strong>server-initiated transfer</strong> via an HTTP{' '}
+        <code>402 Payment Required</code> response from the server.
+      </p>
+
+      <h2>Connection</h2>
+      <pre>{stringify({ address: address ?? null, status }, null, 2)}</pre>
+
+      <h2>Connect</h2>
+      <Connect />
+
+      {status === 'connected' && (
+        <>
+          <h2>Balance</h2>
+          <Balance />
+
+          <h2>Faucet</h2>
+          <Faucet />
+
+          <h2>User-initiated Transfers</h2>
+          <p>
+            The connected account signs and broadcasts a stablecoin transfer via a{' '}
+            <code>wallet_send</code> RPC request from the browser.
+          </p>
+          <Transfer />
+
+          <h2>Server-initiated Transfers</h2>
+          <p>
+            The server demands a transfer via an HTTP <code>402 Payment Required</code> response;
+            the SDK auto-fulfills the challenge and retries the request.
+          </p>
+          <Charge />
+        </>
+      )}
+    </div>
+  )
+}
+
+function Connect() {
+  const { mutate: connect, status, error } = useConnect()
+  const { mutate: disconnect } = useDisconnect()
+  const { address } = useConnection()
+  const connectors = useConnectors()
+  const connector = connectors[0]
+
+  if (!connector) return null
+
+  return (
+    <div>
+      {address ? (
+        <button type="button" onClick={() => disconnect()}>
+          Disconnect
+        </button>
+      ) : (
+        <button type="button" onClick={() => connect({ connector, chainId: tempoModerato.id })}>
+          Sign in
+        </button>
+      )}
+      <div>{status}</div>
+      {error && <pre style={{ color: 'red' }}>{error.message}</pre>}
+    </div>
+  )
+}
+
+function Balance() {
+  const { address } = useConnection()
+  const balance = Hooks.token.useGetBalance({
+    account: address,
+    token: pathUsd,
+    query: { refetchInterval: 1_000 },
+  })
+  return (
+    <div>
+      {balance.isLoading
+        ? 'Loading...'
+        : balance.data !== undefined
+          ? formatUnits(balance.data, 6)
+          : '—'}{' '}
+      pathUSD
+    </div>
+  )
+}
+
+function Faucet() {
+  const { address } = useConnection()
+  const fund = Hooks.faucet.useFundSync()
+  return (
+    <div>
+      <p>Mints testnet pathUSD to your account so the buttons below have something to spend.</p>
+      <button
+        type="button"
+        disabled={fund.isPending || !address}
+        onClick={() => fund.mutate({ account: address! })}
+      >
+        {fund.isPending ? 'Funding...' : 'Fund Account'}
+      </button>
+      {fund.data && <p>✅ Funded.</p>}
+      {fund.error && <pre style={{ color: 'red' }}>{fund.error.message}</pre>}
+    </div>
+  )
+}
+
+function Transfer() {
+  const transfer = Hooks.wallet.useTransfer()
+  return (
+    <div>
+      <p>
+        Sends $1 of pathUSD directly from the connected account. Signed headlessly with the access
+        key authorized in <code>config.ts</code>.
+      </p>
+      <button
+        type="button"
+        disabled={transfer.isPending}
+        onClick={() =>
+          transfer.mutate({
+            amount: '1',
+            to: '0x0000000000000000000000000000000000000001',
+            token: 'pathusd',
+          })
+        }
+      >
+        {transfer.isPending ? 'Sending...' : 'Pay $1'}
+      </button>
+      {transfer.error && (
+        <pre style={{ color: 'red' }}>{`${transfer.error.name}: ${transfer.error.message}`}</pre>
+      )}
+      {transfer.isSuccess && (
+        <p>
+          ✅ Sent.{' '}
+          <a
+            href={`${tempoModerato.blockExplorers.default.url}/tx/${transfer.data.receipt.transactionHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            See receipt
+          </a>
+        </p>
+      )}
+    </div>
+  )
+}
+
+function Charge() {
+  const [data, setData] = useState<unknown>()
+  const [error, setError] = useState<Error | undefined>()
+  const [isPending, setPending] = useState(false)
+  return (
+    <div>
+      <p>
+        $0.01 per call. The server responds with <code>402 Payment Required</code>; the SDK signs
+        and broadcasts a pathUSD transfer with the connected account, and only then does the server
+        return the protected payload.
+      </p>
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={async () => {
+          setPending(true)
+          setError(undefined)
+          setData(undefined)
+          try {
+            const res = await fetch('/api/transfer')
+            const body = await res.json()
+            if (!res.ok) throw new Error(`${res.status}: ${stringify(body)}`)
+            setData(body)
+          } catch (e) {
+            setError(e as Error)
+          } finally {
+            setPending(false)
+          }
+        }}
+      >
+        {isPending ? 'Transferring...' : 'GET /api/transfer'}
+      </button>
+      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
+      {data !== undefined && <pre>{stringify(data, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/examples/with-transfers/src/config.ts
+++ b/examples/with-transfers/src/config.ts
@@ -1,0 +1,34 @@
+import { Expiry } from 'accounts'
+import { parseUnits } from 'viem'
+import { createConfig, http } from 'wagmi'
+import { tempo, tempoModerato } from 'wagmi/chains'
+import { tempoWallet } from 'wagmi/connectors'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+
+export const config = createConfig({
+  chains: [tempoModerato, tempo],
+  connectors: [
+    tempoWallet({
+      authorizeAccessKey: () => ({
+        expiry: Expiry.days(1),
+        limits: [{ token: pathUsd, limit: parseUnits('10', 6) }],
+        scopes: [
+          { address: pathUsd, selector: 'transfer(address,uint256)' },
+          { address: pathUsd, selector: 'transferWithMemo(address,uint256,bytes32)' },
+        ],
+      }),
+    }),
+  ],
+  multiInjectedProviderDiscovery: false,
+  transports: {
+    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
+  },
+})
+
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}

--- a/examples/with-transfers/src/main.tsx
+++ b/examples/with-transfers/src/main.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { WagmiProvider } from 'wagmi'
+
+import App from './App.js'
+import { config } from './config.js'
+
+const queryClient = new QueryClient()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </WagmiProvider>
+  </StrictMode>,
+)

--- a/examples/with-transfers/tsconfig.app.json
+++ b/examples/with-transfers/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vp/client"],
+    "skipLibCheck": true,
+    "customConditions": ["src"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src", "worker", "env.d.ts", "worker-configuration.d.ts"]
+}

--- a/examples/with-transfers/tsconfig.json
+++ b/examples/with-transfers/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/examples/with-transfers/tsconfig.node.json
+++ b/examples/with-transfers/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/with-transfers/vite.config.ts
+++ b/examples/with-transfers/vite.config.ts
@@ -1,0 +1,7 @@
+import { cloudflare } from '@cloudflare/vite-plugin'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vp'
+
+export default defineConfig({
+  plugins: [react(), cloudflare()],
+})

--- a/examples/with-transfers/worker/index.ts
+++ b/examples/with-transfers/worker/index.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono'
+import { Mppx, tempo } from 'mppx/hono'
+import { tempoModerato } from 'viem/chains'
+
+const app = new Hono()
+
+const mppx = Mppx.create({
+  methods: [tempo()],
+})
+
+app.get(
+  '/api/transfer',
+  mppx.charge({
+    amount: '0.01',
+    chainId: tempoModerato.id,
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0x0000000000000000000000000000000000000001',
+  }),
+  (c) =>
+    c.json({
+      success: true,
+    }),
+)
+
+export default app

--- a/examples/with-transfers/wrangler.jsonc
+++ b/examples/with-transfers/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "accounts-with-transfers",
+  "compatibility_date": "2026-03-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
+  "assets": {
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*"],
+  },
+}


### PR DESCRIPTION
Forks `examples/basic` to demonstrate the two ways of transferring from a connected Tempo account.

## What's in the example

| Category                       | Mechanism                       | What it does                                                                                                       |
| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| **User-initiated transfers**   | `wallet_send` RPC from the page | Client signs and broadcasts a stablecoin transfer directly from the user account.                                  |
| **Server-initiated transfers** | `GET /api/transfer`             | Server responds with HTTP `402 Payment Required`; the SDK auto-fulfills the challenge and retries the request.     |

The connector authorizes a one-day access key with a pathUSD spend limit so both flows sign silently in the background — no passkey prompt per call.

## Layout

- `src/App.tsx` — Connect, Faucet, user-initiated transfer button, server-initiated charge button.
- `src/config.ts` — Wagmi config with `tempoWallet({ authorizeAccessKey: ... })`.
- `worker/index.ts` — Hono worker exposing the `GET /api/transfer` endpoint behind `mppx.charge` middleware.
- `.env.example` — `MPP_REALM` and `MPP_SECRET_KEY` stubs.

## Setup

```bash
npx gitpick tempoxyz/accounts/examples/with-transfers
cp .env.example .env
npm i
npm dev
```