### PR TITLE
fix(docker): switch to node:24 image so workerd has CA certs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ name: accounts-sdk
 
 services:
   install:
-    image: node:24-slim
+    image: node:24
     working_dir: /app
     volumes:
       - .:/app
@@ -19,7 +19,7 @@ services:
         pnpm install --frozen-lockfile
 
   playground:
-    image: node:24-slim
+    image: node:24
     working_dir: /app
     volumes:
       - .:/app
@@ -48,7 +48,7 @@ services:
         condition: service_completed_successfully
 
   wagmi:
-    image: node:24-slim
+    image: node:24
     working_dir: /app
     volumes:
       - .:/app
@@ -77,7 +77,7 @@ services:
         condition: service_completed_successfully
 
   dialog-ref:
-    image: node:24-slim
+    image: node:24
     working_dir: /app
     volumes:
       - .:/app
@@ -106,7 +106,7 @@ services:
         condition: service_completed_successfully
 
   docs:
-    image: node:24-slim
+    image: node:24
     working_dir: /app
     volumes:
       - .:/app


### PR DESCRIPTION
## Problem

`node:24-slim` does not include the `ca-certificates` package (`/etc/ssl/certs/ca-certificates.crt` is missing). workerd uses the system CA store for outbound TLS, so any `fetch()` from a Worker to an HTTPS origin (e.g. the wagmi playground's relay proxying `/relay/:chainId` to `https://rpc.moderato.tempo.xyz/`) fails with:

```
kj/compat/tls.c++:256: failed: TLS peer's certificate is not trusted;
reason = unable to get local issuer certificate
```

Surfaces in the browser as a JSON-RPC `-32603` internal error:

```json
{"error":{"code":-32603,"message":"HTTP request failed.\n\nURL: https://rpc.moderato.tempo.xyz/...\nDetails: internal error; reference = ...\nVersion: viem@2.49.2"}}
```

(Node's bundled CAs aren't involved here, so direct `fetch` from `node` inside the same container worked — only workerd was broken.)

## Fix

Switch all 5 docker-compose services from `node:24-slim` → `node:24`. The full image ships with `ca-certificates` so workerd's TLS layer validates upstream certs.

## Verify

```
docker compose down && docker compose up -d
curl -sS -X POST http://localhost:5175/relay/42431 \
  -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":2,"method":"eth_chainId","params":[]}'
# → {"result":"0xa5bf","id":2,"jsonrpc":"2.0"}
```