### PR TITLE
docs(mpp): clarify relay and fee payer setup

### DIFF
--- a/.changeset/mpp-relay-feepayer-docs.md
+++ b/.changeset/mpp-relay-feepayer-docs.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Documented chain-qualified relay routes and showed the MPP example server sponsoring pull-mode charge transactions.

--- a/examples/mpp/README.md
+++ b/examples/mpp/README.md
@@ -37,9 +37,12 @@ payment method:
 ```ts
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
 
 const mppx = Mppx.create({
-  methods: [tempo({ recipient: '0x...', currency: '0x...', testnet: true })],
+  methods: [tempo({ account, currency: '0x...', feePayer: true, testnet: true })],
   realm: 'mpp',
   secretKey: '...',
 })
@@ -53,3 +56,8 @@ On the client, the standard `tempoWallet()` connector is enough — the
 `Provider.create({ mpp: true })` default automatically intercepts the 402
 responses, signs the payment with the connected account, and retries the
 original request with the credential attached.
+
+For pull-mode charge credentials, `feePayer: true` lets the worker co-sign and
+broadcast the signed payment transaction. Without a fee payer, the worker can
+verify the credential shape but cannot pay the transaction fee needed to settle
+the charge on-chain.

--- a/examples/mpp/worker/index.ts
+++ b/examples/mpp/worker/index.ts
@@ -15,6 +15,7 @@ const mppx = Mppx.create({
   methods: [
     tempo({
       account,
+      feePayer: true,
       // pathUSD on Tempo testnet.
       currency: '0x20c0000000000000000000000000000000000000',
       testnet: true,

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -268,6 +268,9 @@ Base URL for a wallet relay endpoint. When set, every chain's transport defaults
 
 Designed to point at a service running [`Handler.relay`](/docs/server/handler.relay) from `accounts/server`.
 
+Pass the base path here. The provider appends the active chain ID, so a base
+path of `/relay` sends chain `33139` requests to `/relay/33139`.
+
 ```ts twoslash
 import { Provider } from 'accounts'
 

--- a/site/src/pages/docs/server/handler.relay.mdx
+++ b/site/src/pages/docs/server/handler.relay.mdx
@@ -569,6 +569,11 @@ const handler = Handler.relay({
 })
 ```
 
+When used with [`Provider.relay`](/docs/api/provider#relay), expose both the
+base path and chain-qualified child paths from your HTTP router. The provider
+posts JSON-RPC to `/relay/:chainId`; direct `POST /relay` calls are only valid
+when your router sends that exact path to the relay handler.
+
 ### resolveTokens
 
 - **Type:** `(chainId: number) => readonly Token[] | Promise<readonly Token[]>`


### PR DESCRIPTION
## Summary
Clarified chain-qualified relay routing and showed MPP pull-mode fee sponsorship in the example worker.

## Motivation
Fixes #474 and fixes #475. The relay client path is chain-qualified, and pull-mode MPP charge servers need a fee payer to settle signed payment transactions.

## Changes
- Added `feePayer: true` to `examples/mpp/worker/index.ts`.
- Updated `examples/mpp/README.md` to show a worker fee payer and explain pull-mode settlement.
- Clarified `Provider.relay` base-path behavior in `site/src/pages/docs/api/provider.mdx`.
- Documented `/relay/:chainId` routing expectations in `site/src/pages/docs/server/handler.relay.mdx`.
- Added `.changeset/mpp-relay-feepayer-docs.md`.

## Testing
- `./node_modules/.bin/vp lint examples/mpp/README.md examples/mpp/worker/index.ts site/src/pages/docs/api/provider.mdx site/src/pages/docs/server/handler.relay.mdx`
- `git diff --check`
- `pnpm --filter mpp build` — built worker and client bundles
- `pnpm --filter site build` — passed; reported existing dead-link warnings in `/docs/adapters/private-key.mdx` and `/docs/adapters/webauthn.mdx`
