### PR TITLE
fix: require dialog message origins

### DIFF
--- a/ref-impls/dialog/src/lib/messenger.ts
+++ b/ref-impls/dialog/src/lib/messenger.ts
@@ -6,9 +6,18 @@ export function init(): Messenger.Bridge {
 
   const target = window.opener ?? window.parent
   if (!target || target === window) return Messenger.noop()
+  const targetOrigin = resolveTargetOrigin()
+  if (!targetOrigin) return Messenger.noop()
 
   return Messenger.bridge({
-    from: Messenger.fromWindow(window),
-    to: Messenger.fromWindow(target),
+    from: Messenger.fromWindow(window, { targetOrigin }),
+    to: Messenger.fromWindow(target, { targetOrigin }),
   })
+}
+
+function resolveTargetOrigin() {
+  const origin = new URLSearchParams(window.location.search).get('origin')
+  if (origin) return new URL(origin).origin
+  if (document.referrer) return new URL(document.referrer).origin
+  return undefined
 }

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -125,6 +125,7 @@ export function iframe(): Dialog {
     const hostUrl = new URL(host)
     hostUrl.searchParams.set('chainId', String(store.getState().chainId))
     hostUrl.searchParams.set('mode', 'iframe')
+    hostUrl.searchParams.set('origin', window.location.origin)
     if (referrer.icon) {
       if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
       else {
@@ -480,6 +481,7 @@ export function popup(options: popup.Options = {}): Dialog {
         const hostUrl = new URL(host)
         hostUrl.searchParams.set('chainId', String(store.getState().chainId))
         hostUrl.searchParams.set('mode', 'popup')
+        hostUrl.searchParams.set('origin', window.location.origin)
         if (referrer.icon) {
           if (typeof referrer.icon === 'string') hostUrl.searchParams.set('icon', referrer.icon)
           else {

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -95,6 +95,7 @@ export function from(messenger: Messenger): Messenger {
  */
 export function fromWindow(w: Window, options: fromWindow.Options = {}): Messenger {
   const { targetOrigin } = options
+  if (!targetOrigin) throw new Error('Messenger.fromWindow requires `targetOrigin`.')
   const listeners = new Map<string, (event: MessageEvent) => void>()
 
   return from({
@@ -106,7 +107,7 @@ export function fromWindow(w: Window, options: fromWindow.Options = {}): Messeng
       function onMessage(event: MessageEvent) {
         if (event.data.topic !== topic) return
         if (id && event.data.id !== id) return
-        if (targetOrigin && event.origin !== targetOrigin) return
+        if (event.origin !== targetOrigin) return
         listener(event.data.payload as never, event)
       }
       w.addEventListener('message', onMessage)
@@ -118,7 +119,7 @@ export function fromWindow(w: Window, options: fromWindow.Options = {}): Messeng
     },
     async send(topic, payload, target) {
       const id = crypto.randomUUID()
-      w.postMessage(normalizeValue({ id, payload, topic }), target ?? targetOrigin ?? '*')
+      w.postMessage(normalizeValue({ id, payload, topic }), target ?? targetOrigin)
       return { id, payload, topic } as never
     },
   })


### PR DESCRIPTION
## Summary

Require explicit postMessage target origins for dialog bridges and stop falling back to wildcard message delivery. Dialog URLs now carry the opener origin so the reference dialog can validate incoming and outgoing messages.