### PR TITLE
fix: require pinned auth domain

### DIFF
--- a/.changeset/pinned-auth-domain.md
+++ b/.changeset/pinned-auth-domain.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+**Breaking:** Changed `Handler.auth()` to require callers to provide `origin` or `domain`, so SIWE challenge and verify flows pinned domain binding instead of deriving it from request `Host` headers.

--- a/examples/authentication/env.d.ts
+++ b/examples/authentication/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite-plugin-cloudflare-tunnel/virtual" />
 
 declare namespace Cloudflare {
-  interface Env {}
+  interface Env {
+    ORIGIN: string
+  }
 }

--- a/examples/authentication/worker/index.ts
+++ b/examples/authentication/worker/index.ts
@@ -13,6 +13,7 @@ export const NonceStorage = Kv.NonceStorage
 // store for one-time-consume SIWE challenge nonces and issued sessions
 // across concurrent worker instances.
 const auth = Handler.auth({
+  origin: env.ORIGIN,
   path: '/auth',
   store: Kv.durableObject(env.NONCE_DO),
 })

--- a/examples/authentication/wrangler.jsonc
+++ b/examples/authentication/wrangler.jsonc
@@ -8,6 +8,9 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/auth", "/auth/*", "/me"],
   },
+  "vars": {
+    "ORIGIN": "http://localhost:5173",
+  },
   "durable_objects": {
     "bindings": [{ "name": "NONCE_DO", "class_name": "NonceStorage" }],
   },

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -13,7 +13,7 @@ const payment = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
 })
 
-const auth = Handler.auth({ path: '/auth' })
+const auth = Handler.auth({ origin: process.env.ORIGIN, path: '/auth' })
 
 const handler = Handler.compose([
   Handler.webAuthn({

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -347,7 +347,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         // Real Hono app: mount the auth handler under `/auth` and add a
         // protected `/me` route — exactly as a dapp would compose them
         // — so the e2e test below exercises the full flow.
-        const auth = Handler.auth()
+        const auth = Handler.auth({ domain: 'localhost' })
         const app = Handler.compose([auth], { path: '/auth' })
         app.get('/me', async (c) => {
           const session = await auth.getSession(c.req.raw)

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -347,37 +347,43 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         // Real Hono app: mount the auth handler under `/auth` and add a
         // protected `/me` route — exactly as a dapp would compose them
         // — so the e2e test below exercises the full flow.
-        const auth = Handler.auth({ domain: 'localhost' })
-        const app = Handler.compose([auth], { path: '/auth' })
-        app.get('/me', async (c) => {
-          const session = await auth.getSession(c.req.raw)
-          if (!session) return c.json({ error: 'unauthenticated' }, 401)
-          return c.json({ address: session.address, chainId: session.chainId })
+        let listener: Parameters<typeof createServer>[0] | undefined
+        server = await createServer((req, res) => {
+          if (!listener) {
+            const auth = Handler.auth({ origin: server.url })
+            const app = Handler.compose([auth], { path: '/auth' })
+            app.get('/me', async (c) => {
+              const session = await auth.getSession(c.req.raw)
+              if (!session) return c.json({ error: 'unauthenticated' }, 401)
+              return c.json({ address: session.address, chainId: session.chainId })
+            })
+            // Bad-challenge / bad-verify endpoints mounted on the same origin
+            // as `/auth` so the same-origin enforcement (`absolutizeAuth`)
+            // doesn't reject the request before the bad-content paths under
+            // test can run. `app.all` so we don't depend on the SDK's request
+            // method (POST).
+            app.all('/bad/verify-401', (c) => c.json({ error: 'unauthorized' }, 401))
+            app.all('/bad/challenge-500', (c) => c.json({ error: 'boom' }, 500))
+            app.all('/bad/challenge-empty', (c) => c.json({}))
+            app.all('/bad/challenge-evil-domain', (c) =>
+              c.json({
+                message: [
+                  'evil.example wants you to sign in with your Ethereum account:',
+                  '0x0000000000000000000000000000000000000000',
+                  '',
+                  '',
+                  'URI: https://evil.example',
+                  'Version: 1',
+                  'Chain ID: 0',
+                  'Nonce: deadbeef00',
+                  'Issued At: 2025-01-01T00:00:00Z',
+                ].join('\n'),
+              }),
+            )
+            listener = app.listener
+          }
+          return listener(req, res)
         })
-        // Bad-challenge / bad-verify endpoints mounted on the same origin
-        // as `/auth` so the same-origin enforcement (`absolutizeAuth`)
-        // doesn't reject the request before the bad-content paths under
-        // test can run. `app.all` so we don't depend on the SDK's request
-        // method (POST).
-        app.all('/bad/verify-401', (c) => c.json({ error: 'unauthorized' }, 401))
-        app.all('/bad/challenge-500', (c) => c.json({ error: 'boom' }, 500))
-        app.all('/bad/challenge-empty', (c) => c.json({}))
-        app.all('/bad/challenge-evil-domain', (c) =>
-          c.json({
-            message: [
-              'evil.example wants you to sign in with your Ethereum account:',
-              '0x0000000000000000000000000000000000000000',
-              '',
-              '',
-              'URI: https://evil.example',
-              'Version: 1',
-              'Chain ID: 0',
-              'Nonce: deadbeef00',
-              'Issued At: 2025-01-01T00:00:00Z',
-            ].join('\n'),
-          }),
-        )
-        server = await createServer(app.listener)
         authBase = `${server.url}/auth`
 
         // Cross-origin bad server kept around for the same-origin enforcement

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -15,6 +15,12 @@ const otherAccount = privateKeyToAccount(
 )
 
 describe('challenge', () => {
+  test('error: requires pinned origin or domain', () => {
+    expect(() => auth()).toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`auth()\` requires \`origin\` or \`domain\` to pin SIWE domain binding.]`,
+    )
+  })
+
   test('returns challenge message with chainId, nonce, zero-address placeholder', async () => {
     const { app } = setup()
 

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -695,7 +695,7 @@ describe('getSession', () => {
 
 describe('store: atomic `take` preferred, non-atomic fallback', () => {
   test('Kv.memory() (has `take`) is accepted', () => {
-    expect(() => auth({ store: Kv.memory() })).not.toThrow()
+    expect(() => auth({ domain: 'wallet.example', store: Kv.memory() })).not.toThrow()
   })
 
   test('store without `take` falls back to non-atomic get + delete', async () => {

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -732,8 +732,7 @@ describe('store: atomic `take` preferred, non-atomic fallback', () => {
 
 describe('origin / trustProxy', () => {
   test('default: ignores `x-forwarded-host` and `x-forwarded-proto`', async () => {
-    // No domain pin — relies on host header. trustProxy defaults to false.
-    const handler = auth()
+    const handler = auth({ domain: 'real.example' })
     const app = new Hono()
     app.route('/', handler)
 
@@ -753,7 +752,7 @@ describe('origin / trustProxy', () => {
   })
 
   test('trustProxy: true → honors `x-forwarded-host` and `x-forwarded-proto`', async () => {
-    const handler = auth({ trustProxy: true })
+    const handler = auth({ domain: 'app.example', trustProxy: true })
     const app = new Hono()
     app.route('/', handler)
 
@@ -811,7 +810,7 @@ describe('origin / trustProxy', () => {
       configurable: true,
     })
     try {
-      const handler = auth()
+      const handler = auth({ domain: 'app.example' })
       const app = new Hono()
       app.route('/', handler)
 

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -138,6 +138,9 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     ...rest
   } = options
 
+  if (!origin_option && !domain)
+    throw new Error('`auth()` requires `origin` or `domain` to pin SIWE domain binding.')
+
   async function take(key: string): Promise<ChallengePayload | undefined> {
     if (store.take) return store.take<ChallengePayload>(key)
     const value = await store.get<ChallengePayload>(key)

--- a/src/server/internal/handlers/session.test.ts
+++ b/src/server/internal/handlers/session.test.ts
@@ -143,7 +143,7 @@ describe('tokenFromRequest (Node.js headers)', () => {
 
 describe('getSession with http.IncomingMessage', () => {
   const store = Kv.memory()
-  const handler = auth({ store, cookie: false })
+  const handler = auth({ store, cookie: false, domain: 'localhost' })
 
   let authServer: Http.Server
   let authUrl: string


### PR DESCRIPTION
## Summary

Require server authentication handlers to pin a SIWE domain through either `origin` or `domain`.

 This prevents challenge and verify flows from deriving domain binding from the incoming Host header, which can be spoofed