### PR TITLE
refactor: centralize access key authorization

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -1,4 +1,4 @@
-import { WebCryptoP256 } from 'ox'
+import { Hex, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { encodeErrorResult } from 'viem'
 import { Abis, Account as TempoAccount, Actions } from 'viem/tempo'
@@ -290,9 +290,9 @@ describe('generate', () => {
   })
 })
 
-describe('prepare', () => {
+describe('prepareAuthorization', () => {
   test('default: prepares generated p256 key authorization', async () => {
-    const result = await AccessKey.prepare({ chainId: 1, expiry: 123 })
+    const result = await AccessKey.prepareAuthorization({ chainId: 1, expiry: 123 })
 
     expect(result.keyAuthorization.address).toMatch(/^0x[0-9a-f]{40}$/i)
     expect(result.keyAuthorization.chainId).toMatchInlineSnapshot(`1n`)
@@ -302,7 +302,7 @@ describe('prepare', () => {
   })
 
   test('behavior: prepares external key authorization from address', async () => {
-    const result = await AccessKey.prepare({
+    const result = await AccessKey.prepareAuthorization({
       address: accounts[1]!.address,
       chainId: 123n,
       expiry: 456,
@@ -354,7 +354,7 @@ describe('prepare', () => {
     const keyPair = await WebCryptoP256.createKeyPair()
     const account = TempoAccount.fromWebCryptoP256(keyPair)
 
-    const result = await AccessKey.prepare({
+    const result = await AccessKey.prepareAuthorization({
       chainId: 123n,
       expiry: 456,
       keyType: 'p256',
@@ -375,13 +375,94 @@ describe('prepare', () => {
   })
 
   test('behavior: defaults external key type to secp256k1', async () => {
-    const result = await AccessKey.prepare({
+    const result = await AccessKey.prepareAuthorization({
       address: accounts[1]!.address,
       chainId: 1,
       expiry: 123,
     })
 
     expect(result.keyAuthorization.type).toMatchInlineSnapshot(`"secp256k1"`)
+  })
+})
+
+describe('saveAuthorization', () => {
+  test('default: saves prepared authorization with provided signature', async () => {
+    const store = createStore()
+    const prepared = await AccessKey.prepareAuthorization({
+      address: accounts[1]!.address,
+      chainId: 1,
+      expiry: 123,
+    })
+    const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}1b` as const
+
+    const result = AccessKey.saveAuthorization({
+      address: rootAddress,
+      prepared,
+      signature,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "chainId": "0x1",
+        "expiry": "0x7b",
+        "keyId": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+        "keyType": "secp256k1",
+        "limits": undefined,
+        "signature": {
+          "r": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "s": "0x2222222222222222222222222222222222222222222222222222222222222222",
+          "type": "secp256k1",
+          "yParity": "0x0",
+        },
+      }
+    `)
+    expect(store.getState().accessKeys.map(({ keyAuthorization: _, ...accessKey }) => accessKey))
+      .toMatchInlineSnapshot(`
+      [
+        {
+          "access": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+          "chainId": 1,
+          "expiry": 123,
+          "keyType": "secp256k1",
+          "limits": undefined,
+          "scopes": undefined,
+        },
+      ]
+    `)
+  })
+})
+
+describe('authorize', () => {
+  test('default: prepares, signs, and saves authorization', async () => {
+    const store = createStore()
+    const digests: Hex.Hex[] = []
+    const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}1b` as const
+    const account = {
+      ...accounts[0]!,
+      sign: async (parameters: { hash: Hex.Hex }) => {
+        digests.push(parameters.hash)
+        return signature
+      },
+    } as TempoAccount.Account
+
+    await AccessKey.authorize({
+      account,
+      chainId: 1,
+      parameters: {
+        address: accounts[1]!.address,
+        expiry: 123,
+      },
+      store,
+    })
+
+    expect(digests).toMatchInlineSnapshot(`
+      [
+        "0xea47721547363fc82a5dca62b4544e4718d861b3df10bfac65d30102594b5c26",
+      ]
+    `)
+    expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -1,5 +1,5 @@
 import { AbiFunction, Address, Hex, Provider, PublicKey, WebCryptoP256 } from 'ox'
-import { KeyAuthorization } from 'ox/tempo'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import type { Client, Transport } from 'viem'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 
@@ -107,7 +107,9 @@ export declare namespace generate {
 }
 
 /** Prepares an unsigned key authorization and local key material when needed. */
-export async function prepare(options: prepare.Options): Promise<prepare.ReturnType> {
+export async function prepareAuthorization(
+  options: prepareAuthorization.Options,
+): Promise<prepareAuthorization.ReturnType> {
   const { address, chainId, expiry, keyType, limits, publicKey, scopes } = options
 
   if (address || publicKey) {
@@ -134,8 +136,8 @@ export async function prepare(options: prepare.Options): Promise<prepare.ReturnT
   return { keyAuthorization, keyPair }
 }
 
-export declare namespace prepare {
-  /** Options for {@link prepare}. */
+export declare namespace prepareAuthorization {
+  /** Options for {@link prepareAuthorization}. */
   type Options = {
     /** External access key address. Alternative to `publicKey`. */
     address?: Address.Address | undefined
@@ -160,6 +162,91 @@ export declare namespace prepare {
     /** Generated WebCrypto key pair for local access keys. */
     keyPair?: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>> | undefined
   }
+}
+
+/** Saves a prepared access key authorization with an existing signature. */
+export function saveAuthorization(
+  options: saveAuthorization.Options,
+): saveAuthorization.ReturnType {
+  const { address, prepared, signature, store } = options
+  const keyAuthorization = KeyAuthorization.from(prepared.keyAuthorization, {
+    signature: SignatureEnvelope.from(signature),
+  })
+
+  save({
+    address,
+    keyAuthorization,
+    ...(prepared.keyPair ? { keyPair: prepared.keyPair } : {}),
+    store,
+  })
+
+  return KeyAuthorization.toRpc(keyAuthorization)
+}
+
+export declare namespace saveAuthorization {
+  /** Options for {@link saveAuthorization}. */
+  type Options = {
+    /** Root account address that owns this access key. */
+    address: Address.Address
+    /** Prepared unsigned key authorization returned by {@link prepareAuthorization}. */
+    prepared: prepareAuthorization.ReturnType
+    /** Signature over the key authorization digest. */
+    signature: Hex.Hex
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Signed key authorization in RPC form. */
+  type ReturnType = KeyAuthorization.Rpc
+}
+
+/** Prepares, signs, and saves an access key authorization. */
+export async function authorize(options: authorize.Options): Promise<authorize.ReturnType> {
+  const { account, chainId, parameters, store } = options
+  const prepared = await prepareAuthorization({
+    ...parameters,
+    chainId: parameters.chainId ?? chainId,
+  })
+  return await signAuthorization({ account, prepared, store })
+}
+
+export declare namespace authorize {
+  /** Options for {@link authorize}. */
+  type Options = {
+    /** Root account that owns this access key and signs its authorization. */
+    account: TempoAccount.Account
+    /** Default chain ID for the authorization when `parameters.chainId` is not set. */
+    chainId: bigint | number
+    /** Access key authorization parameters. */
+    parameters: Omit<prepareAuthorization.Options, 'chainId'> & {
+      /** Chain ID the key authorization is scoped to. */
+      chainId?: bigint | number | undefined
+    }
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Signed key authorization in RPC form. */
+  type ReturnType = KeyAuthorization.Rpc
+}
+
+async function signAuthorization(
+  options: signAuthorization.Options,
+): Promise<signAuthorization.ReturnType> {
+  const { account, prepared, store } = options
+  const digest = KeyAuthorization.getSignPayload(prepared.keyAuthorization)
+  const signature = await account.sign({ hash: digest })
+  return saveAuthorization({ address: account.address, prepared, signature, store })
+}
+
+declare namespace signAuthorization {
+  type Options = {
+    account: TempoAccount.Account
+    prepared: prepareAuthorization.ReturnType
+    store: Store.Store
+  }
+
+  type ReturnType = KeyAuthorization.Rpc
 }
 
 /** Hydrates an access key entry to a viem Account. Only works for locally-generated keys. */

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -31,6 +31,41 @@ describe('local', () => {
         ]
       `)
     })
+
+    test('default: authorizeAccessKey folds the key authorization digest into the ceremony', async () => {
+      const captured: { digest: Hex | undefined }[] = []
+      const { adapter } = setup({
+        loadAccounts: makeLoadAccounts(0, captured),
+      })
+
+      const result = await adapter.actions.loadAccounts(
+        {
+          authorizeAccessKey: {
+            address: core_accounts[1]!.address,
+            expiry: 0,
+            keyType: 'secp256k1',
+          },
+        },
+        { method: 'wallet_connect', params: undefined },
+      )
+
+      expect({
+        digest: captured[0]?.digest,
+        hasSignature: typeof result.signature === 'string',
+        keyAuthorizationSignature: result.keyAuthorization?.signature,
+      }).toMatchInlineSnapshot(`
+        {
+          "digest": "0x64d5413088ae92221fde7900d29b540efc040ac134ccf50d3e916a9011f81bd0",
+          "hasSignature": true,
+          "keyAuthorizationSignature": {
+            "r": "0x876bd6f1719bdffc65382322939303ef37a804df5011b73704e7f4d9e4603cc8",
+            "s": "0x6c377e36d7a76b2dd15fdc9599ed663136a8e0faa33c3950e72c3b503bc18bab",
+            "type": "secp256k1",
+            "yParity": "0x1",
+          },
+        }
+      `)
+    })
   })
 
   describe('loadAccounts: personalSign', () => {

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,5 +1,5 @@
-import { Hex, Provider as ox_Provider } from 'ox'
-import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { Provider as ox_Provider } from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
 import { BaseError, hashMessage } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
@@ -28,48 +28,6 @@ export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
   return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
-    /**
-     * Resolves access key params into an unsigned key authorization.
-     */
-    async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
-      const { address, expiry, keyType, limits, publicKey, scopes } = options
-      return await AccessKey.prepare({
-        address,
-        chainId: options.chainId ?? getClient().chain.id,
-        expiry,
-        keyType,
-        limits,
-        publicKey,
-        scopes,
-      })
-    }
-
-    /**
-     * Signs (or wraps a pre-computed signature into) a key authorization
-     * and saves the result to the store.
-     */
-    async function signKeyAuthorization(
-      account: TempoAccount.Account,
-      prepared: Awaited<ReturnType<typeof prepareKeyAuthorization>>,
-      options: {
-        signature?: Hex.Hex | undefined
-      } = {},
-    ) {
-      const { keyPair } = prepared
-
-      const keyAuthorization = await (async () => {
-        const digest = KeyAuthorization.getSignPayload(prepared.keyAuthorization)
-        const signature = options.signature ?? (await account.sign({ hash: digest }))
-        return KeyAuthorization.from(prepared.keyAuthorization, {
-          signature: SignatureEnvelope.from(signature),
-        })
-      })()
-
-      AccessKey.save({ address: account.address, keyAuthorization, keyPair, store })
-
-      return KeyAuthorization.toRpc(keyAuthorization)
-    }
-
     async function withAccessKey<result>(
       options: Pick<Account.find.Options, 'address' | 'calls' | 'chainId'>,
       fn: (
@@ -126,8 +84,12 @@ export function local(options: local.Options): Adapter.Adapter {
 
           const keyAuthorization = await (async () => {
             if (!grantOptions) return undefined
-            const prepared = await prepareKeyAuthorization(grantOptions)
-            return await signKeyAuthorization(account, prepared)
+            return await AccessKey.authorize({
+              account,
+              chainId: getClient().chain.id,
+              parameters: grantOptions,
+              store,
+            })
           })()
 
           return {
@@ -140,9 +102,13 @@ export function local(options: local.Options): Adapter.Adapter {
           }
         },
         async authorizeAccessKey(parameters) {
-          const prepared = await prepareKeyAuthorization(parameters)
           const account = getAccount({ accessKey: false, signable: true })
-          const keyAuthorization = await signKeyAuthorization(account, prepared)
+          const keyAuthorization = await AccessKey.authorize({
+            account,
+            chainId: getClient().chain.id,
+            parameters,
+            store,
+          })
           return { keyAuthorization, rootAddress: account.address }
         },
         async loadAccounts(parameters) {
@@ -161,7 +127,14 @@ export function local(options: local.Options): Adapter.Adapter {
           const peronsalSign_digest = personalSign ? hashMessage(personalSign.message) : undefined
 
           const keyAuthorization_unsigned = authorizeAccessKey
-            ? await prepareKeyAuthorization(authorizeAccessKey)
+            ? await AccessKey.prepareAuthorization({
+                ...authorizeAccessKey,
+                chainId: authorizeAccessKey.chainId ?? getClient().chain.id,
+              })
+            : undefined
+
+          const keyAuthorization_digest = keyAuthorization_unsigned
+            ? KeyAuthorization.getSignPayload(keyAuthorization_unsigned.keyAuthorization)
             : undefined
 
           // Slot allocation:
@@ -172,11 +145,7 @@ export function local(options: local.Options): Adapter.Adapter {
           // `personalSign` wins the load-accounts ceremony and the key
           // authorization gets its own follow-up `account.sign` ceremony
           // (2 prompts total).
-          const digest =
-            peronsalSign_digest ??
-            (keyAuthorization_unsigned
-              ? KeyAuthorization.getSignPayload(keyAuthorization_unsigned.keyAuthorization)
-              : rest.digest)
+          const digest = peronsalSign_digest ?? keyAuthorization_digest ?? rest.digest
 
           // Pass the prepared digest (or the caller's) into loadAccounts so
           // the ceremony can sign it in a single biometric prompt.
@@ -196,10 +165,15 @@ export function local(options: local.Options): Adapter.Adapter {
           //   - Else (key-auth digest took the slot), reuse `signature_`.
           const keyAuthorization = await (async () => {
             if (!keyAuthorization_unsigned || !account) return undefined
-            if (peronsalSign_digest)
-              return await signKeyAuthorization(account, keyAuthorization_unsigned)
-            return await signKeyAuthorization(account, keyAuthorization_unsigned, {
-              signature: signature_,
+            const signature_keyAuthorization =
+              peronsalSign_digest || !signature_
+                ? await account.sign({ hash: keyAuthorization_digest! })
+                : signature_
+            return AccessKey.saveAuthorization({
+              address: account.address,
+              prepared: keyAuthorization_unsigned,
+              signature: signature_keyAuthorization,
+              store,
             })
           })()
 

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -7,7 +7,7 @@ import {
   RpcResponse,
   Secp256k1,
 } from 'ox'
-import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { KeyAuthorization } from 'ox/tempo'
 import { hashMessage, hashTypedData, isAddressEqual } from 'viem'
 import type { Address } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
@@ -273,48 +273,6 @@ export function turnkey<const client extends turnkey.Client>(
       return signatureToHex(result)
     }
 
-    async function prepareKeyAuthorization(options: Adapter.authorizeAccessKey.Parameters) {
-      const { address, expiry, keyType, limits, publicKey, scopes } = options
-      return await AccessKey.prepare({
-        address,
-        chainId: options.chainId ?? getClient().chain.id,
-        expiry,
-        keyType,
-        limits,
-        publicKey,
-        scopes,
-      })
-    }
-
-    async function signKeyAuthorization(
-      account: turnkey.WalletAccount,
-      prepared: Awaited<ReturnType<typeof prepareKeyAuthorization>>,
-      options: {
-        signature?: Hex.Hex | undefined
-      } = {},
-    ) {
-      const digest = KeyAuthorization.getSignPayload(prepared.keyAuthorization)
-      const signature =
-        options.signature ??
-        (await signPayload({
-          payload: digest,
-          turnkeyClient: await getTurnkeyClient(),
-          walletAccount: account,
-        }))
-      const keyAuthorization = KeyAuthorization.from(prepared.keyAuthorization, {
-        signature: SignatureEnvelope.from(signature),
-      })
-
-      AccessKey.save({
-        address: core_Address.from(account.address),
-        keyAuthorization,
-        ...(prepared.keyPair ? { keyPair: prepared.keyPair } : {}),
-        store,
-      })
-
-      return KeyAuthorization.toRpc(keyAuthorization)
-    }
-
     async function withAccessKey<result>(
       options: {
         address?: Address | undefined
@@ -419,10 +377,12 @@ export function turnkey<const client extends turnkey.Client>(
           const account = walletAccounts[0]
           const keyAuthorization = authorizeAccessKey
             ? account
-              ? await signKeyAuthorization(
-                  account,
-                  await prepareKeyAuthorization(authorizeAccessKey),
-                )
+              ? await AccessKey.authorize({
+                  account: toTempoAccount(account),
+                  chainId: getClient().chain.id,
+                  parameters: authorizeAccessKey,
+                  store,
+                })
               : undefined
             : undefined
 
@@ -461,10 +421,12 @@ export function turnkey<const client extends turnkey.Client>(
           const account = walletAccounts[0]
           const keyAuthorization =
             authorizeAccessKey && account
-              ? await signKeyAuthorization(
-                  account,
-                  await prepareKeyAuthorization(authorizeAccessKey),
-                )
+              ? await AccessKey.authorize({
+                  account: toTempoAccount(account),
+                  chainId: getClient().chain.id,
+                  parameters: authorizeAccessKey,
+                  store,
+                })
               : undefined
 
           return {
@@ -483,8 +445,12 @@ export function turnkey<const client extends turnkey.Client>(
         },
         async authorizeAccessKey(parameters) {
           const account = await accountForSigning(undefined)
-          const prepared = await prepareKeyAuthorization(parameters)
-          const keyAuthorization = await signKeyAuthorization(account, prepared)
+          const keyAuthorization = await AccessKey.authorize({
+            account: toTempoAccount(account),
+            chainId: getClient().chain.id,
+            parameters,
+            store,
+          })
           return { keyAuthorization, rootAddress: core_Address.from(account.address) }
         },
         async signPersonalMessage(parameters) {


### PR DESCRIPTION
## Summary
Move shared access-key authorization ceremony logic into `AccessKey`.

## Motivation
`src/core/adapters/local.ts` and `src/core/adapters/turnkey.ts` had matching prepare/sign/save wrappers. Keeping that logic in `AccessKey` makes the adapter code smaller and leaves transaction lifecycle changes for the stacked PR.

## Changes
- Rename `AccessKey.prepare` to `AccessKey.prepareAuthorization`.
- Add `AccessKey.authorize` and `AccessKey.saveAuthorization`.
- Use the shared helpers from `local` and `turnkey`.
- Add a regression test for folding the key authorization digest into `loadAccounts`.

## Testing
- `./node_modules/.bin/vp lint src/core/AccessKey.ts src/core/AccessKey.test.ts src/core/adapters/local.ts src/core/adapters/local.test.ts src/core/adapters/turnkey.ts`
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts src/core/adapters/local.test.ts src/core/adapters/turnkey.test.ts`