### PR TITLE
chore: remove signature from authorizeAccessKey.Parameters

### DIFF
--- a/.changeset/remove-signature-authorize-access-key-parameters.md
+++ b/.changeset/remove-signature-authorize-access-key-parameters.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Removed `signature` from `authorizeAccessKey.Parameters`.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -132,8 +132,6 @@ declare function authorizeAccessKey(): {
   scopes?:
     | { address: Address; recipients?: readonly Address[]; selector?: Hex | string }[]
     | undefined
-  /** Pre-computed signature over the key authorization digest (skips a second signing ceremony). */
-  signature?: Hex | undefined
 }
 ```
 
@@ -167,8 +165,7 @@ const provider = Provider.create({
   authorizeAccessKey: () => ({ // [!code focus]
     expiry: Expiry.days(7), // [!code focus]
     keyType: 'p256', // [!code focus]
-    publicKey: '0x...', // [!code focus]
-    signature: '0x...', // already-signed authorization digest // [!code focus]
+    publicKey: '0x1234', // [!code focus]
   }), // [!code focus]
 })
 ```

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -155,7 +155,7 @@ const provider = Provider.create({
 })
 ```
 
-You can also pre-derive the access key locally and authorize it without a second signing ceremony by passing `publicKey`/`address`/`keyType`/`signature`:
+You can also pre-derive the access key locally by passing `publicKey` or `address` with `keyType`. The wallet still authorizes that key during `wallet_connect`; the app keeps the signing material.
 
 ```ts twoslash
 // @noErrors

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -311,8 +311,6 @@ export declare namespace authorizeAccessKey {
           recipients?: readonly Address[] | undefined
         }[]
       | undefined
-    /** Pre-computed signature over the key authorization digest (skips a second signing ceremony). */
-    signature?: Hex | undefined
   }
 
   type ReturnType = {

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -144,9 +144,7 @@ export function local(options: local.Options): Adapter.Adapter {
         async authorizeAccessKey(parameters) {
           const prepared = await prepareKeyAuthorization(parameters)
           const account = getAccount({ accessKey: false, signable: true })
-          const keyAuthorization = await signKeyAuthorization(account, prepared, {
-            signature: parameters.signature,
-          })
+          const keyAuthorization = await signKeyAuthorization(account, prepared)
           return { keyAuthorization, rootAddress: account.address }
         },
         async loadAccounts(parameters) {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -423,7 +423,6 @@ export function turnkey<const client extends turnkey.Client>(
               ? await signKeyAuthorization(
                   account,
                   await prepareKeyAuthorization(authorizeAccessKey),
-                  { signature: authorizeAccessKey.signature },
                 )
               : undefined
             : undefined
@@ -466,7 +465,6 @@ export function turnkey<const client extends turnkey.Client>(
               ? await signKeyAuthorization(
                   account,
                   await prepareKeyAuthorization(authorizeAccessKey),
-                  { signature: authorizeAccessKey.signature },
                 )
               : undefined
 
@@ -487,9 +485,7 @@ export function turnkey<const client extends turnkey.Client>(
         async authorizeAccessKey(parameters) {
           const account = await accountForSigning(undefined)
           const prepared = await prepareKeyAuthorization(parameters)
-          const keyAuthorization = await signKeyAuthorization(account, prepared, {
-            signature: parameters.signature,
-          })
+          const keyAuthorization = await signKeyAuthorization(account, prepared)
           return { keyAuthorization, rootAddress: core_Address.from(account.address) }
         },
         async signPersonalMessage(parameters) {


### PR DESCRIPTION
## Summary
Remove `signature` from `Adapter.authorizeAccessKey.Parameters`.

## Motivation
Apps can provide a locally derived access key with `publicKey` or `address`, but they should not pass a pre-signed key authorization into the adapter surface. The wallet still owns authorization signing.

## Changes
- Remove `signature` from `Adapter.authorizeAccessKey.Parameters`.
- Remove local and Turnkey reads of the removed `authorizeAccessKey.signature` field.
- Update provider docs to describe locally pre-derived access keys without a pre-signed authorization.
- Add a patch changeset for the parameter removal.

## Testing
- `./node_modules/.bin/vp lint src/core/Adapter.ts src/core/adapters/local.ts src/core/adapters/turnkey.ts` — 0 warnings, 0 errors
- `./node_modules/.bin/vp test src/core/adapters/local.test.ts src/core/adapters/turnkey.test.ts` — 2 files passed, 27 tests passed
- `./node_modules/.bin/tsc -b --noEmit`
- `git diff --check`
- `rg -n 'authorizeAccessKey\.signature|parameters\.signature|grantOptions\.signature|publicKey`/`address`/`keyType`/`signature|already-signed authorization|pre-signed' src site examples playgrounds ref-impls --glob '!node_modules' --glob '!dist'` — no matches