### PR TITLE
fix(mpp): select session-compatible access keys

### DIFF
--- a/.changeset/mpp-session-access-keys.md
+++ b/.changeset/mpp-session-access-keys.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Select scoped secp256k1 access keys for MPP session payments and default generated session keys to secp256k1.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -270,6 +270,8 @@ const provider = Provider.create({
 
 MPP session endpoints can use `deposit` or `maxDeposit` so the client opens and tops up a payment channel before sending vouchers.
 
+Session voucher verification currently requires secp256k1 signing. When `mpp.deposit` or `mpp.maxDeposit` is configured and `authorizeAccessKey` omits `keyType`, the SDK generates a `secp256k1` access key. Scoped keys must cover the session setup calls, such as token `approve` and escrow `open` or `topUp`.
+
 ```ts twoslash
 import { Provider } from 'accounts'
 

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -1,6 +1,7 @@
+import { Session } from 'mppx/tempo'
 import { WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { encodeErrorResult } from 'viem'
+import { encodeErrorResult, encodeFunctionData } from 'viem'
 import { Abis, Account as TempoAccount, Actions } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
@@ -18,6 +19,7 @@ function createKeyAuthorization(
   address: `0x${string}`,
   options: {
     expiry?: number | undefined
+    keyType?: 'secp256k1' | 'p256' | undefined
     limits?: { token: `0x${string}`; limit: bigint }[] | undefined
     scopes?: KeyAuthorization.Scope[] | undefined
   } = {},
@@ -29,7 +31,7 @@ function createKeyAuthorization(
       expiry: options.expiry,
       limits: options.limits,
       scopes: options.scopes,
-      type: 'p256',
+      type: options.keyType ?? 'p256',
     },
     { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
   )
@@ -288,6 +290,14 @@ describe('generate', () => {
     expect(result.accessKey.source).toMatchInlineSnapshot(`"accessKey"`)
     expect(result.accessKey.accessKeyAddress).toMatch(/^0x[0-9a-f]{40}$/i)
   })
+
+  test('behavior: generates secp256k1 private key', async () => {
+    const result = await AccessKey.generate({ keyType: 'secp256k1' })
+
+    expect(result.accessKey.keyType).toMatchInlineSnapshot(`"secp256k1"`)
+    expect(result.privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+    expect(result.keyPair).toBeUndefined()
+  })
 })
 
 describe('prepare', () => {
@@ -382,6 +392,18 @@ describe('prepare', () => {
     })
 
     expect(result.keyAuthorization.type).toMatchInlineSnapshot(`"secp256k1"`)
+  })
+
+  test('behavior: prepares generated secp256k1 key authorization', async () => {
+    const result = await AccessKey.prepare({
+      chainId: 1,
+      expiry: 123,
+      keyType: 'secp256k1',
+    })
+
+    expect(result.keyAuthorization.type).toMatchInlineSnapshot(`"secp256k1"`)
+    expect(result.privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+    expect(result.keyPair).toBeUndefined()
   })
 })
 
@@ -615,6 +637,100 @@ describe('selectAccount', () => {
     })
 
     expect(result?.source).toMatchInlineSnapshot(`"accessKey"`)
+  })
+
+  test('behavior: key type filter skips otherwise matching keys', async () => {
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const accessKey = TempoAccount.fromSecp256k1(privateKeys[1], { access: rootAddress })
+    const store = setup([
+      {
+        access: rootAddress,
+        address: '0x0000000000000000000000000000000000000099',
+        chainId: 1,
+        keyPair,
+        keyType: 'webCrypto',
+        scopes: [{ address: token, selector: '0xa9059cbb' }],
+      },
+      {
+        access: rootAddress,
+        address: accessKey.accessKeyAddress,
+        chainId: 1,
+        keyType: 'secp256k1',
+        privateKey: privateKeys[1],
+        scopes: [{ address: token, selector: '0xa9059cbb' }],
+      },
+    ])
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      store,
+      calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
+      keyTypes: ['secp256k1'],
+    })
+
+    expect(result?.keyType).toMatchInlineSnapshot(`"secp256k1"`)
+    expect(result?.accessKeyAddress).toMatchInlineSnapshot(
+      `"0x8c8d35429f74ec245f8ef2f4fd1e551cff97d650"`,
+    )
+  })
+
+  test('behavior: scoped secp256k1 key matches session setup calls', () => {
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const escrow = '0x0000000000000000000000000000000000000def' as const
+    const payee = '0x0000000000000000000000000000000000000123' as const
+    const accessKey = TempoAccount.fromSecp256k1(privateKeys[1], { access: rootAddress })
+    const store = setup([
+      {
+        access: rootAddress,
+        address: accessKey.accessKeyAddress,
+        chainId: 1,
+        keyType: 'secp256k1',
+        privateKey: privateKeys[1],
+        scopes: [
+          { address: token, selector: 'approve(address,uint256)', recipients: [escrow] },
+          {
+            address: escrow,
+            selector: 'open(address,address,uint128,bytes32,address)',
+            recipients: [payee],
+          },
+        ],
+      },
+    ])
+
+    const result = AccessKey.selectAccount({
+      address: rootAddress,
+      chainId: 1,
+      keyTypes: ['secp256k1'],
+      store,
+      calls: [
+        {
+          to: token,
+          data: encodeFunctionData({
+            abi: Abis.tip20,
+            functionName: 'approve',
+            args: [escrow, 0n],
+          }),
+        },
+        {
+          to: escrow,
+          data: encodeFunctionData({
+            abi: Session.Chain.escrowAbi,
+            functionName: 'open',
+            args: [
+              payee,
+              token,
+              0n,
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+              rootAddress,
+            ],
+          }),
+        },
+      ],
+    })
+
+    expect(result?.keyType).toMatchInlineSnapshot(`"secp256k1"`)
   })
 
   test('behavior: scoped access key skips calls that do not match', async () => {

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -1,7 +1,7 @@
 import { AbiFunction, Address, Hex, Provider, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import type { Client, Transport } from 'viem'
-import { Account as TempoAccount, Actions } from 'viem/tempo'
+import { Account as TempoAccount, Actions, Secp256k1 } from 'viem/tempo'
 
 import type { OneOf } from '../internal/types.js'
 import * as ExecutionError from './ExecutionError.js'
@@ -81,9 +81,18 @@ export function getPending(
   return entry?.keyAuthorization
 }
 
-/** Generates a P256 key pair and access key account. */
+/** Generates local key material and an access key account. */
 export async function generate(options: generate.Options = {}): Promise<generate.ReturnType> {
   const { account } = options
+  if (options.keyType === 'secp256k1') {
+    const privateKey = Secp256k1.randomPrivateKey()
+    const accessKey = TempoAccount.fromSecp256k1(
+      privateKey,
+      account ? { access: account } : undefined,
+    )
+    return { accessKey, privateKey }
+  }
+
   const keyPair = await WebCryptoP256.createKeyPair()
   const accessKey = TempoAccount.fromWebCryptoP256(
     keyPair,
@@ -96,13 +105,17 @@ export declare namespace generate {
   type Options = {
     /** Root account to attach to the access key. */
     account?: TempoAccount.Account | undefined
+    /** Local key type to generate. Defaults to `p256`. */
+    keyType?: 'secp256k1' | 'p256' | undefined
   }
 
   type ReturnType = {
     /** The generated access key account. */
     accessKey: TempoAccount.AccessKeyAccount
+    /** Generated Secp256k1 private key for local access keys. */
+    privateKey?: Hex.Hex | undefined
     /** Generated key pair to pass to `authorizeAccessKey`. */
-    keyPair: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>>
+    keyPair?: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>> | undefined
   }
 }
 
@@ -120,6 +133,20 @@ export async function prepare(options: prepare.Options): Promise<prepare.ReturnT
       type: keyType ?? 'secp256k1',
     })
     return { keyAuthorization }
+  }
+
+  if (keyType === 'secp256k1') {
+    const privateKey = Secp256k1.randomPrivateKey()
+    const accessKey = TempoAccount.fromSecp256k1(privateKey)
+    const keyAuthorization = KeyAuthorization.from({
+      address: Address.fromPublicKey(PublicKey.from(accessKey.publicKey)),
+      chainId: BigInt(chainId),
+      expiry,
+      limits,
+      scopes,
+      type: 'secp256k1',
+    })
+    return { keyAuthorization, privateKey }
   }
 
   const keyPair = await WebCryptoP256.createKeyPair()
@@ -157,6 +184,8 @@ export declare namespace prepare {
   type ReturnType = {
     /** Unsigned key authorization to sign with the root account. */
     keyAuthorization: KeyAuthorization.KeyAuthorization<false>
+    /** Generated Secp256k1 private key for local access keys. */
+    privateKey?: Hex.Hex | undefined
     /** Generated WebCrypto key pair for local access keys. */
     keyPair?: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>> | undefined
   }
@@ -232,12 +261,13 @@ export function removePending(
 export function selectAccount(
   options: selectAccount.Options,
 ): TempoAccount.AccessKeyAccount | undefined {
-  const { address, calls, chainId, store } = options
+  const { address, calls, chainId, keyTypes, store } = options
   const { accessKeys } = store.getState()
   let accessKeys_next = accessKeys
   for (const key of accessKeys) {
     if (key.access.toLowerCase() !== address.toLowerCase()) continue
     if (key.chainId !== chainId) continue
+    if (keyTypes && !keyTypes.includes(key.keyType)) continue
     if (!('keyPair' in key && !!key.keyPair) && !('privateKey' in key && !!key.privateKey)) continue
 
     if (key.expiry && key.expiry < Date.now() / 1000) {
@@ -260,6 +290,8 @@ export declare namespace selectAccount {
     calls?: readonly { to?: Address.Address | undefined; data?: Hex.Hex | undefined }[] | undefined
     /** Chain ID the access key must be authorized on. */
     chainId: number
+    /** Local key types the access key must use. */
+    keyTypes?: readonly AccessKey['keyType'][] | undefined
     /** Reactive state store. */
     store: Store.Store
   }

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1645,6 +1645,22 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.rootAddress).toBe(rootAddress)
     })
 
+    test('behavior: MPP session authorization defaults to secp256k1', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        mpp: { maxDeposit: '1', polyfill: false },
+      })
+      await connect(provider)
+
+      const result = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      expect(result.keyAuthorization.keyType).toMatchInlineSnapshot(`"secp256k1"`)
+    })
+
     test('behavior: granted access key is used for sendTransactionSync', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       const address = await connect(provider)
@@ -2135,6 +2151,24 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         params: [{ calls: [transferCall] }],
       })
       expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
+    })
+
+    test('behavior: MPP session access keys default to secp256k1', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        authorizeAccessKey: () => ({ expiry: Expiry.days(1) }),
+        mpp: { maxDeposit: '1', polyfill: false },
+      })
+
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { method: 'register' } }],
+      })
+
+      expect(result.accounts[0]!.capabilities.keyAuthorization!.keyType).toMatchInlineSnapshot(
+        `"secp256k1"`,
+      )
     })
 
     test('behavior: explicit authorizeAccessKey overrides default', async () => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,11 +1,19 @@
 import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
+import { Session } from 'mppx/tempo'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
+import {
+  encodeFunctionData,
+  http,
+  parseUnits,
+  type Chain,
+  type Client as ViemClient,
+  type Transport,
+} from 'viem'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import { parseSiweMessage } from 'viem/siwe'
-import { Actions } from 'viem/tempo'
+import { Abis, Account as TempoAccount, Actions } from 'viem/tempo'
 import * as z from 'zod/mini'
 
 import * as AccessKey from './AccessKey.js'
@@ -556,8 +564,10 @@ export function create(options: create.Options = {}): create.ReturnType {
                     if (chainId) store.setState((x) => ({ ...x, chainId }))
 
                     const capabilities = request._decoded.params?.[0]?.capabilities
-                    const authorizeAccessKey =
-                      capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.()
+                    const authorizeAccessKey = normalizeMppAccessKey(
+                      capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.(),
+                      { mpp },
+                    )
 
                     // Server Authentication: pre-resolve `auth` URLs against
                     // this dapp-side Provider's `window.location.origin`. The
@@ -767,7 +777,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                       throw new ox_Provider.UnsupportedMethodError({
                         message: '`authorizeAccessKey` not supported by adapter.',
                       })
-                    const decoded = request._decoded.params[0]
+                    const decoded =
+                      normalizeMppAccessKey(request._decoded.params[0], { mpp }) ??
+                      request._decoded.params[0]
                     const result = await actions.authorizeAccessKey(decoded, request)
                     return {
                       keyAuthorization: {
@@ -1027,6 +1039,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
+    const accounts_mpp = new Map<string, TempoAccount.Account>()
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
       const client = provider.getClient({ chainId })
       const account = provider.getAccount()
@@ -1037,10 +1050,33 @@ export function create(options: create.Options = {}): create.ReturnType {
         mppx_tempo({ ...methodOptions, getClient, mode }),
         mppx_tempo.subscription({ getClient }),
       ],
+      async onChallenge(challenge, { createCredential }) {
+        if (challenge.method !== 'tempo' || challenge.intent !== 'session') return undefined
+        const account = getMppSessionAccount(challenge, {
+          getAccount: provider.getAccount,
+          mpp,
+          store,
+        })
+        accounts_mpp.set(challenge.id, account)
+        try {
+          return await createCredential({ account } as never)
+        } catch (error) {
+          accounts_mpp.delete(challenge.id)
+          throw error
+        }
+      },
       polyfill,
     })
     mppx.onPaymentResponse(({ challenge, method }) => {
-      if (method.name !== 'tempo' || method.intent !== 'charge') return
+      if (method.name !== 'tempo') return
+      if (method.intent === 'session') {
+        const account = accounts_mpp.get(challenge.id)
+        accounts_mpp.delete(challenge.id)
+        if (account && 'source' in account && account.source === 'accessKey')
+          AccessKey.removePending(account, { store })
+        return
+      }
+      if (method.intent !== 'charge') return
       const amount = challenge.request.amount
       if (
         typeof amount !== 'string' &&
@@ -1053,6 +1089,10 @@ export function create(options: create.Options = {}): create.ReturnType {
       const account = provider.getAccount()
       if ('source' in account && account.source === 'accessKey')
         AccessKey.removePending(account, { store })
+    })
+    mppx.onPaymentFailed(({ challenge, method }) => {
+      if (method?.name !== 'tempo' || method.intent !== 'session' || !challenge) return
+      accounts_mpp.delete(challenge.id)
     })
   }
 
@@ -1174,6 +1214,134 @@ export declare namespace mpp {
      */
     polyfill?: boolean | undefined
   }
+}
+
+function normalizeMppAccessKey(
+  options: Adapter.authorizeAccessKey.Parameters | undefined,
+  parameters: { mpp: mpp.Options | undefined },
+): Adapter.authorizeAccessKey.Parameters | undefined {
+  if (!options) return undefined
+  if (!usesMppSession(parameters.mpp)) return options
+  if (options.keyType || options.publicKey || options.address) return options
+  return { ...options, keyType: 'secp256k1' }
+}
+
+function getMppSessionAccount(
+  challenge: {
+    request: {
+      currency?: unknown
+      methodDetails?: unknown
+      recipient?: unknown
+    }
+  },
+  options: {
+    getAccount: Account.Find
+    mpp: mpp.Options
+    store: Store.Store
+  },
+): TempoAccount.Account {
+  const { getAccount, mpp, store } = options
+  const state = store.getState()
+  const address = state.accounts[state.activeAccount]?.address
+  if (!address) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
+
+  const chainId = getMppSessionChainId(challenge, { store })
+  const calls = getMppSessionCalls(challenge, { address, mpp })
+  const account = calls
+    ? AccessKey.selectAccount({
+        address,
+        calls,
+        chainId,
+        keyTypes: ['secp256k1'],
+        store,
+      })
+    : undefined
+  if (account) return account
+
+  const root = (() => {
+    try {
+      return getAccount({ accessKey: false, signable: true })
+    } catch {
+      return undefined
+    }
+  })()
+  if (root?.keyType === 'secp256k1') return root
+
+  throw new ox_Provider.UnsupportedMethodError({
+    message:
+      'MPP session payments require a secp256k1 root account or scoped secp256k1 access key.',
+  })
+}
+
+function getMppSessionCalls(
+  challenge: {
+    request: {
+      currency?: unknown
+      methodDetails?: unknown
+      recipient?: unknown
+    }
+  },
+  options: { address: Address.Address; mpp: mpp.Options },
+): readonly { data?: Hex.Hex | undefined; to?: Address.Address | undefined }[] | undefined {
+  const { address, mpp } = options
+  const methodDetails = getMppSessionMethodDetails(challenge)
+  const currency = getAddress(challenge.request.currency)
+  const escrow = getAddress(methodDetails?.escrowContract) ?? mpp.escrowContract
+  const payee = getAddress(challenge.request.recipient)
+  if (!currency || !escrow || !payee) return undefined
+
+  const approve = encodeFunctionData({
+    abi: Abis.tip20,
+    functionName: 'approve',
+    args: [escrow, 0n],
+  })
+  const open = encodeFunctionData({
+    abi: Session.Chain.escrowAbi,
+    functionName: 'open',
+    args: [payee, currency, 0n, Hex.fromNumber(0, { size: 32 }), address],
+  })
+
+  return [
+    { data: approve, to: currency },
+    { data: open, to: escrow },
+  ]
+}
+
+function getMppSessionChainId(
+  challenge: { request: { methodDetails?: unknown } },
+  options: { store: Store.Store },
+): number {
+  const methodDetails = getMppSessionMethodDetails(challenge)
+  return typeof methodDetails?.chainId === 'number'
+    ? methodDetails.chainId
+    : options.store.getState().chainId
+}
+
+function getMppSessionMethodDetails(challenge: { request: { methodDetails?: unknown } }):
+  | {
+      chainId?: number | undefined
+      escrowContract?: Address.Address | undefined
+    }
+  | undefined {
+  const value = challenge.request.methodDetails
+  if (!value || typeof value !== 'object') return undefined
+  const methodDetails = value as { chainId?: unknown; escrowContract?: unknown }
+  return {
+    ...(typeof methodDetails.chainId === 'number' ? { chainId: methodDetails.chainId } : {}),
+    ...(getAddress(methodDetails.escrowContract)
+      ? { escrowContract: getAddress(methodDetails.escrowContract) }
+      : {}),
+  }
+}
+
+function getAddress(value: unknown): Address.Address | undefined {
+  if (typeof value !== 'string') return undefined
+  if (!Address.validate(value)) return undefined
+  return value
+}
+
+function usesMppSession(mpp: mpp.Options | undefined): boolean {
+  return typeof mpp?.deposit !== 'undefined' || typeof mpp?.maxDeposit !== 'undefined'
 }
 
 function withDetails(error: unknown): Error & { details: string } {

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -116,14 +116,16 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       if (!options) return undefined
       if (options.publicKey || options.address) return undefined
 
-      const { accessKey, keyPair } = await AccessKey.generate()
+      const keyType: 'secp256k1' | 'p256' = options.keyType === 'secp256k1' ? 'secp256k1' : 'p256'
+      const { accessKey, keyPair, privateKey } = await AccessKey.generate({ keyType })
       return {
         accessKey,
         keyPair,
+        privateKey,
         request: {
           ...options,
           publicKey: accessKey.publicKey,
-          keyType: 'p256' as const,
+          keyType,
         },
       }
     }
@@ -135,10 +137,13 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     function saveAccessKey(
       address: Address.Address,
       keyAuth: KeyAuthorization.Rpc,
-      keyPair: AccessKey.generate.ReturnType['keyPair'],
+      key: {
+        keyPair?: AccessKey.generate.ReturnType['keyPair'] | undefined
+        privateKey?: AccessKey.generate.ReturnType['privateKey'] | undefined
+      },
     ) {
       const keyAuthorization = KeyAuthorization.fromRpc(keyAuth)
-      AccessKey.save({ address, keyAuthorization, keyPair, store })
+      AccessKey.save({ address, keyAuthorization, ...key, store })
     }
 
     /**
@@ -227,7 +232,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.keyPair)
+            saveAccessKey(address, keyAuthorization, {
+              keyPair: accessKey.keyPair,
+              privateKey: accessKey.privateKey,
+            })
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -268,7 +276,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.keyPair)
+            saveAccessKey(address, keyAuthorization, {
+              keyPair: accessKey.keyPair,
+              privateKey: accessKey.privateKey,
+            })
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -400,7 +411,10 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
           if (accessKey) {
             const account = getAccount({ accessKey: false, signable: false })
-            saveAccessKey(account.address, result.keyAuthorization, accessKey.keyPair)
+            saveAccessKey(account.address, result.keyAuthorization, {
+              keyPair: accessKey.keyPair,
+              privateKey: accessKey.privateKey,
+            })
           }
 
           return result

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -55,7 +55,7 @@ export function local(options: local.Options): Adapter.Adapter {
         signature?: Hex.Hex | undefined
       } = {},
     ) {
-      const { keyPair } = prepared
+      const { keyPair, privateKey } = prepared
 
       const keyAuthorization = await (async () => {
         const digest = KeyAuthorization.getSignPayload(prepared.keyAuthorization)
@@ -65,7 +65,7 @@ export function local(options: local.Options): Adapter.Adapter {
         })
       })()
 
-      AccessKey.save({ address: account.address, keyAuthorization, keyPair, store })
+      AccessKey.save({ address: account.address, keyAuthorization, keyPair, privateKey, store })
 
       return KeyAuthorization.toRpc(keyAuthorization)
     }

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -309,6 +309,7 @@ export function turnkey<const client extends turnkey.Client>(
         address: core_Address.from(account.address),
         keyAuthorization,
         ...(prepared.keyPair ? { keyPair: prepared.keyPair } : {}),
+        ...(prepared.privateKey ? { privateKey: prepared.privateKey } : {}),
         store,
       })
 

--- a/src/core/mppx.test.ts
+++ b/src/core/mppx.test.ts
@@ -1,5 +1,7 @@
+import { Challenge } from 'mppx'
 import { Fetch } from 'mppx/client'
 import { Mppx as ServerMppx, tempo } from 'mppx/server'
+import { Methods } from 'mppx/tempo'
 import { parseUnits } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Actions } from 'viem/tempo'
@@ -128,6 +130,55 @@ describe('mppx integration', () => {
       expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
     } finally {
       await failingServer.closeAsync()
+    }
+  })
+
+  test('session challenge rejects p256 access key before retry', async () => {
+    const challenge = Challenge.fromMethod(Methods.session, {
+      id: 'session-p256-access-key',
+      realm: 'mppx-test',
+      request: {
+        amount: '1',
+        chainId: chain.id,
+        currency: Addresses.pathUsd,
+        decimals: 6,
+        escrowContract: '0x0000000000000000000000000000000000000e55',
+        recipient: accounts[1]!.address,
+        suggestedDeposit: '1',
+        unitType: 'request',
+      },
+    })
+    const sessionServer = await createServer(async (req, res) => {
+      if (req.headers.authorization) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+        return
+      }
+
+      res.writeHead(402, { 'WWW-Authenticate': Challenge.serialize(challenge) })
+      res.end()
+    })
+
+    try {
+      const provider = Provider.create({
+        adapter: headlessWebAuthn(),
+        chains: [chain],
+        mpp: { maxDeposit: '1' },
+      })
+      await connect(provider)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1), keyType: 'p256' }],
+      })
+
+      await expect(
+        fetch(`${sessionServer.url}/session`),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Provider.UnsupportedMethodError: MPP session payments require a secp256k1 root account or scoped secp256k1 access key.]`,
+      )
+    } finally {
+      await sessionServer.closeAsync()
     }
   })
 })


### PR DESCRIPTION
## Summary
Use session-compatible access keys for MPP stream-channel payments.

## Motivation
Closes #486.
Closes #487.

MPP session auto-management needs a signer that can open the channel and produce vouchers accepted by current `mppx` verification.

## Changes
- Default generated access keys to `secp256k1` when `mpp.deposit` or `mpp.maxDeposit` is configured.
- Pick a scoped secp256k1 access key for `tempo.session` challenges using the session setup calls before the default signer runs.
- Persist generated secp256k1 private keys in dialog, local, and Turnkey adapter paths.
- Add regression coverage for scoped session calls, P256 rejection before retry, and connect/direct authorization defaults.

## Testing
- `./node_modules/.bin/tsc -p src/tsconfig.json --noEmit`
- `./node_modules/.bin/vp lint src/core/AccessKey.ts src/core/AccessKey.test.ts src/core/Provider.ts src/core/Provider.test.ts src/core/adapters/dialog.ts src/core/adapters/local.ts src/core/adapters/turnkey.ts src/core/mppx.test.ts` -> 0 warnings, 0 errors
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts` -> 51 passed
- `./node_modules/.bin/vp test src/core/mppx.test.ts` -> 4 passed
- `./node_modules/.bin/vp test src/core/Provider.test.ts` -> 262 passed
- `./node_modules/.bin/vp test src/core/adapters/dialog.test.ts` -> 3 passed
- `./node_modules/.bin/vp test src/core/adapters/local.test.ts` -> 9 passed
- `./node_modules/.bin/vp test src/core/adapters/turnkey.test.ts -t "authorizeAccessKey"` -> 1 passed, 17 skipped
- `pnpm --filter site build` -> passed; Vocs reported existing dead-link warnings in `/docs/adapters/private-key.mdx` and `/docs/adapters/webauthn.mdx`
- `git diff --check`