### PR TITLE
fix: require explicit trusted hosts

### DIFF
--- a/src/core/TrustedHosts.test.ts
+++ b/src/core/TrustedHosts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vp/test'
+
+import * as TrustedHosts from './TrustedHosts.js'
+
+describe('match', () => {
+  test('behavior: matches explicit trusted host', () => {
+    expect(TrustedHosts.match(['app.example.com'], 'app.example.com')).toMatchInlineSnapshot(`true`)
+  })
+
+  test('behavior: matches explicit wildcard subdomain', () => {
+    expect(TrustedHosts.match(['*.example.com'], 'app.example.com')).toMatchInlineSnapshot(`true`)
+  })
+
+  test('behavior: does not implicitly trust shared hosting siblings', () => {
+    expect(
+      TrustedHosts.match([], 'wallet.vercel.app', 'attacker.vercel.app'),
+    ).toMatchInlineSnapshot(`false`)
+  })
+})

--- a/src/core/TrustedHosts.ts
+++ b/src/core/TrustedHosts.ts
@@ -18,7 +18,7 @@ export const hosts: Record<string, readonly string[]> = _hosts
  * (e.g. `*.workers.dev` matches `foo.workers.dev`).
  */
 export function match(trustedHosts: readonly string[], hostname: string, source?: string) {
-  if (source && sameRegistrableDomain(hostname, source)) return true
+  void source
   return trustedHosts.some((pattern) => {
     if (pattern.startsWith('*.'))
       return hostname.endsWith(pattern.slice(1)) && hostname.length > pattern.length - 1


### PR DESCRIPTION
## Summary

Remove implicit trust for hosts that only share a registrable domain with the dialog origin. Embedded dialogs now rely on explicit trusted host entries and wildcard patterns.