### PR TITLE
chore: align wrangler override in lockfile with workspace catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ overrides:
   tar: 7.5.15
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
-  wrangler: ^4.85.0
+  wrangler: ^4.90.1
 
 patchedDependencies:
   vocs@0.0.0: 0749dd43af96e1423a849f589c6b765ac71042c00b84c5d521e0af05bf159b6e


### PR DESCRIPTION
Fixes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on main.

#444 bumped the catalog wrangler from `^4.85.0` to `^4.90.1`, but pnpm did not refresh the literal `overrides` section in the lockfile because the resolved dependency graph was unchanged (4.90.1 was already the resolved version).

CI runs `pnpm install --frozen-lockfile`, which compares the workspace overrides config to the lockfile literal and fails the install when they don't match. This PR updates the literal in the lockfile to match the new catalog value.