### PR TITLE
fix: bind webauthn credentials to users

### DIFF
--- a/.changeset/bind-webauthn-credentials.md
+++ b/.changeset/bind-webauthn-credentials.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Fix WebAuthn credential storage to bind credentials to their registered user id and reject duplicate credential registration atomically.
+Fixed WebAuthn credential storage to bind credentials to their registered user id and reject duplicate credential registration atomically.

--- a/.changeset/bind-webauthn-credentials.md
+++ b/.changeset/bind-webauthn-credentials.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fix WebAuthn credential storage to bind credentials to their registered user id and reject duplicate credential registration atomically.

--- a/src/server/Kv.test.ts
+++ b/src/server/Kv.test.ts
@@ -47,6 +47,36 @@ describe('memory', () => {
     expect(await kv.get('a')).toMatchInlineSnapshot(`"v2"`)
   })
 
+  test('create: writes only when key is absent', async () => {
+    const kv = Kv.memory()
+
+    expect(await kv.create!('a', 'v1')).toMatchInlineSnapshot(`true`)
+    expect(await kv.create!('a', 'v2')).toMatchInlineSnapshot(`false`)
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v1"`)
+  })
+
+  test('create: replaces expired entries', async () => {
+    let now = 1_000_000
+    const kv = Kv.memory({ now: () => now })
+
+    await kv.set('a', 'v1', { ttl: 1 })
+    now += 2_000
+    expect(await kv.create!('a', 'v2')).toMatchInlineSnapshot(`true`)
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v2"`)
+  })
+
+  test('create: concurrent callers — only one writes', async () => {
+    const kv = Kv.memory()
+
+    const results = await Promise.all([kv.create!('a', 'v1'), kv.create!('a', 'v2')])
+    expect(results.filter(Boolean)).toMatchInlineSnapshot(`
+      [
+        true,
+      ]
+    `)
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v1"`)
+  })
+
   test('take: returns the value and removes the entry', async () => {
     const kv = Kv.memory()
 
@@ -163,6 +193,18 @@ describe('durableObject + NonceStorage', () => {
     `)
   })
 
+  test('create: concurrent callers — only one wins', async () => {
+    const kv = Kv.durableObject(fakeDurableObject())
+
+    const results = await Promise.all([kv.create!('a', 'v1'), kv.create!('a', 'v2')])
+    expect(results.filter(Boolean)).toMatchInlineSnapshot(`
+      [
+        true,
+      ]
+    `)
+    expect(await kv.get('a')).toMatchInlineSnapshot(`"v1"`)
+  })
+
   test('take: missing key returns undefined', async () => {
     const kv = Kv.durableObject(fakeDurableObject())
     expect(await kv.take!('missing')).toMatchInlineSnapshot(`undefined`)
@@ -224,6 +266,15 @@ describe('cloudflare', () => {
       delete: async () => {},
     })
     expect(kv.take).toBeUndefined()
+  })
+
+  test('create: NOT implemented (CF KV is not linearizable)', () => {
+    const kv = Kv.cloudflare({
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {},
+    })
+    expect(kv.create).toBeUndefined()
   })
 
   test('ttl: passes expirationTtl seconds to underlying put', async () => {

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -17,6 +17,16 @@ export type Kv = {
   /** Delete a value by key. */
   delete: (key: string) => Promise<void>
   /**
+   * Atomic create-if-absent. Returns `true` when the value was written,
+   * `false` when a non-expired value already exists.
+   *
+   * Optional. Required for unique-key semantics (e.g. WebAuthn credential
+   * registration). Backends without a linearizable create primitive (e.g.
+   * eventually-consistent stores like Cloudflare KV) should leave this
+   * undefined; consumers that require uniqueness will refuse the store.
+   */
+  create?: (key: string, value: unknown, options?: set.Options | undefined) => Promise<boolean>
+  /**
    * Atomic read-and-delete. Returns the value if present, `undefined` if
    * missing or expired. Across concurrent callers, exactly one observer
    * receives a non-`undefined` return for a given key, and the key is
@@ -147,6 +157,12 @@ export function durableObject(
     async set(key, value, options) {
       await rpc('set', key, { value, ttl: options?.ttl })
     },
+    async create(key, value, options) {
+      const { created } = (await rpc('create', key, { value, ttl: options?.ttl })) as {
+        created: boolean
+      }
+      return created
+    },
     async delete(key) {
       await rpc('delete', key)
     },
@@ -228,6 +244,17 @@ export class NonceStorage {
       await this.state.storage.put(key, entry)
       return Response.json({})
     }
+    if (op === 'create') {
+      const current = await this.state.storage.get<NonceStorage.Entry>(key)
+      if (current && !isExpired(current)) return Response.json({ created: false })
+
+      const body = (await request.json()) as { value: unknown; ttl?: number }
+      const entry: NonceStorage.Entry = body.ttl
+        ? { value: body.value, expiresAt: Date.now() + body.ttl * 1000 }
+        : { value: body.value }
+      await this.state.storage.put(key, entry)
+      return Response.json({ created: true })
+    }
     if (op === 'delete') {
       await this.state.storage.delete(key)
       return Response.json({})
@@ -279,6 +306,13 @@ export function memory(options: memory.Options = {}): Kv {
     async set(key, value, options) {
       const expiresAt = options?.ttl ? now() + options.ttl * 1000 : undefined
       store.set(key, expiresAt !== undefined ? { value, expiresAt } : { value })
+    },
+    async create(key, value, options) {
+      const entry = store.get(key)
+      if (entry && !isExpired(entry)) return false
+      const expiresAt = options?.ttl ? now() + options.ttl * 1000 : undefined
+      store.set(key, expiresAt !== undefined ? { value, expiresAt } : { value })
+      return true
     },
     // Atomic in-process: the synchronous `Map.get` + `Map.delete` runs
     // in a single microtask, so concurrent `take(key)` callers (within

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -67,6 +67,28 @@ describe('POST /register', () => {
   })
 })
 
+describe('kv', () => {
+  test('store without atomic create is rejected', () => {
+    const kv: Kv.Kv = {
+      async get() {
+        return undefined
+      },
+      async set() {},
+      async delete() {},
+    }
+
+    expect(() =>
+      webAuthn({
+        kv,
+        origin: 'http://localhost',
+        rpId: 'localhost',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`webAuthn({ kv })\` requires a Kv with atomic \`create\` support]`,
+    )
+  })
+})
+
 describe('POST /login', () => {
   test('error: unknown credential → 400', async () => {
     const response = await fetch(`${server.url}/login`, {

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -89,6 +89,8 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
     ...rest
   } = options
   const origin = options.origin as string | string[]
+  if (!kv.create) throw new Error('`webAuthn({ kv })` requires a Kv with atomic `create` support')
+  const create = kv.create.bind(kv)
 
   const router = from(rest)
 
@@ -149,10 +151,13 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const userId = stored.userId
         ? Base64.fromBytes(Bytes.fromString(stored.userId), { pad: false, url: true })
         : undefined
-      if (await kv.get(`credential:${credentialId}`)) throw new Error('Credential already exists')
+      const created = await create(`credential:${credentialId}`, {
+        publicKey,
+        ...(userId ? { userId } : {}),
+      })
+      if (!created) throw new Error('Credential already exists')
 
-      const [, hook] = await Promise.all([
-        kv.set(`credential:${credentialId}`, { publicKey, ...(userId ? { userId } : {}) }),
+      const [hook] = await Promise.all([
         onRegister?.({
           credentialId,
           name: stored.name,

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -149,6 +149,7 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const userId = stored.userId
         ? Base64.fromBytes(Bytes.fromString(stored.userId), { pad: false, url: true })
         : undefined
+      if (await kv.get(`credential:${credentialId}`)) throw new Error('Credential already exists')
 
       const [, hook] = await Promise.all([
         kv.set(`credential:${credentialId}`, { publicKey, ...(userId ? { userId } : {}) }),
@@ -263,17 +264,9 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       })
       if (!valid) throw new Error('Authentication failed')
 
-      const rawResponse = response.raw?.response as unknown as Record<string, string> | undefined
-      const userHandle = rawResponse?.userHandle
-
       const credentialId = response.id
       const publicKey = credentialData.publicKey
-      // Surface the authenticator-emitted `userHandle` verbatim
-      // (base64url-encoded user id). Fall back to the base64-encoded
-      // userId we stashed during register, so callers see the same
-      // identifier shape across register and login.
-      const userId =
-        userHandle && userHandle.length > 0 ? userHandle : (credentialData.userId ?? undefined)
+      const userId = credentialData.userId
 
       // Hook for side effects (user provisioning, analytics, allow/deny).
       // The legacy contract — return a `Response` to merge fields onto


### PR DESCRIPTION
## Summary

Prevent WebAuthn credential overwrites during registration and use the stored credential user binding during authentication. 

Login no longer trusts a client-provided userHandle as the authenticated user identity.