### PR TITLE
fix(access-key): preserve pending activation auth

### DIFF
--- a/.changeset/pending-access-key-activation.md
+++ b/.changeset/pending-access-key-activation.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Kept pending access-key authorization through fill and signing-only flows so first-use MPP charges and activation gas estimates could publish the key.

--- a/site/src/pages/docs/rpc/eth_fillTransaction.mdx
+++ b/site/src/pages/docs/rpc/eth_fillTransaction.mdx
@@ -9,6 +9,8 @@ Fills missing transaction fields (gas, nonce, fees) via the node, with wallet-aw
 
 When sent through [`Handler.relay`](/docs/server/handler.relay), the response is enriched with a `capabilities` object containing balance diffs, fee estimates, sponsor info, and swap details.
 
+When the sender has a pending locally managed access key, `Provider` attaches the pending `keyAuthorization` before fill so the returned gas covers first-use key publication. Fill and signing-only flows keep that pending authorization available for retry; successful send and broadcast paths consume it.
+
 ## Request
 
 ```ts

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -141,9 +141,7 @@ export function cli(options: cli.Options): Adapter.Adapter {
       const account = getAccount({ signable: true })
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {
-        const result = await fn(account, keyAuthorization ?? undefined)
-        AccessKey.removePending(account, { store })
-        return result
+        return await fn(account, keyAuthorization ?? undefined)
       } catch (error) {
         AccessKey.remove(account, { store })
         throw error
@@ -300,10 +298,12 @@ export function cli(options: cli.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransaction' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
         async sendTransactionSync(parameters) {
           const { feePayer, ...rest } = parameters
@@ -321,10 +321,12 @@ export function cli(options: cli.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransactionSync' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
         async signPersonalMessage({ address, data }) {
           await loadManagedKey(address)

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -997,6 +997,33 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       `)
     })
 
+    test('behavior: signing keeps pending access key retryable', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
+
+      const signed = await provider.request({
+        method: 'eth_signTransaction',
+        params: [{ calls: [transferCall] }],
+      })
+
+      expect(signed).toMatch(/^0x/)
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+      expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
+    })
+
     test('error: throws when not connected', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
 
@@ -1846,8 +1873,13 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         params: [{ from: address, ...fillTx }],
       })
       expect(result.tx.gas).toBeDefined()
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
 
-      // Pending keyAuthorization should be consumed after successful fill.
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ from: address, ...fillTx, gas: result.tx.gas }],
+      })
+      expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
       expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
     })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -321,7 +321,6 @@ export function create(options: create.Options = {}): create.ReturnType {
                                 ...KeyAuthorization.toRpc(keyAuth),
                               } as never,
                             })
-                            AccessKey.removePending(account, { store })
                             return result
                           } catch (error) {
                             AccessKey.invalidate(account, error, { store })
@@ -1012,9 +1011,24 @@ export function create(options: create.Options = {}): create.ReturnType {
       const account = provider.getAccount()
       return Object.assign(client, { account })
     }
-    Mppx.create({
+    const mppx = Mppx.create({
       methods: [mppx_tempo({ getClient, mode }), mppx_tempo.subscription({ getClient })],
       polyfill,
+    })
+    mppx.onPaymentResponse(({ challenge, method }) => {
+      if (method.name !== 'tempo' || method.intent !== 'charge') return
+      const amount = challenge.request.amount
+      if (
+        typeof amount !== 'string' &&
+        typeof amount !== 'number' &&
+        typeof amount !== 'bigint' &&
+        typeof amount !== 'boolean'
+      )
+        return
+      if (BigInt(amount) === 0n) return
+      const account = provider.getAccount()
+      if ('source' in account && account.source === 'accessKey')
+        AccessKey.removePending(account, { store })
     })
   }
 

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -154,7 +154,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         account: TempoAccount.Account,
         keyAuthorization?: KeyAuthorization.Signed,
       ) => Promise<result>,
-    ): Promise<result | undefined> {
+    ): Promise<{ account: TempoAccount.Account; result: result } | undefined> {
       if (!options.from || typeof options.chainId === 'undefined') return undefined
       const account = AccessKey.selectAccount({
         address: options.from,
@@ -166,8 +166,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {
         const result = await fn(account, keyAuthorization ?? undefined)
-        AccessKey.removePending(account, { store })
-        return result
+        return { account, result }
       } catch (err) {
         if (AccessKey.invalidate(account, err, { store }))
           console.warn('[accounts] access key invalidated, falling through to dialog:', err)
@@ -307,7 +306,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             })
             return await account.signTransaction(prepared as never)
           })
-          if (result !== undefined) return result
+          if (result !== undefined) return result.result
           return await provider.request({
             ...request,
             params: [z.encode(Rpc.transactionRequest, parameters)] as const,
@@ -342,7 +341,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               params: [signed],
             })
           })
-          if (result !== undefined) return result
+          if (result !== undefined) {
+            AccessKey.removePending(result.account, { store })
+            return result.result
+          }
           return await provider.request({
             ...request,
             params: [z.encode(Rpc.transactionRequest, parameters)] as const,
@@ -373,7 +375,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               params: [signed],
             })
           })
-          if (result !== undefined) return result
+          if (result !== undefined) {
+            AccessKey.removePending(result.account, { store })
+            return result.result
+          }
           return await provider.request({
             ...request,
             params: [z.encode(Rpc.transactionRequest, parameters)] as const,

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -80,9 +80,7 @@ export function local(options: local.Options): Adapter.Adapter {
       const account = getAccount({ ...options, signable: true })
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {
-        const result = await fn(account, keyAuthorization ?? undefined)
-        AccessKey.removePending(account, { store })
-        return result
+        return await fn(account, keyAuthorization ?? undefined)
       } catch (error) {
         if (account.source !== 'accessKey') throw error
         AccessKey.invalidate(account, error, { store })
@@ -299,10 +297,12 @@ export function local(options: local.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransaction' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
         async sendTransactionSync(parameters) {
           const { feePayer, ...rest } = parameters
@@ -328,10 +328,12 @@ export function local(options: local.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransactionSync' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
       },
     }

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -325,7 +325,7 @@ export function turnkey<const client extends turnkey.Client>(
         account: TempoAccount.Account,
         keyAuthorization?: KeyAuthorization.Signed,
       ) => Promise<result>,
-    ) {
+    ): Promise<{ account: TempoAccount.Account; result: result } | undefined> {
       const account = (() => {
         try {
           return getAccount({ ...options, signable: true })
@@ -338,8 +338,7 @@ export function turnkey<const client extends turnkey.Client>(
       const keyAuthorization = AccessKey.getPending(account, { store })
       try {
         const result = await fn(account, keyAuthorization ?? undefined)
-        AccessKey.removePending(account, { store })
-        return result
+        return { account, result }
       } catch (error) {
         AccessKey.invalidate(account, error, { store })
         return undefined
@@ -516,7 +515,7 @@ export function turnkey<const client extends turnkey.Client>(
               return await account.signTransaction(prepared as never)
             },
           )
-          if (result !== undefined) return result
+          if (result !== undefined) return result.result
           return await signTransaction(parameters)
         },
         async signTypedData(parameters) {
@@ -557,7 +556,10 @@ export function turnkey<const client extends turnkey.Client>(
               })
             },
           )
-          if (result !== undefined) return result
+          if (result !== undefined) {
+            AccessKey.removePending(result.account, { store })
+            return result.result
+          }
           const signed = await signTransaction(parameters)
           const viemClient = getClient({
             chainId: parameters.chainId,
@@ -591,7 +593,10 @@ export function turnkey<const client extends turnkey.Client>(
               })
             },
           )
-          if (result !== undefined) return result
+          if (result !== undefined) {
+            AccessKey.removePending(result.account, { store })
+            return result.result
+          }
           const signed = await signTransaction(parameters)
           const viemClient = getClient({
             chainId: parameters.chainId,

--- a/src/core/mppx.test.ts
+++ b/src/core/mppx.test.ts
@@ -1,12 +1,14 @@
+import { Fetch } from 'mppx/client'
 import { Mppx as ServerMppx, tempo } from 'mppx/server'
 import { parseUnits } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Actions } from 'viem/tempo'
-import { afterAll, beforeAll, describe, expect, test } from 'vp/test'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
 
 import { headlessWebAuthn } from '../../test/adapters.js'
 import { accounts, chain, getClient } from '../../test/config.js'
 import { type Server, createServer } from '../../test/utils.js'
+import * as Expiry from './Expiry.js'
 import * as Provider from './Provider.js'
 
 const client = getClient()
@@ -40,6 +42,8 @@ beforeAll(async () => {
 
 afterAll(() => server?.closeAsync())
 
+afterEach(() => Fetch.restore())
+
 describe('mppx integration', () => {
   test('polyfilled fetch handles 402 charge automatically', async () => {
     const provider = Provider.create({
@@ -49,15 +53,7 @@ describe('mppx integration', () => {
     })
 
     const address = await connect(provider)
-
-    const client = getClient()
-    await Actions.token.transferSync(client, {
-      account: accounts[0]!,
-      feeToken: Addresses.pathUsd,
-      to: address,
-      token: Addresses.pathUsd,
-      amount: parseUnits('10', 6),
-    })
+    await fund(address)
 
     const res = await fetch(`${server.url}/fortune`)
     expect(res.status).toBe(200)
@@ -69,6 +65,71 @@ describe('mppx integration', () => {
       }
     `)
   })
+
+  test('pull mode publishes a pending access key on first charge', async () => {
+    const provider = Provider.create({
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: { mode: 'pull' },
+    })
+    const address = await connect(provider)
+    await fund(address)
+
+    await provider.request({
+      method: 'wallet_authorizeAccessKey',
+      params: [{ expiry: Expiry.days(1) }],
+    })
+
+    const key = provider.store.getState().accessKeys[0]!
+    expect(key.keyAuthorization).toBeDefined()
+
+    const res = await fetch(`${server.url}/fortune`)
+    expect(res.status).toBe(200)
+    expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
+
+    const metadata = await Actions.accessKey.getMetadata(client, {
+      account: address,
+      accessKey: key.address,
+    })
+    expect(metadata.isRevoked).toMatchInlineSnapshot(`false`)
+  })
+
+  test('pull mode keeps pending access key after failed verification', async () => {
+    const failingServer = await createServer(async (req, res) => {
+      if (req.headers.authorization) {
+        res.writeHead(402, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ title: 'Verification Failed' }))
+        return
+      }
+
+      await ServerMppx.toNodeListener(
+        payment.charge({
+          amount: '1',
+        }),
+      )(req, res)
+    })
+
+    try {
+      const provider = Provider.create({
+        adapter: headlessWebAuthn(),
+        chains: [chain],
+        mpp: { mode: 'pull' },
+      })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      const res = await fetch(`${failingServer.url}/fortune`)
+      expect(res.status).toMatchInlineSnapshot(`402`)
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
+    } finally {
+      await failingServer.closeAsync()
+    }
+  })
 })
 
 async function connect(provider: ReturnType<typeof Provider.create>) {
@@ -79,4 +140,14 @@ async function connect(provider: ReturnType<typeof Provider.create>) {
     params: [{ capabilities: { method: 'register' } }],
   })
   return register.accounts[0]!.address
+}
+
+async function fund(address: `0x${string}`) {
+  await Actions.token.transferSync(client, {
+    account: accounts[0]!,
+    feeToken: Addresses.pathUsd,
+    to: address,
+    token: Addresses.pathUsd,
+    amount: parseUnits('10', 6),
+  })
 }

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -205,9 +205,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           keyAuthorization = await reauthorizeManagedKey(rootAddress, managedKey)
 
       try {
-        const result = await fn(account, keyAuthorization ?? undefined)
-        AccessKey.removePending(account, { store })
-        return result
+        return await fn(account, keyAuthorization ?? undefined)
       } catch (error) {
         AccessKey.remove(account, { store })
         throw error
@@ -348,10 +346,12 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransaction' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
         async sendTransactionSync(parameters) {
           const { feePayer, ...rest } = parameters
@@ -369,10 +369,12 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
             }),
           )
           const signed = await account.signTransaction(prepared as never)
-          return await client.request({
+          const result = await client.request({
             method: 'eth_sendRawTransactionSync' as never,
             params: [signed],
           })
+          AccessKey.removePending(account, { store })
+          return result
         },
         async signPersonalMessage({ address, data }) {
           await loadManagedKey(address)


### PR DESCRIPTION
## Summary
Preserves pending access-key authorization through fill and signing-only flows, then clears it after successful send or MPP charge responses.

## Motivation
Closes #466.
Closes #470.
Closes #472.

First-use activation needed pending key authorization during fill/signing so gas estimates and pull-mode MPP charges could publish the key, while failed pull-mode verification needed to stay retryable.

## Changes
- Stopped consuming pending `keyAuthorization` after `eth_fillTransaction` in `src/core/Provider.ts`.
- Kept pending authorization through adapter `signTransaction` paths and consumed it after successful raw send paths.
- Cleared pending access-key authorization after successful positive MPP charge responses in `Provider.create({ mpp })`.
- Added provider and MPP pull-mode regressions plus `eth_fillTransaction` activation docs.

## Testing
- `./node_modules/.bin/vp test src/core/Provider.test.ts -t "eth_signTransaction|eth_fillTransaction"` — 24 passed, 230 skipped.
- `./node_modules/.bin/vp test src/core/mppx.test.ts` — 3 passed.
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`.
- `./node_modules/.bin/vp lint src/core/AccessKey.ts src/core/Provider.ts src/core/adapters/local.ts src/core/adapters/dialog.ts src/core/adapters/turnkey.ts src/cli/adapter.ts src/react-native/adapter.ts src/core/Provider.test.ts src/core/mppx.test.ts site/src/pages/docs/rpc/eth_fillTransaction.mdx .changeset/pending-access-key-activation.md`.
- `git diff --check`.
- `pnpm --filter site build` — passed with existing dead-link warnings for `/docs/adapters/webauthn.mdx` and `/docs/adapters/private-key.mdx` production links.
- Live local-node script with real MPP pull-mode fetch returned `success.beforePending=true`, `success.afterPending=false`, `success.keyPublished=true`, and `failedVerification.afterPending=true`.
