### PR TITLE
refactor(privy): remove subpath shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,11 +147,6 @@
       "src": "./src/react/index.ts",
       "default": "./dist/react/index.js"
     },
-    "./privy": {
-      "types": "./dist/privy/index.d.ts",
-      "src": "./src/privy/index.ts",
-      "default": "./dist/privy/index.js"
-    },
     "./wagmi": {
       "types": "./dist/wagmi/index.d.ts",
       "src": "./src/wagmi/index.ts",

--- a/src/privy/index.ts
+++ b/src/privy/index.ts
@@ -1,1 +1,0 @@
-export { privy } from '../core/adapters/privy.js'


### PR DESCRIPTION
## Summary

Remove the `accounts/privy` subpath export and its one-line shim so Privy matches Turnkey's root-export structure.

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm test src/core/adapters/privy.test.ts`