### PR TITLE
refactor(playground): remove MPP mode radio

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -2010,15 +2010,15 @@ function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }
 
   return (
     <>
-      <MppOneTimeCharges applyMode={applyMode} mode={mode} />
+      <MppOneTimeCharges applyMode={applyMode} />
       <MppSessions adapterType={adapterType} mode={mode} />
       <MppSubscriptions />
     </>
   )
 }
 
-function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void>; mode: MppMode }) {
-  const { applyMode, mode } = props
+function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void> }) {
+  const { applyMode } = props
   const request = useMppRequest()
 
   async function run(label: string, path: string) {
@@ -2037,20 +2037,6 @@ function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void>;
       result={request.result}
       error={request.error}
     >
-      <fieldset style={{ border: 'none', padding: 0 }}>
-        <legend>Provider Mode</legend>
-        {(['push', 'pull'] as const).map((value) => (
-          <label key={value} style={{ marginRight: 12 }}>
-            <input
-              type="radio"
-              name="mppChargeMode"
-              checked={mode === value}
-              onChange={() => void applyMode(value)}
-            />{' '}
-            {value}
-          </label>
-        ))}
-      </fieldset>
       <Button disabled={request.pending} onClick={() => run('Free proof', '/mpp/charge/free')}>
         Free Proof
       </Button>


### PR DESCRIPTION
## Summary
Remove the redundant provider mode radio from the web playground MPP charge panel.

## Motivation
The one-time MPP section already has explicit `Paid Push` and `Paid Pull` actions. Keeping a separate provider mode radio made the flow feel like two controls for the same choice.

## Changes
- Drop the `Provider Mode` fieldset from `playgrounds/web/src/App.tsx`
- Keep `Free Proof`, `Paid Push`, and `Paid Pull` as the charge scenarios

## Testing
- `CI=true pnpm vp fmt playgrounds/web/src/App.tsx`
- `CI=true pnpm --filter './playgrounds/web' check:types`
- `CI=true pnpm --filter './playgrounds/web' build`
- Browser smoke confirmed the one-time MPP buttons render and the radio is gone

Pre-commit also ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it passed with existing unused-variable warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.test.ts`.
