### PR TITLE
fix: show approval exposure in balance diffs

### DIFF
--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -922,12 +922,12 @@ describe('behavior: capabilities', () => {
     expect(diffs.find((d) => d.address.toLowerCase() === base.toLowerCase())).toBeUndefined()
   })
 
-  test('behavior: approval covered by transfer is suppressed', async () => {
+  test('behavior: approval and transfer both show outgoing exposure', async () => {
     const sender = accounts[6]!
     const recipient = accounts[7]!
     const token = addresses.alphaUsd
 
-    // approve(100) + transfer(100) to same spender → approval fully covered.
+    // approve(100) + transfer(100) to same spender → both remain separate exposure.
     const result = await fillTransaction(client, {
       account: sender.address,
       calls: [
@@ -947,17 +947,17 @@ describe('behavior: capabilities', () => {
 
     const diffs = findDiffs(meta?.balanceDiffs, sender.address)!
     const tokenDiff = diffs.find((d) => d.address.toLowerCase() === token.toLowerCase())!
-    // Only the transfer shows — approval is fully covered.
-    expect(tokenDiff.value).toBe('0x64')
+    // Transfer does not consume the approval allowance.
+    expect(tokenDiff.value).toBe('0xc8')
     expect(tokenDiff.direction).toBe('outgoing')
   })
 
-  test('behavior: uncovered approval shows as outgoing', async () => {
+  test('behavior: approval is not reduced by transfer to spender', async () => {
     const sender = accounts[6]!
     const spender = accounts[7]!
     const token = addresses.alphaUsd
 
-    // approve(200) + transfer(50) to same spender → 150 uncovered approval.
+    // approve(200) + transfer(50) to same spender → 250 outgoing exposure.
     const result = await fillTransaction(client, {
       account: sender.address,
       calls: [
@@ -977,8 +977,8 @@ describe('behavior: capabilities', () => {
 
     const diffs = findDiffs(meta?.balanceDiffs, sender.address)!
     const tokenDiff = diffs.find((d) => d.address.toLowerCase() === token.toLowerCase())!
-    // transfer(50) + uncovered approval(150) = 200 outgoing.
-    expect(tokenDiff.value).toBe('0xc8')
+    // Direct transfer does not reduce the approved allowance.
+    expect(tokenDiff.value).toBe('0xfa')
     expect(tokenDiff.direction).toBe('outgoing')
   })
 })

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -1115,9 +1115,6 @@ async function buildBalanceDiffs(client: Client, options: buildBalanceDiffs.Opti
     { incoming: bigint; outgoing: bigint; recipients: Set<Address>; token: Address }
   >()
 
-  // Track total transferred per (token, spender) so we can suppress covered approvals.
-  const transferredBySpender = new Map<string, bigint>()
-
   for (const log of transferLogs) {
     const token = log.address.toLowerCase()
     const fromLower = log.args.from.toLowerCase()
@@ -1138,14 +1135,12 @@ async function buildBalanceDiffs(client: Client, options: buildBalanceDiffs.Opti
     if (fromLower === accountLower) {
       entry.outgoing += log.args.amount
       entry.recipients.add(log.args.to)
-      const key = `${token}:${toLower}`
-      transferredBySpender.set(key, (transferredBySpender.get(key) ?? 0n) + log.args.amount)
     }
     if (toLower === accountLower) entry.incoming += log.args.amount
     tokenMap.set(token, entry)
   }
 
-  // Treat approvals as outgoing unless the spender already transferred >= approval amount.
+  // Treat approvals as outgoing exposure. Direct transfers do not consume allowances.
   for (const log of approvalLogs) {
     if (log.args.owner.toLowerCase() !== accountLower) continue
     const token = log.address.toLowerCase()
@@ -1153,17 +1148,13 @@ async function buildBalanceDiffs(client: Client, options: buildBalanceDiffs.Opti
     // Skip swap-related approvals (reported in capabilities.autoSwap instead).
     if (swap && token === swapTokenIn && log.args.spender.toLowerCase() === dexLower) continue
 
-    const spenderKey = `${token}:${log.args.spender.toLowerCase()}`
-    const transferred = transferredBySpender.get(spenderKey) ?? 0n
-    if (log.args.amount <= transferred) continue
-
     const entry = tokenMap.get(token) ?? {
       incoming: 0n,
       outgoing: 0n,
       recipients: new Set<Address>(),
       token: log.address,
     }
-    entry.outgoing += log.args.amount - transferred
+    entry.outgoing += log.args.amount
     entry.recipients.add(log.args.spender)
     tokenMap.set(token, entry)
   }


### PR DESCRIPTION
## Summary

Stop suppressing token approvals when a transaction also transfers tokens to the same spender. Balance diffs now include approval exposure independently because direct transfers do not consume allowances.