### PR TITLE
chore: bump wrangler catalog to ^4.90.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,7 +531,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
-        version: 1.33.2(vite@8.0.10)(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
       '@types/node':
         specifier: ^25.6.0
         version: 25.7.0
@@ -543,13 +543,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.10)
+        version: 5.2.0(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite-plus:
         specifier: ~0.1.18
-        version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10)(yaml@2.8.3)
+        version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
         specifier: ^4.85.0
         version: 4.85.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ overrides:
   tar: 7.5.15
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
-  wrangler: ^4.85.0
+  wrangler: ^4.90.1
 
 patchedDependencies:
   vocs@0.0.0: 0749dd43af96e1423a849f589c6b765ac71042c00b84c5d521e0af05bf159b6e
@@ -258,7 +258,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.7.0
@@ -281,8 +281,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/authentication:
     dependencies:
@@ -310,7 +310,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.7.0
@@ -333,8 +333,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12)(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/basic:
     dependencies:
@@ -427,7 +427,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.7.0
@@ -450,8 +450,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12)(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/fee-payer-and-webauthn:
     dependencies:
@@ -479,7 +479,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.7.0
@@ -499,8 +499,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/mpp:
     dependencies:
@@ -531,7 +531,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
-        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.7.0
@@ -551,8 +551,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/subscriptions:
     dependencies:
@@ -583,7 +583,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
-        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.7.0
@@ -603,8 +603,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/transfers:
     dependencies:
@@ -635,7 +635,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
-        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.7.0
@@ -655,8 +655,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   examples/webauthn:
     dependencies:
@@ -684,7 +684,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.7.0
@@ -707,8 +707,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   playgrounds/react-native:
     dependencies:
@@ -788,7 +788,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
-        version: 1.36.4(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.36.4(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: latest
         version: 25.6.0
@@ -808,8 +808,8 @@ importers:
         specifier: ~0.1.18
         version: 0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12)(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   playgrounds/web:
     dependencies:
@@ -840,7 +840,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@iconify/json':
         specifier: ^2.2.461
         version: 2.2.469
@@ -866,8 +866,8 @@ importers:
         specifier: npm:vite-plus@~0.1.18
         version: vite-plus@0.1.18(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   ref-impls/cli-auth:
     dependencies:
@@ -886,7 +886,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.33.2(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)
+        version: 1.33.2(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
@@ -912,8 +912,8 @@ importers:
         specifier: npm:vite-plus@~0.1.18
         version: vite-plus@0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.12)(yaml@2.8.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.90.1
+        version: 4.90.1
 
   ref-impls/dialog:
     dependencies:
@@ -1566,9 +1566,9 @@ packages:
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
-  '@cloudflare/kv-asset-handler@0.4.2':
-    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
-    engines: {node: '>=18.0.0'}
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
 
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
@@ -1583,13 +1583,13 @@ packages:
     resolution: {integrity: sha512-XI6+XkDn8W6tlvtYUoS6C89Te7fwhyDLrhUBUbagPO1StJ6ofbR0vpqNNqNskUp9592xTRCDk5ukqcjz6xMo+g==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.85.0
+      wrangler: ^4.90.1
 
   '@cloudflare/vite-plugin@1.36.4':
     resolution: {integrity: sha512-/nMlXSOB58eg2CiU5efg33RYswMj54sxolfw49sYlZF8JiYdlBxkHE9+iOAerXTFyYZpKPYMGdApMyZgtgGhmg==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.85.0
+      wrangler: ^4.90.1
 
   '@cloudflare/workerd-darwin-64@1.20260424.1':
     resolution: {integrity: sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==}
@@ -9265,12 +9265,12 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.85.0:
-    resolution: {integrity: sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==}
-    engines: {node: '>=20.3.0'}
+  wrangler@4.90.1:
+    resolution: {integrity: sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260424.1
+      '@cloudflare/workers-types': ^4.20260508.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -10236,13 +10236,7 @@ snapshots:
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
-  '@cloudflare/kv-asset-handler@0.4.2': {}
-
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260424.1
+  '@cloudflare/kv-asset-handler@0.5.0': {}
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)':
     dependencies:
@@ -10250,65 +10244,52 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260508.1
 
-  '@cloudflare/vite-plugin@1.33.2(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)':
+  '@cloudflare/vite-plugin@1.33.2(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
       miniflare: 4.20260424.0
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.85.0
+      wrangler: 4.90.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)':
+  '@cloudflare/vite-plugin@1.33.2(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
       miniflare: 4.20260424.0
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.85.0
+      wrangler: 4.90.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.36.4(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)':
+  '@cloudflare/vite-plugin@1.36.4(vite@8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
       miniflare: 4.20260508.0
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.85.0
+      wrangler: 4.90.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0)':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
-      miniflare: 4.20260508.0
-      unenv: 2.0.0-rc.24
-      vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.85.0
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
-
-  '@cloudflare/vite-plugin@1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.85.0)':
+  '@cloudflare/vite-plugin@1.36.4(vite@8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.12))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260508.1)(wrangler@4.90.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
       miniflare: 4.20260508.0
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.85.0
+      wrangler: 4.90.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -19626,16 +19607,16 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260508.1
       '@cloudflare/workerd-windows-64': 1.20260508.1
 
-  wrangler@4.85.0:
+  wrangler@4.90.1:
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260508.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260424.0
+      miniflare: 4.20260508.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260424.1
+      workerd: 1.20260508.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ catalog:
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
   wagmi: ^3.6.15
-  wrangler: ^4.85.0
+  wrangler: ^4.90.1
   zod: ^4.3.6
 
 minimumReleaseAge: 1440


### PR DESCRIPTION
Fixes the Wagmi CI build failure on main:
```
The installed version of Wrangler (4.85.0) does not satisfy the peer dependency
required by @cloudflare/vite-plugin (^4.90.1).
```

`@cloudflare/vite-plugin@1.36.4` (which `playgrounds/wagmi` pulls in via `latest`) requires `wrangler ^4.90.1` as a peer dependency. The catalog was pinned to `^4.85.0`, so `playgrounds/wagmi` (which uses `wrangler: catalog:`) resolved to 4.85.0 and failed peer dep checks at build time.