### PR TITLE
fix: enforce access key recipients

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -1,6 +1,6 @@
 import { WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { encodeErrorResult } from 'viem'
+import { encodeErrorResult, encodeFunctionData } from 'viem'
 import { Abis, Account as TempoAccount } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
@@ -658,6 +658,97 @@ describe('selectAccount', () => {
     })
 
     expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
+  })
+
+  test('behavior: scoped access key selects when recipient matches', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const recipient = '0x0000000000000000000000000000000000000def' as const
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [{ address: token, recipients: [recipient], selector: '0xa9059cbb' }],
+      },
+    ])
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [
+        {
+          to: token,
+          data: encodeFunctionData({
+            abi: [
+              {
+                type: 'function',
+                name: 'transfer',
+                inputs: [
+                  { type: 'address', name: 'to' },
+                  { type: 'uint256', name: 'amount' },
+                ],
+                outputs: [],
+                stateMutability: 'nonpayable',
+              },
+            ],
+            functionName: 'transfer',
+            args: [recipient, 1n],
+          }),
+        },
+      ],
+    })
+
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
+  })
+
+  test('behavior: scoped access key skips when recipient does not match', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const recipient = '0x0000000000000000000000000000000000000def' as const
+    const attacker = '0x0000000000000000000000000000000000000bad' as const
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [{ address: token, recipients: [recipient], selector: '0xa9059cbb' }],
+      },
+    ])
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [
+        {
+          to: token,
+          data: encodeFunctionData({
+            abi: [
+              {
+                type: 'function',
+                name: 'transfer',
+                inputs: [
+                  { type: 'address', name: 'to' },
+                  { type: 'uint256', name: 'amount' },
+                ],
+                outputs: [],
+                stateMutability: 'nonpayable',
+              },
+            ],
+            functionName: 'transfer',
+            args: [attacker, 1n],
+          }),
+        },
+      ],
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
   })
 
   test('behavior: scoped access key without selector allows any call to that address', async () => {

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -281,15 +281,51 @@ function scopesMatch(
     const callSelector = call.data?.slice(0, 10).toLowerCase()
     return key.scopes!.some((scope) => {
       if (scope.address.toLowerCase() !== callTo) return false
-      if (!scope.selector) return true
+      if (!scope.selector) return !scope.recipients || scope.recipients.length === 0
       const scopeSelector = (
         scope.selector.startsWith('0x') && scope.selector.length === 10
           ? scope.selector
           : AbiFunction.getSelector(scope.selector)
       ).toLowerCase()
-      return callSelector === scopeSelector
+      if (callSelector !== scopeSelector) return false
+      return recipientsMatch(scope, call.data)
     })
   })
+}
+
+function recipientsMatch(
+  scope: NonNullable<AccessKey['scopes']>[number],
+  data: Hex.Hex | undefined,
+): boolean {
+  const { recipients } = scope
+  if (!recipients || recipients.length === 0) return true
+  if (!data) return false
+  const selector = data.slice(0, 10).toLowerCase()
+  const indexes = recipientIndexes[selector]
+  if (!indexes) return false
+  const allowed = recipients.map((recipient) => recipient.toLowerCase())
+  return indexes.some((index) => {
+    const recipient = wordAddress(data, index)
+    return recipient ? allowed.includes(recipient) : false
+  })
+}
+
+const recipientIndexes: Record<string, readonly number[]> = {
+  [AbiFunction.getSelector('approve(address,uint256)').toLowerCase()]: [0],
+  [AbiFunction.getSelector('safeTransferFrom(address,address,uint256)').toLowerCase()]: [1],
+  [AbiFunction.getSelector('safeTransferFrom(address,address,uint256,bytes)').toLowerCase()]: [1],
+  [AbiFunction.getSelector(
+    'safeTransferFrom(address,address,uint256,uint256,bytes)',
+  ).toLowerCase()]: [1],
+  [AbiFunction.getSelector('transfer(address,uint256)').toLowerCase()]: [0],
+  [AbiFunction.getSelector('transferFrom(address,address,uint256)').toLowerCase()]: [1],
+}
+
+function wordAddress(data: Hex.Hex, index: number): Address.Address | undefined {
+  const offset = 10 + index * 64
+  const word = data.slice(offset, offset + 64)
+  if (word.length !== 64) return undefined
+  return `0x${word.slice(24)}` as Address.Address
 }
 
 function shouldRemoveForError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Enforce recipient restrictions when selecting scoped access keys for transaction signing. Recipient-scoped token calls now require calldata recipients to match the authorized addresses, and recipient scopes without decodable selectors are not selected.