### PR TITLE
fix: validate fee payer urls

### DIFF
--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -112,9 +112,18 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
  * browser; on the server, relative paths are returned as-is.
  */
 function normalizeFeePayerUrl(url: string): string {
-  if (url.startsWith('http://') || url.startsWith('https://')) return url
-  if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
-  return url
+  if (typeof window !== 'undefined')
+    return validateFeePayerUrl(new URL(url, window.location.origin))
+  return validateFeePayerUrl(new URL(url))
+}
+
+function validateFeePayerUrl(url: URL): string {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:')
+    throw new Error('Fee payer URL must use http or https.')
+  url.username = ''
+  url.password = ''
+  url.hash = ''
+  return url.href
 }
 
 function feePayerTransport(

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -112,18 +112,9 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
  * browser; on the server, relative paths are returned as-is.
  */
 function normalizeFeePayerUrl(url: string): string {
-  if (typeof window !== 'undefined')
-    return validateFeePayerUrl(new URL(url, window.location.origin))
-  return validateFeePayerUrl(new URL(url))
-}
-
-function validateFeePayerUrl(url: URL): string {
-  if (url.protocol !== 'https:' && url.protocol !== 'http:')
-    throw new Error('Fee payer URL must use http or https.')
-  url.username = ''
-  url.password = ''
-  url.hash = ''
-  return url.href
+  if (url.startsWith('http://') || url.startsWith('https://')) return url
+  if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
+  return url
 }
 
 function feePayerTransport(

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -393,6 +393,7 @@ describe('behavior: with feePayer.feeToken', () => {
 
 describe('behavior: external feePayer URL validation', () => {
   const externalUrl = 'https://relay.example.com'
+  const walletFeePayerAccount = accounts[1]!
   let appServer: Server
   let walletServer: Server
   let client: ReturnType<typeof getClient<typeof chain>>
@@ -402,6 +403,7 @@ describe('behavior: external feePayer URL validation', () => {
     appServer = await createServer(
       relay({
         chains: [chain],
+        features: 'all',
         transports: { [chain.id]: http() },
         feePayer: {
           account: feePayerAccount,
@@ -413,9 +415,10 @@ describe('behavior: external feePayer URL validation', () => {
     walletServer = await createServer(
       relay({
         chains: [chain],
+        features: 'all',
         transports: { [chain.id]: http() },
         feePayer: {
-          account: feePayerAccount,
+          account: walletFeePayerAccount,
           validate: () => false,
         },
       }).listener,
@@ -435,7 +438,7 @@ describe('behavior: external feePayer URL validation', () => {
     walletServer.close()
   })
 
-  test('proxies allowed external URL', async () => {
+  test('proxies allowed external URL and relays app sponsor metadata', async () => {
     const result = await fillTransaction(client, {
       account: userAccount.address,
       calls: [transferCall()],
@@ -443,8 +446,110 @@ describe('behavior: external feePayer URL validation', () => {
     })
 
     expect(result.transaction.feePayerSignature).toBeDefined()
+    expect(result.transaction.gas).toBeDefined()
     expect(result.capabilities?.sponsored).toBe(true)
-    expect(result.capabilities?.sponsor?.name).toBe('App Sponsor')
+    expect(result.capabilities?.sponsor).toMatchInlineSnapshot(`
+      {
+        "address": "${feePayerAccount.address}",
+        "name": "App Sponsor",
+        "url": "https://app.example.com",
+      }
+    `)
+  })
+
+  test('behavior: externally sponsored tx can be signed and broadcast', async () => {
+    const { transaction } = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: externalUrl as never,
+    })
+    const serialized = (await Transaction.serialize(transaction as never)) as `0x76${string}`
+    const envelope = TxEnvelopeTempo.deserialize(serialized)
+    const signature = await userAccount.sign({
+      hash: TxEnvelopeTempo.getSignPayload(envelope),
+    })
+    const signed = TxEnvelopeTempo.serialize(envelope, {
+      signature: SignatureEnvelope.from(signature),
+    })
+    const receipt = (await getClient().request({
+      method: 'eth_sendRawTransactionSync' as never,
+      params: [signed],
+    })) as { feePayer?: string | undefined }
+
+    expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    expect(receipt.feePayer).not.toBe(walletFeePayerAccount.address.toLowerCase())
+  })
+
+  test('behavior: external feePayer autoSwap recovers from InsufficientBalance', async () => {
+    const sender = accounts[11]!
+
+    const rpc = getClient({ account: accounts[0]! })
+    const { token: base } = await Actions.token.createSync(rpc, {
+      name: 'External Swap Base',
+      symbol: 'EXTBASE',
+      currency: 'USD',
+      quoteToken: addresses.alphaUsd,
+    })
+    await sendTransactionSync(rpc, {
+      calls: [
+        Actions.token.grantRoles.call({ token: base, role: 'issuer', to: rpc.account!.address }),
+        Actions.token.mint.call({
+          token: base,
+          to: rpc.account!.address,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.mint.call({
+          token: addresses.alphaUsd,
+          to: rpc.account!.address,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.approve.call({
+          token: base,
+          spender: Addresses.stablecoinDex,
+          amount: parseUnits('10000', 6),
+        }),
+        Actions.token.approve.call({
+          token: addresses.alphaUsd,
+          spender: Addresses.stablecoinDex,
+          amount: parseUnits('10000', 6),
+        }),
+      ],
+    })
+    await Actions.dex.createPairSync(rpc, { base })
+    await Actions.dex.placeSync(rpc, {
+      token: base,
+      amount: parseUnits('500', 6),
+      type: 'sell',
+      tick: Tick.fromPrice('1.001'),
+    })
+
+    await Actions.token.mintSync(rpc, {
+      token: addresses.alphaUsd,
+      amount: parseUnits('1000', 6),
+      to: sender.address,
+    })
+    await Actions.fee.setUserToken(getClient({ account: sender }), { token: addresses.alphaUsd })
+
+    const transferAmount = parseUnits('5', 6)
+    const result = await fillTransaction(client, {
+      account: sender.address,
+      ...Actions.token.transfer.call({
+        token: base,
+        to: recipient.address,
+        amount: transferAmount,
+      }),
+      feePayer: externalUrl as never,
+    })
+
+    const { transaction, capabilities } = result
+    expect(transaction.calls).toHaveLength(3)
+    expect(transaction.feePayerSignature).toBeDefined()
+    expect(capabilities?.sponsored).toBe(true)
+    expect(capabilities?.sponsor?.name).toBe('App Sponsor')
+    expect(capabilities?.autoSwap?.slippage).toBe(0.05)
+    expect(capabilities?.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
+    expect(capabilities?.autoSwap?.minOut.symbol).toBe('EXTBASE')
+    expect(capabilities?.autoSwap?.minOut.formatted).toBe('5')
   })
 
   test.each([

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -391,172 +391,37 @@ describe('behavior: with feePayer.feeToken', () => {
   })
 })
 
-describe('behavior: with app-provided feePayer URL', () => {
-  let appServer: Server
-  let walletServer: Server
+describe('behavior: external feePayer URL validation', () => {
+  let server: Server
   let client: ReturnType<typeof getClient<typeof chain>>
 
   beforeAll(async () => {
-    // App relay: has a fee payer account and signs transactions.
-    appServer = await createServer(
-      relay({
-        chains: [chain],
-        transports: { [chain.id]: http() },
-        feePayer: {
-          account: feePayerAccount,
-          name: 'App Sponsor',
-          url: 'https://app.example.com',
-        },
-      }).listener,
-    )
-
-    // Wallet relay: no fee payer configured — proxies to app relay.
-    walletServer = await createServer(
+    server = await createServer(
       relay({
         chains: [chain],
         transports: { [chain.id]: http() },
       }).listener,
     )
 
-    client = getClient({ transport: http(walletServer.url) })
+    client = getClient({ transport: http(server.url) })
   })
 
   afterAll(() => {
-    appServer.close()
-    walletServer.close()
+    server.close()
   })
 
-  test('default: rejects unsafe app relay URLs', async () => {
+  test.each([
+    ['invalid URL', 'not a url'],
+    ['non-HTTPS URL', 'http://relay.example.com'],
+    ['localhost URL', 'https://localhost'],
+    ['private IPv4 URL', 'https://192.168.0.1'],
+    ['IPv6 URL', 'https://[::1]'],
+  ])('rejects %s', async (_name, feePayer) => {
     await expect(
       fillTransaction(client, {
         account: userAccount.address,
         calls: [transferCall()],
-        feePayer: appServer.url as never,
-      }),
-    ).rejects.toThrow(/Invalid parameters/)
-  })
-
-  test('behavior: rejects localhost app relay before forwarding', async () => {
-    await expect(
-      fillTransaction(client, {
-        account: userAccount.address,
-        calls: [transferCall()],
-        feePayer: appServer.url as never,
-      }),
-    ).rejects.toThrow(/Invalid parameters/)
-  })
-
-  test('behavior: rejects non-https app relay URLs', async () => {
-    await expect(
-      fillTransaction(client, {
-        account: userAccount.address,
-        calls: [transferCall()],
-        feePayer: 'http://relay.example.com' as never,
-      }),
-    ).rejects.toThrow(/Invalid parameters/)
-  })
-})
-
-describe('behavior: with app-provided feePayer URL + autoSwap', () => {
-  let appServer: Server
-  let walletServer: Server
-  let client: ReturnType<typeof getClient<typeof chain>>
-
-  beforeAll(async () => {
-    // App relay sponsors fees AND has `features: 'all'` so it can recover
-    // from InsufficientBalance via autoSwap.
-    appServer = await createServer(
-      relay({
-        chains: [chain],
-        features: 'all',
-        transports: { [chain.id]: http() },
-        feePayer: {
-          account: feePayerAccount,
-          name: 'App Sponsor',
-          url: 'https://app.example.com',
-        },
-      }).listener,
-    )
-
-    // Wallet relay forwards to the app relay; also has features:'all' so its
-    // own fill() can detect upstream `capabilities.error` as InsufficientBalance.
-    walletServer = await createServer(
-      relay({
-        chains: [chain],
-        features: 'all',
-        transports: { [chain.id]: http() },
-      }).listener,
-    )
-
-    client = getClient({ transport: http(walletServer.url) })
-  })
-
-  afterAll(() => {
-    appServer.close()
-    walletServer.close()
-  })
-
-  test('behavior: rejects unsafe external feePayer URL before autoSwap', async () => {
-    await expect(
-      fillTransaction(client, {
-        account: accounts[6]!.address,
-        calls: [transferCall()],
-        feePayer: appServer.url as never,
-      }),
-    ).rejects.toThrow(/Invalid parameters/)
-  })
-})
-
-describe('behavior: app-provided feePayer URL bypasses wallet validate', () => {
-  let appServer: Server
-  let walletServer: Server
-  let client: ReturnType<typeof getClient<typeof chain>>
-
-  beforeAll(async () => {
-    // App relay is the authoritative sponsor — it has its own fee payer
-    // account and signs sponsored transactions.
-    appServer = await createServer(
-      relay({
-        chains: [chain],
-        transports: { [chain.id]: http() },
-        feePayer: {
-          account: feePayerAccount,
-          name: 'App Sponsor',
-          url: 'https://app.example.com',
-        },
-      }).listener,
-    )
-
-    // Wallet relay has its own fee payer with a `validate` that ALWAYS
-    // rejects. This guards the wallet's own fee payer; it must NOT gate
-    // sponsorship when the dapp supplies its own external feePayer URL.
-    walletServer = await createServer(
-      relay({
-        chains: [chain],
-        features: 'all',
-        transports: { [chain.id]: http() },
-        feePayer: {
-          account: feePayerAccount,
-          name: 'Wallet Sponsor',
-          validate: () => false,
-        },
-      }).listener,
-    )
-
-    client = getClient({ transport: http(walletServer.url) })
-  })
-
-  afterAll(() => {
-    appServer.close()
-    walletServer.close()
-  })
-
-  test('behavior: unsafe external feePayer URL is rejected before wallet validate', async () => {
-    await expect(
-      fillTransaction(client, {
-        account: userAccount.address,
-        calls: [transferCall()],
-        feePayer: appServer.url as never,
+        feePayer: feePayer as never,
       }),
     ).rejects.toThrow(/Invalid parameters/)
   })

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -392,22 +392,59 @@ describe('behavior: with feePayer.feeToken', () => {
 })
 
 describe('behavior: external feePayer URL validation', () => {
-  let server: Server
+  const externalUrl = 'https://relay.example.com'
+  let appServer: Server
+  let walletServer: Server
   let client: ReturnType<typeof getClient<typeof chain>>
+  let fetch_: typeof fetch = globalThis.fetch
 
   beforeAll(async () => {
-    server = await createServer(
+    appServer = await createServer(
       relay({
         chains: [chain],
         transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          name: 'App Sponsor',
+          url: 'https://app.example.com',
+        },
       }).listener,
     )
-
-    client = getClient({ transport: http(server.url) })
+    walletServer = await createServer(
+      relay({
+        chains: [chain],
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          validate: () => false,
+        },
+      }).listener,
+    )
+    client = getClient({ transport: http(walletServer.url) })
+    fetch_ = globalThis.fetch
+    globalThis.fetch = ((input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.startsWith(externalUrl)) return fetch_(appServer.url, init)
+      return fetch_(input as never, init)
+    }) as typeof fetch
   })
 
   afterAll(() => {
-    server.close()
+    globalThis.fetch = fetch_
+    appServer.close()
+    walletServer.close()
+  })
+
+  test('proxies allowed external URL', async () => {
+    const result = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: externalUrl as never,
+    })
+
+    expect(result.transaction.feePayerSignature).toBeDefined()
+    expect(result.capabilities?.sponsored).toBe(true)
+    expect(result.capabilities?.sponsor?.name).toBe('App Sponsor')
   })
 
   test.each([

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -415,7 +415,9 @@ describe('behavior: external feePayer URL validation', () => {
     ['non-HTTPS URL', 'http://relay.example.com'],
     ['localhost URL', 'https://localhost'],
     ['private IPv4 URL', 'https://192.168.0.1'],
-    ['IPv6 URL', 'https://[::1]'],
+    ['loopback IPv6 URL', 'https://[::1]'],
+    ['link-local IPv6 URL', 'https://[fe80::1]'],
+    ['unique-local IPv6 URL', 'https://[fc00::1]'],
   ])('rejects %s', async (_name, feePayer) => {
     await expect(
       fillTransaction(client, {

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -426,54 +426,34 @@ describe('behavior: with app-provided feePayer URL', () => {
     walletServer.close()
   })
 
-  test('default: proxies fill to app relay and returns sponsored tx', async () => {
-    const { transaction } = await fillTransaction(client, {
-      account: userAccount.address,
-      calls: [transferCall()],
-      feePayer: appServer.url as never,
-    })
-
-    expect(transaction.feePayerSignature).toBeDefined()
-    expect(transaction.gas).toBeDefined()
+  test('default: rejects unsafe app relay URLs', async () => {
+    await expect(
+      fillTransaction(client, {
+        account: userAccount.address,
+        calls: [transferCall()],
+        feePayer: appServer.url as never,
+      }),
+    ).rejects.toThrow(/Invalid parameters/)
   })
 
-  test('behavior: relays sponsor metadata from app relay', async () => {
-    const result = await fillTransaction(client, {
-      account: userAccount.address,
-      calls: [transferCall()],
-      feePayer: appServer.url as never,
-    })
-
-    expect(result.capabilities?.sponsored).toBe(true)
-    expect(result.capabilities?.sponsor).toMatchInlineSnapshot(`
-      {
-        "address": "${feePayerAccount.address}",
-        "name": "App Sponsor",
-        "url": "https://app.example.com",
-      }
-    `)
+  test('behavior: rejects localhost app relay before forwarding', async () => {
+    await expect(
+      fillTransaction(client, {
+        account: userAccount.address,
+        calls: [transferCall()],
+        feePayer: appServer.url as never,
+      }),
+    ).rejects.toThrow(/Invalid parameters/)
   })
 
-  test('behavior: sponsored tx from app relay can be signed and broadcast', async () => {
-    const { transaction } = await fillTransaction(client, {
-      account: userAccount.address,
-      calls: [transferCall()],
-      feePayer: appServer.url as never,
-    })
-    const serialized = (await Transaction.serialize(transaction as never)) as `0x76${string}`
-    const envelope = TxEnvelopeTempo.deserialize(serialized)
-    const signature = await userAccount.sign({
-      hash: TxEnvelopeTempo.getSignPayload(envelope),
-    })
-    const signed = TxEnvelopeTempo.serialize(envelope, {
-      signature: SignatureEnvelope.from(signature),
-    })
-    const receipt = (await getClient().request({
-      method: 'eth_sendRawTransactionSync' as never,
-      params: [signed],
-    })) as { feePayer?: string | undefined }
-
-    expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
+  test('behavior: rejects non-https app relay URLs', async () => {
+    await expect(
+      fillTransaction(client, {
+        account: userAccount.address,
+        calls: [transferCall()],
+        feePayer: 'http://relay.example.com' as never,
+      }),
+    ).rejects.toThrow(/Invalid parameters/)
   })
 })
 
@@ -516,85 +496,14 @@ describe('behavior: with app-provided feePayer URL + autoSwap', () => {
     walletServer.close()
   })
 
-  test('behavior: autoSwap recovers when external feePayer surfaces InsufficientBalance', async () => {
-    const sender = accounts[6]!
-
-    // Token pair + DEX liquidity. Use alphaUsd as the quote token so the
-    // relay can swap alphaUsd → base to cover the deficit.
-    const rpc = getClient({ account: accounts[0]! })
-    const { token: base } = await Actions.token.createSync(rpc, {
-      name: 'External Swap Base',
-      symbol: 'EXTBASE',
-      currency: 'USD',
-      quoteToken: addresses.alphaUsd,
-    })
-    await sendTransactionSync(rpc, {
-      calls: [
-        Actions.token.grantRoles.call({ token: base, role: 'issuer', to: rpc.account!.address }),
-        Actions.token.mint.call({
-          token: base,
-          to: rpc.account!.address,
-          amount: parseUnits('10000', 6),
-        }),
-        Actions.token.mint.call({
-          token: addresses.alphaUsd,
-          to: rpc.account!.address,
-          amount: parseUnits('10000', 6),
-        }),
-        Actions.token.approve.call({
-          token: base,
-          spender: Addresses.stablecoinDex,
-          amount: parseUnits('10000', 6),
-        }),
-        Actions.token.approve.call({
-          token: addresses.alphaUsd,
-          spender: Addresses.stablecoinDex,
-          amount: parseUnits('10000', 6),
-        }),
-      ],
-    })
-    await Actions.dex.createPairSync(rpc, { base })
-    await Actions.dex.placeSync(rpc, {
-      token: base,
-      amount: parseUnits('500', 6),
-      type: 'sell',
-      tick: Tick.fromPrice('1.001'),
-    })
-
-    // Give sender alphaUsd (fee + swap source) but NO base tokens.
-    await Actions.token.mintSync(rpc, {
-      token: addresses.alphaUsd,
-      amount: parseUnits('1000', 6),
-      to: sender.address,
-    })
-    await Actions.fee.setUserToken(getClient({ account: sender }), { token: addresses.alphaUsd })
-
-    // Sender attempts to transfer base via the wallet relay, which forwards
-    // to the app relay. The app relay returns 200 with capabilities.error =
-    // InsufficientBalance and a stub tx; the wallet relay must convert that
-    // into a synthetic throw so its own fill() autoSwap branch can recover.
-    const transferAmount = parseUnits('5', 6)
-    const result = await fillTransaction(client, {
-      account: sender.address,
-      ...Actions.token.transfer.call({
-        token: base,
-        to: accounts[7]!.address,
-        amount: transferAmount,
+  test('behavior: rejects unsafe external feePayer URL before autoSwap', async () => {
+    await expect(
+      fillTransaction(client, {
+        account: accounts[6]!.address,
+        calls: [transferCall()],
+        feePayer: appServer.url as never,
       }),
-      feePayer: appServer.url as never,
-    })
-
-    const { transaction, capabilities } = result
-
-    // Tx is filled with the swap calls prepended (approve + buy + transfer).
-    expect(transaction.calls).toHaveLength(3)
-    expect(transaction.feePayerSignature).toBeDefined()
-
-    // autoSwap metadata is surfaced.
-    expect(capabilities?.autoSwap?.slippage).toBe(0.05)
-    expect(capabilities?.autoSwap?.maxIn.symbol).toBe('AlphaUSD')
-    expect(capabilities?.autoSwap?.minOut.symbol).toBe('EXTBASE')
-    expect(capabilities?.autoSwap?.minOut.formatted).toBe('5')
+    ).rejects.toThrow(/Invalid parameters/)
   })
 })
 
@@ -642,18 +551,14 @@ describe('behavior: app-provided feePayer URL bypasses wallet validate', () => {
     walletServer.close()
   })
 
-  test('behavior: external feePayer URL is sponsored even when wallet validate rejects', async () => {
-    const result = await fillTransaction(client, {
-      account: userAccount.address,
-      calls: [transferCall()],
-      feePayer: appServer.url as never,
-    })
-
-    expect(result.transaction.feePayerSignature).toBeDefined()
-    expect(result.transaction.maxFeePerGas).toBeDefined()
-    expect(result.transaction.maxFeePerGas).not.toBe(0n)
-    expect(result.capabilities?.sponsored).toBe(true)
-    expect(result.capabilities?.sponsor?.name).toBe('App Sponsor')
+  test('behavior: unsafe external feePayer URL is rejected before wallet validate', async () => {
+    await expect(
+      fillTransaction(client, {
+        account: userAccount.address,
+        calls: [transferCall()],
+        feePayer: appServer.url as never,
+      }),
+    ).rejects.toThrow(/Invalid parameters/)
   })
 })
 

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -1413,14 +1413,21 @@ function normalizeExternalFeePayerUrl(value: string): string {
 
 /** Blocks local/private hosts that should never receive user-supplied fill payloads. */
 function isUnsafeHostname(hostname: string): boolean {
-  const host = hostname.toLowerCase()
+  const host = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .split('%')[0]!
   if (host === 'localhost' || host.endsWith('.localhost')) return true
-  if (host === '0.0.0.0') return true
-  if (host.includes(':')) return isUnsafeIpv6Host(host)
-  const parts = host.split('.').map((part) => Number(part))
+  const ipv4 = parseIpv4(host)
+  if (ipv4) return isUnsafeIpv4(ipv4)
+  return host.includes(':') && isUnsafeIpv6(host)
+}
+
+function parseIpv4(value: string): [number, number, number, number] | undefined {
+  const parts = value.split('.').map((part) => Number(part))
   if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255))
-    return false
-  return isUnsafeIpv4(parts as [number, number, number, number])
+    return undefined
+  return parts as [number, number, number, number]
 }
 
 function isUnsafeIpv4(parts: [number, number, number, number]): boolean {
@@ -1432,56 +1439,27 @@ function isUnsafeIpv4(parts: [number, number, number, number]): boolean {
   return false
 }
 
-function isUnsafeIpv6Host(hostname: string): boolean {
-  const parts = parseIpv6(hostname)
-  if (!parts) return true
-  const [a] = parts
-  if (parts.every((part) => part === 0)) return true
-  if (parts.slice(0, 7).every((part) => part === 0) && parts[7] === 1) return true
+function isUnsafeIpv6(host: string): boolean {
+  if (host === '::' || host === '::1') return true
+  const a = Number.parseInt(host.split(':')[0] || '0', 16)
+  if (!Number.isInteger(a)) return true
   if ((a & 0xfe00) === 0xfc00) return true
   if ((a & 0xffc0) === 0xfe80) return true
   if ((a & 0xffc0) === 0xfec0) return true
   if ((a & 0xff00) === 0xff00) return true
-  if (
-    parts.slice(0, 5).every((part) => part === 0) &&
-    parts[5] === 0xffff &&
-    isUnsafeIpv4([parts[6]! >> 8, parts[6]! & 0xff, parts[7]! >> 8, parts[7]! & 0xff])
-  )
-    return true
+  if (host.startsWith('::ffff:') && isUnsafeIpv4MappedHost(host.slice(7))) return true
   return false
 }
 
-function parseIpv6(
-  hostname: string,
-): [number, number, number, number, number, number, number, number] | undefined {
-  const host = hostname.replace(/^\[|\]$/g, '').split('%')[0]!
-  const value = host.includes('.') ? replaceIpv4Tail(host) : host
-  if (!value) return undefined
-  const halves = value.split('::')
-  if (halves.length > 2) return undefined
-  const left = halves[0] ? halves[0].split(':') : []
-  const right = halves[1] ? halves[1].split(':') : []
-  const missing = halves.length === 2 ? 8 - left.length - right.length : 0
-  const parts = [...left, ...Array(Math.max(0, missing)).fill('0'), ...right]
-  if (parts.length !== 8) return undefined
-  const numbers = parts.map((part) =>
-    /^[\da-f]{1,4}$/i.test(part) ? Number.parseInt(part, 16) : NaN,
-  )
-  if (numbers.some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return undefined
-  return numbers as [number, number, number, number, number, number, number, number]
-}
-
-function replaceIpv4Tail(hostname: string): string | undefined {
-  const index = hostname.lastIndexOf(':')
-  if (index === -1) return undefined
-  const parts = hostname
-    .slice(index + 1)
-    .split('.')
-    .map((part) => Number(part))
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255))
-    return undefined
-  const [a, b, c, d] = parts as [number, number, number, number]
-  return `${hostname.slice(0, index)}:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`
+function isUnsafeIpv4MappedHost(host: string): boolean {
+  const ipv4 = parseIpv4(host)
+  if (ipv4) return isUnsafeIpv4(ipv4)
+  const [a, b] = host
+    .split(':')
+    .slice(-2)
+    .map((part) => Number.parseInt(part, 16))
+  if (!Number.isInteger(a) || !Number.isInteger(b)) return false
+  return isUnsafeIpv4([a! >> 8, a! & 0xff, b! >> 8, b! & 0xff])
 }
 
 /**

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -1416,16 +1416,72 @@ function isUnsafeHostname(hostname: string): boolean {
   const host = hostname.toLowerCase()
   if (host === 'localhost' || host.endsWith('.localhost')) return true
   if (host === '0.0.0.0') return true
-  if (host.includes(':')) return true
+  if (host.includes(':')) return isUnsafeIpv6Host(host)
   const parts = host.split('.').map((part) => Number(part))
   if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255))
     return false
-  const [a, b] = parts as [number, number, number, number]
+  return isUnsafeIpv4(parts as [number, number, number, number])
+}
+
+function isUnsafeIpv4(parts: [number, number, number, number]): boolean {
+  const [a, b] = parts
   if (a === 10 || a === 127 || a === 0) return true
   if (a === 169 && b === 254) return true
   if (a === 172 && b >= 16 && b <= 31) return true
   if (a === 192 && b === 168) return true
   return false
+}
+
+function isUnsafeIpv6Host(hostname: string): boolean {
+  const parts = parseIpv6(hostname)
+  if (!parts) return true
+  const [a] = parts
+  if (parts.every((part) => part === 0)) return true
+  if (parts.slice(0, 7).every((part) => part === 0) && parts[7] === 1) return true
+  if ((a & 0xfe00) === 0xfc00) return true
+  if ((a & 0xffc0) === 0xfe80) return true
+  if ((a & 0xffc0) === 0xfec0) return true
+  if ((a & 0xff00) === 0xff00) return true
+  if (
+    parts.slice(0, 5).every((part) => part === 0) &&
+    parts[5] === 0xffff &&
+    isUnsafeIpv4([parts[6]! >> 8, parts[6]! & 0xff, parts[7]! >> 8, parts[7]! & 0xff])
+  )
+    return true
+  return false
+}
+
+function parseIpv6(
+  hostname: string,
+): [number, number, number, number, number, number, number, number] | undefined {
+  const host = hostname.replace(/^\[|\]$/g, '').split('%')[0]!
+  const value = host.includes('.') ? replaceIpv4Tail(host) : host
+  if (!value) return undefined
+  const halves = value.split('::')
+  if (halves.length > 2) return undefined
+  const left = halves[0] ? halves[0].split(':') : []
+  const right = halves[1] ? halves[1].split(':') : []
+  const missing = halves.length === 2 ? 8 - left.length - right.length : 0
+  const parts = [...left, ...Array(Math.max(0, missing)).fill('0'), ...right]
+  if (parts.length !== 8) return undefined
+  const numbers = parts.map((part) =>
+    /^[\da-f]{1,4}$/i.test(part) ? Number.parseInt(part, 16) : NaN,
+  )
+  if (numbers.some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return undefined
+  return numbers as [number, number, number, number, number, number, number, number]
+}
+
+function replaceIpv4Tail(hostname: string): string | undefined {
+  const index = hostname.lastIndexOf(':')
+  if (index === -1) return undefined
+  const parts = hostname
+    .slice(index + 1)
+    .split('.')
+    .map((part) => Number(part))
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255))
+    return undefined
+  const [a, b, c, d] = parts as [number, number, number, number]
+  return `${hostname.slice(0, index)}:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`
 }
 
 /**

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -1360,9 +1360,10 @@ function buildSwapCalls(
  * built for sponsorship signing throws `CallsEmptyError` or
  * `Cannot convert undefined to a BigInt` when serializing.
  *
- * Result fields take precedence (they are the chain's authoritative filled
- * values); request fields fill in everything else. Calls are normalized
- * separately so legacy `to`/`data`/`value` requests are also supported.
+ * Result fields take precedence because externally signed fee-payer relays may
+ * change envelope fields before producing `feePayerSignature`; request fields
+ * only fill gaps. Calls are normalized separately so legacy `to`/`data`/`value`
+ * requests are also supported.
  */
 function mergeCallsFromRequest(
   resultTx: Record<string, unknown>,
@@ -1392,6 +1393,7 @@ function mergeCallsFromRequest(
   return merged
 }
 
+/** Normalizes external fee-payer relay URLs before the wallet relay forwards fills. */
 function normalizeExternalFeePayerUrl(value: string): string {
   let url: URL
   try {
@@ -1409,6 +1411,7 @@ function normalizeExternalFeePayerUrl(value: string): string {
   return url.href
 }
 
+/** Blocks local/private hosts that should never receive user-supplied fill payloads. */
 function isUnsafeHostname(hostname: string): boolean {
   const host = hostname.toLowerCase()
   if (host === 'localhost' || host.endsWith('.localhost')) return true

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -150,7 +150,9 @@ export function relay(options: relay.Options = {}): Handler {
           const requestFeeToken =
             typeof parameters.feeToken === 'string' ? (parameters.feeToken as Address) : undefined
           const externalFeePayerUrl =
-            typeof parameters.feePayer === 'string' ? parameters.feePayer : undefined
+            typeof parameters.feePayer === 'string'
+              ? normalizeExternalFeePayerUrl(parameters.feePayer)
+              : undefined
           const requestsSponsorship =
             (!!feePayerOptions || !!externalFeePayerUrl) && parameters.feePayer !== false
           // Default to `true`. Dapps that don't render diffs can pass
@@ -1388,6 +1390,39 @@ function mergeCallsFromRequest(
     },
   ]
   return merged
+}
+
+function normalizeExternalFeePayerUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new RpcResponse.InvalidParamsError({ message: 'Invalid fee payer URL.' })
+  }
+  if (url.protocol !== 'https:')
+    throw new RpcResponse.InvalidParamsError({ message: 'Invalid fee payer URL protocol.' })
+  if (isUnsafeHostname(url.hostname))
+    throw new RpcResponse.InvalidParamsError({ message: 'Invalid fee payer URL host.' })
+  url.username = ''
+  url.password = ''
+  url.hash = ''
+  return url.href
+}
+
+function isUnsafeHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  if (host === 'localhost' || host.endsWith('.localhost')) return true
+  if (host === '0.0.0.0') return true
+  if (host.includes(':')) return true
+  const parts = host.split('.').map((part) => Number(part))
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255))
+    return false
+  const [a, b] = parts as [number, number, number, number]
+  if (a === 10 || a === 127 || a === 0) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  return false
 }
 
 /**


### PR DESCRIPTION
## Summary

Reject unsafe external fee-payer URLs before forwarding relay fill requests.