### PR TITLE
fix(tests): require scopes in wallet_authorizeAccessKey and cast result.tx.gas

### DIFF
--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1951,7 +1951,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const receipt = await provider.request({
         method: 'eth_sendTransactionSync',
-        params: [{ from: address, ...fillTx, gas: result.tx.gas }],
+        params: [{ from: address, ...fillTx, gas: result.tx.gas as Hex.Hex }],
       })
       expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
       expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()

--- a/src/core/Remote.test.ts
+++ b/src/core/Remote.test.ts
@@ -53,6 +53,7 @@ describe('validateSearch', () => {
           {
             expiry: 100,
             limits: [{ token: '0x0000000000000000000000000000000000000001', limit: '0xa' }],
+            scopes: [{ address: '0x0000000000000000000000000000000000000002' }],
           },
         ],
       },
@@ -68,6 +69,11 @@ describe('validateSearch', () => {
               {
                 "limit": 10n,
                 "token": "0x0000000000000000000000000000000000000001",
+              },
+            ],
+            "scopes": [
+              {
+                "address": "0x0000000000000000000000000000000000000002",
               },
             ],
           },
@@ -92,6 +98,7 @@ describe('validateSearch', () => {
               authorizeAccessKey: {
                 expiry: 100,
                 limits: [{ token: '0x0000000000000000000000000000000000000001', limit: '0xa' }],
+                scopes: [{ address: '0x0000000000000000000000000000000000000002' }],
               },
             },
           },


### PR DESCRIPTION
Fixes two pre-existing test failures on main:

- **Type check** in [src/core/Provider.test.ts](https://github.com/tempoxyz/accounts/blob/main/src/core/Provider.test.ts): `result.tx.gas` is typed `unknown` from `eth_fillTransaction`. Added `as Hex.Hex` cast where it is forwarded to `eth_sendTransactionSync`.
- **Runtime** in [src/core/Remote.test.ts](https://github.com/tempoxyz/accounts/blob/main/src/core/Remote.test.ts): #480 made `scopes` required in the strict `wallet_authorizeAccessKey` schema. Updated `validates wallet_authorizeAccessKey with expiry and limits` and `validates wallet_connect with authorizeAccessKey containing limits` to include a `scopes` entry, plus updated the snapshot.

`pnpm tsc -b --noEmit` clean; `pnpm test src/core/Remote.test.ts` 12/12 passing.