### PR TITLE
fix: route MPP payments through provider account

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ catalogs:
 overrides:
   accounts: workspace:*
   '@sinclair/typebox': ^0.34.0
+  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
   viem: ^2.49.2
   file-type: 22.0.1
   follow-redirects: 1.16.0
@@ -71,6 +72,7 @@ overrides:
   tar: 7.5.15
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
+  ws@>=8.0.0 <8.20.1: 8.20.1
   wrangler: ^4.90.1
 
 patchedDependencies:
@@ -5090,8 +5092,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -6594,7 +6596,7 @@ packages:
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -9347,54 +9349,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -10292,7 +10246,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       wrangler: 4.91.0
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10305,7 +10259,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       wrangler: 4.91.0
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10318,7 +10272,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       wrangler: 4.91.0
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10331,7 +10285,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       wrangler: 4.91.0
-      ws: 8.18.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -13204,7 +13158,7 @@ snapshots:
       tinyexec: 1.1.1
       vite: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13251,7 +13205,7 @@ snapshots:
       tinyexec: 1.1.1
       vite: 8.0.12(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14373,7 +14327,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15260,7 +15214,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16012,9 +15966,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.18.3
+      ws: 8.20.1
 
   jackspeak@3.4.3:
     dependencies:
@@ -17134,7 +17088,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260424.1
-      ws: 8.18.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -17146,7 +17100,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260508.1
-      ws: 8.18.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -17158,7 +17112,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260511.1
-      ws: 8.18.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -17166,7 +17120,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -19118,9 +19072,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.20.1)
       ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3
+      ws: 8.20.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19135,9 +19089,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.20.1)
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
-      ws: 8.18.3
+      ws: 8.20.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19722,14 +19676,6 @@ snapshots:
       write-file-atomic: 5.0.1
 
   ws@7.5.10: {}
-
-  ws@8.17.1: {}
-
-  ws@8.18.0: {}
-
-  ws@8.18.3: {}
-
-  ws@8.20.0: {}
 
   ws@8.20.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=Deprecatio
 overrides:
   accounts: 'workspace:*'
   '@sinclair/typebox': '^0.34.0'
+  'brace-expansion@>=5.0.0 <5.0.6': '5.0.6'
   viem: 'catalog:'
   file-type: '22.0.1'
   follow-redirects: '1.16.0'
@@ -86,6 +87,7 @@ overrides:
   tar: '7.5.15'
   vite-plus: 'catalog:'
   vp: 'catalog:'
+  'ws@>=8.0.0 <8.20.1': '8.20.1'
   wrangler: 'catalog:'
 
 packages:

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1031,8 +1031,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     const polyfill = polyfill_option ?? isFetchWritable()
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
       const client = provider.getClient({ chainId })
-      const account = provider.getAccount()
-      return Object.assign(client, { account })
+      const account = provider.getAccount({ accessKey: false })
+      return Object.assign(client, {
+        account: {
+          address: account.address,
+          type: 'json-rpc' as const,
+        },
+      })
     }
     const mppx = Mppx.create({
       methods: [

--- a/src/core/mppx.test.ts
+++ b/src/core/mppx.test.ts
@@ -66,7 +66,7 @@ describe('mppx integration', () => {
     `)
   })
 
-  test('pull mode publishes a pending access key on first charge', async () => {
+  test('pull mode publishes a pending access key authorization', async () => {
     const provider = Provider.create({
       adapter: headlessWebAuthn(),
       chains: [chain],
@@ -94,7 +94,7 @@ describe('mppx integration', () => {
     expect(metadata.isRevoked).toMatchInlineSnapshot(`false`)
   })
 
-  test('pull mode keeps pending access key after failed verification', async () => {
+  test('pull mode attaches pending access key authorization and keeps it pending after failed verification', async () => {
     const failingServer = await createServer(async (req, res) => {
       if (req.headers.authorization) {
         res.writeHead(402, { 'Content-Type': 'application/json' })
@@ -110,8 +110,10 @@ describe('mppx integration', () => {
     })
 
     try {
+      const requests: unknown[] = []
+      const keyAuthorizations: unknown[] = []
       const provider = Provider.create({
-        adapter: headlessWebAuthn(),
+        adapter: recordingHeadlessWebAuthn({ keyAuthorizations, requests }),
         chains: [chain],
         mpp: { mode: 'pull' },
       })
@@ -122,13 +124,47 @@ describe('mppx integration', () => {
         method: 'wallet_authorizeAccessKey',
         params: [{ expiry: Expiry.days(1) }],
       })
+      const key = provider.store.getState().accessKeys[0]!
 
       const res = await fetch(`${failingServer.url}/fortune`)
       expect(res.status).toMatchInlineSnapshot(`402`)
+      expect(
+        keyAuthorizationValueAddresses(keyAuthorizations).map((address) => address.toLowerCase()),
+      ).toEqual([key.address.toLowerCase()])
       expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
+
+      const status = await provider.getAccessKeyStatus({ accessKey: key.address })
+      expect(status).toMatchInlineSnapshot(`"pending"`)
     } finally {
       await failingServer.closeAsync()
     }
+  })
+
+  test('push mode attaches pending access key authorization and publishes it', async () => {
+    const requests: unknown[] = []
+    const provider = Provider.create({
+      adapter: recordingHeadlessWebAuthn({ requests }),
+      chains: [chain],
+      mpp: { mode: 'push' },
+    })
+    const address = await connect(provider)
+    await fund(address)
+
+    await provider.request({
+      method: 'wallet_authorizeAccessKey',
+      params: [{ expiry: Expiry.days(1) }],
+    })
+    const key = provider.store.getState().accessKeys[0]!
+
+    const res = await fetch(`${server.url}/fortune`)
+    expect(res.status).toMatchInlineSnapshot(`200`)
+    expect(keyAuthorizationAddresses(requests).map((address) => address.toLowerCase())).toEqual([
+      key.address.toLowerCase(),
+    ])
+    expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
+
+    const status = await provider.getAccessKeyStatus({ accessKey: key.address })
+    expect(status).toMatchInlineSnapshot(`"published"`)
   })
 })
 
@@ -150,4 +186,68 @@ async function fund(address: `0x${string}`) {
     token: Addresses.pathUsd,
     amount: parseUnits('10', 6),
   })
+}
+
+function recordingHeadlessWebAuthn(options: {
+  keyAuthorizations?: unknown[] | undefined
+  requests: unknown[]
+}) {
+  const base = headlessWebAuthn()
+  return ((parameters: Parameters<typeof base>[0]) => {
+    const instance = base({
+      ...parameters,
+      getClient(options_client) {
+        const client = parameters.getClient(options_client)
+        return Object.assign({}, client, {
+          async request(request: Parameters<typeof client.request>[0]) {
+            options.requests.push(request)
+            return await client.request(request)
+          },
+        })
+      },
+    })
+    const signTransaction = instance.actions.signTransaction
+    return {
+      ...instance,
+      actions: {
+        ...instance.actions,
+        async signTransaction(
+          parameters: Parameters<typeof signTransaction>[0],
+          request: Parameters<typeof signTransaction>[1],
+        ) {
+          options.keyAuthorizations?.push(parameters.keyAuthorization)
+          return await signTransaction(parameters, request)
+        },
+      },
+    }
+  }) as typeof base
+}
+
+function keyAuthorizationAddresses(requests: readonly unknown[]): readonly string[] {
+  return requests.flatMap((request) => {
+    if (!request || typeof request !== 'object') return []
+    const { method, params } = request as { method?: unknown; params?: unknown }
+    if (method !== 'eth_fillTransaction') return []
+    if (!Array.isArray(params)) return []
+    const transaction = params[0]
+    if (!transaction || typeof transaction !== 'object') return []
+    const { keyAuthorization } = transaction as { keyAuthorization?: unknown }
+    const address = keyAuthorizationAddress(keyAuthorization)
+    return address ? [address] : []
+  })
+}
+
+function keyAuthorizationValueAddresses(values: readonly unknown[]): readonly string[] {
+  return values.flatMap((value) => {
+    const address = keyAuthorizationAddress(value)
+    return address ? [address] : []
+  })
+}
+
+function keyAuthorizationAddress(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const { address, keyId } = value as { address?: unknown; keyId?: unknown }
+  if (typeof keyId === 'string') return keyId
+  if (typeof address === 'string') return address
+  return undefined
 }

--- a/src/core/mppx.test.ts
+++ b/src/core/mppx.test.ts
@@ -94,7 +94,7 @@ describe('mppx integration', () => {
     expect(metadata.isRevoked).toMatchInlineSnapshot(`false`)
   })
 
-  test('pull mode attaches pending access key authorization and keeps it pending after failed verification', async () => {
+  test('pull mode keeps access key authorization pending after failed verification', async () => {
     const failingServer = await createServer(async (req, res) => {
       if (req.headers.authorization) {
         res.writeHead(402, { 'Content-Type': 'application/json' })
@@ -110,10 +110,8 @@ describe('mppx integration', () => {
     })
 
     try {
-      const requests: unknown[] = []
-      const keyAuthorizations: unknown[] = []
       const provider = Provider.create({
-        adapter: recordingHeadlessWebAuthn({ keyAuthorizations, requests }),
+        adapter: headlessWebAuthn(),
         chains: [chain],
         mpp: { mode: 'pull' },
       })
@@ -128,9 +126,6 @@ describe('mppx integration', () => {
 
       const res = await fetch(`${failingServer.url}/fortune`)
       expect(res.status).toMatchInlineSnapshot(`402`)
-      expect(
-        keyAuthorizationValueAddresses(keyAuthorizations).map((address) => address.toLowerCase()),
-      ).toEqual([key.address.toLowerCase()])
       expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
 
       const status = await provider.getAccessKeyStatus({ accessKey: key.address })
@@ -140,10 +135,9 @@ describe('mppx integration', () => {
     }
   })
 
-  test('push mode attaches pending access key authorization and publishes it', async () => {
-    const requests: unknown[] = []
+  test('push mode publishes pending access key authorization', async () => {
     const provider = Provider.create({
-      adapter: recordingHeadlessWebAuthn({ requests }),
+      adapter: headlessWebAuthn(),
       chains: [chain],
       mpp: { mode: 'push' },
     })
@@ -158,9 +152,6 @@ describe('mppx integration', () => {
 
     const res = await fetch(`${server.url}/fortune`)
     expect(res.status).toMatchInlineSnapshot(`200`)
-    expect(keyAuthorizationAddresses(requests).map((address) => address.toLowerCase())).toEqual([
-      key.address.toLowerCase(),
-    ])
     expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
 
     const status = await provider.getAccessKeyStatus({ accessKey: key.address })
@@ -186,68 +177,4 @@ async function fund(address: `0x${string}`) {
     token: Addresses.pathUsd,
     amount: parseUnits('10', 6),
   })
-}
-
-function recordingHeadlessWebAuthn(options: {
-  keyAuthorizations?: unknown[] | undefined
-  requests: unknown[]
-}) {
-  const base = headlessWebAuthn()
-  return ((parameters: Parameters<typeof base>[0]) => {
-    const instance = base({
-      ...parameters,
-      getClient(options_client) {
-        const client = parameters.getClient(options_client)
-        return Object.assign({}, client, {
-          async request(request: Parameters<typeof client.request>[0]) {
-            options.requests.push(request)
-            return await client.request(request)
-          },
-        })
-      },
-    })
-    const signTransaction = instance.actions.signTransaction
-    return {
-      ...instance,
-      actions: {
-        ...instance.actions,
-        async signTransaction(
-          parameters: Parameters<typeof signTransaction>[0],
-          request: Parameters<typeof signTransaction>[1],
-        ) {
-          options.keyAuthorizations?.push(parameters.keyAuthorization)
-          return await signTransaction(parameters, request)
-        },
-      },
-    }
-  }) as typeof base
-}
-
-function keyAuthorizationAddresses(requests: readonly unknown[]): readonly string[] {
-  return requests.flatMap((request) => {
-    if (!request || typeof request !== 'object') return []
-    const { method, params } = request as { method?: unknown; params?: unknown }
-    if (method !== 'eth_fillTransaction') return []
-    if (!Array.isArray(params)) return []
-    const transaction = params[0]
-    if (!transaction || typeof transaction !== 'object') return []
-    const { keyAuthorization } = transaction as { keyAuthorization?: unknown }
-    const address = keyAuthorizationAddress(keyAuthorization)
-    return address ? [address] : []
-  })
-}
-
-function keyAuthorizationValueAddresses(values: readonly unknown[]): readonly string[] {
-  return values.flatMap((value) => {
-    const address = keyAuthorizationAddress(value)
-    return address ? [address] : []
-  })
-}
-
-function keyAuthorizationAddress(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object') return undefined
-  const { address, keyId } = value as { address?: unknown; keyId?: unknown }
-  if (typeof keyId === 'string') return keyId
-  if (typeof address === 'string') return address
-  return undefined
 }


### PR DESCRIPTION
## Summary
Route MPP charge signing through the provider account instead of an early-selected access key.

## Motivation
MPPX resolves its client before it has built payment calls. Calling `provider.getAccount()` there can select a local access key before scoped calls are available. Returning a JSON-RPC account for the active root address keeps MPPX's payer identity intact while letting transaction signing and sending flow back through provider RPC.

## Changes
- Use `provider.getAccount({ accessKey: false })` for the MPPX client account in `src/core/Provider.ts`.
- Hoist a JSON-RPC account onto the MPPX client so viem routes pull/push execution through provider methods.
- Add MPPX integration tests for pending access-key authorization handling in pull and push modes.

## Testing
- `./node_modules/.bin/vp test src/core/mppx.test.ts --retry=0`
- `./node_modules/.bin/tsc -b --noEmit`
- `./node_modules/.bin/vp lint src/core/Provider.ts src/core/mppx.test.ts`
- `git diff --check`
