### PR TITLE
fix: domain-separate local digest fallback

### DIFF
--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -185,7 +185,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
     })
 
-    test('behavior: digest signature is verifiable on-chain', async () => {
+    test('behavior: caller digest signature is not a raw hash signature', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       const client = provider.getClient()
 
@@ -201,7 +201,14 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         hash: digest,
         signature: result.accounts[0]!.capabilities.signature!,
       })
-      expect(valid).toMatchInlineSnapshot(`true`)
+      expect(valid).toMatchInlineSnapshot(`false`)
+
+      const messageValid = await verifyMessage(client, {
+        address: result.accounts[0]!.address,
+        message: { raw: digest },
+        signature: result.accounts[0]!.capabilities.signature!,
+      })
+      expect(messageValid).toMatchInlineSnapshot(`true`)
     })
 
     test('behavior: login without digest returns empty capabilities', async () => {
@@ -231,7 +238,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
     })
 
-    test('behavior: register digest signature is verifiable on-chain', async () => {
+    test('behavior: register caller digest signature is not a raw hash signature', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       const client = provider.getClient()
 
@@ -246,7 +253,14 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         hash: digest,
         signature: result.accounts[0]!.capabilities.signature!,
       })
-      expect(valid).toMatchInlineSnapshot(`true`)
+      expect(valid).toMatchInlineSnapshot(`false`)
+
+      const messageValid = await verifyMessage(client, {
+        address: result.accounts[0]!.address,
+        message: { raw: digest },
+        signature: result.accounts[0]!.capabilities.signature!,
+      })
+      expect(messageValid).toMatchInlineSnapshot(`true`)
     })
 
     test('behavior: login with personalSign echoes { message } and surfaces signature at root', async () => {

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -31,6 +31,26 @@ describe('local', () => {
         ]
       `)
     })
+
+    test('default: caller digest fallback signs an EIP-191 raw message', async () => {
+      const digest = `0x${'12'.repeat(32)}` as const
+      const { adapter } = setup({
+        loadAccounts: makeLoadAccounts(0, []),
+      })
+
+      const result = await adapter.actions.loadAccounts(
+        { digest },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect(
+        await verifyMessage({
+          address: core_accounts[0]!.address,
+          message: { raw: digest },
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+    })
   })
 
   describe('loadAccounts: personalSign', () => {
@@ -191,6 +211,34 @@ describe('local', () => {
       ).toBe(true)
     })
 
+    test('default: caller digest fallback signs an EIP-191 raw message', async () => {
+      const digest = `0x${'34'.repeat(32)}` as const
+      const { adapter } = setup({
+        createAccount: async () => ({
+          accounts: [
+            {
+              address: core_accounts[1].address,
+              keyType: 'secp256k1' as const,
+              privateKey: privateKeys[1]!,
+            },
+          ],
+        }),
+      })
+
+      const result = await adapter.actions.createAccount(
+        { name: 'test', digest },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect(
+        await verifyMessage({
+          address: core_accounts[1]!.address,
+          message: { raw: digest },
+          signature: result.signature!,
+        }),
+      ).toBe(true)
+    })
+
     test('error: createAccount rejects when personalSign and digest are both set', async () => {
       const { adapter } = setup({
         createAccount: async () => ({
@@ -232,8 +280,8 @@ describe('local', () => {
 /**
  * Builds a `loadAccounts` callback backed by `privateKeys[index]` (secp256k1)
  * that records each `digest` it receives into `captured`. Returns the account
- * but no signature, so the local adapter signs the digest itself via
- * `account.sign({ hash })` — exercising the real signing path end-to-end.
+ * but no signature, so the local adapter exercises the real fallback
+ * signing path end-to-end.
  */
 function makeLoadAccounts(
   index: number,

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -124,7 +124,11 @@ export function local(options: local.Options): Adapter.Adapter {
 
           // If the caller requested a digest signature but the adapter didn't
           // produce one (e.g. secp256k1 adapters), sign it ourselves.
-          const signature_ = digest && !signature ? await account.sign({ hash: digest }) : signature
+          const signature_ = await (async () => {
+            if (!digest || signature) return signature
+            if (personalSign) return await account.signMessage({ message: personalSign.message })
+            return await account.signMessage({ message: { raw: digest } })
+          })()
 
           const keyAuthorization = await (async () => {
             if (!grantOptions) return undefined
@@ -192,7 +196,16 @@ export function local(options: local.Options): Adapter.Adapter {
 
           // Fall back to local signing if the adapter didn't return a signature.
           let signature_ = signature
-          if (digest && !signature_ && account) signature_ = await account.sign({ hash: digest })
+          if (digest && !signature_ && account) {
+            if (personalSign)
+              signature_ = await account.signMessage({ message: personalSign.message })
+            else if (
+              keyAuthorization_unsigned &&
+              digest === KeyAuthorization.getSignPayload(keyAuthorization_unsigned.keyAuthorization)
+            )
+              signature_ = await account.sign({ hash: digest })
+            else signature_ = await account.signMessage({ message: { raw: digest } })
+          }
 
           // Key auth signing path:
           //   - If `personalSign` took the ceremony slot AND `authorizeAccessKey`


### PR DESCRIPTION
## Summary

Prevent local wallet connect fallback signing from producing raw signatures over caller-supplied digests. Key authorization digests still use the required raw signing path, while arbitrary connect digests are signed as EIP-191 raw messages.