### PR TITLE
fix: constrain upstream filled fields

### DIFF
--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -1071,7 +1071,7 @@ describe('behavior: AMM resolution', () => {
     const { transaction, capabilities } = result
     expect(transaction.gas).toBeDefined()
     expect(transaction.nonce).toBeDefined()
-    expect(transaction.feeToken).toBe(addresses.alphaUsd)
+    expect(transaction.feeToken?.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())
     expect(transaction.calls).toHaveLength(3) // approve + swap + transfer
 
     const m = capabilities

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -1623,7 +1623,7 @@ describe('behavior: fee token resolution', () => {
       calls: [transferCall()],
     })
 
-    expect(transaction.feeToken).toBe(preferredToken)
+    expect(transaction.feeToken?.toLowerCase()).toBe(preferredToken.toLowerCase())
   })
 
   test('behavior: resolves to highest-balance token from token list', async () => {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -677,7 +677,7 @@ async function fill(client: Client, options: fill.Options) {
     if (!sourceToken || sourceToken.toLowerCase() === insufficientToken.toLowerCase()) return null
 
     const maxAmountIn = deficit + (deficit * BigInt(Math.round(autoSwap.slippage * 1000))) / 1000n
-    const originalCalls = (request.calls as Call[] | undefined) ?? []
+    const originalCalls = extractCalls(request)
     const swapCalls = buildSwapCalls(sourceToken, insufficientToken, deficit, maxAmountIn)
 
     const result = await client.request({

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -662,7 +662,9 @@ async function fill(client: Client, options: fill.Options) {
 
   // Skip re-formatting if already in RPC format (e.g. from viem's fillTransaction).
   const format = (value: Record<string, unknown>) =>
-    value.type === '0x76' ? value : Utils.formatFillTransactionRequest(client, value)
+    Utils.normalizeFillTransactionRequest(
+      value.type === '0x76' ? value : Utils.formatFillTransactionRequest(client, value),
+    )
 
   // Re-fill the transaction with prepended swap calls so the user can
   // mint the missing `insufficientToken` (typically the fee token) from

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -1358,17 +1358,18 @@ function buildSwapCalls(
  * built for sponsorship signing throws `CallsEmptyError` or
  * `Cannot convert undefined to a BigInt` when serializing.
  *
- * Result fields take precedence (they are the chain's authoritative filled
- * values); request fields fill in everything else. Calls are normalized
+ * Only gas, fee, nonce, and signature fields from the fill result are trusted;
+ * request fields define the transaction being filled. Calls are normalized
  * separately so legacy `to`/`data`/`value` requests are also supported.
  */
 function mergeCallsFromRequest(
   resultTx: Record<string, unknown>,
   request: Record<string, unknown>,
 ): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...request, ...resultTx }
-  const resultCalls = resultTx.calls
-  if (Array.isArray(resultCalls) && resultCalls.length > 0) return merged
+  const merged: Record<string, unknown> = {
+    ...request,
+    ...pickFillFields(resultTx),
+  }
 
   const reqCalls = request.calls
   if (Array.isArray(reqCalls) && reqCalls.length > 0) {
@@ -1388,6 +1389,20 @@ function mergeCallsFromRequest(
     },
   ]
   return merged
+}
+
+function pickFillFields(tx: Record<string, unknown>): Record<string, unknown> {
+  const fields = [
+    'feePayerSignature',
+    'gas',
+    'gasPrice',
+    'maxFeePerGas',
+    'maxPriorityFeePerGas',
+    'nonce',
+  ] as const
+  const picked: Record<string, unknown> = {}
+  for (const field of fields) if (typeof tx[field] !== 'undefined') picked[field] = tx[field]
+  return picked
 }
 
 /**

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -679,12 +679,13 @@ async function fill(client: Client, options: fill.Options) {
     const maxAmountIn = deficit + (deficit * BigInt(Math.round(autoSwap.slippage * 1000))) / 1000n
     const originalCalls = extractCalls(request)
     const swapCalls = buildSwapCalls(sourceToken, insufficientToken, deficit, maxAmountIn)
+    const { data: _, to: __, value: ___, ...requestWithoutLegacyCall } = request
 
     const result = await client.request({
       method: 'eth_fillTransaction',
       params: [
         format({
-          ...request,
+          ...requestWithoutLegacyCall,
           calls: [...swapCalls, ...originalCalls],
         }) as never,
       ],
@@ -693,7 +694,7 @@ async function fill(client: Client, options: fill.Options) {
       | { address: Address; name?: string; url?: string }
       | undefined
     const mergedTx = mergeCallsFromRequest(result.tx as Record<string, unknown>, {
-      ...request,
+      ...requestWithoutLegacyCall,
       calls: [...swapCalls, ...originalCalls],
     })
     return {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -751,7 +751,10 @@ async function fill(client: Client, options: fill.Options) {
     // The chain's `eth_fillTransaction` doesn't echo back `calls`, so merge
     // them in from the original request before normalizing — otherwise the
     // typed envelope built for sponsorship signing throws CallsEmptyError.
-    const mergedTx = mergeCallsFromRequest(result.tx as Record<string, unknown>, request)
+    const mergedTx = mergeCallsFromRequest(
+      result.tx as Record<string, unknown>,
+      swap ? { ...request, calls: [...swap.calls, ...extractCalls(request)] } : request,
+    )
 
     // The node's `eth_fillTransaction` may pick a fee token the user
     // doesn't yet hold (e.g. one this transaction will mint via a

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -662,7 +662,7 @@ async function fill(client: Client, options: fill.Options) {
 
   // Skip re-formatting if already in RPC format (e.g. from viem's fillTransaction).
   const format = (value: Record<string, unknown>) =>
-    Utils.normalizeFillTransactionRequest(
+    normalizeFillRequestForRpc(
       value.type === '0x76' ? value : Utils.formatFillTransactionRequest(client, value),
     )
 
@@ -1008,6 +1008,26 @@ function extractCalls(transaction: Record<string, unknown>): readonly Call[] {
       ...(transaction.value ? { value: transaction.value as bigint } : {}),
     },
   ] as readonly Call[]
+}
+
+// TODO: cleanup/remove
+function normalizeFillRequestForRpc(transaction: Record<string, unknown>): Record<string, unknown> {
+  const calls = transaction.calls as readonly Record<string, unknown>[] | undefined
+  if (!calls?.length) return transaction
+  return {
+    ...transaction,
+    calls: calls.map((call) => ({
+      ...call,
+      value: normalizeCallValueForRpc(call.value),
+    })),
+  }
+}
+
+function normalizeCallValueForRpc(value: unknown) {
+  if (typeof value === 'bigint') return Hex.fromNumber(value)
+  if (value === '0x') return '0x0'
+  if (typeof value === 'undefined') return '0x0'
+  return value
 }
 
 // TODO: cleanup/remove

--- a/src/server/internal/handlers/sponsorship.ts
+++ b/src/server/internal/handlers/sponsorship.ts
@@ -79,7 +79,7 @@ export function isPreparedTransaction(value: Record<string, unknown>) {
 /** Signs a filled transaction as the fee payer. */
 export async function sign(options: sign.Options) {
   const { account, transaction, sender } = options
-  const from = (transaction.from as Address | undefined) ?? sender
+  const from = sender ?? (transaction.from as Address | undefined)
   const { signature: _, ...withoutSenderSig } = transaction
   const prepared = { ...withoutSenderSig, from }
 


### PR DESCRIPTION
## Summary

Constrain merged upstream fill responses to gas, fee, nonce, and fee-payer signature fields. 

Sponsorship signing now prioritizes the original request sender so validation and signing use the same sender.