### PR TITLE
refactor: separate Turnkey metadata cache from connected accounts

### DIFF
--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -94,10 +94,10 @@ describe('turnkey', () => {
     `)
   })
 
-  test('default: loadAccounts delegates login and caches wallet accounts for signing', async () => {
-    const { adapter, client } = setup()
+  test('default: loadAccounts returns accounts for store-backed signing', async () => {
+    const { adapter, client, store } = setup()
 
-    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    await connect({ adapter, store })
     const result = await adapter.actions.signPersonalMessage(
       { address, data: '0x68656c6c6f' },
       { method: 'personal_sign', params: ['0x68656c6c6f', address] },
@@ -148,9 +148,9 @@ describe('turnkey', () => {
   })
 
   test('default: signs transactions with a hydrated Tempo account', async () => {
-    const { adapter, client } = setup()
+    const { adapter, client, store } = setup()
 
-    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    await connect({ adapter, store })
     const result = await adapter.actions.signTransaction(
       {
         chainId: 1,
@@ -181,7 +181,7 @@ describe('turnkey', () => {
   })
 
   test('default: accepts prefixed Turnkey public keys', async () => {
-    const { adapter, client } = setup()
+    const { adapter, client, store } = setup()
     const walletAccount = toWalletAccount(account)
     client.wallets = [
       {
@@ -194,7 +194,7 @@ describe('turnkey', () => {
       },
     ]
 
-    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    await connect({ adapter, store })
     const result = await adapter.actions.signTransaction(
       {
         chainId: 1,
@@ -319,7 +319,7 @@ describe('turnkey', () => {
     expect(client.signPayloads).toMatchInlineSnapshot(`[]`)
   })
 
-  test('behavior: silent restore only reconnects persisted provider accounts', async () => {
+  test('behavior: silent restore uses persisted provider accounts', async () => {
     const { adapter, client, store } = setup()
     client.wallets = [
       {
@@ -347,7 +347,7 @@ describe('turnkey', () => {
     `)
   })
 
-  test('behavior: silent restore ignores non-Ethereum wallet accounts', async () => {
+  test('behavior: silent restore rejects connected accounts missing from Turnkey metadata', async () => {
     const { adapter, client, store } = setup()
     client.wallets = [
       {
@@ -367,9 +367,43 @@ describe('turnkey', () => {
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
-    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: No Turnkey account connected.]')
+    ).rejects.toMatchInlineSnapshot(
+      '[RpcResponse.InternalError: Connected Turnkey account "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" was not found in fetched Turnkey wallet accounts. Reconnect with Turnkey.]',
+    )
 
+    expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
     expect(client.signPayloads).toMatchInlineSnapshot(`[]`)
+    expect(store.getState().accounts).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        },
+      ]
+    `)
+  })
+
+  test('behavior: reconnecting refreshes wallet account metadata', async () => {
+    const { adapter, client, store } = setup()
+
+    await connect({ adapter, store })
+    client.wallets = [
+      {
+        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
+      },
+    ]
+    await connect({ adapter, store })
+
+    await adapter.actions.signPersonalMessage(
+      { address, data: '0x68656c6c6f' },
+      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
+    )
+
+    expect(client.fetchCalls).toMatchInlineSnapshot(`2`)
+    expect(client.signPayloads).toMatchInlineSnapshot(`
+      [
+        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
+      ]
+    `)
   })
 
   test('behavior: expired sessions clear provider accounts', async () => {
@@ -404,8 +438,8 @@ describe('turnkey', () => {
   })
 
   test('error: signing an unconnected account fails', async () => {
-    const { adapter } = setup()
-    await adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined })
+    const { adapter, store } = setup()
+    await connect({ adapter, store })
 
     await expect(
       adapter.actions.signPersonalMessage(
@@ -479,6 +513,16 @@ function setup(options: setup.Options = {}) {
     store,
   })
   return { adapter, client, store }
+}
+
+async function connect(options: Pick<ReturnType<typeof setup>, 'adapter' | 'store'>) {
+  const { adapter, store } = options
+  const loaded = await adapter.actions.loadAccounts(undefined, {
+    method: 'wallet_connect',
+    params: undefined,
+  })
+  store.setState({ accounts: loaded.accounts, activeAccount: 0 })
+  return loaded
 }
 
 declare namespace setup {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -74,7 +74,7 @@ export function turnkey<const client extends turnkey.Client>(
     let turnkeyClient_promise: Promise<client> | undefined
     let expiry_timeout: ReturnType<typeof setTimeout> | undefined
     let restore_promise: Promise<void> | undefined
-    let walletAccounts: readonly turnkey.WalletAccount[] = []
+    let walletAccounts_cache: readonly turnkey.WalletAccount[] | undefined
 
     async function getTurnkeyClient(): Promise<client> {
       turnkeyClient_promise ??= (async () => {
@@ -135,6 +135,16 @@ export function turnkey<const client extends turnkey.Client>(
       )
     }
 
+    async function refreshWalletAccounts() {
+      walletAccounts_cache = await fetchWalletAccounts()
+      return walletAccounts_cache
+    }
+
+    async function getWalletAccounts() {
+      walletAccounts_cache ??= await fetchWalletAccounts()
+      return walletAccounts_cache
+    }
+
     function selectWalletAccounts(
       accounts: readonly turnkey.WalletAccount[],
       addresses: turnkey.AccountSelection,
@@ -158,7 +168,7 @@ export function turnkey<const client extends turnkey.Client>(
       if (expiry_timeout) clearTimeout(expiry_timeout)
       expiry_timeout = undefined
       restore_promise = undefined
-      walletAccounts = []
+      walletAccounts_cache = undefined
       store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
     }
 
@@ -185,7 +195,7 @@ export function turnkey<const client extends turnkey.Client>(
 
     async function restore() {
       await Store.waitForHydration(store)
-      if (walletAccounts.length > 0) return
+      if (walletAccounts_cache) return
       if (restore_promise) return await restore_promise
 
       restore_promise = (async () => {
@@ -196,21 +206,7 @@ export function turnkey<const client extends turnkey.Client>(
         const session = await getValidSession()
         if (!session) return
 
-        const restored = await fetchWalletAccounts()
-        walletAccounts = persisted
-          .map((account) =>
-            restored.find((walletAccount) =>
-              isAddressEqual(core_Address.from(walletAccount.address), account.address),
-            ),
-          )
-          .filter((account): account is turnkey.WalletAccount => !!account)
-
-        if (walletAccounts.length === 0) return
-
-        store.setState({
-          accounts: walletAccounts.map((account) => toStoreAccount(account)),
-          activeAccount: Math.min(state.activeAccount, walletAccounts.length - 1),
-        })
+        await refreshWalletAccounts()
       })()
 
       try {
@@ -225,24 +221,32 @@ export function turnkey<const client extends turnkey.Client>(
       if (!session) throw new ox_Provider.DisconnectedError({ message: 'Turnkey session expired.' })
     }
 
-    async function accountForSigning(address: Address | undefined) {
+    async function getTurnkeyAccount(address: Address | undefined) {
       await restore()
       await requireSession()
 
-      const address_ = address ?? store.getState().accounts[store.getState().activeAccount]?.address
-      if (!address_) throw new ox_Provider.DisconnectedError({ message: 'No accounts connected.' })
+      const state = store.getState()
+      const address_ = address ?? state.accounts[state.activeAccount]?.address
+      if (!address_) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
 
-      const account = walletAccounts.find((account) =>
-        isAddressEqual(core_Address.from(account.address), address_),
-      )
-      if (account) return account
-
-      if (walletAccounts.length === 0)
+      if (state.accounts.length === 0)
         throw new ox_Provider.DisconnectedError({
           message: 'No Turnkey account connected.',
         })
 
-      throw new ox_Provider.UnauthorizedError({ message: `Account "${address_}" not found.` })
+      const connected = state.accounts.some((account) => isAddressEqual(account.address, address_))
+      if (!connected)
+        throw new ox_Provider.UnauthorizedError({ message: `Account "${address_}" not found.` })
+
+      const find = (accounts: readonly turnkey.WalletAccount[]) =>
+        accounts.find((account) => isAddressEqual(core_Address.from(account.address), address_))
+
+      const account = find(await getWalletAccounts())
+      if (account) return toTempoAccount(account)
+
+      throw new RpcResponse.InternalError({
+        message: `Connected Turnkey account "${address_}" was not found in fetched Turnkey wallet accounts. Reconnect with Turnkey.`,
+      })
     }
 
     function signatureToHex(value: turnkey.SignatureResponse): Hex.Hex {
@@ -304,7 +308,7 @@ export function turnkey<const client extends turnkey.Client>(
     }
 
     async function signTransaction(parameters: Adapter.signTransaction.Parameters) {
-      const account = toTempoAccount(await accountForSigning(parameters.from))
+      const account = await getTurnkeyAccount(parameters.from)
       const { feePayer, ...rest } = parameters
       const viemClient = getClient({
         chainId: parameters.chainId,
@@ -370,11 +374,11 @@ export function turnkey<const client extends turnkey.Client>(
                 },
               })
           await requireSession()
-          walletAccounts = selectWalletAccounts(await fetchWalletAccounts(), addresses)
+          const accounts = selectWalletAccounts(await refreshWalletAccounts(), addresses)
           restore_promise = undefined
 
           const digest = personalSign ? hashMessage(personalSign.message) : parameters.digest
-          const account = walletAccounts[0]
+          const account = accounts[0]
           const keyAuthorization = authorizeAccessKey
             ? account
               ? await AccessKey.authorize({
@@ -387,7 +391,7 @@ export function turnkey<const client extends turnkey.Client>(
             : undefined
 
           return {
-            accounts: walletAccounts.map((account, index) =>
+            accounts: accounts.map((account, index) =>
               toStoreAccount(account, index === 0 ? parameters.name : undefined),
             ),
             ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
@@ -414,11 +418,11 @@ export function turnkey<const client extends turnkey.Client>(
           const turnkeyClient = await getTurnkeyClient()
           const addresses = await options.loadAccounts({ client: turnkeyClient, parameters })
           await requireSession()
-          walletAccounts = selectWalletAccounts(await fetchWalletAccounts(), addresses)
+          const accounts = selectWalletAccounts(await refreshWalletAccounts(), addresses)
           restore_promise = undefined
 
           const digest = personalSign ? hashMessage(personalSign.message) : parameters?.digest
-          const account = walletAccounts[0]
+          const account = accounts[0]
           const keyAuthorization =
             authorizeAccessKey && account
               ? await AccessKey.authorize({
@@ -430,7 +434,7 @@ export function turnkey<const client extends turnkey.Client>(
               : undefined
 
           return {
-            accounts: walletAccounts.map((account) => toStoreAccount(account)),
+            accounts: accounts.map((account) => toStoreAccount(account)),
             ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
             ...(keyAuthorization ? { keyAuthorization } : {}),
             signature:
@@ -444,22 +448,20 @@ export function turnkey<const client extends turnkey.Client>(
           }
         },
         async authorizeAccessKey(parameters) {
-          const account = await accountForSigning(undefined)
+          const account = await getTurnkeyAccount(undefined)
           const keyAuthorization = await AccessKey.authorize({
-            account: toTempoAccount(account),
+            account,
             chainId: getClient().chain.id,
             parameters,
             store,
           })
-          return { keyAuthorization, rootAddress: core_Address.from(account.address) }
+          return { keyAuthorization, rootAddress: account.address }
         },
         async signPersonalMessage(parameters) {
-          const turnkeyClient = await getTurnkeyClient()
-          const account = await accountForSigning(parameters.address)
-          return await signPayload({
-            payload: hashMessage({ raw: parameters.data }),
-            turnkeyClient,
-            walletAccount: account,
+          return await (
+            await getTurnkeyAccount(parameters.address)
+          ).sign({
+            hash: hashMessage({ raw: parameters.data }),
           })
         },
         async signTransaction(parameters) {
@@ -485,18 +487,16 @@ export function turnkey<const client extends turnkey.Client>(
           return await signTransaction(parameters)
         },
         async signTypedData(parameters) {
-          const turnkeyClient = await getTurnkeyClient()
-          const account = await accountForSigning(parameters.address)
           const typedData = JSON.parse(parameters.data) as {
             domain: Record<string, unknown>
             message: Record<string, unknown>
             primaryType: string
             types: Record<string, unknown>
           }
-          return await signPayload({
-            payload: hashTypedData(typedData as never),
-            turnkeyClient,
-            walletAccount: account,
+          return await (
+            await getTurnkeyAccount(parameters.address)
+          ).sign({
+            hash: hashTypedData(typedData as never),
           })
         },
         async sendTransaction(parameters) {


### PR DESCRIPTION
## Summary
Separate Turnkey wallet metadata from provider connected-account state.

## Motivation
The Turnkey adapter needs wallet account public keys to hydrate Tempo accounts, but `store.accounts` should remain the authority for which addresses are connected. The old `walletAccounts` value mixed those roles.

## Changes
- Rename the Turnkey wallet account state in `src/core/adapters/turnkey.ts` into a metadata cache backed by `fetchWallets()`.
- Route root signing through `getTurnkeyAccount`, which validates against `store.accounts` and hydrates a Turnkey-powered Tempo account from cached metadata.
- Fetch Turnkey metadata at connect/create and silent restore boundaries, then fail explicitly if cached metadata cannot hydrate a connected account.
- Add a `connect()` helper in `src/core/adapters/turnkey.test.ts` for direct adapter tests that need the Provider store handoff.

## Testing
- `pnpm test src/core/adapters/turnkey.test.ts` — 19 tests passed
- `pnpm check:types` — passed
- `pnpm check` — passed with existing unrelated warnings in `src/server/internal/handlers/exchange.test.ts` and `site/src/pages.gen.ts`