### PR TITLE
fix(provider): preserve dialog error codes

### DIFF
--- a/.changeset/provider-policy-error-mapping.md
+++ b/.changeset/provider-policy-error-mapping.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Preserved wallet-host RPC error codes when dialog requests failed so validation errors were no longer reported as user rejection.

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -118,7 +118,9 @@ describe('dialog', () => {
       request,
     )
 
-    await Promise.resolve()
+    await vi.waitFor(() => {
+      if (!store.getState().requestQueue[0]) throw new Error('request not queued')
+    })
 
     const queued = store.getState().requestQueue[0]!
     store.setState({
@@ -133,5 +135,68 @@ describe('dialog', () => {
 
     await expect(promise).resolves.toMatchInlineSnapshot(`"0x1234"`)
     expect(lookups).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('error: wallet validation errors keep their RPC code', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    vi.spyOn(AccessKey, 'selectAccount').mockReturnValue(undefined)
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+    const promise = adapter.actions.sendTransaction(
+      {
+        calls: [{ data: '0x12345678', to: recipient }],
+        chainId: 1,
+        from: address,
+      },
+      {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            calls: [{ data: '0x12345678' as const, to: recipient }],
+            chainId: '0x1' as const,
+            from: address,
+          },
+        ] as const,
+      },
+    )
+
+    await vi.waitFor(() => {
+      if (!store.getState().requestQueue[0]) throw new Error('request not queued')
+    })
+
+    const queued = store.getState().requestQueue[0]!
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          error: {
+            code: -32602,
+            message: '`authorizeAccessKey` must include at least one `limits` entry.',
+          },
+          status: 'error',
+        },
+      ],
+    })
+
+    await expect(
+      promise.catch((error) => ({
+        code: error.code,
+        message: error.message,
+        name: error.name,
+      })),
+    ).resolves.toMatchInlineSnapshot(`
+      {
+        "code": -32602,
+        "message": "\`authorizeAccessKey\` must include at least one \`limits\` entry.",
+        "name": "RpcResponse.InvalidParamsError",
+      }
+    `)
   })
 })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -69,7 +69,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           listeners.delete(listener)
 
           if (queued.status === 'success') resolve(queued.result)
-          else reject(new ox_Provider.UserRejectedRequestError({ message: queued.error.message }))
+          else reject(ox_Provider.parseError(queued.error))
 
           // Remove the resolved request from the queue.
           store.setState((x) => ({


### PR DESCRIPTION
## Summary
Preserved wallet-host RPC error codes when dialog requests fail.

## Motivation
Fixes #467. Dialog forwarding wrapped every wallet-host failure as `Provider.UserRejectedRequestError`, which made policy validation errors indistinguishable from user cancellation.

## Changes
- Changed `src/core/adapters/dialog.ts` to parse returned RPC errors instead of forcing user rejection.
- Added dialog adapter coverage in `src/core/adapters/dialog.test.ts` for a wallet-host validation error with code `-32602`.
- Added `.changeset/provider-policy-error-mapping.md`.

## Testing
- `./node_modules/.bin/vp test src/core/adapters/dialog.test.ts` — passed, 3 tests.
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit` — passed.
- `./node_modules/.bin/vp lint src/core/adapters/dialog.ts src/core/adapters/dialog.test.ts .changeset/provider-policy-error-mapping.md` — passed, 0 warnings.
- `git diff --check` — passed.
- Live dialog adapter script returned `RpcResponse.InvalidParamsError` with code `-32602` for a queued wallet validation error.

Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it passed with existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`.