### PR TITLE
fix: require local sponsor validation

### DIFF
--- a/examples/fee-payer-and-webauthn/worker/index.ts
+++ b/examples/fee-payer-and-webauthn/worker/index.ts
@@ -8,6 +8,7 @@ app.all('/relay/*', (c) =>
   Handler.relay({
     feePayer: {
       account: privateKeyToAccount(c.env.FEE_PAYER_PRIVATE_KEY),
+      validate: () => true,
     },
     path: '/relay',
   }).fetch(c.req.raw),

--- a/examples/fee-payer/worker/index.ts
+++ b/examples/fee-payer/worker/index.ts
@@ -8,6 +8,7 @@ app.all('/relay/*', (c) =>
   Handler.relay({
     feePayer: {
       account: privateKeyToAccount(c.env.FEE_PAYER_PRIVATE_KEY),
+      validate: () => true,
     },
     path: '/relay',
   }).fetch(c.req.raw),

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -27,6 +27,7 @@ const handler = Handler.compose([
       account: privateKeyToAccount(process.env.PRIVATE_KEY),
       name: 'Playground',
       url: 'https://playground.tempo.xyz',
+      validate: () => true,
     },
     path: '/relay',
   }),

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -2173,6 +2173,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           chains: [chain],
           feePayer: {
             account: feePayerAccount,
+            validate: () => true,
           },
           transports: { [chain.id]: http() },
         }).listener,

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -221,6 +221,7 @@ describe('behavior: with feePayer', () => {
           account: feePayerAccount,
           name: 'Test Sponsor',
           url: 'https://test.com',
+          validate: () => true,
         },
         onRequest: async (request) => {
           requests.push(request)
@@ -321,6 +322,7 @@ describe('behavior: with feePayer.feeToken', () => {
         feePayer: {
           account: feePayerAccount,
           feeToken: sponsorFeeToken,
+          validate: () => true,
         },
         resolveTokens: () => localnetTokens,
       }).listener,
@@ -406,6 +408,7 @@ describe('behavior: with app-provided feePayer URL', () => {
           account: feePayerAccount,
           name: 'App Sponsor',
           url: 'https://app.example.com',
+          validate: () => true,
         },
       }).listener,
     )
@@ -494,6 +497,7 @@ describe('behavior: with app-provided feePayer URL + autoSwap', () => {
           account: feePayerAccount,
           name: 'App Sponsor',
           url: 'https://app.example.com',
+          validate: () => true,
         },
       }).listener,
     )
@@ -614,6 +618,7 @@ describe('behavior: app-provided feePayer URL bypasses wallet validate', () => {
           account: feePayerAccount,
           name: 'App Sponsor',
           url: 'https://app.example.com',
+          validate: () => true,
         },
       }).listener,
     )
@@ -1374,6 +1379,7 @@ describe('behavior: path A — guaranteed sponsorship (no validate)', () => {
         feePayer: {
           account: feePayerAccount,
           name: 'Path A Sponsor',
+          validate: () => true,
         },
         onRequest: async (request) => {
           requests.push(request)

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -153,6 +153,10 @@ export function relay(options: relay.Options = {}): Handler {
             typeof parameters.feePayer === 'string' ? parameters.feePayer : undefined
           const requestsSponsorship =
             (!!feePayerOptions || !!externalFeePayerUrl) && parameters.feePayer !== false
+          if (requestsSponsorship && feePayerOptions && !feePayerOptions.validate)
+            throw new RpcResponse.InvalidParamsError({
+              message: 'Local fee payer sponsorship requires a validate callback.',
+            })
           // Default to `true`. Dapps that don't render diffs can pass
           // `capabilities.balanceDiffs: false` to skip the post-fill
           // `tempo_simulateV1` round trip (~250-400ms).
@@ -356,6 +360,7 @@ export function relay(options: relay.Options = {}): Handler {
             })(),
             // Sign as fee payer (if sponsored and not already signed).
             (async () => {
+              if (externalFeePayerUrl) return transaction_filled
               if (!(sponsored && feePayerOptions && !alreadySigned)) return transaction_filled
               return Sponsorship.sign({
                 account: feePayerOptions.account,
@@ -530,7 +535,12 @@ export function relay(options: relay.Options = {}): Handler {
             getClient,
             method: request.method as Sponsorship.handleRawTransaction.Options['method'],
             request: { params: 'params' in request ? request.params : undefined },
-            validate: feePayerOptions.validate,
+            validate: (() => {
+              if (feePayerOptions.validate) return feePayerOptions.validate
+              throw new RpcResponse.InvalidParamsError({
+                message: 'Local fee payer sponsorship requires a validate callback.',
+              })
+            })(),
           })
           return RpcResponse.from({ result } as never, { request } as never)
         } catch (error) {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -63,6 +63,7 @@ const defaultCacheTtl = 10 * 60
  * const handler = Handler.relay({
  *   feePayer: {
  *     account: privateKeyToAccount('0x...'),
+ *     validate: () => true,
  *   },
  * })
  * ```


### PR DESCRIPTION
## Summary

Makes fee sponsorship flow safer, but requiring an explicit validation hook, and separating external and local sponsorship

* Require local fee-payer sponsorship to provide a validation callback before signing. 
* External fee-payer fills are kept separate from local sponsor signing so a client-provided fee payer URL cannot trigger local sponsorship.