### PR TITLE
fix(relay): resolve default feeToken in Path A and protect it from fill() clobber

### DIFF
--- a/.changeset/yellow-wings-read.md
+++ b/.changeset/yellow-wings-read.md
@@ -2,8 +2,4 @@
 "accounts": patch
 ---
 
-`Handler.relay`: Default `feeToken` to the chain's first configured
-token on sponsored fills when neither the wallet nor the caller supplies
-one, and re-inject it after `fill()` when the chain echoes `feeToken:
-null`. Prevents sponsored transactions from being broadcast without a
-`feeToken`.
+Defaulted `feeToken` to chain settlement token in Path A. Protected resolved token from `fill()` null-clobber. Fixed sponsored transactions reverting with insufficient FeeAMM liquidity.

--- a/.changeset/yellow-wings-read.md
+++ b/.changeset/yellow-wings-read.md
@@ -1,0 +1,9 @@
+---
+"accounts": patch
+---
+
+`Handler.relay`: Default `feeToken` to the chain's first configured
+token on sponsored fills when neither the wallet nor the caller supplies
+one, and re-inject it after `fill()` when the chain echoes `feeToken:
+null`. Prevents sponsored transactions from being broadcast without a
+`feeToken`.

--- a/src/server/internal/handlers/relay.test.ts
+++ b/src/server/internal/handlers/relay.test.ts
@@ -1426,6 +1426,30 @@ describe('behavior: path A — guaranteed sponsorship (no validate)', () => {
     expect(result.transaction.feePayerSignature).toBeDefined()
     expect(result.capabilities?.sponsored).toBe(true)
   })
+
+  test('behavior: defaults feeToken to chain default when caller omits it', async () => {
+    // Without the default, the broadcast envelope has no feeToken and
+    // the chain falls back to the sender's account token, which often
+    // lacks FeeAMM liquidity.
+    const result = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+    })
+
+    expect(result.transaction.feeToken?.toLowerCase()).toBe(
+      localnetTokens[0]!.address.toLowerCase(),
+    )
+  })
+
+  test('behavior: preserves caller-supplied feeToken', async () => {
+    const result = await fillTransaction(client, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feeToken: addresses.alphaUsd as Address,
+    })
+
+    expect(result.transaction.feeToken?.toLowerCase()).toBe(addresses.alphaUsd.toLowerCase())
+  })
 })
 
 describe('behavior: path B — conditional sponsorship (validate)', () => {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -222,7 +222,14 @@ export function relay(options: relay.Options = {}): Handler {
             //   - the app supplied its own external fee payer URL (that
             //     relay is the sponsorship authority — the wallet's own
             //     `validate` only governs the wallet's own fee payer).
-            const transaction = { ...baseTx, feePayer: true }
+            // Default to the chain's first token so the broadcast envelope
+            // always carries a feeToken the chain can charge.
+            if (!feeToken) feeToken = (await getTokens(chainId))[0]
+            const transaction = {
+              ...baseTx,
+              feePayer: true,
+              ...(feeToken ? { feeToken } : {}),
+            }
             if (Sponsorship.isPreparedTransaction(transaction)) {
               filled = {
                 transaction: Utils.normalizeTempoTransaction(transaction),
@@ -236,6 +243,15 @@ export function relay(options: relay.Options = {}): Handler {
                 resolveFeeToken: resolveFeeTokenForSwap,
                 transaction,
               })
+              // The chain echoes feeToken: null for sponsored fills served
+              // by viem clients that strip feeToken pre-sign; re-inject
+              // before the spread in mergeCallsFromRequest drops it.
+              if (
+                feeToken &&
+                filled?.transaction &&
+                (filled.transaction as { feeToken?: Address | null }).feeToken == null
+              )
+                (filled.transaction as { feeToken?: Address }).feeToken = feeToken
             }
             sponsored = true
           } else if (requestsSponsorship && feePayerOptions?.validate) {


### PR DESCRIPTION
## Summary

When `Handler.relay` serves a sponsored fill (`feePayer: true`) and
neither `feePayerOptions.feeToken` nor the request's `feeToken` is
set, the broadcast envelope is sent with no `feeToken`. The chain
falls back to the sender's default account token, which often has no
FeeAMM liquidity, and the tx reverts with `insufficient liquidity in
FeeAMM pool to swap fee tokens`.

Two underlying issues:

1. The guaranteed-sponsorship branch calls `fill()` with `feeToken:
   undefined` when nothing else is set; nothing later injects a
   default.
2. Viem clients strip `feeToken` from the request when `feePayer ===
   true`. The chain echoes that as `feeToken: null` in the response,
   and `mergeCallsFromRequest`'s `{ ...request, ...resultTx }` spread
   then overrides any token the relay resolved.

## Changes

In the guaranteed-sponsorship branch of `relay.ts`:

- Default `feeToken` to `(await getTokens(chainId))[0]` when nothing
  else is set.
- Re-inject the resolved `feeToken` on `filled.transaction` if the
  chain echoed `null`.

Adds two regression tests.

## Testing

- `pnpm check`, `pnpm check:types`: clean.
- `pnpm vp test src/server/internal/handlers/relay.test.ts`: 53/53
  pass.
- Verified end-to-end against a live Tempo network with a fee-sponsor
  worker.

## Related

The re-inject guard is partially redundant once
[wevm/viem#4622](https://github.com/wevm/viem/pull/4622) lands, but
kept as defense in depth for older viem versions.
