### PR TITLE
feat(access-key): expose publication status

### DIFF
--- a/.changeset/access-key-status-scopes.md
+++ b/.changeset/access-key-status-scopes.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added access-key publication status helpers and matched scoped key policies locally without crashing on malformed scope data.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -7,7 +7,7 @@ description: Create an EIP-1193 provider for managing accounts on Tempo.
 
 Creates an EIP-1193 provider with a pluggable adapter for managing accounts on Tempo.
 
-The returned object implements [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) (`request`, `on`, `removeListener`, `emit`, ...) and exposes a few convenience helpers (`getAccount`, `getClient`, `store`, `chains`). See [Return Type](#return-type) for the full surface.
+The returned object implements [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) (`request`, `on`, `removeListener`, `emit`, ...) and exposes a few convenience helpers (`getAccount`, `getAccessKeyStatus`, `getClient`, `store`, `chains`). See [Return Type](#return-type) for the full surface.
 
 ## Usage
 
@@ -51,6 +51,28 @@ const { receipt } = await client.token.transferSync({ // [!code focus]
   to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
   token: '0x20c0000000000000000000000000000000000001', // [!code focus]
 }) // [!code focus]
+```
+
+### Access Key Status
+
+Use `getAccessKeyStatus` to check whether the active account has a matching delegated key before starting a paid or delegated flow.
+
+```ts twoslash
+// @noErrors
+import { Provider } from 'accounts'
+
+const provider = Provider.create()
+
+const status = await provider.getAccessKeyStatus({ // [!code focus]
+  calls: [{ // [!code focus]
+    to: '0x20c0000000000000000000000000000000000001', // [!code focus]
+    data: '0xa9059cbb', // [!code focus]
+  }], // [!code focus]
+}) // [!code focus]
+
+if (status === 'pending') {
+  // The next matching transaction will publish the key authorization.
+}
 ```
 
 ## Parameters
@@ -110,6 +132,8 @@ const provider = Provider.create({
 - **Optional**
 
 Default access key parameters for `wallet_connect`. When set, `wallet_connect` will automatically authorize an access key.
+
+Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Local adapters accept unbounded keys, but production apps should pass both so local and wallet-hosted flows use the same policy.
 
 ```ts
 declare function authorizeAccessKey(): {
@@ -333,7 +357,7 @@ const provider = Provider.create({
 The provider type is exported as `Provider` and is the intersection of [`ox.Provider.Provider`](https://oxlib.sh/Provider) (the EIP-1193 surface) and [`ox.Provider.Emitter`](https://oxlib.sh/Provider#emitter) plus a few extra accessors:
 
 ```ts
-import type { Account, Provider as ox_Provider } from 'ox'
+import type { Account, Address, Hex, Provider as ox_Provider } from 'ox'
 import type { Chain, Client as ViemClient, Transport } from 'viem'
 import type { tempo } from 'viem/chains'
 
@@ -342,6 +366,13 @@ export type Provider = ox_Provider.Provider & ox_Provider.Emitter & {
   chains: readonly [Chain, ...Chain[]]
   /** Returns a viem Account for the given address (or active account). */
   getAccount: Account.Find
+  /** Returns local or on-chain publication status for an access key. */
+  getAccessKeyStatus(options?: {
+    address?: Address | undefined
+    accessKey?: Address | undefined
+    calls?: readonly { to?: Address | undefined; data?: Hex | undefined }[] | undefined
+    chainId?: number | undefined
+  }): Promise<'missing' | 'pending' | 'published' | 'expired'>
   /** Returns a viem Client for the given (or current) chain ID. */
   getClient(options?: {
     chainId?: number | undefined

--- a/site/src/pages/docs/rpc/wallet_authorizeAccessKey.mdx
+++ b/site/src/pages/docs/rpc/wallet_authorizeAccessKey.mdx
@@ -5,7 +5,7 @@ description: Authorize an access key for delegated transaction signing.
 
 # `wallet_authorizeAccessKey`
 
-Authorizes an access key with an expiry and optional spending limits for delegated transaction signing.
+Authorizes an access key with an expiry, spending limits, and optional call scopes for delegated transaction signing.
 
 ## Request
 
@@ -47,6 +47,8 @@ type Request = {
   }]
 }
 ```
+
+Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Use the `address` field on each scope for the target contract; malformed scope entries are rejected before approval.
 
 ## Response
 
@@ -91,6 +93,9 @@ const result = await provider.request({
     expiry: Expiry.days(1),
     limits: [
       { token: '0x20c0000000000000000000000000000000000001', limit: '0x5F5E100' },
+    ],
+    scopes: [
+      { address: '0x20c0000000000000000000000000000000000001' },
     ],
   }],
 })

--- a/site/src/pages/docs/wagmi/tempoWallet.mdx
+++ b/site/src/pages/docs/wagmi/tempoWallet.mdx
@@ -29,10 +29,12 @@ Accepts all [`dialog`](/docs/api/dialog) adapter options, plus all [`Provider`](
 
 ### authorizeAccessKey
 
-- **Type:** `() => { expiry: number; limits?: { token: Address; limit: bigint }[] }`
+- **Type:** `() => { expiry: number; limits?: { token: Address; limit: bigint }[]; scopes?: { address: Address; selector?: Hex | string }[] }`
 - **Optional**
 
 Default access key parameters for `wallet_connect`.
+
+Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Local adapters accept unbounded keys, but production apps should pass both so local and wallet-hosted flows use the same policy.
 
 ```ts twoslash
 import { createConfig, http } from 'wagmi'
@@ -50,6 +52,10 @@ export const config = createConfig({
         limits: [{ // [!code focus]
           token: '0x20c0000000000000000000000000000000000001', // [!code focus]
           limit: parseUnits('500', 6), // [!code focus]
+        }], // [!code focus]
+        scopes: [{ // [!code focus]
+          address: '0x20c0000000000000000000000000000000000001', // [!code focus]
+          selector: 'transfer(address,uint256)', // [!code focus]
         }], // [!code focus]
       }), // [!code focus]
     }),

--- a/site/src/pages/docs/wagmi/webAuthn.mdx
+++ b/site/src/pages/docs/wagmi/webAuthn.mdx
@@ -60,10 +60,12 @@ export const config = createConfig({
 
 ### authorizeAccessKey
 
-- **Type:** `() => { expiry: number; limits?: { token: Address; limit: bigint }[] }`
+- **Type:** `() => { expiry: number; limits?: { token: Address; limit: bigint }[]; scopes?: { address: Address; selector?: Hex | string }[] }`
 - **Optional**
 
 Default access key parameters for `wallet_connect`.
+
+Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Local adapters accept unbounded keys, but production apps should pass both so local and wallet-hosted flows use the same policy.
 
 ```ts twoslash
 import { createConfig, http } from 'wagmi'
@@ -82,6 +84,10 @@ export const config = createConfig({
         limits: [{ // [!code focus]
           token: '0x20c0000000000000000000000000000000000001', // [!code focus]
           limit: parseUnits('500', 6), // [!code focus]
+        }], // [!code focus]
+        scopes: [{ // [!code focus]
+          address: '0x20c0000000000000000000000000000000000001', // [!code focus]
+          selector: 'transfer(address,uint256)', // [!code focus]
         }], // [!code focus]
       }), // [!code focus]
     }),

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -1,7 +1,7 @@
 import { WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { encodeErrorResult } from 'viem'
-import { Abis, Account as TempoAccount } from 'viem/tempo'
+import { Abis, Account as TempoAccount, Actions } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { accounts, privateKeys } from '../../test/config.js'
@@ -16,7 +16,11 @@ const rootAddress = accounts[0]!.address
 
 function createKeyAuthorization(
   address: `0x${string}`,
-  options: { expiry?: number | undefined; limits?: { token: `0x${string}`; limit: bigint }[] } = {},
+  options: {
+    expiry?: number | undefined
+    limits?: { token: `0x${string}`; limit: bigint }[] | undefined
+    scopes?: KeyAuthorization.Scope[] | undefined
+  } = {},
 ) {
   return KeyAuthorization.from(
     {
@@ -24,6 +28,7 @@ function createKeyAuthorization(
       chainId: 1n,
       expiry: options.expiry,
       limits: options.limits,
+      scopes: options.scopes,
       type: 'p256',
     },
     { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
@@ -660,6 +665,96 @@ describe('selectAccount', () => {
     expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
   })
 
+  test('behavior: scoped access key checks recipient allowlist', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const recipient = '0x0000000000000000000000000000000000000def' as const
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [
+          { address: token, selector: 'transfer(address,uint256)', recipients: [recipient] },
+        ],
+      },
+    ])
+    const call = Actions.token.transfer.call({
+      amount: 1n,
+      to: recipient,
+      token,
+    })
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [call],
+    })
+
+    expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
+  })
+
+  test('behavior: scoped access key skips non-allowlisted recipients', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [
+          {
+            address: token,
+            selector: 'transfer(address,uint256)',
+            recipients: ['0x0000000000000000000000000000000000000def'],
+          },
+        ],
+      },
+    ])
+    const call = Actions.token.transfer.call({
+      amount: 1n,
+      to: '0x0000000000000000000000000000000000000fed',
+      token,
+    })
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [call],
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('behavior: malformed scopes skip the access key', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [{}],
+      } as never,
+    ])
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [{ to: '0x0000000000000000000000000000000000000abc', data: '0xa9059cbb' }],
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+
   test('behavior: scoped access key without selector allows any call to that address', async () => {
     const keyPair = await WebCryptoP256.createKeyPair()
     const token = '0x0000000000000000000000000000000000000abc' as const
@@ -700,6 +795,81 @@ describe('selectAccount', () => {
     const result = AccessKey.selectAccount({ address: rootAddress, chainId: 1, store })
 
     expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
+describe('getStatus', () => {
+  test('behavior: returns pending for locally stored key authorization', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair)
+    const keyAuthorization = createKeyAuthorization(accessKey.address)
+
+    AccessKey.save({ address: rootAddress, keyAuthorization, keyPair, store })
+
+    const result = await AccessKey.getStatus({
+      address: rootAddress,
+      chainId: 1,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`"pending"`)
+  })
+
+  test('behavior: returns published for local key without pending authorization', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const keyAuthorization = createKeyAuthorization(accessKey.accessKeyAddress)
+
+    AccessKey.save({ address: rootAddress, keyAuthorization, keyPair, store })
+    AccessKey.removePending(accessKey, { store })
+
+    const result = await AccessKey.getStatus({
+      address: rootAddress,
+      chainId: 1,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`"published"`)
+  })
+
+  test('behavior: returns expired for expired local key', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair)
+    const keyAuthorization = createKeyAuthorization(accessKey.address, { expiry: 100 })
+
+    AccessKey.save({ address: rootAddress, keyAuthorization, keyPair, store })
+
+    const result = await AccessKey.getStatus({
+      address: rootAddress,
+      chainId: 1,
+      now: 101,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`"expired"`)
+  })
+
+  test('behavior: returns missing when no local key matches the policy', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair)
+    const keyAuthorization = createKeyAuthorization(accessKey.address, {
+      scopes: [{ address: '0x0000000000000000000000000000000000000abc' }],
+    })
+
+    AccessKey.save({ address: rootAddress, keyAuthorization, keyPair, store })
+
+    const result = await AccessKey.getStatus({
+      address: rootAddress,
+      calls: [{ to: '0x0000000000000000000000000000000000000def', data: '0xdeadbeef' }],
+      chainId: 1,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`"missing"`)
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -1,6 +1,7 @@
 import { AbiFunction, Address, Hex, Provider, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { Account as TempoAccount } from 'viem/tempo'
+import type { Client, Transport } from 'viem'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
 
 import type { OneOf } from '../internal/types.js'
 import * as ExecutionError from './ExecutionError.js'
@@ -15,6 +16,21 @@ const removalErrorNames = new Set([
   'KeyNotFound',
   'SignatureTypeMismatch',
 ])
+
+/** Access-key publication states. */
+export const status = {
+  /** No matching usable access key was found. */
+  missing: 'missing',
+  /** A matching key exists locally and still needs its first transaction to publish the authorization. */
+  pending: 'pending',
+  /** A matching key exists on-chain and can be used. */
+  published: 'published',
+  /** A matching key exists but is past its expiry. */
+  expired: 'expired',
+} as const
+
+/** Publication state for an access key. */
+export type Status = (typeof status)[keyof typeof status]
 
 /** Access key entry stored alongside accounts. */
 export type AccessKey = {
@@ -249,6 +265,48 @@ export declare namespace selectAccount {
   }
 }
 
+/** Returns publication status for a stored or on-chain access key. */
+export async function getStatus(options: getStatus.Options): Promise<getStatus.ReturnType> {
+  const { accessKey, address, calls, chainId, client, store } = options
+  const now = options.now ?? Date.now() / 1000
+  const local = store
+    .getState()
+    .accessKeys.find((key) => matches(key, { accessKey, address, calls, chainId }))
+
+  if (local) {
+    if (isExpired(local.expiry, now)) return status.expired
+    if (local.keyAuthorization) return status.pending
+    if (client) return await getPublishedStatus(client, { accessKey: local.address, address, now })
+    return status.published
+  }
+
+  if (accessKey && client) return await getPublishedStatus(client, { accessKey, address, now })
+  return status.missing
+}
+
+export declare namespace getStatus {
+  /** Options for {@link getStatus}. */
+  type Options = {
+    /** Root account address that owns the access key. */
+    address: Address.Address
+    /** Specific access key address to query. When omitted, the first locally matching key is used. */
+    accessKey?: Address.Address | undefined
+    /** Calls to match against access key scopes. */
+    calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
+    /** Client used to verify published state on-chain. */
+    client?: Client<Transport> | undefined
+    /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
+    now?: number | undefined
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Access-key publication status. */
+  type ReturnType = Status
+}
+
 /** Removes an access key from the store. */
 export function revoke(options: revoke.Options): void {
   const { address, store } = options
@@ -273,23 +331,111 @@ function scopesMatch(
     calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
   },
 ): boolean {
-  if (!key.scopes) return true
+  const scopes = key.scopes
+  if (typeof scopes === 'undefined') return true
+  if (!Array.isArray(scopes)) return false
   if (!options.calls) return false
   return options.calls.every((call) => {
     if (!call.to) return false
     const callTo = call.to.toLowerCase()
     const callSelector = call.data?.slice(0, 10).toLowerCase()
-    return key.scopes!.some((scope) => {
+    return scopes.some((scope) => {
+      if (!isScope(scope)) return false
       if (scope.address.toLowerCase() !== callTo) return false
-      if (!scope.selector) return true
-      const scopeSelector = (
-        scope.selector.startsWith('0x') && scope.selector.length === 10
-          ? scope.selector
-          : AbiFunction.getSelector(scope.selector)
-      ).toLowerCase()
-      return callSelector === scopeSelector
+      if (!scope.selector) return scope.recipients ? scope.recipients.length === 0 : true
+      const scopeSelector = getSelector(scope.selector)
+      if (!scopeSelector || callSelector !== scopeSelector) return false
+      return recipientsMatch(scope.recipients, call.data)
     })
   })
+}
+
+function matches(
+  key: AccessKey,
+  options: {
+    accessKey?: Address.Address | undefined
+    address: Address.Address
+    calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
+    chainId: number
+  },
+): boolean {
+  const { accessKey, address, calls, chainId } = options
+  if (key.access.toLowerCase() !== address.toLowerCase()) return false
+  if (key.chainId !== chainId) return false
+  if (accessKey && key.address.toLowerCase() !== accessKey.toLowerCase()) return false
+  return scopesMatch(key, { calls })
+}
+
+function isExpired(expiry: number | undefined, now: number): boolean {
+  return typeof expiry === 'number' && expiry < now
+}
+
+async function getPublishedStatus(
+  client: Client<Transport>,
+  options: { accessKey: Address.Address; address: Address.Address; now: number },
+): Promise<Status> {
+  const { accessKey, address, now } = options
+  try {
+    const metadata = await Actions.accessKey.getMetadata(client, {
+      account: address,
+      accessKey,
+    })
+    if (metadata.isRevoked) return status.missing
+    if (metadata.expiry > 0n && metadata.expiry < BigInt(Math.floor(now))) return status.expired
+    return status.published
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
+    const parsed = ExecutionError.parse(error)
+    if (parsed.errorName === 'KeyNotFound' || parsed.errorName === 'KeyAlreadyRevoked')
+      return status.missing
+    throw error
+  }
+}
+
+function isScope(scope: unknown): scope is NonNullable<AccessKey['scopes']>[number] {
+  if (!scope || typeof scope !== 'object') return false
+  const value = scope as {
+    address?: unknown
+    recipients?: unknown
+    selector?: unknown
+  }
+  if (typeof value.address !== 'string' || !Address.validate(value.address)) return false
+  if (typeof value.selector !== 'undefined' && typeof value.selector !== 'string') return false
+  if (typeof value.recipients !== 'undefined') {
+    if (!Array.isArray(value.recipients)) return false
+    if (value.recipients.some((recipient) => typeof recipient !== 'string')) return false
+    if (value.recipients.some((recipient) => !Address.validate(recipient))) return false
+  }
+  return true
+}
+
+function getSelector(selector: string): string | undefined {
+  try {
+    return (
+      selector.startsWith('0x') && selector.length === 10
+        ? selector
+        : AbiFunction.getSelector(selector)
+    ).toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+function recipientsMatch(
+  recipients: readonly Address.Address[] | undefined,
+  data: Hex.Hex | undefined,
+): boolean {
+  if (!recipients || recipients.length === 0) return true
+  const recipient = getCallRecipient(data)
+  if (!recipient) return false
+  return recipients.some((address) => address.toLowerCase() === recipient.toLowerCase())
+}
+
+function getCallRecipient(data: Hex.Hex | undefined): Address.Address | undefined {
+  if (!data || data.length < 74) return undefined
+  const recipient = `0x${data.slice(34, 74)}` as Address.Address
+  if (!Address.validate(recipient)) return undefined
+  return recipient
 }
 
 function shouldRemoveForError(error: unknown): boolean {

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1581,6 +1581,26 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
     })
 
+    test('behavior: access key status moves from pending to published', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      await expect(provider.getAccessKeyStatus()).resolves.toMatchInlineSnapshot(`"pending"`)
+
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      await expect(provider.getAccessKeyStatus()).resolves.toMatchInlineSnapshot(`"published"`)
+    })
+
     test('behavior: with expiry option', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       await connect(provider)

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -27,6 +27,10 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
     chains: readonly [Chain, ...Chain[]]
     /** Returns a viem Account for the given address (or active account). */
     getAccount: Account.Find
+    /** Returns local or on-chain publication status for an access key. */
+    getAccessKeyStatus(
+      options?: getAccessKeyStatus.Options | undefined,
+    ): Promise<getAccessKeyStatus.ReturnType>
     /** Returns a viem Client for the given (or current) chain ID. */
     getClient(options?: {
       chainId?: number | undefined
@@ -965,6 +969,19 @@ export function create(options: create.Options = {}): create.ReturnType {
     {
       chains,
       getAccount,
+      async getAccessKeyStatus(options: getAccessKeyStatus.Options = {}) {
+        const state = store.getState()
+        const address = options.address ?? state.accounts[state.activeAccount]?.address
+        if (!address) return AccessKey.status.missing
+        const chainId = options.chainId ?? state.chainId
+        return await AccessKey.getStatus({
+          ...options,
+          address,
+          chainId,
+          client: provider.getClient({ chainId }),
+          store,
+        })
+      },
       getClient(options: { chainId?: number | undefined; feePayer?: string | undefined } = {}) {
         const { chainId, feePayer } = options
         return Client.fromChainId(chainId, {
@@ -1105,6 +1122,23 @@ export declare namespace create {
     transports?: Record<number, Transport> | undefined
   }
   type ReturnType = Provider
+}
+
+export declare namespace getAccessKeyStatus {
+  /** Options for {@link Provider.getAccessKeyStatus}. */
+  type Options = {
+    /** Root account address. Defaults to the active account. */
+    address?: Address.Address | undefined
+    /** Specific access key address to query. When omitted, the first locally matching key is used. */
+    accessKey?: Address.Address | undefined
+    /** Calls to match against access key scopes. */
+    calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
+    /** Chain ID the access key must be authorized on. Defaults to the active chain. */
+    chainId?: number | undefined
+  }
+
+  /** Access-key publication status. */
+  type ReturnType = AccessKey.Status
 }
 
 export declare namespace mpp {

--- a/src/core/Remote.test.ts
+++ b/src/core/Remote.test.ts
@@ -144,7 +144,8 @@ describe('validateSearch', () => {
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `[RpcResponse.InvalidParamsError: Invalid params for "wallet_authorizeAccessKey":
-  - limits: Expected array]`,
+  - limits: Expected array
+  - scopes: Expected array]`,
     )
     expect(remote.rejectAll).toHaveBeenCalledOnce()
   })
@@ -171,7 +172,8 @@ describe('validateSearch', () => {
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `[RpcResponse.InvalidParamsError: Invalid params for "wallet_connect":
-  - capabilities.authorizeAccessKey.limits: Expected array]`,
+  - capabilities.authorizeAccessKey.limits: Expected array
+  - capabilities.authorizeAccessKey.scopes: Expected array]`,
     )
     expect(remote.rejectAll).toHaveBeenCalledOnce()
   })
@@ -192,15 +194,68 @@ describe('validateSearch', () => {
     expect(remote.rejectAll).not.toHaveBeenCalled()
   })
 
-  test('strict: passes wallet_authorizeAccessKey with empty limits array', () => {
+  test('strict: rejects wallet_authorizeAccessKey with empty policy arrays', () => {
+    const remote = createMockRemote()
+    expect(() =>
+      Remote.validateSearch(
+        remote,
+        {
+          method: 'wallet_authorizeAccessKey',
+          id: 8,
+          jsonrpc: '2.0',
+          params: [{ expiry: 100, limits: [], scopes: [] }],
+        },
+        { method: 'wallet_authorizeAccessKey' },
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Invalid params for "wallet_authorizeAccessKey":
+  - limits: Invalid input
+  - scopes: Invalid input]`,
+    )
+    expect(remote.rejectAll).toHaveBeenCalledOnce()
+  })
+
+  test('strict: rejects wallet_authorizeAccessKey with malformed scope', () => {
+    const remote = createMockRemote()
+    expect(() =>
+      Remote.validateSearch(
+        remote,
+        {
+          method: 'wallet_authorizeAccessKey',
+          id: 9,
+          jsonrpc: '2.0',
+          params: [
+            {
+              expiry: 100,
+              limits: [{ token: '0x20c0000000000000000000000000000000000001', limit: '0x1' }],
+              scopes: [{ selector: 'transfer(address,uint256)' }],
+            },
+          ],
+        },
+        { method: 'wallet_authorizeAccessKey' },
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Invalid params for "wallet_authorizeAccessKey":
+  - params.0.scopes.0.address: Expected string]`,
+    )
+    expect(remote.rejectAll).toHaveBeenCalledOnce()
+  })
+
+  test('strict: passes wallet_authorizeAccessKey with bounded policy', () => {
     const remote = createMockRemote()
     const result = Remote.validateSearch(
       remote,
       {
         method: 'wallet_authorizeAccessKey',
-        id: 8,
+        id: 10,
         jsonrpc: '2.0',
-        params: [{ expiry: 100, limits: [] }],
+        params: [
+          {
+            expiry: 100,
+            limits: [{ token: '0x20c0000000000000000000000000000000000001', limit: '0x1' }],
+            scopes: [{ address: '0x20c0000000000000000000000000000000000001' }],
+          },
+        ],
       },
       { method: 'wallet_authorizeAccessKey' },
     )
@@ -210,7 +265,17 @@ describe('validateSearch', () => {
         "params": [
           {
             "expiry": 100,
-            "limits": [],
+            "limits": [
+              {
+                "limit": 1n,
+                "token": "0x20c0000000000000000000000000000000000001",
+              },
+            ],
+            "scopes": [
+              {
+                "address": "0x20c0000000000000000000000000000000000001",
+              },
+            ],
           },
         ],
       }

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -393,19 +393,21 @@ export namespace wallet_authorizeAccessKey_strict {
     expiry: z.number(),
     keyType: z.optional(keyType),
     limits: z.readonly(
-      z.array(z.object({ token: u.address(), limit: u.bigint(), period: z.optional(z.number()) })),
+      z
+        .array(z.object({ token: u.address(), limit: u.bigint(), period: z.optional(z.number()) }))
+        .check(z.minLength(1)),
     ),
     publicKey: z.optional(u.hex()),
-    scopes: z.optional(
-      z.readonly(
-        z.array(
+    scopes: z.readonly(
+      z
+        .array(
           z.object({
             address: u.address(),
             selector: z.optional(z.union([u.hex(), z.string()])),
             recipients: z.optional(z.readonly(z.array(u.address()))),
           }),
-        ),
-      ),
+        )
+        .check(z.minLength(1)),
     ),
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * as AccessKey from './core/AccessKey.js'
 export * as Adapter from './core/Adapter.js'
 export * as IntersectionObserver from './core/IntersectionObserver.js'
 export * as Dialog from './core/Dialog.js'


### PR DESCRIPTION
## Summary
Added access-key publication status and aligned scoped policy validation for wallet-hosted approval flows.

## Motivation
Closes #468.
Closes #471.

Apps needed one bounded policy shape for local and live wallet paths, plus a way to tell whether a delegated key was missing, pending, published, or expired before starting paid flows.

## Changes
- Added `AccessKey.getStatus` and `provider.getAccessKeyStatus` in `src/core/AccessKey.ts` and `src/core/Provider.ts`.
- Matched scoped access keys by target, selector, and recipient allowlists without throwing on malformed persisted scope data.
- Required non-empty `limits` and `scopes` for strict `wallet_authorizeAccessKey` validation in `src/core/zod/rpc.ts`.
- Documented access-key status and bounded policy requirements in provider, RPC, and Wagmi docs.

## Testing
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts` — 47 passed.
- `./node_modules/.bin/vp test src/core/Provider.test.ts -t "wallet_authorizeAccessKey"` — 20 passed, 234 skipped.
- `./node_modules/.bin/vp test src/core/Remote.test.ts -t "strict"` — 6 passed, 6 skipped.
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`.
- `./node_modules/.bin/vp lint src/core/AccessKey.ts src/core/AccessKey.test.ts src/core/Provider.ts src/core/Provider.test.ts src/core/Remote.test.ts src/core/zod/rpc.ts src/index.ts site/src/pages/docs/api/provider.mdx site/src/pages/docs/rpc/wallet_authorizeAccessKey.mdx site/src/pages/docs/wagmi/tempoWallet.mdx site/src/pages/docs/wagmi/webAuthn.mdx .changeset/access-key-status-scopes.md`.
- `git diff --check`.
- `pnpm --filter site build` — passed with existing dead-link warnings for `/docs/adapters/private-key.mdx` and `/docs/adapters/webauthn.mdx` production links.
- Live local-node script using `Provider.create({ adapter: secp256k1(...) })` returned `{ "before": "pending", "after": "published" }` after sending the first matching transaction.
