### PR TITLE
docs: add subscriptions guide

### DIFF
--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -6,8 +6,12 @@ SDK auto-fulfills the `402 Payment Required` challenge by signing a recurring
 access key authorization with the connected account.
 
 Subsequent requests within the billing period reuse the active subscription
-(no wallet prompt, no on-chain transaction). When the period elapses, the
-server uses the recurring access key to bill the next period automatically.
+(no wallet prompt, no on-chain transaction). This example uses a 10-second
+development period (`periodUnit: 'dev_second'`) so renewals can be tested
+locally.
+
+In production, use day or week periods. When the period elapses, the server
+uses the recurring access key to bill the next period automatically.
 
 ## Setup
 
@@ -20,6 +24,11 @@ npm dev
 
 Sign in with a Tempo Wallet account on testnet, click **Fund Account** to mint
 some pathUSD, then click **GET /api/articles** to subscribe.
+
+To test renewal, subscribe and watch the renewal countdown. Every 10 seconds,
+the dev endpoint fast-forwards local state and runs the same renewal helper that
+the scheduled Worker calls. The Tempo access key spending window still advances
+on-chain in real time.
 
 ## How it works
 
@@ -57,6 +66,11 @@ the same `X-Subscriber` header are served immediately from the active
 subscription. Once the billing period elapses, the server uses the stored
 access key to bill the next period before serving the response.
 
+The Worker also registers a cron trigger. Every 15 minutes, the scheduled
+handler calls `tempo.renewSubscription` for known subscription IDs. That helper
+only bills overdue periods and reuses the configured fee-payer account and
+policy for sponsored renewals.
+
 See [`worker/index.ts`](./worker/index.ts) for the server-side configuration
 and [`src/App.tsx`](./src/App.tsx) for the client.
 
@@ -64,7 +78,8 @@ and [`src/App.tsx`](./src/App.tsx) for the client.
 
 - The example uses an in-memory store (`Store.memory()`) so subscriptions
   reset whenever the worker restarts. In production, swap in a durable store
-  (Cloudflare KV, Durable Objects, Postgres, etc.).
+  (Cloudflare KV, Durable Objects, Postgres, etc.) and persist the subscription
+  ID index used by the cron renewal loop.
 - The `X-Subscriber` header is used purely for demonstration. Real apps
   should derive the lookup key from a session cookie, JWT, or API key the
   server already trusts.

--- a/examples/subscriptions/src/App.tsx
+++ b/examples/subscriptions/src/App.tsx
@@ -1,13 +1,15 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatUnits, stringify } from 'viem'
 import { useConnect, useConnection, useConnectors, useDisconnect } from 'wagmi'
 import { tempoModerato } from 'wagmi/chains'
 import { Hooks } from 'wagmi/tempo'
 
 const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+const devSubscriptionPeriodSeconds = 10
 
 export default function App() {
   const { address, status } = useConnection()
+  const [subscriptionVersion, setSubscriptionVersion] = useState(0)
   return (
     <div>
       <h1>Subscriptions Example</h1>
@@ -16,7 +18,7 @@ export default function App() {
         recurring pathUSD subscription, and the SDK auto-fulfills the{' '}
         <code>402 Payment Required</code> challenge by signing a recurring access key authorization
         with the connected account. Subsequent requests within the billing period reuse the active
-        subscription, and the server renews it automatically when the period elapses.
+        subscription, and the server collects payment automatically when the period elapses.
       </p>
 
       <h2>Connection</h2>
@@ -34,9 +36,77 @@ export default function App() {
           <Faucet />
 
           <h2>Subscribe</h2>
-          <Subscribe address={address} />
+          <Subscribe
+            address={address}
+            onSubscribed={() => setSubscriptionVersion((value) => value + 1)}
+          />
+
+          <h2>Renewal Test</h2>
+          <RenewalTest subscriptionVersion={subscriptionVersion} />
         </>
       )}
+    </div>
+  )
+}
+
+function RenewalTest({ subscriptionVersion }: { subscriptionVersion: number }) {
+  const isRenewingRef = useRef(false)
+  const [countdown, setCountdown] = useState(devSubscriptionPeriodSeconds)
+  const [data, setData] = useState<unknown>()
+  const [error, setError] = useState<Error | undefined>()
+  const [isPending, setPending] = useState(false)
+
+  const renew = useCallback(async () => {
+    if (isRenewingRef.current) return
+    isRenewingRef.current = true
+    setPending(true)
+    setError(undefined)
+    setData(undefined)
+    try {
+      const res = await fetch('/api/dev/subscriptions/renew', { method: 'POST' })
+      const body = await res.json()
+      if (!res.ok) throw new Error(`${res.status}: ${stringify(body)}`)
+      setData(body)
+    } catch (e) {
+      setError(e as Error)
+    } finally {
+      isRenewingRef.current = false
+      setPending(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      if (isRenewingRef.current) return
+      setCountdown((seconds) => Math.max(0, seconds - 1))
+    }, 1_000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (countdown > 0) return
+    let ignore = false
+    void renew().finally(() => {
+      if (!ignore) setCountdown(devSubscriptionPeriodSeconds)
+    })
+    return () => {
+      ignore = true
+    }
+  }, [renew, countdown])
+
+  useEffect(() => {
+    setCountdown(devSubscriptionPeriodSeconds)
+  }, [subscriptionVersion])
+
+  return (
+    <div>
+      <p>
+        Every {devSubscriptionPeriodSeconds} seconds, this fast-forwards local state and runs the
+        same renewal helper that the scheduled Worker calls.
+      </p>
+      <div>{isPending ? 'Renewing...' : `Next renewal in ${countdown}s`}</div>
+      {error && <pre style={{ color: 'red' }}>{`${error.name}: ${error.message}`}</pre>}
+      {data !== undefined && <pre>{stringify(data, null, 2)}</pre>}
     </div>
   )
 }
@@ -107,15 +177,22 @@ function Faucet() {
   )
 }
 
-function Subscribe({ address }: { address: `0x${string}` }) {
+function Subscribe({
+  address,
+  onSubscribed,
+}: {
+  address: `0x${string}`
+  onSubscribed: () => void
+}) {
   const [data, setData] = useState<unknown>()
   const [error, setError] = useState<Error | undefined>()
   const [isPending, setPending] = useState(false)
   return (
     <div>
       <p>
-        $0.01 / day for unlimited articles. The first call prompts you to authorize a recurring
-        access key; later calls within the period skip the on-chain transfer and the wallet prompt.
+        $0.01 / {devSubscriptionPeriodSeconds} seconds for unlimited articles. The first call
+        prompts you to authorize a recurring access key; later calls within the period skip the
+        on-chain transfer and the wallet prompt.
       </p>
       <button
         type="button"
@@ -131,6 +208,7 @@ function Subscribe({ address }: { address: `0x${string}` }) {
             const body = await res.json()
             if (!res.ok) throw new Error(`${res.status}: ${stringify(body)}`)
             setData(body)
+            onSubscribed()
           } catch (e) {
             setError(e as Error)
           } finally {

--- a/examples/subscriptions/src/config.ts
+++ b/examples/subscriptions/src/config.ts
@@ -1,6 +1,6 @@
 import { createConfig, http } from 'wagmi'
 import { tempo, tempoModerato } from 'wagmi/chains'
-import { tempoWallet } from 'wagmi/connectors'
+import { tempoWallet } from 'wagmi/tempo'
 
 export const config = createConfig({
   chains: [tempoModerato, tempo],

--- a/examples/subscriptions/worker/index.ts
+++ b/examples/subscriptions/worker/index.ts
@@ -4,18 +4,100 @@ import { Mppx, tempo } from 'mppx/hono'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono()
+const devSubscriptionPeriodSeconds = 10
+const periodUnitSeconds = {
+  dev_second: 1,
+  day: 86_400,
+  week: 604_800,
+} as const
+const account = privateKeyToAccount(process.env.ACCOUNT_PRIVATE_KEY)
+const feePayerPolicy = {
+  maxGas: 6_000_000n,
+  maxTotalFee: 1_000_000_000_000_000_000n,
+}
+const subscriptionIds = new Set<string>()
+const subscriptionHooks = {
+  activated: ({ subscription }) => {
+    subscriptionIds.add(subscription.subscriptionId)
+  },
+  renewed: ({ subscription }) => {
+    subscriptionIds.add(subscription.subscriptionId)
+  },
+} satisfies NonNullable<Parameters<typeof tempo.subscription>[0]['hooks']>
 
 // Persisted subscription state. In-memory is fine for the example, but in
 // production use a durable store (Cloudflare KV, Durable Objects, Postgres,
 // etc.) so subscriptions survive worker restarts.
 const store = Store.memory()
 
+async function fastForwardSubscription(subscriptionId: string) {
+  return store.update(`tempo:subscription:record:${subscriptionId}`, (current) => {
+    const record = current as Record<string, unknown> | null
+    if (!record) return { op: 'noop', result: false }
+    const periodCount = typeof record.periodCount === 'string' ? Number(record.periodCount) : NaN
+    const periodUnit =
+      typeof record.periodUnit === 'string'
+        ? periodUnitSeconds[record.periodUnit as keyof typeof periodUnitSeconds]
+        : undefined
+    const periodSeconds =
+      Number.isFinite(periodCount) && periodUnit
+        ? periodCount * periodUnit
+        : devSubscriptionPeriodSeconds
+    const lastChargedPeriod =
+      typeof record.lastChargedPeriod === 'number' && Number.isFinite(record.lastChargedPeriod)
+        ? record.lastChargedPeriod
+        : 0
+    const targetPeriodIndex = lastChargedPeriod + 1
+    const billingAnchor = new Date(
+      Date.now() - (targetPeriodIndex * periodSeconds + 1) * 1_000,
+    ).toISOString()
+    return {
+      op: 'set',
+      value: {
+        ...record,
+        billingAnchor,
+      },
+      result: true,
+    }
+  })
+}
+
+async function renewSubscriptions() {
+  await Promise.all(
+    [...subscriptionIds].map((subscriptionId) =>
+      tempo.renewSubscription({ store, subscriptionId }),
+    ),
+  )
+}
+
+function toErrorDetails(error: unknown) {
+  const value = error as {
+    details?: unknown
+    message?: unknown
+    name?: unknown
+    shortMessage?: unknown
+  }
+  const message =
+    typeof value.shortMessage === 'string'
+      ? value.shortMessage
+      : typeof value.message === 'string'
+        ? value.message
+        : 'Subscription renewal failed.'
+  return {
+    details: typeof value.details === 'string' ? value.details : undefined,
+    message,
+    name: typeof value.name === 'string' ? value.name : 'Error',
+  }
+}
+
 const mppx = Mppx.create({
   methods: [
     tempo.subscription({
-      account: privateKeyToAccount(process.env.ACCOUNT_PRIVATE_KEY),
+      account,
       currency: '0x20c0000000000000000000000000000000000000',
       feePayer: true,
+      feePayerPolicy,
+      hooks: subscriptionHooks,
       // The lookup key identifies *which* subscription a request belongs to.
       // For this example we scope subscriptions per `X-Subscriber` header
       // (the connected account address). Real apps would derive it from
@@ -35,8 +117,8 @@ app.get(
   '/api/articles',
   mppx.subscription({
     amount: '0.01',
-    periodCount: 1,
-    periodUnit: 'day',
+    periodCount: devSubscriptionPeriodSeconds,
+    periodUnit: 'dev_second',
     subscriptionExpires: new Date(
       Math.ceil((Date.now() + 365 * 24 * 60 * 60 * 1_000) / 1_000) * 1_000,
     ).toISOString(),
@@ -51,4 +133,43 @@ app.get(
     }),
 )
 
-export default app
+app.post('/api/dev/subscriptions/renew', async (c) => {
+  const results = await Promise.all(
+    [...subscriptionIds].map(async (subscriptionId) => {
+      let fastForwarded: unknown
+      try {
+        fastForwarded = await fastForwardSubscription(subscriptionId)
+        const renewal = await tempo.renewSubscription({ store, subscriptionId })
+        return {
+          fastForwarded,
+          receipt: renewal?.receipt ?? null,
+          renewed: renewal !== null,
+          subscriptionId,
+        }
+      } catch (error) {
+        const details = toErrorDetails(error)
+        console.warn('Subscription renewal failed.', { error: details, subscriptionId })
+        return {
+          error: {
+            ...details,
+            hint: details.message.includes('SpendingLimitExceeded')
+              ? 'Wait for one real dev billing period after activation; local fast-forwarding cannot move the on-chain spending window.'
+              : undefined,
+          },
+          fastForwarded,
+          receipt: null,
+          renewed: false,
+          subscriptionId,
+        }
+      }
+    }),
+  )
+  return c.json({ results })
+})
+
+export default {
+  fetch: app.fetch,
+  scheduled(_event: ScheduledEvent, _env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(renewSubscriptions())
+  },
+}

--- a/examples/subscriptions/wrangler.jsonc
+++ b/examples/subscriptions/wrangler.jsonc
@@ -8,4 +8,7 @@
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/api/*"],
   },
+  "triggers": {
+    "crons": ["*/15 * * * *"],
+  },
 }

--- a/patches/mppx@0.6.23.patch
+++ b/patches/mppx@0.6.23.patch
@@ -1,0 +1,928 @@
+diff --git a/dist/tempo/Methods.d.ts b/dist/tempo/Methods.d.ts
+index 3f3234f3f55f026b8dca0444907360c449fbb4ae..61bf3ac49ffd2ee008a562c1b7c3534a7ee7dfa7 100644
+--- a/dist/tempo/Methods.d.ts
++++ b/dist/tempo/Methods.d.ts
+@@ -207,6 +207,7 @@ export declare const subscription: {
+             }, z.core.$strip>>;
+             periodCount: z.ZodMiniPipe<z.ZodMiniUnion<readonly [z.ZodMiniString<string>, z.ZodMiniBigInt<bigint>, z.ZodMiniCustom<number, number>]>, z.ZodMiniTransform<string, string | number | bigint>>;
+             periodUnit: z.ZodMiniEnum<{
++                dev_second: "dev_second";
+                 day: "day";
+                 week: "week";
+             }>;
+@@ -221,7 +222,7 @@ export declare const subscription: {
+             subscriptionExpires: string;
+             currency: `0x${string}`;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             description?: string | undefined;
+             externalId?: string | undefined;
+@@ -230,7 +231,7 @@ export declare const subscription: {
+             currency: `0x${string}`;
+             decimals: number;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             subscriptionExpires: Date;
+             accessKey?: {
+diff --git a/dist/tempo/Methods.js b/dist/tempo/Methods.js
+index 4431b4f663e298fa3bf6de54ebb2b432f9c0fc27..52d032ad97eaa28da788c287f8617d576ba656a3 100644
+--- a/dist/tempo/Methods.js
++++ b/dist/tempo/Methods.js
+@@ -8,8 +8,11 @@ const split = z.object({
+     recipient: z.pipe(z.string(), z.transform((v) => v)),
+ });
+ const uint64Max = (1n << 64n) - 1n;
+-const secondsPerDay = 86400n;
+-const secondsPerWeek = 604800n;
++const subscriptionPeriodUnitSeconds = {
++    dev_second: 1n,
++    day: 86400n,
++    week: 604800n,
++};
+ const normalizedAddress = z.pipe(z.address(), z.transform((value) => value.toLowerCase()));
+ const subscriptionAccessKey = z.object({
+     accessKeyAddress: normalizedAddress,
+@@ -22,7 +25,7 @@ const subscriptionMethodDetails = z.object({
+ const subscriptionExpires = z
+     .datetimeInput('subscriptionExpires must be a valid date')
+     .check(z.refine((value) => value.getTime() % 1_000 === 0, 'subscriptionExpires must be representable as whole seconds'));
+-const subscriptionPeriodUnits = ['day', 'week'];
++const subscriptionPeriodUnits = ['dev_second', 'day', 'week'];
+ const subscriptionPeriodUnit = z.enum(subscriptionPeriodUnits);
+ const uint64String = z
+     .pipe(z.union([
+@@ -47,7 +50,9 @@ function positiveParsedAmount(message) {
+ function subscriptionPeriodFitsUint64(value) {
+     const { periodCount, periodUnit } = value;
+     try {
+-        const unitSeconds = periodUnit === 'day' ? secondsPerDay : secondsPerWeek;
++        const unitSeconds = subscriptionPeriodUnitSeconds[periodUnit];
++        if (unitSeconds === undefined)
++            return false;
+         return BigInt(periodCount) * unitSeconds <= uint64Max;
+     }
+     catch {
+diff --git a/dist/tempo/client/Subscription.d.ts b/dist/tempo/client/Subscription.d.ts
+index e8965f327f8d5f6cc25e6b7d365c3df33c40257c..5df09edbf3da5832abbcb364575d64717648e781 100644
+--- a/dist/tempo/client/Subscription.d.ts
++++ b/dist/tempo/client/Subscription.d.ts
+@@ -51,6 +51,7 @@ export declare function subscription(parameters?: subscription.Parameters): Meth
+             }, z.core.$strip>>;
+             periodCount: z.ZodMiniPipe<z.ZodMiniUnion<readonly [z.ZodMiniString<string>, z.ZodMiniBigInt<bigint>, z.ZodMiniCustom<number, number>]>, z.ZodMiniTransform<string, string | number | bigint>>;
+             periodUnit: z.ZodMiniEnum<{
++                dev_second: "dev_second";
+                 day: "day";
+                 week: "week";
+             }>;
+@@ -72,7 +73,7 @@ export declare function subscription(parameters?: subscription.Parameters): Meth
+             subscriptionExpires: string;
+             currency: `0x${string}`;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             description?: string | undefined;
+             externalId?: string | undefined;
+@@ -81,7 +82,7 @@ export declare function subscription(parameters?: subscription.Parameters): Meth
+             currency: `0x${string}`;
+             decimals: number;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             subscriptionExpires: Date;
+             accessKey?: {
+diff --git a/dist/tempo/server/Subscription.d.ts b/dist/tempo/server/Subscription.d.ts
+index a2e78f1422aded78f708554b12207ff5e9f2bfcc..1b06a429b5b28d399595deac15b045d230b41e96 100644
+--- a/dist/tempo/server/Subscription.d.ts
++++ b/dist/tempo/server/Subscription.d.ts
+@@ -52,6 +52,7 @@ export declare function subscription<const parameters extends subscription.Param
+             }, import("zod/v4/core").$strip>>;
+             periodCount: import("zod/mini").ZodMiniPipe<import("zod/mini").ZodMiniUnion<readonly [import("zod/mini").ZodMiniString<string>, import("zod/mini").ZodMiniBigInt<bigint>, import("zod/mini").ZodMiniCustom<number, number>]>, import("zod/mini").ZodMiniTransform<string, string | number | bigint>>;
+             periodUnit: import("zod/mini").ZodMiniEnum<{
++                dev_second: "dev_second";
+                 day: "day";
+                 week: "week";
+             }>;
+@@ -73,7 +74,7 @@ export declare function subscription<const parameters extends subscription.Param
+             subscriptionExpires: string;
+             currency: `0x${string}`;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             description?: string | undefined;
+             externalId?: string | undefined;
+@@ -82,7 +83,7 @@ export declare function subscription<const parameters extends subscription.Param
+             currency: `0x${string}`;
+             decimals: number;
+             periodCount: string;
+-            periodUnit: "day" | "week";
++            periodUnit: "dev_second" | "day" | "week";
+             recipient: `0x${string}`;
+             subscriptionExpires: Date;
+             accessKey?: {
+@@ -111,7 +112,7 @@ export declare function subscription<const parameters extends subscription.Param
+ export declare function renew(parameters: renew.Parameters): Promise<renew.Result | null>;
+ export declare namespace renew {
+     /** Parameters for renewing an overdue subscription outside the request path. */
+-    type Parameters = {
++    type Parameters = Account.resolve.Parameters & {
+         /** The subscription to renew. */
+         subscriptionId: string;
+         /** Billing callback — same signature as the `renew` hook on {@link subscription}. */
+@@ -121,6 +122,13 @@ export declare namespace renew {
+             periodIndex: number;
+             subscription: SubscriptionRecord;
+         }) => Promise<subscription.RenewalResult>) | undefined;
++        hooks?: {
++            renewed?: ((parameters: {
++                periodIndex: number;
++                receipt: SubscriptionReceiptValue;
++                subscription: SubscriptionRecord;
++            }) => MaybePromise<void>) | undefined;
++        } | undefined;
+         /** Store containing subscription records. */
+         store: Store.AtomicStore<Record<string, unknown>>;
+         /**
+@@ -128,6 +136,11 @@ export declare namespace renew {
+          * Keeps concurrent renewal safe while allowing recovery from abandoned attempts.
+          */
+         renewalTimeoutMs?: number | undefined;
++        /**
++         * Override the fee-payer policy for sponsored subscription payments.
++         * Useful when the access key renewal tx requires more gas than the default policy allows.
++         */
++        feePayerPolicy?: Partial<FeePayer.Policy> | undefined;
+         waitForConfirmation?: boolean | undefined;
+     } & Client.getResolver.Parameters;
+     /** Renewal result returned by {@link renew}. */
+diff --git a/dist/tempo/server/Subscription.js b/dist/tempo/server/Subscription.js
+index 543b01685143a100409f723c531113df112e34fc..e0066844369e96760b6f3fbb78532ff5e9017692 100644
+--- a/dist/tempo/server/Subscription.js
++++ b/dist/tempo/server/Subscription.js
+@@ -17,6 +17,7 @@ import * as Methods from '../Methods.js';
+ import { assertSubscriptionTiming, toSubscriptionPeriodSeconds, verifySubscriptionKeyAuthorization, } from '../subscription/KeyAuthorization.js';
+ import * as SubscriptionReceipt from '../subscription/Receipt.js';
+ import * as SubscriptionStore from '../subscription/Store.js';
++const subscriptionContexts = new WeakMap();
+ /**
+  * Creates a Tempo subscription method for recurring TIP-20 token payments.
+  *
+@@ -40,7 +41,15 @@ export function subscription(p) {
+         getClient: parameters.getClient,
+         rpcUrl: defaults.rpcUrl,
+     });
+-    return Method.toServer(Methods.subscription, {
++    subscriptionContexts.set(rawStore, {
++        feePayer,
++        feePayerPolicy: parameters.feePayerPolicy,
++        getClient,
++        parameters,
++        store,
++        waitForConfirmation,
++    });
++    const method = Method.toServer(Methods.subscription, {
+         defaults: {
+             amount,
+             currency,
+@@ -231,6 +240,7 @@ export function subscription(p) {
+             return activation.result.receipt;
+         },
+     });
++    return method;
+ }
+ function requestFromCaptured(capturedRequest) {
+     if (!capturedRequest)
+@@ -638,31 +648,53 @@ function createSubscriptionId() {
+  */
+ export async function renew(parameters) {
+     const { store: rawStore, waitForConfirmation = true } = parameters;
+-    const store = SubscriptionStore.fromStore(rawStore, {
+-        renewalTimeoutMs: parameters.renewalTimeoutMs,
+-    });
+-    const getClient = ClientResolver.getResolver({
+-        chain: tempo_chain,
+-        getClient: parameters.getClient,
+-        rpcUrl: defaults.rpcUrl,
+-    });
+-    const record = await store.get(parameters.subscriptionId);
++    const configured = subscriptionContexts.get(rawStore);
++    let context;
++    if (configured && !parameters.account && !parameters.feePayer && !parameters.getClient && !parameters.renew) {
++        context = {
++            ...configured,
++            feePayerPolicy: parameters.feePayerPolicy ?? configured.feePayerPolicy,
++            waitForConfirmation: parameters.waitForConfirmation ?? configured.waitForConfirmation,
++        };
++    }
++    else {
++        const { feePayer } = Account.resolve(parameters);
++        const store = SubscriptionStore.fromStore(rawStore, {
++            renewalTimeoutMs: parameters.renewalTimeoutMs,
++        });
++        const getClient = ClientResolver.getResolver({
++            chain: tempo_chain,
++            getClient: parameters.getClient,
++            rpcUrl: defaults.rpcUrl,
++        });
++        context = {
++            feePayer,
++            feePayerPolicy: parameters.feePayerPolicy,
++            getClient,
++            parameters,
++            store,
++            waitForConfirmation,
++        };
++    }
++    const record = await context.store.get(parameters.subscriptionId);
+     if (!record)
+         return null;
+     if (!isActive(record))
+         return null;
+-    const active = await store.getByKey(record.lookupKey);
++    const active = await context.store.getByKey(record.lookupKey);
+     if (active?.subscriptionId !== record.subscriptionId)
+         return null;
+     const periodIndex = getPeriodIndex(record);
+     if (periodIndex <= record.lastChargedPeriod)
+         return null;
+     const renew = resolveRenewalHandler({
+-        getClient,
+-        parameters,
+-        store,
++        feePayer: context.feePayer,
++        feePayerPolicy: context.feePayerPolicy,
++        getClient: context.getClient,
++        parameters: context.parameters,
++        store: context.store,
+         subscription: record,
+-        waitForConfirmation,
++        waitForConfirmation: context.waitForConfirmation,
+     });
+     if (!renew)
+         return null;
+@@ -670,9 +702,16 @@ export async function renew(parameters) {
+         expectedLookupKey: record.lookupKey,
+         periodIndex,
+         renew,
+-        store,
++        store: context.store,
+         subscription: record,
+     });
+-    return renewal?.status === 'renewed' ? renewal.result : null;
++    if (renewal?.status !== 'renewed')
++        return null;
++    await context.parameters.hooks?.renewed?.({
++        periodIndex,
++        receipt: renewal.result.receipt,
++        subscription: renewal.result.subscription,
++    });
++    return renewal.result;
+ }
+ //# sourceMappingURL=Subscription.js.map
+diff --git a/dist/tempo/subscription/KeyAuthorization.d.ts b/dist/tempo/subscription/KeyAuthorization.d.ts
+index 2c63df20f13d4d05cc467f9ba9f8243c9924d891..eca9e704ccb8da7d0ee877c060b025f26f4c848a 100644
+--- a/dist/tempo/subscription/KeyAuthorization.d.ts
++++ b/dist/tempo/subscription/KeyAuthorization.d.ts
+@@ -4,8 +4,10 @@ import type * as Methods from '../Methods.js';
+ import type { SubscriptionAccessKey, SubscriptionCredentialPayload, SubscriptionPeriodUnit } from './Types.js';
+ /** 4-byte selector for TIP-20 `transfer(address,uint256)`. */
+ export declare const transferSelector = "0xa9059cbb";
+-/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes)`. */
++/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
+ export declare const transferWithMemoSelector = "0x95777d59";
++/** Human-readable selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
++export declare const transferWithMemoSignature = "transferWithMemo(address,uint256,bytes32)";
+ type SubscriptionRequest = ReturnType<typeof Methods.subscription.schema.request.parse>;
+ /**
+  * Converts a subscription expiry timestamp into the Unix seconds value required by Tempo key
+@@ -31,21 +33,14 @@ export declare function assertSubscriptionTiming(parameters: {
+ /** Builds the Tempo access-key call scopes required for a subscription payment. */
+ export declare function getSubscriptionScopes(request: Pick<SubscriptionRequest, 'currency' | 'recipient'>): readonly [{
+     readonly address: `0x${string}`;
+-    readonly selector: "0xa9059cbb";
+-    readonly recipients: readonly [`0x${string}`];
+-}, {
+-    readonly address: `0x${string}`;
+-    readonly selector: "0x95777d59";
++    readonly selector: "transferWithMemo(address,uint256,bytes32)";
+     readonly recipients: readonly [`0x${string}`];
+ }];
+ /** Builds the RPC `allowedCalls` payload passed to `wallet_authorizeAccessKey`. */
+ export declare function getSubscriptionRpcAllowedCalls(request: Pick<SubscriptionRequest, 'currency' | 'recipient'>): readonly [{
+     readonly target: `0x${string}`;
+     readonly selectorRules: readonly [{
+-        readonly selector: "0xa9059cbb";
+-        readonly recipients: readonly [`0x${string}`];
+-    }, {
+-        readonly selector: "0x95777d59";
++        readonly selector: "transferWithMemo(address,uint256,bytes32)";
+         readonly recipients: readonly [`0x${string}`];
+     }];
+ }];
+@@ -71,15 +66,11 @@ export declare function signSubscriptionKeyAuthorization(parameters: {
+         readonly limit: bigint;
+         readonly period: number;
+     }[];
+-    readonly scopes: readonly ({
++    readonly scopes: readonly {
+         readonly address: `0x${string}`;
+-        readonly selector: "0xa9059cbb";
++        readonly selector: "transferWithMemo(address,uint256,bytes32)";
+         readonly recipients: readonly `0x${string}`[];
+-    } | {
+-        readonly address: `0x${string}`;
+-        readonly selector: "0x95777d59";
+-        readonly recipients: readonly `0x${string}`[];
+-    })[];
++    }[];
+     readonly type: "secp256k1" | "p256" | "webAuthn";
+     signature: {
+         signature: {
+diff --git a/dist/tempo/subscription/KeyAuthorization.js b/dist/tempo/subscription/KeyAuthorization.js
+index fe861b03192004f6302f0b8640ce7ecbf1057ad6..b443e6910b6e997e0d4e268f284174d5f9e84f00 100644
+--- a/dist/tempo/subscription/KeyAuthorization.js
++++ b/dist/tempo/subscription/KeyAuthorization.js
+@@ -1,13 +1,18 @@
+ import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo';
+-import { isAddress, isAddressEqual } from 'viem';
++import { isAddress, isAddressEqual, toFunctionSelector } from 'viem';
+ import { VerificationFailedError } from '../../Errors.js';
+ /** 4-byte selector for TIP-20 `transfer(address,uint256)`. */
+ export const transferSelector = '0xa9059cbb';
+-/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes)`. */
++/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
+ export const transferWithMemoSelector = '0x95777d59';
++/** Human-readable selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
++export const transferWithMemoSignature = 'transferWithMemo(address,uint256,bytes32)';
+ const uint64Max = (1n << 64n) - 1n;
+-const secondsPerDay = 86400n;
+-const secondsPerWeek = 604800n;
++const subscriptionPeriodUnitSeconds = {
++    dev_second: 1n,
++    day: 86400n,
++    week: 604800n,
++};
+ /**
+  * Converts a subscription expiry timestamp into the Unix seconds value required by Tempo key
+  * authorizations.
+@@ -41,10 +46,10 @@ export function toSubscriptionPeriodSeconds(request) {
+     if (!/^[1-9]\d*$/.test(request.periodCount)) {
+         throw new VerificationFailedError({ reason: 'periodCount is invalid' });
+     }
+-    if (request.periodUnit !== 'day' && request.periodUnit !== 'week') {
++    const unitSeconds = subscriptionPeriodUnitSeconds[request.periodUnit];
++    if (unitSeconds === undefined) {
+         throw new VerificationFailedError({ reason: 'periodUnit is invalid' });
+     }
+-    const unitSeconds = request.periodUnit === 'day' ? secondsPerDay : secondsPerWeek;
+     const value = BigInt(request.periodCount) * unitSeconds;
+     if (value > uint64Max) {
+         throw new VerificationFailedError({
+@@ -81,27 +86,18 @@ export function getSubscriptionScopes(request) {
+     return [
+         {
+             address: currency,
+-            selector: transferSelector,
+-            recipients: [recipient],
+-        },
+-        {
+-            address: currency,
+-            selector: transferWithMemoSelector,
++            selector: transferWithMemoSignature,
+             recipients: [recipient],
+         },
+     ];
+ }
+ /** Builds the RPC `allowedCalls` payload passed to `wallet_authorizeAccessKey`. */
+ export function getSubscriptionRpcAllowedCalls(request) {
+-    const [transfer, transferWithMemo] = getSubscriptionScopes(request);
++    const [transferWithMemo] = getSubscriptionScopes(request);
+     return [
+         {
+             target: normalizeAddress(request.currency, 'currency'),
+             selectorRules: [
+-                {
+-                    selector: transfer.selector,
+-                    recipients: transfer.recipients,
+-                },
+                 {
+                     selector: transferWithMemo.selector,
+                     recipients: transferWithMemo.recipients,
+@@ -258,9 +254,6 @@ function assertAuthorizationScopes(scopes, request) {
+             throw new VerificationFailedError({ reason: 'keyAuthorization recipient mismatch' });
+         }
+     }
+-    if (!seen.has(transferSelector)) {
+-        throw new VerificationFailedError({ reason: 'keyAuthorization must allow transfer' });
+-    }
+     if (!seen.has(transferWithMemoSelector)) {
+         throw new VerificationFailedError({ reason: 'keyAuthorization must allow transferWithMemo' });
+     }
+@@ -292,6 +285,13 @@ function normalizeAddress(value, name) {
+ function normalizeSelector(value) {
+     if (typeof value !== 'string')
+         return '';
+-    return value.toLowerCase();
++    if (value.startsWith('0x'))
++        return value.toLowerCase();
++    try {
++        return toFunctionSelector(value).toLowerCase();
++    }
++    catch {
++        return '';
++    }
+ }
+ //# sourceMappingURL=KeyAuthorization.js.map
+diff --git a/dist/tempo/subscription/Types.d.ts b/dist/tempo/subscription/Types.d.ts
+index 67d66a3448ad1d051d972bb5a7dcebfeea59678d..82771f48dc1dd19183c6b8d53a2464a044b84976 100644
+--- a/dist/tempo/subscription/Types.d.ts
++++ b/dist/tempo/subscription/Types.d.ts
+@@ -1,6 +1,6 @@
+ import type { Address } from 'viem';
+-/** Tempo-supported subscription period units. The shared intent also defines `month`, but Tempo cannot represent calendar-month periods exactly. */
+-export type SubscriptionPeriodUnit = 'day' | 'week';
++/** Tempo-supported subscription period units. Use `day` or `week` in production; shorter units are for development and tests. */
++export type SubscriptionPeriodUnit = 'dev_second' | 'day' | 'week';
+ /** Access key information used to authorize recurring Tempo payments. */
+ export type SubscriptionAccessKey = {
+     accessKeyAddress: Address;
+diff --git a/src/tempo/Methods.test.ts b/src/tempo/Methods.test.ts
+index cb5f505b000f66ade63fe8be4a044153577cd37c..3594a37f4fff9cec734e6fc36b2418325804b906 100644
+--- a/src/tempo/Methods.test.ts
++++ b/src/tempo/Methods.test.ts
+@@ -313,6 +313,23 @@ describe('subscription', () => {
+     expect(request.periodCount).toBe(expected)
+   })
+ 
++  test.each(['dev_second'] as const)(
++    'schema: accepts %s subscription periods for development and tests',
++    (periodUnit) => {
++      const request = Methods.subscription.schema.request.parse({
++        amount: '10',
++        currency: '0x20c0000000000000000000000000000000000001',
++        decimals: 6,
++        periodCount: '5',
++        periodUnit,
++        recipient: '0x1234567890abcdef1234567890abcdef12345678',
++        subscriptionExpires: '2026-01-01T00:00:00Z',
++      })
++
++      expect(request.periodUnit).toBe(periodUnit)
++    },
++  )
++
+   test('schema: rejects non-numeric periodCount', () => {
+     const result = Methods.subscription.schema.request.safeParse({
+       amount: '10',
+diff --git a/src/tempo/Methods.ts b/src/tempo/Methods.ts
+index d6d776feeaeb9a49bd31c244c4814a721b2115e1..7f7447ceb0f8ed665e0d7e82ce3cd20c6cf21a0d 100644
+--- a/src/tempo/Methods.ts
++++ b/src/tempo/Methods.ts
+@@ -19,8 +19,11 @@ const split = z.object({
+ })
+ 
+ const uint64Max = (1n << 64n) - 1n
+-const secondsPerDay = 86_400n
+-const secondsPerWeek = 604_800n
++const subscriptionPeriodUnitSeconds = {
++  dev_second: 1n,
++  day: 86_400n,
++  week: 604_800n,
++} satisfies Record<SubscriptionPeriodUnit, bigint>
+ 
+ const normalizedAddress = z.pipe(
+   z.address(),
+@@ -46,7 +49,11 @@ const subscriptionExpires = z
+     ),
+   )
+ 
+-const subscriptionPeriodUnits = ['day', 'week'] as const satisfies readonly SubscriptionPeriodUnit[]
++const subscriptionPeriodUnits = [
++  'dev_second',
++  'day',
++  'week',
++] as const satisfies readonly SubscriptionPeriodUnit[]
+ const subscriptionPeriodUnit = z.enum(subscriptionPeriodUnits)
+ 
+ const uint64String = z
+@@ -82,7 +89,8 @@ function subscriptionPeriodFitsUint64(value: unknown) {
+     periodUnit: SubscriptionPeriodUnit
+   }
+   try {
+-    const unitSeconds = periodUnit === 'day' ? secondsPerDay : secondsPerWeek
++    const unitSeconds = subscriptionPeriodUnitSeconds[periodUnit]
++    if (unitSeconds === undefined) return false
+     return BigInt(periodCount) * unitSeconds <= uint64Max
+   } catch {
+     return false
+diff --git a/src/tempo/client/Subscription.test.ts b/src/tempo/client/Subscription.test.ts
+index ebc5ec4b1f4915a777a50f5e2f5b6ef1e0f65855..64da3a370f3d5b155d04916cf3e3df99ad348ed5 100644
+--- a/src/tempo/client/Subscription.test.ts
++++ b/src/tempo/client/Subscription.test.ts
+@@ -4,7 +4,10 @@ import { privateKeyToAccount } from 'viem/accounts'
+ import { describe, expect, test } from 'vp/test'
+ 
+ import * as Methods from '../Methods.js'
+-import { signSubscriptionKeyAuthorization } from '../subscription/KeyAuthorization.js'
++import {
++  signSubscriptionKeyAuthorization,
++  transferWithMemoSignature,
++} from '../subscription/KeyAuthorization.js'
+ import type { SubscriptionAccessKey } from '../subscription/Types.js'
+ import { subscription } from './Subscription.js'
+ 
+@@ -104,7 +107,7 @@ describe('tempo.subscription client', () => {
+     )
+   })
+ 
+-  test('passes hex-encoded `scopes` and `limits` to wallet_authorizeAccessKey', async () => {
++  test('passes human-readable `scopes` and hex-encoded `limits` to wallet_authorizeAccessKey', async () => {
+     const challenge = createChallenge()
+     const keyAuthorization = await signSubscriptionKeyAuthorization({
+       accessKey,
+@@ -142,12 +145,7 @@ describe('tempo.subscription client', () => {
+       scopes: [
+         {
+           address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+-          selector: expect.stringMatching(/^0x/),
+-          recipients: expect.any(Array),
+-        },
+-        {
+-          address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+-          selector: expect.stringMatching(/^0x/),
++          selector: transferWithMemoSignature,
+           recipients: expect.any(Array),
+         },
+       ],
+diff --git a/src/tempo/server/Subscription.ts b/src/tempo/server/Subscription.ts
+index 8fef81172db0c2cbb4f49b5de423c945e32625d1..7acf5d9519374735eb134703a7458ac48d4fc570 100644
+--- a/src/tempo/server/Subscription.ts
++++ b/src/tempo/server/Subscription.ts
+@@ -35,12 +35,43 @@ import type {
+   SubscriptionAccessKey,
+   SubscriptionCredentialPayload,
+   SubscriptionLookup,
+-  SubscriptionPeriodUnit,
+   SubscriptionRecord,
+   SubscriptionReceipt as SubscriptionReceiptValue,
+ } from '../subscription/Types.js'
+ 
+ type SubscriptionRequest = ReturnType<typeof Methods.subscription.schema.request.parse>
++type SubscriptionContextParameters = {
++  hooks?:
++    | {
++        renewed?:
++          | ((parameters: {
++              periodIndex: number
++              receipt: SubscriptionReceiptValue
++              subscription: SubscriptionRecord
++            }) => MaybePromise<void>)
++          | undefined
++      }
++    | undefined
++  renew?:
++    | ((parameters: {
++        inFlightReference: string
++        periodIndex: number
++        subscription: SubscriptionRecord
++      }) => Promise<subscription.RenewalResult>)
++    | undefined
++}
++type SubscriptionContext = {
++  feePayer?: ReturnType<typeof Account.resolve>['feePayer'] | undefined
++  feePayerPolicy?: Partial<FeePayer.Policy> | undefined
++  getClient: (parameters: { chainId?: number | undefined }) => MaybePromise<ViemClient>
++  parameters: SubscriptionContextParameters
++  store: SubscriptionStore.SubscriptionStore
++  waitForConfirmation: boolean
++}
++const subscriptionContexts = new WeakMap<
++  Store.AtomicStore<Record<string, unknown>>,
++  SubscriptionContext
++>()
+ 
+ /**
+  * Creates a Tempo subscription method for recurring TIP-20 token payments.
+@@ -80,9 +111,17 @@ export function subscription<const parameters extends subscription.Parameters>(
+     getClient: parameters.getClient,
+     rpcUrl: defaults.rpcUrl,
+   })
++  subscriptionContexts.set(rawStore, {
++    feePayer,
++    feePayerPolicy: parameters.feePayerPolicy,
++    getClient,
++    parameters,
++    store,
++    waitForConfirmation,
++  })
+ 
+   type Defaults = subscription.DeriveDefaults<parameters>
+-  return Method.toServer<typeof Methods.subscription, Defaults>(Methods.subscription, {
++  const method = Method.toServer<typeof Methods.subscription, Defaults>(Methods.subscription, {
+     defaults: {
+       amount,
+       currency,
+@@ -290,6 +329,7 @@ export function subscription<const parameters extends subscription.Parameters>(
+       return activation.result.receipt
+     },
+   })
++  return method
+ }
+ 
+ function requestFromCaptured(capturedRequest: Method.CapturedRequest | undefined): Request {
+@@ -896,30 +936,52 @@ function createSubscriptionId() {
+  */
+ export async function renew(parameters: renew.Parameters): Promise<renew.Result | null> {
+   const { store: rawStore, waitForConfirmation = true } = parameters
+-  const store = SubscriptionStore.fromStore(rawStore, {
+-    renewalTimeoutMs: parameters.renewalTimeoutMs,
+-  })
+-  const getClient = ClientResolver.getResolver({
+-    chain: tempo_chain,
+-    getClient: parameters.getClient,
+-    rpcUrl: defaults.rpcUrl,
+-  })
++  const configured = subscriptionContexts.get(rawStore)
++  let context: SubscriptionContext
++
++  if (configured && !parameters.account && !parameters.feePayer && !parameters.getClient && !parameters.renew) {
++    context = {
++      ...configured,
++      feePayerPolicy: parameters.feePayerPolicy ?? configured.feePayerPolicy,
++      waitForConfirmation: parameters.waitForConfirmation ?? configured.waitForConfirmation,
++    }
++  } else {
++    const { feePayer } = Account.resolve(parameters)
++    const store = SubscriptionStore.fromStore(rawStore, {
++      renewalTimeoutMs: parameters.renewalTimeoutMs,
++    })
++    const getClient = ClientResolver.getResolver({
++      chain: tempo_chain,
++      getClient: parameters.getClient,
++      rpcUrl: defaults.rpcUrl,
++    })
++    context = {
++      feePayer,
++      feePayerPolicy: parameters.feePayerPolicy,
++      getClient,
++      parameters,
++      store,
++      waitForConfirmation,
++    }
++  }
+ 
+-  const record = await store.get(parameters.subscriptionId)
++  const record = await context.store.get(parameters.subscriptionId)
+   if (!record) return null
+   if (!isActive(record)) return null
+-  const active = await store.getByKey(record.lookupKey)
++  const active = await context.store.getByKey(record.lookupKey)
+   if (active?.subscriptionId !== record.subscriptionId) return null
+ 
+   const periodIndex = getPeriodIndex(record)
+   if (periodIndex <= record.lastChargedPeriod) return null
+ 
+   const renew = resolveRenewalHandler({
+-    getClient,
+-    parameters,
+-    store,
++    feePayer: context.feePayer,
++    feePayerPolicy: context.feePayerPolicy,
++    getClient: context.getClient,
++    parameters: context.parameters,
++    store: context.store,
+     subscription: record,
+-    waitForConfirmation,
++    waitForConfirmation: context.waitForConfirmation,
+   })
+   if (!renew) return null
+ 
+@@ -927,15 +989,22 @@ export async function renew(parameters: renew.Parameters): Promise<renew.Result
+     expectedLookupKey: record.lookupKey,
+     periodIndex,
+     renew,
+-    store,
++    store: context.store,
+     subscription: record,
+   })
+-  return renewal?.status === 'renewed' ? renewal.result : null
++  if (renewal?.status !== 'renewed') return null
++
++  await context.parameters.hooks?.renewed?.({
++    periodIndex,
++    receipt: renewal.result.receipt,
++    subscription: renewal.result.subscription,
++  })
++  return renewal.result
+ }
+ 
+ export declare namespace renew {
+   /** Parameters for renewing an overdue subscription outside the request path. */
+-  type Parameters = {
++  type Parameters = Account.resolve.Parameters & {
+     /** The subscription to renew. */
+     subscriptionId: string
+     /** Billing callback — same signature as the `renew` hook on {@link subscription}. */
+@@ -947,6 +1016,17 @@ export declare namespace renew {
+           subscription: SubscriptionRecord
+         }) => Promise<subscription.RenewalResult>)
+       | undefined
++    hooks?:
++      | {
++          renewed?:
++            | ((parameters: {
++                periodIndex: number
++                receipt: SubscriptionReceiptValue
++                subscription: SubscriptionRecord
++              }) => MaybePromise<void>)
++            | undefined
++        }
++      | undefined
+     /** Store containing subscription records. */
+     store: Store.AtomicStore<Record<string, unknown>>
+     /**
+@@ -954,6 +1034,11 @@ export declare namespace renew {
+      * Keeps concurrent renewal safe while allowing recovery from abandoned attempts.
+      */
+     renewalTimeoutMs?: number | undefined
++    /**
++     * Override the fee-payer policy for sponsored subscription payments.
++     * Useful when the access key renewal tx requires more gas than the default policy allows.
++     */
++    feePayerPolicy?: Partial<FeePayer.Policy> | undefined
+     waitForConfirmation?: boolean | undefined
+   } & Client.getResolver.Parameters
+ 
+diff --git a/src/tempo/subscription/KeyAuthorization.test.ts b/src/tempo/subscription/KeyAuthorization.test.ts
+index 91efb4ab5ba5851967ffac4aaef739ef81c4e416..312c05bb4b769addc54092b86e5ddd515ce95aff 100644
+--- a/src/tempo/subscription/KeyAuthorization.test.ts
++++ b/src/tempo/subscription/KeyAuthorization.test.ts
+@@ -11,6 +11,8 @@ import {
+   toSubscriptionExpiryDate,
+   toSubscriptionExpirySeconds,
+   toSubscriptionPeriodSeconds,
++  transferSelector,
++  transferWithMemoSignature,
+   verifySubscriptionKeyAuthorization,
+ } from './KeyAuthorization.js'
+ import type { SubscriptionAccessKey } from './Types.js'
+@@ -89,13 +91,12 @@ describe('tempo subscription key authorization', () => {
+     const request = parseRequest()
+ 
+     expect(getSubscriptionScopes(request)).toMatchObject([
+-      { address: currency, recipients: [recipient] },
+-      { address: currency, recipients: [recipient] },
++      { address: currency, recipients: [recipient], selector: transferWithMemoSignature },
+     ])
+     expect(getSubscriptionRpcAllowedCalls(request)).toMatchObject([
+       {
+         target: currency,
+-        selectorRules: [{ recipients: [recipient] }, { recipients: [recipient] }],
++        selectorRules: [{ recipients: [recipient], selector: transferWithMemoSignature }],
+       },
+     ])
+   })
+@@ -158,7 +159,10 @@ describe('tempo subscription key authorization', () => {
+     const authorization = KeyAuthorization.deserialize(payload.signature)
+     const transferOnly = KeyAuthorization.serialize({
+       ...authorization,
+-      scopes: authorization.scopes?.slice(0, 1),
++      scopes: authorization.scopes?.map((scope) => ({
++        ...scope,
++        selector: transferSelector,
++      })),
+     })
+ 
+     expect(() =>
+@@ -183,6 +187,11 @@ describe('tempo subscription key authorization', () => {
+     ).toThrow('subscription period cannot be represented exactly by this Tempo client')
+   })
+ 
++  test('accepts dev-prefixed subscription periods for development and tests', () => {
++    expect(toSubscriptionPeriodSeconds({ periodCount: '15', periodUnit: 'dev_second' })).toBe(15)
++    expect(toSubscriptionPeriodSeconds({ periodCount: '120', periodUnit: 'dev_second' })).toBe(120)
++  })
++
+   test('rejects subscription expiries that cannot be represented by Tempo key authorizations', () => {
+     expect(() =>
+       toSubscriptionExpirySeconds(toSubscriptionExpiryDate('2026-01-01T00:00:00.500Z')),
+diff --git a/src/tempo/subscription/KeyAuthorization.ts b/src/tempo/subscription/KeyAuthorization.ts
+index 44f4cf76c5a0b5562e9756f5ef16a6b1f6483dc4..631dd18fd1264206ef610c5f687dd6fcb329abba 100644
+--- a/src/tempo/subscription/KeyAuthorization.ts
++++ b/src/tempo/subscription/KeyAuthorization.ts
+@@ -1,5 +1,5 @@
+ import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+-import { isAddress, isAddressEqual, type Address } from 'viem'
++import { isAddress, isAddressEqual, toFunctionSelector, type Address } from 'viem'
+ 
+ import { VerificationFailedError } from '../../Errors.js'
+ import type * as Methods from '../Methods.js'
+@@ -12,12 +12,18 @@ import type {
+ /** 4-byte selector for TIP-20 `transfer(address,uint256)`. */
+ export const transferSelector = '0xa9059cbb'
+ 
+-/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes)`. */
++/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
+ export const transferWithMemoSelector = '0x95777d59'
+ 
++/** Human-readable selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
++export const transferWithMemoSignature = 'transferWithMemo(address,uint256,bytes32)'
++
+ const uint64Max = (1n << 64n) - 1n
+-const secondsPerDay = 86_400n
+-const secondsPerWeek = 604_800n
++const subscriptionPeriodUnitSeconds = {
++  dev_second: 1n,
++  day: 86_400n,
++  week: 604_800n,
++} satisfies Record<SubscriptionPeriodUnit, bigint>
+ 
+ type SubscriptionRequest = ReturnType<typeof Methods.subscription.schema.request.parse>
+ type Authorization = KeyAuthorization.KeyAuthorization
+@@ -63,11 +69,11 @@ export function toSubscriptionPeriodSeconds(request: {
+   if (!/^[1-9]\d*$/.test(request.periodCount)) {
+     throw new VerificationFailedError({ reason: 'periodCount is invalid' })
+   }
+-  if (request.periodUnit !== 'day' && request.periodUnit !== 'week') {
++  const unitSeconds = subscriptionPeriodUnitSeconds[request.periodUnit]
++  if (unitSeconds === undefined) {
+     throw new VerificationFailedError({ reason: 'periodUnit is invalid' })
+   }
+ 
+-  const unitSeconds = request.periodUnit === 'day' ? secondsPerDay : secondsPerWeek
+   const value = BigInt(request.periodCount) * unitSeconds
+   if (value > uint64Max) {
+     throw new VerificationFailedError({
+@@ -115,12 +121,7 @@ export function getSubscriptionScopes(
+   return [
+     {
+       address: currency,
+-      selector: transferSelector,
+-      recipients: [recipient],
+-    },
+-    {
+-      address: currency,
+-      selector: transferWithMemoSelector,
++      selector: transferWithMemoSignature,
+       recipients: [recipient],
+     },
+   ] as const
+@@ -130,15 +131,11 @@ export function getSubscriptionScopes(
+ export function getSubscriptionRpcAllowedCalls(
+   request: Pick<SubscriptionRequest, 'currency' | 'recipient'>,
+ ) {
+-  const [transfer, transferWithMemo] = getSubscriptionScopes(request)
++  const [transferWithMemo] = getSubscriptionScopes(request)
+   return [
+     {
+       target: normalizeAddress(request.currency, 'currency'),
+       selectorRules: [
+-        {
+-          selector: transfer.selector,
+-          recipients: transfer.recipients,
+-        },
+         {
+           selector: transferWithMemo.selector,
+           recipients: transferWithMemo.recipients,
+@@ -353,9 +350,6 @@ function assertAuthorizationScopes(
+     }
+   }
+ 
+-  if (!seen.has(transferSelector)) {
+-    throw new VerificationFailedError({ reason: 'keyAuthorization must allow transfer' })
+-  }
+   if (!seen.has(transferWithMemoSelector)) {
+     throw new VerificationFailedError({ reason: 'keyAuthorization must allow transferWithMemo' })
+   }
+@@ -390,5 +384,10 @@ function normalizeAddress(value: string, name: string): Address {
+ 
+ function normalizeSelector(value: unknown): string {
+   if (typeof value !== 'string') return ''
+-  return value.toLowerCase()
++  if (value.startsWith('0x')) return value.toLowerCase()
++  try {
++    return toFunctionSelector(value).toLowerCase()
++  } catch {
++    return ''
++  }
+ }
+diff --git a/src/tempo/subscription/Types.ts b/src/tempo/subscription/Types.ts
+index acaf2e0f648ac60043d7056f506b0df0f7b79be8..fe4e4315f80179af838753b16bd35de35b7023a5 100644
+--- a/src/tempo/subscription/Types.ts
++++ b/src/tempo/subscription/Types.ts
+@@ -1,7 +1,7 @@
+ import type { Address } from 'viem'
+ 
+-/** Tempo-supported subscription period units. The shared intent also defines `month`, but Tempo cannot represent calendar-month periods exactly. */
+-export type SubscriptionPeriodUnit = 'day' | 'week'
++/** Tempo-supported subscription period units. Use `day` or `week` in production; `dev_*` units are for development and tests. */
++export type SubscriptionPeriodUnit = 'dev_second' | 'day' | 'week'
+ 
+ /** Access key information used to authorize recurring Tempo payments. */
+ export type SubscriptionAccessKey = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ overrides:
   wrangler: ^4.90.1
 
 patchedDependencies:
+  mppx@0.6.23: bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f
   vocs@0.0.0: 0749dd43af96e1423a849f589c6b765ac71042c00b84c5d521e0af05bf159b6e
 
 importers:
@@ -94,7 +95,7 @@ importers:
         version: 0.0.7(typescript@5.9.3)
       mppx:
         specifier: 'catalog:'
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.3.6))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.3.6))
       ox:
         specifier: ~0.14.18
         version: 0.14.20(typescript@5.9.3)(zod@4.3.6)
@@ -516,7 +517,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.23
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -568,7 +569,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.23
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -620,7 +621,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.23
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -773,7 +774,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -822,7 +823,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -978,7 +979,7 @@ importers:
         version: 11.15.0
       mppx:
         specifier: 'catalog:'
-        version: 0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3))
       ox:
         specifier: ~0.14.18
         version: 0.14.20(typescript@5.9.3)(zod@4.4.3)
@@ -17207,7 +17208,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.3.6)):
+  mppx@0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       incur: 0.4.5
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
@@ -17221,7 +17222,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.6.23(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3)):
+  mppx@0.6.23(patch_hash=bb3bcf73df04aef2ff59994eefe152d50723b3ec1f99e21c84c82707fcf1002f)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.49.2(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.5
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,4 +114,5 @@ trustPolicyExclude:
   - undici-types@6.19.8
 
 patchedDependencies:
+  mppx@0.6.23: patches/mppx@0.6.23.patch
   vocs@0.0.0: patches/vocs@0.0.0.patch

--- a/site/src/components/ServerSubscription.tsx
+++ b/site/src/components/ServerSubscription.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from 'regen-ui'
+import { useConnection } from 'wagmi'
+import LucideCircleCheck from '~icons/lucide/circle-check'
+
+import * as Steps from './Steps.js'
+
+/**
+ * Composite step that owns the recurring articles subscription flow.
+ */
+export function ServerSubscription() {
+  const steps = Steps.useStep()
+  const { address } = useConnection()
+  const [data, setData] = useState<{ articles?: { id: number; title: string }[] } | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [isPending, setPending] = useState(false)
+
+  return (
+    <Steps.Step
+      value={steps.value}
+      label="Subscribe to the articles endpoint."
+      action={
+        <Button
+          variant={steps.active ? 'primary' : 'secondary'}
+          disabled={!steps.active || !address}
+          loading={isPending}
+          onClick={async () => {
+            setPending(true)
+            setError(null)
+            setData(null)
+            try {
+              const res = await fetch('/api/articles', {
+                headers: { 'X-Subscriber': address! },
+              })
+              const body = await res.json()
+              if (!res.ok)
+                throw new Error(`${res.status}: ${JSON.stringify(body)}`)
+              setData(body)
+            } catch (e) {
+              setError(e as Error)
+            } finally {
+              setPending(false)
+            }
+          }}
+        >
+          GET /api/articles
+        </Button>
+      }
+    >
+      {data ? (
+        <div className="text-[14px] flex flex-col gap-1">
+          <div className="inline-flex items-center gap-x-1.5">
+            <LucideCircleCheck aria-hidden className="size-4 text-success shrink-0" />
+            <span className="text-success font-medium">Subscribed.</span>
+            <span className="text-secondary">Articles unlocked.</span>
+          </div>
+          {data.articles ? (
+            <ul className="text-secondary list-disc pl-5">
+              {data.articles.map((article) => (
+                <li key={article.id}>{article.title}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+      {error ? (
+        <pre className="text-[12px] text-danger whitespace-pre-wrap">
+          {error.name}: {error.message}
+        </pre>
+      ) : null}
+    </Steps.Step>
+  )
+}

--- a/site/src/pages/_api/api/articles.ts
+++ b/site/src/pages/_api/api/articles.ts
@@ -1,0 +1,59 @@
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+const demoPrivateKey =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const
+const account = privateKeyToAccount(
+  (process.env.ACCOUNT_PRIVATE_KEY as `0x${string}` | undefined) ?? demoPrivateKey,
+)
+const store = Store.memory()
+const oneYear = 365 * 24 * 60 * 60 * 1_000
+const subscriptionExpires = new Date(
+  Math.ceil((Date.now() + oneYear) / 1_000) * 1_000,
+).toISOString()
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.subscription({
+      account,
+      currency: pathUsd,
+      feePayer: true,
+      feePayerPolicy: {
+        maxGas: 6_000_000n,
+        maxTotalFee: 1_000_000_000_000_000_000n,
+      },
+      resolve: ({ input }) => {
+        const subscriber = input.headers.get('X-Subscriber')
+        if (!subscriber) return null
+        return { key: `articles:${subscriber.toLowerCase()}` }
+      },
+      store,
+      testnet: true,
+    }),
+  ],
+  realm: 'accounts.tempo.xyz',
+  secretKey: process.env.MPP_SECRET_KEY ?? 'demo',
+})
+
+/** Handles the docs subscription demo endpoint. */
+export async function GET(request: Request) {
+  const result = await mppx.tempo.subscription({
+    amount: '0.01',
+    description: 'Articles subscription demo',
+    periodCount: 1,
+    periodUnit: 'day',
+    subscriptionExpires,
+  })(request)
+
+  if (result.status === 402) return result.challenge
+
+  return result.withReceipt(
+    Response.json({
+      articles: [
+        { id: 1, title: 'Subscriptions are live' },
+        { id: 2, title: 'Recurring access keys keep requests quiet' },
+      ],
+    }),
+  )
+}

--- a/site/src/pages/docs/guides/subscriptions.mdx
+++ b/site/src/pages/docs/guides/subscriptions.mdx
@@ -1,50 +1,278 @@
 ---
 title: Subscriptions
-description: Build recurring payment flows with account permissions.
+description: Charge connected accounts on a recurring schedule with MPP subscriptions.
 ---
+
+import { Cards, Card } from 'vocs'
+import { ConnectAccount } from '../../../components/ConnectAccount'
+import { Demo, DemoReset } from '../../../components/Demo'
+import { ServerSubscription } from '../../../components/ServerSubscription'
+import * as Steps from '../../../components/Steps'
 
 # Subscriptions
 
-Build a recurring payment flow that uses account permissions for repeat charges.
+Build recurring payments with a server-owned subscription endpoint and a connected Tempo account.
+
+Subscriptions use the Machine Payments Protocol (MPP). Your server returns a `402 Payment Required` challenge for a recurring plan, and the Accounts SDK fulfills it from the connected account before retrying the original `fetch`.
+
+The first request activates the subscription and collects the first period. Later requests in the same period use the active subscription. When a new period starts, the server renews before returning the protected resource.
+
+Tempo subscriptions currently support `day` and `week` periods. The smallest period is `1 day`. Use `periodCount: 30` with `periodUnit: 'day'` for a fixed 30-day plan.
 
 ## Demo
 
-Target workspace: `examples/subscriptions/`.
+By the end of this section you'll have an HTTP endpoint that charges a recurring $0.01 pathUSD subscription before returning articles.
 
-:::warning[Stub]
-This guide needs product and protocol decisions before implementation: billing cadence, cancellation UX, spend caps, and how the server proves each charge is authorized.
-:::
+The button below hits a real `/api/articles` endpoint hosted on this docs site. The connected account auto-fulfills the `402 Payment Required` challenge, activates the subscription, and retries the request.
+
+<Demo
+  title="Subscriptions"
+  githubUrl="https://github.com/tempoxyz/accounts/tree/main/examples/subscriptions"
+  headerAction={<DemoReset />}
+  className="flex flex-col gap-3"
+>
+  <Steps.Step
+    label="Create an account, or use an existing one."
+    action={<ConnectAccount />}
+  />
+  <ServerSubscription />
+</Demo>
 
 ## Walkthrough
 
 ::::steps
 
-### Install the SDK
+### Install Dependencies
 
-```bash
-pnpm add accounts wagmi viem
+Install the Accounts SDK, Wagmi, Hono, and `mppx`.
+
+:::code-group
+
+```bash [npm]
+npm i accounts @tanstack/react-query wagmi viem mppx hono
 ```
 
-### Configure the Provider
+```bash [pnpm]
+pnpm i accounts @tanstack/react-query wagmi viem mppx hono
+```
 
-Use Tempo Wallet, WebAuthn, or a custom adapter depending on who owns signing.
+```bash [bun]
+bun i accounts @tanstack/react-query wagmi viem mppx hono
+```
 
-### Connect the user's account
+:::
 
-Connect the subscriber account and display the subscription terms.
+### Configure the Client
 
-### Submit the request
+Use the Tempo connector in Wagmi. The Accounts SDK handles MPP subscription challenges through the connected account.
 
-Request the permission needed for recurring charges.
+```ts twoslash [src/config.ts]
+// @noErrors
+import { createConfig, http } from 'wagmi'
+import { tempo, tempoModerato } from 'wagmi/chains'
+import { tempoWallet } from 'wagmi/tempo'
 
-### Verify the result
+export const config = createConfig({
+  chains: [tempoModerato, tempo],
+  connectors: [tempoWallet()],
+  multiInjectedProviderDiscovery: false,
+  transports: {
+    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
+  },
+})
 
-Run one scheduled charge in the example workspace and show cancellation state.
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+```
+
+### Create the Subscription Endpoint
+
+Create an MPP instance with `tempo.subscription`, then gate the protected route. The method owns activation, renewal, and subscription lookup.
+
+```ts twoslash [worker/index.ts]
+// @noErrors
+import { Hono } from 'hono'
+import { Store } from 'mppx'
+import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+const app = new Hono()
+const oneYear = 365 * 24 * 60 * 60 * 1_000
+const account = privateKeyToAccount(process.env.ACCOUNT_PRIVATE_KEY)
+const store = Store.memory()
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.subscription({
+      account,
+      currency: pathUsd,
+      feePayer: true,
+      feePayerPolicy: {
+        maxGas: 6_000_000n,
+        maxTotalFee: 1_000_000_000_000_000_000n,
+      },
+      resolve: ({ input }) => {
+        const subscriber = input.headers.get('X-Subscriber')
+        if (!subscriber) return null
+        return { key: `articles:${subscriber.toLowerCase()}` }
+      },
+      store,
+      testnet: true,
+    }),
+  ],
+  realm: process.env.MPP_REALM,
+  secretKey: process.env.MPP_SECRET_KEY,
+})
+
+app.get(
+  '/api/articles',
+  mppx.subscription({
+    amount: '0.01',
+    periodCount: 1,
+    periodUnit: 'day',
+    subscriptionExpires: new Date(
+      Math.ceil((Date.now() + oneYear) / 1_000) * 1_000,
+    ).toISOString(),
+  }),
+  (c) =>
+    c.json({
+      articles: [
+        { id: 1, title: 'Subscriptions are live' },
+        { id: 2, title: 'Recurring access keys keep requests quiet' },
+      ],
+    }),
+)
+
+async function renewSubscriptions(subscriptionIds: string[]) {
+  await Promise.all(
+    subscriptionIds.map((subscriptionId) =>
+      tempo.renewSubscription({ store, subscriptionId }),
+    ),
+  )
+}
+
+export default app
+```
+
+The `resolve` callback maps each authenticated request to one subscription record. This example uses `X-Subscriber` for clarity; production apps should derive the key from an authenticated session, JWT, or API key.
+
+`subscriptionExpires` must be representable as whole seconds. Once it passes, the server stops treating the subscription as reusable and issues a fresh challenge.
+
+Call `tempo.renewSubscription` from a cron job or queue worker. It bills only overdue subscriptions and returns `null` when the subscription is already current.
+
+### Call It from React
+
+Call the route with `fetch`. The SDK intercepts the `402`, asks for approval once, submits the subscription credential, and retries the request.
+
+```tsx twoslash [Articles.tsx]
+// @noErrors
+import { useState } from 'react'
+import { useConnection } from 'wagmi'
+
+export function Articles() {
+  const { address } = useConnection()
+  const [data, setData] = useState<unknown>()
+  const [error, setError] = useState<Error | undefined>()
+  const [isPending, setPending] = useState(false)
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={isPending || !address}
+        onClick={async () => {
+          setPending(true)
+          setError(undefined)
+          try {
+            const res = await fetch('/api/articles', {
+              headers: { 'X-Subscriber': address! },
+            })
+            const body = await res.json()
+            if (!res.ok) throw new Error(`${res.status}: ${JSON.stringify(body)}`)
+            setData(body)
+          } catch (e) {
+            setError(e as Error)
+          } finally {
+            setPending(false)
+          }
+        }}
+      >
+        {isPending ? 'Loading...' : 'GET /api/articles'}
+      </button>
+      {error && <pre>{error.message}</pre>}
+      {data !== undefined && <pre>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  )
+}
+```
 
 ::::
 
+## Best Practices
+
+### Authenticate the Lookup Key
+
+Do not trust a client-supplied subscriber header in production. Derive the subscription key from a session cookie, JWT, API key, or another server-verified identity.
+
+### Use Durable Storage
+
+`Store.memory()` is only for examples. Use Cloudflare KV, Durable Objects, Postgres, or another atomic store so subscriptions survive restarts and concurrent renewal attempts stay safe.
+
+### Keep Plan Terms Stable
+
+Treat `amount`, `currency`, `recipient`, `periodUnit`, `periodCount`, and `subscriptionExpires` as the subscription contract. If any of them changes, issue a new challenge and activate a new subscription.
+
+### Handle Cancellation
+
+Give users a clear way to cancel. Record the cancellation effective time, stop renewals after the paid period ends, and return a fresh `402` for requests after cancellation.
+
+### Monitor Renewals
+
+Log activation and renewal receipts with the subscription ID and period index. Alert on failed renewals, insufficient balances, stale in-flight renewals, and expired authorizations.
+
+## Production Checklist
+
+- [ ] Replace `X-Subscriber` with a server-authenticated identity.
+- [ ] Use a durable atomic `Store`.
+- [ ] Store `ACCOUNT_PRIVATE_KEY` in a secret manager.
+- [ ] Generate a strong `MPP_SECRET_KEY`.
+- [ ] Show amount, currency, period, recipient, and expiry before activation.
+- [ ] Use production chain, currency, and recipient values.
+- [ ] Persist subscription ID, lookup key, billing anchor, and period index.
+- [ ] Add cancellation and revocation handling.
+- [ ] Test concurrent requests against the same subscription.
+- [ ] Test expired subscriptions, failed renewals, and insufficient balances.
+
 ## Next Steps
 
-- [Spend Permissions](/docs/guides/spend-permissions)
-- [Transfers](/docs/guides/transfers)
-- [Bring Your Auth](/docs/enterprise/bring-your-auth)
+<Cards>
+  <Card
+    description="Send stablecoin transfers from a connected account, initiated by the user or by your server."
+    to="/docs/guides/transfers"
+    icon="lucide:send"
+    title="Transfers"
+  />
+  <Card
+    description="Authorize spend limits, scopes, and durations for repeat account activity."
+    to="/docs/guides/spend-permissions"
+    icon="lucide:shield"
+    title="Spend Permissions"
+  />
+  <Card
+    description="Sponsor transaction fees for users so subscriptions feel seamless."
+    to="/docs/guides/fee-sponsorship"
+    icon="lucide:badge-dollar-sign"
+    title="Fee Sponsorship"
+  />
+  <Card
+    description="Let agents and other servers pay your endpoints with the Machine Payments Protocol."
+    to="/docs/guides/machine-payments"
+    icon="lucide:bot"
+    title="Machine Payments (MPP)"
+  />
+</Cards>


### PR DESCRIPTION
Adds a concise Subscriptions guide with an inline docs demo, best practices, and a production checklist. The subscriptions example now covers short dev periods, scheduled renewal, fee-payer-backed `tempo.renewSubscription`, and a local renewal tester.

Includes a temporary `mppx@0.6.23` patch for `dev_second`, single `transferWithMemo` scopes, human-readable selector normalization, and subscription context reuse for background renewal.

Validated with `pnpm --filter subscriptions build` and `pnpm --filter site build`. Lint and format ran during commit; lint reported existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`.