### PR TITLE
fix(mpp): preserve send calls error details

### DIFF
--- a/.changeset/mpp-sendcalls-error-details.md
+++ b/.changeset/mpp-sendcalls-error-details.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added error details to `wallet_sendCalls` failures so viem push-mode fallbacks preserved the original provider error.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,8 +1,9 @@
 import { Hex, Provider as core_Provider, WebCryptoP256 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { type Address, createClient, custom, parseUnits } from 'viem'
+import { type Address, createClient, createWalletClient, custom, parseUnits } from 'viem'
 import {
   getBalance,
+  sendCalls,
   sendTransactionSync,
   signMessage,
   verifyHash,
@@ -18,6 +19,7 @@ import { headlessWebAuthn, secp256k1 } from '../../test/adapters.js'
 import { accounts, chain, getClient, http } from '../../test/config.js'
 import { createServer, type Server } from '../../test/utils.js'
 import * as Handler from '../server/Handler.js'
+import * as Adapter from './Adapter.js'
 import { local as core_local } from './adapters/local.js'
 import * as Expiry from './Expiry.js'
 import * as Provider from './Provider.js'
@@ -1054,6 +1056,58 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.version).toMatchInlineSnapshot(`"2.0.0"`)
       expect(result.receipts?.length).toMatchInlineSnapshot(`1`)
       expect(result.receipts?.[0]?.status).toMatchInlineSnapshot(`"0x1"`)
+    })
+
+    test('error: preserves adapter failure details for viem fallback handling', async () => {
+      const failing = Adapter.define({}, () => ({
+        actions: {
+          async createAccount() {
+            return { accounts: [{ address: accounts[0]!.address }] }
+          },
+          async loadAccounts() {
+            return { accounts: [{ address: accounts[0]!.address }] }
+          },
+          async sendTransaction() {
+            throw new Error('plain send failure')
+          },
+          async sendTransactionSync() {
+            throw new Error('plain sync failure')
+          },
+          async signPersonalMessage() {
+            return '0x'
+          },
+          async signTransaction() {
+            return '0x'
+          },
+          async signTypedData() {
+            return '0x'
+          },
+        },
+      }))
+      const provider = Provider.create({
+        adapter: failing,
+        chains: [chain],
+        storage: Storage.memory(),
+      })
+      await provider.request({ method: 'wallet_connect' })
+      const client = createWalletClient({ chain, transport: custom(provider) })
+
+      await expect(
+        sendCalls(client, {
+          account: accounts[0]!.address,
+          calls: [transferCall],
+          experimental_fallback: true,
+          experimental_fallbackDelay: 0,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [TransactionExecutionError: An internal error was received.
+
+        Request Arguments:
+          from:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
+        Details: plain send failure
+        Version: viem@2.49.2]
+      `)
     })
   })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -397,45 +397,49 @@ export function create(options: create.Options = {}): create.ReturnType {
                   }
 
                   case 'wallet_sendCalls': {
-                    assertConnected()
-                    const decoded = request._decoded.params?.[0]
-                    const { calls = [], capabilities, chainId, from } = decoded ?? {}
-                    const sync = capabilities?.sync
-                    const feePayer = resolveFeePayer(
-                      capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
-                    )
-                    const state = store.getState()
-                    const txRequest = {
-                      calls,
-                      chainId,
-                      from: from ?? state.accounts[state.activeAccount]?.address,
-                      ...(feePayer ? { feePayer } : {}),
-                    }
-                    if (!sync) {
-                      const hash = await actions.sendTransaction(txRequest, {
-                        method: 'eth_sendTransaction',
+                    try {
+                      assertConnected()
+                      const decoded = request._decoded.params?.[0]
+                      const { calls = [], capabilities, chainId, from } = decoded ?? {}
+                      const sync = capabilities?.sync
+                      const feePayer = resolveFeePayer(
+                        capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
+                      )
+                      const state = store.getState()
+                      const txRequest = {
+                        calls,
+                        chainId,
+                        from: from ?? state.accounts[state.activeAccount]?.address,
+                        ...(feePayer ? { feePayer } : {}),
+                      }
+                      if (!sync) {
+                        const hash = await actions.sendTransaction(txRequest, {
+                          method: 'eth_sendTransaction',
+                          params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
+                        })
+                        const chainId = Hex.fromNumber(store.getState().chainId)
+                        const id = Hex.concat(hash, Hex.padLeft(chainId, 32), sendCallsMagic)
+                        return { capabilities: { sync }, id }
+                      }
+                      const receipt = await actions.sendTransactionSync(txRequest as never, {
+                        method: 'eth_sendTransactionSync',
                         params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
                       })
-                      const chainId = Hex.fromNumber(store.getState().chainId)
-                      const id = Hex.concat(hash, Hex.padLeft(chainId, 32), sendCallsMagic)
-                      return { capabilities: { sync }, id }
+                      const hash = receipt.transactionHash
+                      const chainIdHex = Hex.fromNumber(store.getState().chainId)
+                      const id = Hex.concat(hash, Hex.padLeft(chainIdHex, 32), sendCallsMagic)
+                      return {
+                        atomic: true,
+                        capabilities: { sync },
+                        chainId: chainIdHex,
+                        id,
+                        receipts: [receipt],
+                        status: (receipt as { status: string }).status === '0x1' ? 200 : 500,
+                        version: '2.0.0',
+                      } satisfies Rpc.wallet_sendCalls.Encoded['returns']
+                    } catch (error) {
+                      throw withDetails(error)
                     }
-                    const receipt = await actions.sendTransactionSync(txRequest as never, {
-                      method: 'eth_sendTransactionSync',
-                      params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
-                    })
-                    const hash = receipt.transactionHash
-                    const chainIdHex = Hex.fromNumber(store.getState().chainId)
-                    const id = Hex.concat(hash, Hex.padLeft(chainIdHex, 32), sendCallsMagic)
-                    return {
-                      atomic: true,
-                      capabilities: { sync },
-                      chainId: chainIdHex,
-                      id,
-                      receipts: [receipt],
-                      status: (receipt as { status: string }).status === '0x1' ? 200 : 500,
-                      version: '2.0.0',
-                    } satisfies Rpc.wallet_sendCalls.Encoded['returns']
                   }
 
                   case 'wallet_getBalances': {
@@ -1128,6 +1132,18 @@ export declare namespace mpp {
      */
     polyfill?: boolean | undefined
   }
+}
+
+function withDetails(error: unknown): Error & { details: string } {
+  if (error instanceof Error) {
+    const details = (error as { details?: unknown }).details
+    if (typeof details === 'string') return error as Error & { details: string }
+    Object.assign(error, { details: error.message })
+    return error as Error & { details: string }
+  }
+  const next = new Error(String(error))
+  Object.assign(next, { details: next.message })
+  return next as Error & { details: string }
 }
 
 /**


### PR DESCRIPTION
## Summary
Preserved `wallet_sendCalls` error details so viem fallback handling keeps the provider failure.

## Motivation
Fixes #473. viem push-mode fallback checks `error.details` when `wallet_sendCalls` fails. Plain adapter errors did not always include that field, which could hide the real provider failure.

## Changes
- Added a `wallet_sendCalls` error boundary in `src/core/Provider.ts` that fills missing `details` from the thrown message.
- Added a regression test in `src/core/Provider.test.ts` that exercises viem `sendCalls(... experimental_fallback: true)`.
- Added `.changeset/mpp-sendcalls-error-details.md`.

## Testing
- `./node_modules/.bin/vp test src/core/Provider.test.ts -t "wallet_sendCalls"` — passed, 14 tests.
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit` — passed.
- `./node_modules/.bin/vp lint src/core/Provider.ts src/core/Provider.test.ts .changeset/mpp-sendcalls-error-details.md` — passed, 0 warnings.
- `git diff --check` — passed.
- Live viem script with a plain throwing adapter returned `TransactionExecutionError` with `details: "plain send failure"` and `causeDetails: "plain send failure"`.

Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it passed with existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`.