### PR TITLE
fix(mpp): pass session options through provider

### DIFF
--- a/.changeset/mpp-session-options.md
+++ b/.changeset/mpp-session-options.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Passed MPP session options from `Provider.create({ mpp })` through to mppx so clients could configure session deposits.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -244,6 +244,19 @@ const provider = Provider.create({
 })
 ```
 
+MPP session endpoints can use `deposit` or `maxDeposit` so the client opens and tops up a payment channel before sending vouchers.
+
+```ts twoslash
+import { Provider } from 'accounts'
+
+const provider = Provider.create({
+  mpp: { // [!code focus]
+    maxDeposit: '10', // [!code focus]
+    mode: 'pull', // [!code focus]
+  }, // [!code focus]
+})
+```
+
 ### persistCredentials
 
 - **Type:** `boolean`

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -1,6 +1,7 @@
 import type { RpcSchema } from 'ox'
 import { describe, expectTypeOf, test } from 'vp/test'
 
+import * as Provider from './Provider.js'
 import type * as Schema from './Schema.js'
 
 type Result<method extends RpcSchema.MethodNameGeneric<Schema.Ox>> = RpcSchema.ExtractReturnType<
@@ -55,5 +56,19 @@ describe('request', () => {
 
   test('wallet_switchEthereumChain', () => {
     expectTypeOf<Result<'wallet_switchEthereumChain'>>().toEqualTypeOf<undefined>()
+  })
+})
+
+describe('create options', () => {
+  test('mpp accepts session deposit options', () => {
+    expectTypeOf<NonNullable<Parameters<typeof Provider.create>[0]>>().toMatchTypeOf<{
+      mpp?:
+        | boolean
+        | {
+            deposit?: string | undefined
+            maxDeposit?: string | undefined
+          }
+        | undefined
+    }>()
   })
 })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1003,17 +1003,20 @@ export function create(options: create.Options = {}): create.ReturnType {
     return {}
   })()
   if (mpp) {
-    const { mode = 'push' } = mpp
+    const { mode = 'push', polyfill: polyfill_option, ...methodOptions } = mpp
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
-    const polyfill = mpp.polyfill ?? isFetchWritable()
+    const polyfill = polyfill_option ?? isFetchWritable()
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
       const client = provider.getClient({ chainId })
       const account = provider.getAccount()
       return Object.assign(client, { account })
     }
     Mppx.create({
-      methods: [mppx_tempo({ getClient, mode }), mppx_tempo.subscription({ getClient })],
+      methods: [
+        mppx_tempo({ ...methodOptions, getClient, mode }),
+        mppx_tempo.subscription({ getClient }),
+      ],
       polyfill,
     })
   }
@@ -1109,16 +1112,7 @@ export declare namespace create {
 
 export declare namespace mpp {
   /** Options for Machine Payment Protocol (mppx) integration. */
-  type Options = {
-    /**
-     * Charge mode for `mppx/tempo`.
-     *
-     * - `'push'`: Client broadcasts the transaction and sends the tx hash to the server.
-     * - `'pull'`: Client signs the transaction and sends the serialized tx to the server for broadcast.
-     *
-     * @default 'push'
-     */
-    mode?: 'push' | 'pull' | undefined
+  type Options = Omit<mppx_tempo.Parameters, 'account' | 'getClient'> & {
     /**
      * Whether to polyfill `globalThis.fetch` with the payment-aware wrapper.
      *


### PR DESCRIPTION
## Summary
Passed MPP session options from `Provider.create({ mpp })` into the mppx Tempo client method.

## Motivation
Fixes #469. Session-backed MPP endpoints need client-side deposit configuration, but Accounts only passed `mode` through to mppx.

## Changes
- Forwarded MPP method options from `src/core/Provider.ts` while keeping `polyfill` local to Accounts.
- Added type coverage for `deposit` and `maxDeposit` in `src/core/Provider.test-d.ts`.
- Documented session deposit configuration in `site/src/pages/docs/api/provider.mdx`.
- Added `.changeset/mpp-session-options.md`.

## Testing
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`
- `./node_modules/.bin/vp lint src/core/Provider.ts src/core/Provider.test-d.ts site/src/pages/docs/api/provider.mdx`
- `git diff --check`
- `node --import tsx --eval "import { Provider, Storage, secp256k1 } from './src/index.ts'; const provider = Provider.create({ adapter: secp256k1({ privateKey: '0x59c6995e998f97a5a004497e5da637d63e4a3cda3ec740f2c87e1087108bbd06' }), mpp: { maxDeposit: '1', mode: 'pull', polyfill: false }, storage: Storage.memory(), testnet: true }); console.log(JSON.stringify({ chains: provider.chains.length, mpp: 'configured' }));"` — `{"chains":3,"mpp":"configured"}`
- `pnpm --filter site build` — passed; reported existing dead-link warnings in `/docs/adapters/private-key.mdx` and `/docs/adapters/webauthn.mdx`
