### PR TITLE
feat: update `wallet_deposit` params

### DIFF
--- a/.changeset/wallet-deposit-amount-token.md
+++ b/.changeset/wallet-deposit-amount-token.md
@@ -1,0 +1,13 @@
+---
+'accounts': minor
+---
+
+**Breaking:** Updated `wallet_deposit` params to use `amount` and `token` and removed `value`.
+
+```diff
+provider.request({
+  method: 'wallet_deposit',
+- params: [{ value: '25' }],
++ params: [{ amount: '25', token: 'pathUSD' }],
+})
+```

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -314,36 +314,36 @@ function WalletDeposit() {
           execute(() =>
             provider.request({
               method: 'wallet_deposit',
-              params: [{}],
+              params: [{ amount: '25' }],
             }),
           )
         }
       >
-        Deposit
+        Deposit $25
       </Button>
       <Button
         onClick={() =>
           execute(() =>
             provider.request({
               method: 'wallet_deposit',
-              params: [{ value: '50' }],
+              params: [{ amount: '200' }],
             }),
           )
         }
       >
-        Deposit ($50)
+        Deposit $200
       </Button>
       <Button
         onClick={() =>
           execute(() =>
             provider.request({
               method: 'wallet_deposit',
-              params: [{ displayName: 'DoorDash' }],
+              params: [{ amount: '25', token: 'pathusd' }],
             }),
           )
         }
       >
-        Deposit (displayName: DoorDash)
+        Deposit $25 pathUSD
       </Button>
     </Method>
   )

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -314,6 +314,18 @@ function WalletDeposit() {
           execute(() =>
             provider.request({
               method: 'wallet_deposit',
+              params: [{}],
+            }),
+          )
+        }
+      >
+        Deposit
+      </Button>
+      <Button
+        onClick={() =>
+          execute(() =>
+            provider.request({
+              method: 'wallet_deposit',
               params: [{ amount: '25' }],
             }),
           )

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -166,7 +166,7 @@ export function define(meta: Meta, fn: SetupFn): Adapter {
 
 /** Spreads decoded params. */
 export type ActionRequest<item extends Schema.Item> =
-  Schema.Decoded<item>['params'] extends readonly [infer first] ? first : never
+  NonNullable<Schema.Decoded<item>['params']> extends readonly [infer first] ? first : never
 
 export declare namespace getClient {
   type Options = {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -793,7 +793,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         message: '`deposit` not supported by adapter.',
                       })
                     return (await actions.deposit(
-                      request._decoded.params[0],
+                      request._decoded.params?.[0] ?? {},
                       request,
                     )) satisfies Rpc.wallet_deposit.Encoded['returns']
                   }

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -156,6 +156,24 @@ describe('Encoded', () => {
     }>()
   })
 
+  test('wallet_deposit', () => {
+    expectTypeOf<Rpc.wallet_deposit.Encoded>().toMatchTypeOf<{
+      method: 'wallet_deposit'
+      params:
+        | readonly [
+            {
+              address?: Hex | undefined
+              amount?: string | undefined
+              chainId?: Hex | undefined
+              displayName?: string | undefined
+              token?: Hex | string | undefined
+            },
+          ]
+        | undefined
+      returns: { receipts?: readonly { transactionHash: Hex }[] | undefined } | undefined
+    }>()
+  })
+
   test('wallet_switchEthereumChain', () => {
     expectTypeOf<Rpc.wallet_switchEthereumChain.Encoded>().toEqualTypeOf<{
       method: 'wallet_switchEthereumChain'

--- a/src/core/zod/request.test.ts
+++ b/src/core/zod/request.test.ts
@@ -115,6 +115,42 @@ describe('validate', () => {
     `)
   })
 
+  test('default: validates wallet_deposit with amount and token symbol', () => {
+    const result = RpcRequest.validate(Schema.Request, {
+      method: 'wallet_deposit',
+      params: [
+        {
+          amount: '50',
+          displayName: 'DoorDash',
+          token: 'USDC',
+        },
+      ],
+    })
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_deposit",
+        "params": [
+          {
+            "amount": "50",
+            "displayName": "DoorDash",
+            "token": "USDC",
+          },
+        ],
+      }
+    `)
+  })
+
+  test('default: validates wallet_deposit without params', () => {
+    const result = RpcRequest.validate(Schema.Request, {
+      method: 'wallet_deposit',
+    })
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_deposit",
+      }
+    `)
+  })
+
   test('behavior: preserves original request properties', () => {
     const result = RpcRequest.validate(Schema.Request, {
       method: 'eth_accounts',

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -743,16 +743,23 @@ export namespace wallet_switchEthereumChain {
 export namespace wallet_deposit {
   export const schema = Schema.defineItem({
     method: z.literal('wallet_deposit'),
-    params: z.readonly(
-      z.tuple([
-        z.object({
-          address: z.optional(u.address()),
-          chainId: z.optional(u.number()),
-          displayName: z.optional(z.string()),
-          token: z.optional(u.address()),
-          value: z.optional(z.string()),
-        }),
-      ]),
+    params: z.optional(
+      z.readonly(
+        z.tuple([
+          z.object({
+            address: z.optional(u.address()),
+            /** Human-readable amount to pre-fill (e.g. `"50"`). */
+            amount: z.optional(z.string()),
+            chainId: z.optional(u.number()),
+            displayName: z.optional(z.string()),
+            /**
+             * Token to pre-fill, accepted as either a contract address or a
+             * supported deposit token symbol (case-insensitive, e.g. `"USDC"`).
+             */
+            token: z.optional(z.union([u.address(), z.string()])),
+          }),
+        ]),
+      ),
     ),
     returns: z.optional(
       z.object({


### PR DESCRIPTION
Updates `wallet_deposit` to accept optional params with `amount` and `token`, matching the transfer and swap request shape. The old `value` alias is removed and no-param deposit requests continue to call adapter `deposit` with an empty object.

The web playground now exercises empty params, `$25`, `$200`, and `$25 pathUSD` deposit paths. Added schema, type, request coverage, and a changeset documenting the breaking migration.

Validated with focused SDK lint, request tests, source typecheck, and web playground typecheck.