### PR TITLE
feat(playground): expand MPP coverage

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import { Hex, Json } from 'ox'
 import {
   type ComponentProps,
@@ -8,7 +9,7 @@ import {
   useState,
 } from 'react'
 import { Button as RegenButton } from 'regen-ui'
-import { parseUnits } from 'viem'
+import { formatUnits, parseUnits } from 'viem'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
@@ -17,13 +18,16 @@ import { Actions } from 'viem/tempo'
 import {
   type AdapterType,
   type DialogMode,
+  type MppMode,
   dialogMode,
   provider,
   switchAdapter,
   switchDialogMode,
+  switchMppMode,
   switchTheme,
   theme,
   env,
+  mppMode,
   testnet,
   tokens,
 } from './provider.js'
@@ -134,8 +138,7 @@ export function App() {
           </PlaygroundSection>
 
           <PlaygroundSection id="mpp" title="MPP">
-            <Fortune />
-            <MppZeroDollarAuth />
+            <MppPlayground adapterType={adapterType} rerender={() => rerender((n) => n + 1)} />
           </PlaygroundSection>
 
           <PlaygroundSection id="auth" title="Server Authentication">
@@ -1967,26 +1970,765 @@ function WalletRevokeAccessKey() {
   )
 }
 
-function Fortune() {
-  const [result, error, execute] = useRequest()
+type MppScenarioResult = {
+  balanceAfter?: unknown
+  balanceBefore?: unknown
+  body: unknown
+  elapsedMs: number
+  events?: readonly MppSseEvent[] | undefined
+  headers: Record<string, string | null>
+  inspection?: unknown
+  label: string
+  ok: boolean
+  receipt?: unknown
+  status: number
+  url: string
+}
+
+type MppRun = (
+  label: string,
+  path: string,
+  init?: RequestInit | undefined,
+) => Promise<MppScenarioResult>
+type MppSseEvent = { data: unknown; event: string }
+type MppSessionState = {
+  acceptedCumulative?: string | undefined
+  channelId?: string | undefined
+  lastAction?: string | undefined
+  remaining?: string | undefined
+  spent?: string | undefined
+  status: 'active' | 'closed' | 'idle' | 'open'
+}
+type MppSubscriptionState = {
+  billingAnchor?: string | undefined
+  canceledAt?: string | undefined
+  lastChargedPeriod?: string | number | undefined
+  reference?: string | undefined
+  status: 'active' | 'canceled' | 'missing' | 'renewal due'
+  subscriptionId?: string | undefined
+}
+
+function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }) {
+  const { adapterType, rerender } = props
+  const [mode, setMode] = useState<MppMode>(mppMode)
+
+  async function applyMode(next: MppMode) {
+    if (next === mode) return
+    switchMppMode(next, adapterType)
+    setMode(next)
+    rerender()
+    await provider.request({ method: 'eth_accounts' }).catch(() => undefined)
+  }
+
+  const runRaw: MppRun = (label, path, init) =>
+    (async () => {
+      Mppx.restore()
+      try {
+        return await runMppRequest(label, path, init)
+      } finally {
+        switchMppMode(mode, adapterType)
+        rerender()
+        await provider.request({ method: 'eth_accounts' }).catch(() => undefined)
+      }
+    })()
+
   return (
-    <Method method="fetch /fortune" result={result} error={error}>
-      <Button onClick={() => execute(() => fetch('/fortune').then((r) => r.json()))}>
-        Get Fortune (0.01 pathUSD)
-      </Button>
-    </Method>
+    <>
+      <MppOneTimeCharges applyMode={applyMode} mode={mode} />
+      <MppSessions adapterType={adapterType} mode={mode} />
+      <MppSubscriptions />
+      <MppFailureLab applyMode={applyMode} runRaw={runRaw} />
+    </>
   )
 }
 
-function MppZeroDollarAuth() {
-  const [result, error, execute] = useRequest()
+function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void>; mode: MppMode }) {
+  const { applyMode, mode } = props
+  const request = useMppRequest()
+
+  async function run(label: string, path: string) {
+    await request.execute(label, () => runMppRequest(label, path))
+  }
+
+  async function runPaid(next: MppMode) {
+    await applyMode(next)
+    await run(`Paid ${next}`, '/mpp/charge/paid')
+  }
+
   return (
-    <Method method="fetch /zero-dollar-auth" result={result} error={error}>
-      <Button onClick={() => execute(() => fetch('/zero-dollar-auth').then((r) => r.json()))}>
-        Zero-Dollar Auth
+    <MppPanel
+      title="One-Time Charges"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <MppStateTable
+        rows={[
+          ['Provider mode', mode],
+          ['Paid challenge', 'server accepts push or pull'],
+        ]}
+      />
+      <div>
+        <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
+          <legend>Provider Mode</legend>
+          {(['push', 'pull'] as const).map((value) => (
+            <label key={value} style={{ marginRight: 12 }}>
+              <input
+                type="radio"
+                name="mppChargeMode"
+                checked={mode === value}
+                onChange={() => void applyMode(value)}
+              />{' '}
+              {value}
+            </label>
+          ))}
+        </fieldset>
+      </div>
+      <Button disabled={request.pending} onClick={() => run('Free proof', '/mpp/charge/free')}>
+        Free Proof
       </Button>
-    </Method>
+      <Button disabled={request.pending} onClick={() => runPaid('push')}>
+        Paid Push
+      </Button>
+      <Button disabled={request.pending} onClick={() => runPaid('pull')}>
+        Paid Pull
+      </Button>
+    </MppPanel>
   )
+}
+
+function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
+  const { adapterType, mode } = props
+  const request = useMppRequest()
+  const [manager, setManager] = useState(() => createMppSessionManager())
+  const [session, setSession] = useState<MppSessionState>({ status: 'idle' })
+
+  useEffect(() => {
+    setManager(createMppSessionManager())
+    setSession({ status: 'idle' })
+  }, [adapterType, mode])
+
+  async function run(label: string, fn: () => Promise<MppScenarioResult>, action?: string) {
+    const result = await request.execute(label, fn)
+    if (result) setSession(readMppSessionState(result, action))
+  }
+
+  async function reset() {
+    setManager(createMppSessionManager())
+    setSession({ status: 'idle' })
+    await request.execute('Reset local session', () => runMppLocalResult('Reset local session'))
+  }
+
+  return (
+    <MppPanel
+      title="Sessions"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <MppStateTable
+        rows={[
+          ['State', session.status],
+          ['Channel', session.channelId ?? 'none'],
+          ['Last action', session.lastAction ?? 'none'],
+          ['Authorized', formatMppAmount(session.acceptedCumulative)],
+          ['Spent', formatMppAmount(session.spent)],
+          ['Unspent authorization', formatMppAmount(session.remaining)],
+        ]}
+      />
+      <Button
+        disabled={request.pending || session.status === 'closed'}
+        onClick={() =>
+          run(
+            'Start session',
+            () =>
+              runMppManagedRequest('Start session', '/mpp/session/content', () =>
+                manager.fetch('/mpp/session/content'),
+              ),
+            'open',
+          )
+        }
+      >
+        Start Session
+      </Button>
+      <Button
+        disabled={request.pending || session.status === 'idle' || session.status === 'closed'}
+        onClick={() =>
+          run(
+            'Pay another',
+            () =>
+              runMppManagedRequest('Pay another', '/mpp/session/content', () =>
+                manager.fetch('/mpp/session/content'),
+              ),
+            'voucher',
+          )
+        }
+      >
+        Pay Another
+      </Button>
+      <Button
+        disabled={request.pending || session.status === 'closed'}
+        onClick={() =>
+          run('Stream chunks', () => runMppManagedSse('Stream chunks', manager), 'voucher')
+        }
+      >
+        Stream Chunks
+      </Button>
+      <Button
+        disabled={request.pending || session.status === 'idle' || session.status === 'closed'}
+        onClick={() =>
+          run('Close session', () => runMppSessionClose('Close session', manager), 'close')
+        }
+      >
+        Close Session
+      </Button>
+      <Button disabled={request.pending} onClick={reset}>
+        Reset Local Session
+      </Button>
+    </MppPanel>
+  )
+}
+
+function MppSubscriptions() {
+  const request = useMppRequest()
+  const [subscription, setSubscription] = useState<MppSubscriptionState>({ status: 'missing' })
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  async function refresh() {
+    const state = await getSubscriptionState()
+    setSubscription(readMppSubscriptionState(state))
+    return state
+  }
+
+  async function run(label: string, path: string) {
+    await request.execute(label, async () => {
+      const result = await runMppRequest(label, path)
+      const state = await refresh()
+      return {
+        ...result,
+        body: {
+          response: result.body,
+          state,
+        },
+      }
+    })
+  }
+
+  return (
+    <MppPanel
+      title="Subscriptions"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <MppStateTable
+        rows={[
+          ['State', subscription.status],
+          ['Subscription', subscription.subscriptionId ?? 'none'],
+          ['Last charged period', subscription.lastChargedPeriod ?? 'none'],
+          ['Billing anchor', subscription.billingAnchor ?? 'none'],
+          ['Reference', subscription.reference ?? 'none'],
+          ['Canceled at', subscription.canceledAt ?? 'none'],
+        ]}
+      />
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Activate subscription', '/mpp/subscription/news')}
+      >
+        Activate
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Access again', '/mpp/subscription/news')}
+      >
+        Access Again
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Make renewal due', '/mpp/subscription/force-renewal')}
+      >
+        Make Renewal Due
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Renew subscription', '/mpp/subscription/news')}
+      >
+        Renew
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Cancel subscription', '/mpp/subscription/cancel')}
+      >
+        Cancel
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Reactivate subscription', '/mpp/subscription/news')}
+      >
+        Reactivate
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Refresh state', '/mpp/subscription/state')}
+      >
+        Refresh State
+      </Button>
+    </MppPanel>
+  )
+}
+
+function MppFailureLab(props: { applyMode: (mode: MppMode) => Promise<void>; runRaw: MppRun }) {
+  const { applyMode, runRaw } = props
+  const request = useMppRequest()
+
+  async function run(label: string, path: string) {
+    await request.execute(label, () => runMppRequest(label, path))
+  }
+
+  return (
+    <MppPanel
+      title="Failure Lab"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <MppStateTable
+        rows={[
+          ['Insufficient balance', 'account cannot satisfy the charge'],
+          ['Expired challenge', 'client receives an already expired challenge'],
+          ['Unsupported mode', 'provider is push, server requires pull'],
+          ['Raw 402', 'payment-aware fetch is intentionally disabled'],
+        ]}
+      />
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Insufficient balance', '/mpp/failure/insufficient-balance')}
+      >
+        Insufficient Balance
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('Expired challenge', '/mpp/failure/expired')}
+      >
+        Expired Challenge
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={async () => {
+          await applyMode('push')
+          await run('Unsupported mode', '/mpp/failure/unsupported-mode')
+        }}
+      >
+        Unsupported Mode
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => request.execute('Raw 402', () => runRaw('Raw 402', '/mpp/failure/raw-402'))}
+      >
+        Raw 402
+      </Button>
+    </MppPanel>
+  )
+}
+
+function useMppRequest() {
+  const [result, setResult] = useState<MppScenarioResult>()
+  const [error, setError] = useState<Error>()
+  const [pending, setPending] = useState(false)
+
+  async function execute(label: string, fn: () => Promise<MppScenarioResult>) {
+    setPending(true)
+    setError(undefined)
+    try {
+      const next = await fn()
+      setResult(next)
+      return next
+    } catch (e) {
+      setResult(undefined)
+      setError(e instanceof Error ? e : new Error(`${label}: ${String(e)}`))
+      return undefined
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return { error, execute, pending, result } as const
+}
+
+function MppPanel(props: {
+  children: ReactNode
+  error?: Error | undefined
+  pending: boolean
+  result?: MppScenarioResult | undefined
+  title: string
+}) {
+  const { children, error, pending, result, title } = props
+  const display = pending ? { status: 'pending' } : result ? summarizeMppResult(result) : undefined
+  return (
+    <article className="method-panel">
+      <header className="method-header">
+        <h3>{title}</h3>
+      </header>
+      <div className="method-body">{children}</div>
+      {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {display !== undefined && (
+        <pre className="method-result">{Json.stringify(display, null, 2)}</pre>
+      )}
+    </article>
+  )
+}
+
+function MppStateTable(props: { rows: readonly (readonly [string, unknown])[] }) {
+  const { rows } = props
+  return (
+    <table>
+      <tbody>
+        {rows.map(([label, value]) => (
+          <tr key={label}>
+            <th>{label}</th>
+            <td>
+              {value === undefined || value === null || value === '' ? 'none' : String(value)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function createMppSessionManager() {
+  return mppx_tempo.session({
+    getClient(options: { chainId?: number | undefined } = {}) {
+      const client = provider.getClient({ chainId: options.chainId })
+      const account = provider.getAccount()
+      return Object.assign(client, { account })
+    },
+    maxDeposit: '0.05',
+  })
+}
+
+async function runMppRequest(
+  label: string,
+  path: string,
+  init: RequestInit | undefined = undefined,
+): Promise<MppScenarioResult> {
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const response = await fetch(path, init)
+  const elapsedMs = Math.round(performance.now() - started)
+  const body = await readResponseBody(response)
+  const receipt = decodePaymentReceipt(response.headers.get('Payment-Receipt'))
+  const inspection = await readInspection(receipt)
+  const balanceAfter = await getPathUsdBalance()
+  return {
+    balanceAfter,
+    balanceBefore,
+    body,
+    elapsedMs,
+    headers: readPaymentHeaders(response),
+    inspection,
+    label,
+    ok: response.ok,
+    receipt,
+    status: response.status,
+    url: path,
+  }
+}
+
+async function runMppManagedRequest(
+  label: string,
+  path: string,
+  fetcher: () => Promise<Response & { receipt?: unknown | null | undefined }>,
+): Promise<MppScenarioResult> {
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const response = await fetcher()
+  const elapsedMs = Math.round(performance.now() - started)
+  const body = await readResponseBody(response)
+  const receipt = response.receipt ?? decodePaymentReceipt(response.headers.get('Payment-Receipt'))
+  const inspection = await readInspection(receipt)
+  const balanceAfter = await getPathUsdBalance()
+  return {
+    balanceAfter,
+    balanceBefore,
+    body,
+    elapsedMs,
+    headers: readPaymentHeaders(response),
+    inspection,
+    label,
+    ok: response.ok,
+    receipt,
+    status: response.status,
+    url: path,
+  }
+}
+
+async function runMppManagedSse(
+  label: string,
+  manager: ReturnType<typeof createMppSessionManager>,
+): Promise<MppScenarioResult> {
+  const receipts: unknown[] = []
+  const chunks: string[] = []
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const stream = await manager.sse('/mpp/session/stream', {
+    onReceipt(receipt) {
+      receipts.push(receipt)
+    },
+  })
+
+  for await (const chunk of stream) chunks.push(chunk)
+
+  const elapsedMs = Math.round(performance.now() - started)
+  const receipt = receipts.at(-1)
+  const inspection = await readInspection(receipt)
+  return {
+    balanceAfter: await getPathUsdBalance(),
+    balanceBefore,
+    body: { chunks },
+    elapsedMs,
+    events: [
+      ...chunks.map((chunk) => ({ data: chunk, event: 'message' })),
+      ...receipts.map((item) => ({ data: item, event: 'payment-receipt' })),
+    ],
+    headers: {},
+    inspection,
+    label,
+    ok: true,
+    receipt,
+    status: 200,
+    url: '/mpp/session/stream',
+  }
+}
+
+async function runMppSessionClose(
+  label: string,
+  manager: ReturnType<typeof createMppSessionManager>,
+): Promise<MppScenarioResult> {
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const receipt = await manager.close()
+  const elapsedMs = Math.round(performance.now() - started)
+  const inspection = await readInspection(receipt)
+  return {
+    balanceAfter: await getPathUsdBalance(),
+    balanceBefore,
+    body: receipt ? { closed: true } : { closed: false },
+    elapsedMs,
+    headers: {},
+    inspection,
+    label,
+    ok: true,
+    receipt,
+    status: receipt ? 204 : 200,
+    url: '/mpp/session/content',
+  }
+}
+
+async function runMppLocalResult(label: string): Promise<MppScenarioResult> {
+  const balance = await getPathUsdBalance()
+  return {
+    balanceAfter: balance,
+    balanceBefore: balance,
+    body: { reset: true },
+    elapsedMs: 0,
+    headers: {},
+    label,
+    ok: true,
+    status: 200,
+    url: 'local',
+  }
+}
+
+async function getPathUsdBalance() {
+  try {
+    const accounts = await provider.request({ method: 'eth_accounts' })
+    const account = accounts[0]
+    if (!account) return null
+    const balances = await provider.request({
+      method: 'wallet_getBalances',
+      params: [{ account, tokens: [tokens.pathUSD] }],
+    })
+    return balances[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+async function readResponseBody(response: Response) {
+  const text = await response.text()
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function readPaymentHeaders(response: Response) {
+  return {
+    'content-type': response.headers.get('content-type'),
+    'payment-receipt': response.headers.get('Payment-Receipt'),
+    'www-authenticate': response.headers.get('WWW-Authenticate'),
+  }
+}
+
+function summarizeMppResult(result: MppScenarioResult) {
+  return {
+    balance: {
+      after: result.balanceAfter ?? null,
+      before: result.balanceBefore ?? null,
+    },
+    body: result.body,
+    elapsedMs: result.elapsedMs,
+    headers: {
+      'content-type': result.headers['content-type'],
+      'www-authenticate': result.headers['www-authenticate'],
+    },
+    ...(result.events ? { events: result.events } : {}),
+    ...(result.inspection ? { inspection: result.inspection } : {}),
+    label: result.label,
+    ok: result.ok,
+    ...(result.receipt ? { receipt: result.receipt } : {}),
+    status: result.status,
+    url: result.url,
+  }
+}
+
+function readMppSessionState(result: MppScenarioResult, actionFallback?: string | undefined) {
+  const receipt = isRecord(result.receipt) ? result.receipt : undefined
+  const action = readMppCredentialAction(result) ?? actionFallback
+  if (!receipt)
+    return {
+      ...(action ? { lastAction: action } : {}),
+      status: action === 'close' ? 'closed' : 'idle',
+    } satisfies MppSessionState
+
+  const acceptedCumulative = stringValue(receipt.acceptedCumulative)
+  const spent = stringValue(receipt.spent)
+  return {
+    acceptedCumulative,
+    channelId: stringValue(receipt.channelId),
+    ...(action ? { lastAction: action } : {}),
+    remaining: subtractMppAmounts(acceptedCumulative, spent),
+    spent,
+    status: action === 'close' ? 'closed' : action === 'open' ? 'open' : 'active',
+  } satisfies MppSessionState
+}
+
+function readMppCredentialAction(result: MppScenarioResult) {
+  if (!isRecord(result.inspection)) return undefined
+  const credential = result.inspection.credential
+  if (!isRecord(credential)) return undefined
+  return stringValue(credential.action)
+}
+
+async function getSubscriptionState() {
+  const response = await fetch('/mpp/subscription/state')
+  if (!response.ok)
+    return {
+      body: await readResponseBody(response),
+      status: response.status,
+    }
+  return response.json()
+}
+
+function readMppSubscriptionState(value: unknown) {
+  if (!isRecord(value) || value.status === 'missing')
+    return { status: 'missing' } satisfies MppSubscriptionState
+
+  const billingAnchor = stringValue(value.billingAnchor)
+  const canceledAt = stringValue(value.canceledAt)
+  const lastChargedPeriod =
+    typeof value.lastChargedPeriod === 'string' || typeof value.lastChargedPeriod === 'number'
+      ? value.lastChargedPeriod
+      : undefined
+  const status = (() => {
+    if (canceledAt) return 'canceled'
+    if (isSubscriptionRenewalDue(billingAnchor, lastChargedPeriod)) return 'renewal due'
+    return 'active'
+  })()
+
+  return {
+    billingAnchor,
+    canceledAt,
+    lastChargedPeriod,
+    reference: stringValue(value.reference),
+    status,
+    subscriptionId: stringValue(value.subscriptionId),
+  } satisfies MppSubscriptionState
+}
+
+function isSubscriptionRenewalDue(
+  billingAnchor: string | undefined,
+  lastChargedPeriod: string | number | undefined,
+) {
+  if (!billingAnchor) return false
+  if (Number(lastChargedPeriod) > 0) return false
+  const time = Date.parse(billingAnchor)
+  return Number.isFinite(time) && Date.now() - time >= 86_400_000
+}
+
+function formatMppAmount(value: string | undefined) {
+  if (!value) return 'none'
+  try {
+    return `${formatUnits(BigInt(value), 6)} pathUSD`
+  } catch {
+    return value
+  }
+}
+
+function subtractMppAmounts(left: string | undefined, right: string | undefined) {
+  if (!left || !right) return undefined
+  try {
+    const value = BigInt(left) - BigInt(right)
+    return value > 0n ? value.toString() : '0'
+  } catch {
+    return undefined
+  }
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
+function decodePaymentReceipt(header: string | null) {
+  if (!header) return undefined
+  try {
+    return JSON.parse(decodeBase64Url(header))
+  } catch {
+    return { raw: header }
+  }
+}
+
+function decodeBase64Url(value: string) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  return atob(padded)
+}
+
+async function readInspection(receipt: unknown) {
+  const reference = receiptReference(receipt)
+  if (!reference) return undefined
+  const response = await fetch(`/mpp/inspect?reference=${encodeURIComponent(reference)}`)
+  if (!response.ok) return undefined
+  return response.json()
+}
+
+function receiptReference(receipt: unknown) {
+  if (!isRecord(receipt)) return undefined
+  for (const key of ['reference', 'subscriptionId', 'channelId'] as const) {
+    const value = receipt[key]
+    if (typeof value === 'string') return value
+  }
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 function Authenticate() {

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Mppx, tempo as mppx_tempo } from 'mppx/client'
+import { tempo as mppx_tempo } from 'mppx/client'
 import { Hex, Json } from 'ox'
 import {
   type ComponentProps,
@@ -1985,27 +1985,15 @@ type MppScenarioResult = {
   url: string
 }
 
-type MppRun = (
-  label: string,
-  path: string,
-  init?: RequestInit | undefined,
-) => Promise<MppScenarioResult>
 type MppSseEvent = { data: unknown; event: string }
 type MppSessionState = {
-  acceptedCumulative?: string | undefined
-  channelId?: string | undefined
   lastAction?: string | undefined
   remaining?: string | undefined
   spent?: string | undefined
   status: 'active' | 'closed' | 'idle' | 'open'
 }
 type MppSubscriptionState = {
-  billingAnchor?: string | undefined
-  canceledAt?: string | undefined
-  lastChargedPeriod?: string | number | undefined
-  reference?: string | undefined
   status: 'active' | 'canceled' | 'missing' | 'renewal due'
-  subscriptionId?: string | undefined
 }
 
 function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }) {
@@ -2020,24 +2008,11 @@ function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }
     await provider.request({ method: 'eth_accounts' }).catch(() => undefined)
   }
 
-  const runRaw: MppRun = (label, path, init) =>
-    (async () => {
-      Mppx.restore()
-      try {
-        return await runMppRequest(label, path, init)
-      } finally {
-        switchMppMode(mode, adapterType)
-        rerender()
-        await provider.request({ method: 'eth_accounts' }).catch(() => undefined)
-      }
-    })()
-
   return (
     <>
       <MppOneTimeCharges applyMode={applyMode} mode={mode} />
       <MppSessions adapterType={adapterType} mode={mode} />
       <MppSubscriptions />
-      <MppFailureLab applyMode={applyMode} runRaw={runRaw} />
     </>
   )
 }
@@ -2062,28 +2037,20 @@ function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void>;
       result={request.result}
       error={request.error}
     >
-      <MppStateTable
-        rows={[
-          ['Provider mode', mode],
-          ['Paid challenge', 'server accepts push or pull'],
-        ]}
-      />
-      <div>
-        <fieldset style={{ marginBottom: 8, border: 'none', padding: 0 }}>
-          <legend>Provider Mode</legend>
-          {(['push', 'pull'] as const).map((value) => (
-            <label key={value} style={{ marginRight: 12 }}>
-              <input
-                type="radio"
-                name="mppChargeMode"
-                checked={mode === value}
-                onChange={() => void applyMode(value)}
-              />{' '}
-              {value}
-            </label>
-          ))}
-        </fieldset>
-      </div>
+      <fieldset style={{ border: 'none', padding: 0 }}>
+        <legend>Provider Mode</legend>
+        {(['push', 'pull'] as const).map((value) => (
+          <label key={value} style={{ marginRight: 12 }}>
+            <input
+              type="radio"
+              name="mppChargeMode"
+              checked={mode === value}
+              onChange={() => void applyMode(value)}
+            />{' '}
+            {value}
+          </label>
+        ))}
+      </fieldset>
       <Button disabled={request.pending} onClick={() => run('Free proof', '/mpp/charge/free')}>
         Free Proof
       </Button>
@@ -2126,16 +2093,7 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
       result={request.result}
       error={request.error}
     >
-      <MppStateTable
-        rows={[
-          ['State', session.status],
-          ['Channel', session.channelId ?? 'none'],
-          ['Last action', session.lastAction ?? 'none'],
-          ['Authorized', formatMppAmount(session.acceptedCumulative)],
-          ['Spent', formatMppAmount(session.spent)],
-          ['Unspent authorization', formatMppAmount(session.remaining)],
-        ]}
-      />
+      <MppSummary>{formatMppSessionSummary(session)}</MppSummary>
       <Button
         disabled={request.pending || session.status === 'closed'}
         onClick={() =>
@@ -2224,27 +2182,15 @@ function MppSubscriptions() {
       result={request.result}
       error={request.error}
     >
-      <MppStateTable
-        rows={[
-          ['State', subscription.status],
-          ['Subscription', subscription.subscriptionId ?? 'none'],
-          ['Last charged period', subscription.lastChargedPeriod ?? 'none'],
-          ['Billing anchor', subscription.billingAnchor ?? 'none'],
-          ['Reference', subscription.reference ?? 'none'],
-          ['Canceled at', subscription.canceledAt ?? 'none'],
-        ]}
-      />
+      <MppSummary>{formatMppSubscriptionSummary(subscription)}</MppSummary>
       <Button
         disabled={request.pending}
         onClick={() => run('Activate subscription', '/mpp/subscription/news')}
       >
         Activate
       </Button>
-      <Button
-        disabled={request.pending}
-        onClick={() => run('Access again', '/mpp/subscription/news')}
-      >
-        Access Again
+      <Button disabled={request.pending} onClick={() => run('Access', '/mpp/subscription/news')}>
+        Access
       </Button>
       <Button
         disabled={request.pending}
@@ -2254,9 +2200,9 @@ function MppSubscriptions() {
       </Button>
       <Button
         disabled={request.pending}
-        onClick={() => run('Renew subscription', '/mpp/subscription/news')}
+        onClick={() => run('Access / renew', '/mpp/subscription/news')}
       >
-        Renew
+        Access / Renew
       </Button>
       <Button
         disabled={request.pending}
@@ -2266,69 +2212,9 @@ function MppSubscriptions() {
       </Button>
       <Button
         disabled={request.pending}
-        onClick={() => run('Reactivate subscription', '/mpp/subscription/news')}
-      >
-        Reactivate
-      </Button>
-      <Button
-        disabled={request.pending}
         onClick={() => run('Refresh state', '/mpp/subscription/state')}
       >
-        Refresh State
-      </Button>
-    </MppPanel>
-  )
-}
-
-function MppFailureLab(props: { applyMode: (mode: MppMode) => Promise<void>; runRaw: MppRun }) {
-  const { applyMode, runRaw } = props
-  const request = useMppRequest()
-
-  async function run(label: string, path: string) {
-    await request.execute(label, () => runMppRequest(label, path))
-  }
-
-  return (
-    <MppPanel
-      title="Failure Lab"
-      pending={request.pending}
-      result={request.result}
-      error={request.error}
-    >
-      <MppStateTable
-        rows={[
-          ['Insufficient balance', 'account cannot satisfy the charge'],
-          ['Expired challenge', 'client receives an already expired challenge'],
-          ['Unsupported mode', 'provider is push, server requires pull'],
-          ['Raw 402', 'payment-aware fetch is intentionally disabled'],
-        ]}
-      />
-      <Button
-        disabled={request.pending}
-        onClick={() => run('Insufficient balance', '/mpp/failure/insufficient-balance')}
-      >
-        Insufficient Balance
-      </Button>
-      <Button
-        disabled={request.pending}
-        onClick={() => run('Expired challenge', '/mpp/failure/expired')}
-      >
-        Expired Challenge
-      </Button>
-      <Button
-        disabled={request.pending}
-        onClick={async () => {
-          await applyMode('push')
-          await run('Unsupported mode', '/mpp/failure/unsupported-mode')
-        }}
-      >
-        Unsupported Mode
-      </Button>
-      <Button
-        disabled={request.pending}
-        onClick={() => request.execute('Raw 402', () => runRaw('Raw 402', '/mpp/failure/raw-402'))}
-      >
-        Raw 402
+        Refresh
       </Button>
     </MppPanel>
   )
@@ -2381,22 +2267,8 @@ function MppPanel(props: {
   )
 }
 
-function MppStateTable(props: { rows: readonly (readonly [string, unknown])[] }) {
-  const { rows } = props
-  return (
-    <table>
-      <tbody>
-        {rows.map(([label, value]) => (
-          <tr key={label}>
-            <th>{label}</th>
-            <td>
-              {value === undefined || value === null || value === '' ? 'none' : String(value)}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
+function MppSummary(props: { children: ReactNode }) {
+  return <p className="w-full text-sm text-foreground-secondary">{props.children}</p>
 }
 
 function createMppSessionManager() {
@@ -2610,8 +2482,6 @@ function readMppSessionState(result: MppScenarioResult, actionFallback?: string 
   const acceptedCumulative = stringValue(receipt.acceptedCumulative)
   const spent = stringValue(receipt.spent)
   return {
-    acceptedCumulative,
-    channelId: stringValue(receipt.channelId),
     ...(action ? { lastAction: action } : {}),
     remaining: subtractMppAmounts(acceptedCumulative, spent),
     spent,
@@ -2653,13 +2523,22 @@ function readMppSubscriptionState(value: unknown) {
   })()
 
   return {
-    billingAnchor,
-    canceledAt,
-    lastChargedPeriod,
-    reference: stringValue(value.reference),
     status,
-    subscriptionId: stringValue(value.subscriptionId),
   } satisfies MppSubscriptionState
+}
+
+function formatMppSessionSummary(session: MppSessionState) {
+  if (session.status === 'idle') return 'No local session yet.'
+  const parts = [`Session ${session.status}`]
+  if (session.lastAction) parts.push(`last ${session.lastAction}`)
+  if (session.spent) parts.push(`${formatMppAmount(session.spent)} spent`)
+  if (session.remaining) parts.push(`${formatMppAmount(session.remaining)} left`)
+  return parts.join(' · ')
+}
+
+function formatMppSubscriptionSummary(subscription: MppSubscriptionState) {
+  if (subscription.status === 'missing') return 'No subscription stored.'
+  return `Subscription ${subscription.status}.`
 }
 
 function isSubscriptionRenewalDue(

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -19,6 +19,7 @@ import { requestTurnkeyEmailOtp, type TurnkeyEmailOtpClient } from './turnkeyOtp
 export type AdapterType = 'secp256k1' | 'webAuthn' | 'turnkey' | 'tempoWallet' | 'dialogRefImpl'
 export type Env = 'mainnet' | 'testnet' | 'devnet'
 export type DialogMode = 'iframe' | 'popup'
+export type MppMode = 'push' | 'pull'
 export type ProviderValue = ReturnType<typeof Provider.create>
 type TurnkeyPlaygroundClient = turnkey.Client & TurnkeyEmailOtpClient
 
@@ -63,9 +64,17 @@ export const host =
   new URLSearchParams(window.location.search).get('host') ?? import.meta.env.VITE_WALLET_HOST
 
 export let dialogMode: DialogMode = 'iframe'
+export let mppMode: MppMode = 'push'
 export let theme: DialogNs.Theme | undefined
 export let provider: ProviderValue = createProvider('tempoWallet')
 let turnkeyClient: TurnkeyClient | undefined
+
+function mpp() {
+  return {
+    maxDeposit: '0.05',
+    mode: mppMode,
+  } as const
+}
 
 export function createProvider(adapterType: AdapterType): ProviderValue {
   if (adapterType === 'tempoWallet')
@@ -75,7 +84,7 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
         host,
         theme,
       }),
-      mpp: true,
+      mpp: mpp(),
       testnet,
     })
 
@@ -86,7 +95,7 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
         host: import.meta.env.VITE_REF_DIALOG_HOST,
         theme,
       }),
-      mpp: true,
+      mpp: mpp(),
       testnet,
     })
 
@@ -94,7 +103,7 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
     const ceremony = WebAuthnCeremony.server({ url: '/webauthn' })
     return Provider.create({
       adapter: webAuthn({ ceremony }),
-      mpp: true,
+      mpp: mpp(),
       testnet,
     })
   }
@@ -118,7 +127,7 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
           })
         },
       }),
-      mpp: true,
+      mpp: mpp(),
       testnet,
     })
   }
@@ -134,7 +143,7 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
         return { accounts: [newAccount] }
       },
     }),
-    mpp: true,
+    mpp: mpp(),
     testnet,
   })
 }
@@ -146,6 +155,12 @@ export function switchAdapter(adapterType: AdapterType) {
 
 export function switchDialogMode(mode: DialogMode, adapterType: AdapterType = 'tempoWallet') {
   dialogMode = mode
+  Mppx.restore()
+  provider = createProvider(adapterType)
+}
+
+export function switchMppMode(mode: MppMode, adapterType: AdapterType = 'tempoWallet') {
+  mppMode = mode
   Mppx.restore()
   provider = createProvider(adapterType)
 }

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -42,7 +42,7 @@ const payment = Mppx.create({
         const record = {
           accessKey: subscriptionAccessKey,
           amount: request.amount,
-          billingAnchor: new Date().toISOString(),
+          billingAnchor: secondIso(),
           chainId: request.methodDetails?.chainId,
           currency: request.currency,
           lastChargedPeriod: 0,
@@ -54,7 +54,7 @@ const payment = Mppx.create({
           reference: txHash(activationCount),
           subscriptionExpires: request.subscriptionExpires,
           subscriptionId: `playground_${activationCount}`,
-          timestamp: new Date().toISOString(),
+          timestamp: secondIso(),
         } satisfies Subscription.SubscriptionRecord
         return {
           receipt: Subscription.createSubscriptionReceipt(record),
@@ -72,7 +72,7 @@ const payment = Mppx.create({
           ...subscription,
           lastChargedPeriod: periodIndex,
           reference: txHash(100 + renewalCount),
-          timestamp: new Date().toISOString(),
+          timestamp: secondIso(),
         }
         return {
           receipt: Subscription.createSubscriptionReceipt(record),
@@ -81,7 +81,7 @@ const payment = Mppx.create({
       },
       resolve: ({ input }) => ({ accessKey: subscriptionAccessKey, key: subscriptionKey(input) }),
       store,
-      subscriptionExpires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1_000).toISOString(),
+      subscriptionExpires: secondIso(Date.now() + 365 * 24 * 60 * 60 * 1_000),
       testnet,
     }),
   ],
@@ -128,7 +128,7 @@ export default {
       if (!subscription) return Response.json({ status: 'missing' })
       await subscriptions.put({
         ...subscription,
-        billingAnchor: new Date(Date.now() - 2 * 24 * 60 * 60 * 1_000).toISOString(),
+        billingAnchor: secondIso(Date.now() - 2 * 24 * 60 * 60 * 1_000),
         lastChargedPeriod: 0,
       })
       return Response.json({ status: 'ready', subscriptionId: subscription.subscriptionId })
@@ -139,7 +139,7 @@ export default {
       if (!subscription) return Response.json({ status: 'missing' })
       await subscriptions.put({
         ...subscription,
-        canceledAt: new Date().toISOString(),
+        canceledAt: secondIso(),
       })
       return Response.json({ status: 'canceled', subscriptionId: subscription.subscriptionId })
     }
@@ -184,28 +184,6 @@ export default {
         }),
       )
     }
-
-    if (url.pathname === '/mpp/failure/insufficient-balance')
-      return charge(request, { amount: '1000000', description: 'Insufficient balance' })
-
-    if (url.pathname === '/mpp/failure/expired')
-      return charge(request, {
-        amount: '0.01',
-        description: 'Expired challenge',
-        expires: new Date(Date.now() - 1_000),
-      })
-
-    if (url.pathname === '/mpp/failure/unsupported-mode')
-      return charge(request, {
-        amount: '0.01',
-        description: 'Unsupported settlement mode',
-        supportedModes: ['pull'],
-      })
-
-    if (url.pathname === '/mpp/failure/raw-402')
-      return problem('payment_required', 'MPP disabled raw 402', {
-        detail: 'This response intentionally skips an MPP challenge.',
-      })
 
     if (url.pathname === '/zero-dollar-auth') {
       const result = await payment.charge({
@@ -281,21 +259,8 @@ function txHash(index: number) {
   return `0x${index.toString(16).padStart(64, '0')}` as const
 }
 
-function problem(code: string, title: string, options: { detail: string }) {
-  return Response.json(
-    {
-      detail: options.detail,
-      status: 402,
-      title,
-      type: `https://playground.tempo.xyz/problems/${code}`,
-    },
-    {
-      headers: {
-        'Cache-Control': 'no-store',
-      },
-      status: 402,
-    },
-  )
+function secondIso(ms = Date.now()) {
+  return new Date(Math.ceil(ms / 1_000) * 1_000).toISOString()
 }
 
 function recordInspection(

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -1,17 +1,94 @@
 import { Handler, Kv } from 'accounts/server'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store as MppStore, tempo } from 'mppx/server'
+import { Subscription } from 'mppx/tempo'
 import { privateKeyToAccount } from 'viem/accounts'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000' as const
+const testnet = process.env.VITE_ENV !== 'mainnet'
+const account = privateKeyToAccount(process.env.PRIVATE_KEY)
+const subscriptionAccessAccount = privateKeyToAccount(
+  '0x0000000000000000000000000000000000000000000000000000000000000002',
+)
+const subscriptionAccessKey = {
+  accessKeyAddress: subscriptionAccessAccount.address,
+  keyType: 'secp256k1',
+} as const
+const store = MppStore.memory()
+const subscriptions = Subscription.fromStore(store)
+const inspections = new Map<string, unknown>()
+let activationCount = 0
+let renewalCount = 0
 
 const payment = Mppx.create({
   methods: [
     tempo.charge({
-      currency: '0x20c0000000000000000000000000000000000000',
-      recipient: '0x0000000000000000000000000000000000000001',
-      testnet: process.env.VITE_ENV === 'testnet',
+      account,
+      currency: pathUsd,
+      feePayer: true,
+      testnet,
+    }),
+    tempo.session({
+      account,
+      currency: pathUsd,
+      feePayer: true,
+      sse: { poll: true },
+      store,
+      suggestedDeposit: '0.03',
+      testnet,
+    }),
+    tempo.subscription({
+      activate: async ({ request, resolved, source }) => {
+        activationCount += 1
+        const record = {
+          accessKey: subscriptionAccessKey,
+          amount: request.amount,
+          billingAnchor: new Date().toISOString(),
+          chainId: request.methodDetails?.chainId,
+          currency: request.currency,
+          lastChargedPeriod: 0,
+          lookupKey: resolved.key,
+          payer: source ?? undefined,
+          periodCount: request.periodCount,
+          periodUnit: request.periodUnit,
+          recipient: request.recipient,
+          reference: txHash(activationCount),
+          subscriptionExpires: request.subscriptionExpires,
+          subscriptionId: `playground_${activationCount}`,
+          timestamp: new Date().toISOString(),
+        } satisfies Subscription.SubscriptionRecord
+        return {
+          receipt: Subscription.createSubscriptionReceipt(record),
+          subscription: record,
+        }
+      },
+      amount: '0.01',
+      currency: pathUsd,
+      periodCount: '1',
+      periodUnit: 'day',
+      recipient: account.address,
+      renew: async ({ periodIndex, subscription }) => {
+        renewalCount += 1
+        const record = {
+          ...subscription,
+          lastChargedPeriod: periodIndex,
+          reference: txHash(100 + renewalCount),
+          timestamp: new Date().toISOString(),
+        }
+        return {
+          receipt: Subscription.createSubscriptionReceipt(record),
+          subscription: record,
+        }
+      },
+      resolve: ({ input }) => ({ accessKey: subscriptionAccessKey, key: subscriptionKey(input) }),
+      store,
+      subscriptionExpires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1_000).toISOString(),
+      testnet,
     }),
   ],
   secretKey: process.env.MPP_SECRET_KEY,
 })
+
+payment.onPaymentSuccess(recordInspection)
 
 const auth = Handler.auth({ origin: process.env.ORIGIN, path: '/auth' })
 
@@ -24,7 +101,7 @@ const handler = Handler.compose([
   }),
   Handler.relay({
     feePayer: {
-      account: privateKeyToAccount(process.env.PRIVATE_KEY),
+      account,
       name: 'Playground',
       url: 'https://playground.tempo.xyz',
     },
@@ -36,6 +113,99 @@ const handler = Handler.compose([
 export default {
   async fetch(request) {
     const url = new URL(request.url)
+
+    if (url.pathname === '/mpp/inspect') {
+      const reference = url.searchParams.get('reference')
+      if (!reference) return Response.json({ error: 'reference required' }, { status: 400 })
+      return Response.json(inspections.get(reference) ?? null)
+    }
+
+    if (url.pathname === '/mpp/subscription/state')
+      return Response.json(await getSubscriptionState(request))
+
+    if (url.pathname === '/mpp/subscription/force-renewal') {
+      const subscription = await subscriptions.getByKey(subscriptionKey(request))
+      if (!subscription) return Response.json({ status: 'missing' })
+      await subscriptions.put({
+        ...subscription,
+        billingAnchor: new Date(Date.now() - 2 * 24 * 60 * 60 * 1_000).toISOString(),
+        lastChargedPeriod: 0,
+      })
+      return Response.json({ status: 'ready', subscriptionId: subscription.subscriptionId })
+    }
+
+    if (url.pathname === '/mpp/subscription/cancel') {
+      const subscription = await subscriptions.getByKey(subscriptionKey(request))
+      if (!subscription) return Response.json({ status: 'missing' })
+      await subscriptions.put({
+        ...subscription,
+        canceledAt: new Date().toISOString(),
+      })
+      return Response.json({ status: 'canceled', subscriptionId: subscription.subscriptionId })
+    }
+
+    if (url.pathname === '/mpp/charge/free')
+      return charge(request, { amount: '0', description: 'Free proof' })
+
+    if (url.pathname === '/mpp/charge/paid')
+      return charge(request, { amount: '0.01', description: 'Paid fortune' })
+
+    if (url.pathname === '/mpp/session/content') {
+      const result = await payment.tempo.session({
+        amount: '0.01',
+        suggestedDeposit: '0.03',
+        unitType: 'request',
+      })(request)
+      if (result.status === 402) return result.challenge
+      return result.withReceipt(
+        Response.json({
+          message: 'paid session content',
+        }),
+      )
+    }
+
+    if (url.pathname === '/mpp/session/stream') {
+      const result = await payment.tempo.session({
+        amount: '0.005',
+        suggestedDeposit: '0.05',
+        unitType: 'chunk',
+      })(request)
+      if (result.status === 402) return result.challenge
+      return result.withReceipt(streamChunks())
+    }
+
+    if (url.pathname === '/mpp/subscription/news') {
+      const result = await payment.tempo.subscription({})(request)
+      if (result.status === 402) return result.challenge
+      return result.withReceipt(
+        Response.json({
+          article: 'The MPP playground now covers recurring access.',
+          state: await getSubscriptionState(request),
+        }),
+      )
+    }
+
+    if (url.pathname === '/mpp/failure/insufficient-balance')
+      return charge(request, { amount: '1000000', description: 'Insufficient balance' })
+
+    if (url.pathname === '/mpp/failure/expired')
+      return charge(request, {
+        amount: '0.01',
+        description: 'Expired challenge',
+        expires: new Date(Date.now() - 1_000),
+      })
+
+    if (url.pathname === '/mpp/failure/unsupported-mode')
+      return charge(request, {
+        amount: '0.01',
+        description: 'Unsupported settlement mode',
+        supportedModes: ['pull'],
+      })
+
+    if (url.pathname === '/mpp/failure/raw-402')
+      return problem('payment_required', 'MPP disabled raw 402', {
+        detail: 'This response intentionally skips an MPP challenge.',
+      })
 
     if (url.pathname === '/zero-dollar-auth') {
       const result = await payment.charge({
@@ -70,3 +240,97 @@ export default {
     return handler.fetch(request)
   },
 } satisfies ExportedHandler<Cloudflare.Env>
+
+async function charge(request: Request, options: Parameters<typeof payment.tempo.charge>[0]) {
+  const result = await payment.tempo.charge(options)(request)
+  if (result.status === 402) return result.challenge
+  return result.withReceipt(
+    Response.json({
+      amount: options.amount,
+      message: 'paid charge content',
+      modes: options.supportedModes ?? ['push', 'pull'],
+    }),
+  )
+}
+
+async function getSubscriptionState(request: Request) {
+  const subscription = await subscriptions.getByKey(subscriptionKey(request))
+  if (!subscription) return { status: 'missing' }
+  return {
+    billingAnchor: subscription.billingAnchor,
+    canceledAt: subscription.canceledAt ?? null,
+    lastChargedPeriod: subscription.lastChargedPeriod,
+    reference: subscription.reference,
+    subscriptionId: subscription.subscriptionId,
+  }
+}
+
+async function* streamChunks() {
+  const chunks = ['session', 'payments', 'meter', 'streaming', 'chunks']
+  for (const chunk of chunks) {
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    yield chunk
+  }
+}
+
+function subscriptionKey(input: Request) {
+  return `playground:${input.headers.get('X-User-Id') ?? 'default'}:news`
+}
+
+function txHash(index: number) {
+  return `0x${index.toString(16).padStart(64, '0')}` as const
+}
+
+function problem(code: string, title: string, options: { detail: string }) {
+  return Response.json(
+    {
+      detail: options.detail,
+      status: 402,
+      title,
+      type: `https://playground.tempo.xyz/problems/${code}`,
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+      status: 402,
+    },
+  )
+}
+
+function recordInspection(
+  context: Parameters<typeof payment.onPaymentSuccess>[0] extends (
+    context: infer context,
+  ) => unknown
+    ? context
+    : never,
+) {
+  const receipt = context.receipt as { reference: string; subscriptionId?: string | undefined }
+  const payload = context.credential?.payload as Record<string, unknown> | undefined
+  const summary = {
+    challenge: {
+      id: context.challenge.id,
+      intent: context.challenge.intent,
+      method: context.challenge.method,
+      request: context.challenge.request,
+    },
+    credential: summarizeCredential(payload),
+    method: context.method,
+    receipt: context.receipt,
+  }
+  inspections.set(receipt.reference, summary)
+  if (receipt.subscriptionId) inspections.set(receipt.subscriptionId, summary)
+  inspections.set(context.challenge.id, summary)
+}
+
+function summarizeCredential(payload: Record<string, unknown> | undefined) {
+  if (!payload) return undefined
+  if (typeof payload.action === 'string')
+    return {
+      action: payload.action,
+      channelId: payload.channelId,
+      type: payload.type ?? 'voucher',
+    }
+  if (typeof payload.type === 'string') return { type: payload.type }
+  return undefined
+}

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -15,6 +15,7 @@
       "/relay",
       "/fortune",
       "/zero-dollar-auth",
+      "/mpp/*",
     ],
   },
 }


### PR DESCRIPTION
## Summary
Expands the web playground MPP panel around charge, session, and subscription flows.

## Motivation
The playground had limited MPP coverage, and the first pass became too noisy. This keeps the accounts-specific flows visible while dropping server-only and failure-only cases. Dialog-signed pull MPP follow-up is tracked in #489.

## Changes
- Add one-time free/paid MPP charge controls and a push/pull mode switch in `playgrounds/web/src/App.tsx` and `playgrounds/web/src/provider.ts`
- Add stateful session actions for start, pay another, stream chunks, close, and local reset
- Add subscription activation, access, renewal, cancellation, and refresh paths backed by `playgrounds/web/worker/index.ts`
- Remove the Failure Lab UI and worker endpoints
- Round playground subscription timestamps to whole seconds for mppx validation

## Testing
- `CI=true pnpm vp fmt playgrounds/web/src/App.tsx playgrounds/web/worker/index.ts`
- `CI=true pnpm --filter './playgrounds/web' check:types`
- `CI=true pnpm --filter './playgrounds/web' build`
- `curl -sS -D /tmp/mpp-subscription-headers.txt http://127.0.0.1:5173/mpp/subscription/news -o /tmp/mpp-subscription-body.txt` returned a normal 402 MPP challenge with `subscriptionExpires` ending in `.000Z`
- Playwright smoke against `http://127.0.0.1:5173/#mpp` confirmed the simplified MPP UI, current subscription buttons, and no console errors

Pre-commit also ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it passed with existing unused-variable warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`.
