### PR TITLE
fix: allow `Handler.webAuthn` `Kv` without `create`

### DIFF
--- a/.changeset/bind-webauthn-credentials.md
+++ b/.changeset/bind-webauthn-credentials.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Fixed WebAuthn credential storage to bind credentials to their registered user id and reject duplicate credential registration atomically.
+Fixed WebAuthn credential storage to bind credentials to their registered user id and use atomic duplicate rejection when the configured `Kv` supports it.

--- a/site/src/pages/docs/server/kv.cloudflare.mdx
+++ b/site/src/pages/docs/server/kv.cloudflare.mdx
@@ -8,7 +8,7 @@ description: Kv adapter backed by a Cloudflare Workers KV namespace.
 Adapts a Cloudflare Workers KV namespace (or compatible binding) into a [`Kv`](/docs/server/kv). Uses the underlying store's native `expirationTtl` for TTL — Cloudflare KV's minimum TTL is 60 seconds, enforced by the platform independent of what's passed here.
 
 :::warning
-**Not safe for one-time-consume semantics.** Cloudflare KV is eventually consistent across data centers — concurrent read+delete races can let the same key be "consumed" twice. The optional [`take`](/docs/server/kv#take-key-optional) method is intentionally NOT implemented. Use [`Kv.durableObject`](/docs/server/kv.durableObject) (or another linearizable backend) for the SIWE challenge nonce store.
+**Not safe for one-time-consume or unique-key semantics.** Cloudflare KV is eventually consistent across data centers — concurrent read+delete races can let the same key be "consumed" twice, and concurrent create-if-absent checks can race. The optional [`take`](/docs/server/kv#take-key-optional) and [`create`](/docs/server/kv#create-key-value-options-optional) methods are intentionally NOT implemented. Use [`Kv.durableObject`](/docs/server/kv.durableObject) (or another linearizable backend) when strict atomicity is required.
 :::
 
 ## Usage
@@ -63,4 +63,4 @@ export default {
 
 ## Return Type
 
-A [`Kv`](/docs/server/kv#interface) instance with `get`, `set`, and `delete`. `take` is intentionally omitted — handlers that require atomic read-and-delete (e.g. [`Handler.auth`](/docs/server/handler.auth)) will refuse to accept this adapter and should be paired with [`Kv.durableObject`](/docs/server/kv.durableObject) instead.
+A [`Kv`](/docs/server/kv#interface) instance with `get`, `set`, and `delete`. `take` and `create` are intentionally omitted — handlers that require strict atomicity should be paired with [`Kv.durableObject`](/docs/server/kv.durableObject) instead.

--- a/site/src/pages/docs/server/kv.durableObject.mdx
+++ b/site/src/pages/docs/server/kv.durableObject.mdx
@@ -1,11 +1,11 @@
 ---
 title: Kv.durableObject
-description: Kv adapter backed by a Cloudflare Durable Object with atomic take.
+description: Kv adapter backed by a Cloudflare Durable Object with atomic take and create.
 ---
 
 # `Kv.durableObject`
 
-Adapts a Cloudflare Durable Object namespace into a [`Kv`](/docs/server/kv) with atomic [`take`](/docs/server/kv#take-key-optional). Unlike [`Kv.cloudflare`](/docs/server/kv.cloudflare), a Durable Object's storage is single-actor and linearizable — `take` (read+delete) is guaranteed atomic across concurrent callers, which makes this the recommended backend for SIWE challenge nonce storage on Cloudflare Workers.
+Adapts a Cloudflare Durable Object namespace into a [`Kv`](/docs/server/kv) with atomic [`take`](/docs/server/kv#take-key-optional) and [`create`](/docs/server/kv#create-key-value-options-optional). Unlike [`Kv.cloudflare`](/docs/server/kv.cloudflare), a Durable Object's storage is single-actor and linearizable — `take` (read+delete) and `create` (create-if-absent) are guaranteed atomic across concurrent callers, which makes this the recommended backend for SIWE challenge nonce storage on Cloudflare Workers.
 
 Pair with [`NonceStorage`](/docs/server/kv#noncestorage) (or your own DO class implementing the same fetch protocol).
 
@@ -81,4 +81,4 @@ const handler = Handler.auth({
 
 ## Return Type
 
-A [`Kv`](/docs/server/kv#interface) instance with `get`, `set`, `delete`, and the linearizable `take`.
+A [`Kv`](/docs/server/kv#interface) instance with `get`, `set`, `delete`, and the linearizable `take` and `create`.

--- a/site/src/pages/docs/server/kv.mdx
+++ b/site/src/pages/docs/server/kv.mdx
@@ -17,10 +17,10 @@ import { Kv } from 'accounts/server'
 // In-memory (for development/testing).
 const kv = Kv.memory()
 
-// Cloudflare Workers KV (eventually consistent — no atomic `take`).
+// Cloudflare Workers KV (eventually consistent — no atomic `take` or `create`).
 const kv = Kv.cloudflare(env.MY_KV_NAMESPACE)
 
-// Cloudflare Durable Object (linearizable — atomic `take` available).
+// Cloudflare Durable Object (linearizable — atomic `take` and `create` available).
 const kv = Kv.durableObject(env.NONCE_DO)
 ```
 
@@ -48,13 +48,13 @@ type memory.Options = {
 
 Creates a key-value store backed by a Cloudflare Workers KV namespace (or compatible binding). Uses the underlying store's native `expirationTtl` for TTL — Cloudflare KV's minimum TTL is 60 seconds, enforced by the platform independent of what's passed here.
 
-**Not safe for one-time-consume semantics.** Cloudflare KV is eventually consistent across data centers — concurrent read+delete races can let the same key be "consumed" twice. The optional [`take`](#take-key-optional) method is intentionally NOT implemented. Use [`Kv.durableObject`](#kv-durableobject-namespace-options) (or another linearizable backend) for the SIWE challenge nonce store.
+**Not safe for one-time-consume or unique-key semantics.** Cloudflare KV is eventually consistent across data centers — concurrent read+delete races can let the same key be "consumed" twice, and concurrent create-if-absent checks can race. The optional [`take`](#take-key-optional) and [`create`](#create-key-value-options-optional) methods are intentionally NOT implemented. Use [`Kv.durableObject`](#kv-durableobject-namespace-options) (or another linearizable backend) when strict atomicity is required.
 
 - **namespace** — Cloudflare KV namespace binding.
 
 ### Kv.durableObject(namespace, options?)
 
-Adapts a Cloudflare Durable Object namespace into a `Kv` with atomic [`take`](#take-key-optional). Unlike `Kv.cloudflare`, a Durable Object's storage is single-actor and linearizable — `take` (read+delete) is guaranteed atomic across concurrent callers, which makes this the recommended backend for SIWE challenge nonce storage on Cloudflare Workers.
+Adapts a Cloudflare Durable Object namespace into a `Kv` with atomic [`take`](#take-key-optional) and [`create`](#create-key-value-options-optional). Unlike `Kv.cloudflare`, a Durable Object's storage is single-actor and linearizable — `take` (read+delete) and `create` (create-if-absent) are guaranteed atomic across concurrent callers, which makes this the recommended backend for SIWE challenge nonce storage on Cloudflare Workers.
 
 Pair with [`NonceStorage`](#noncestorage) (or your own DO class implementing the same fetch protocol).
 
@@ -163,6 +163,10 @@ type Kv = {
   /** Delete a value by key. */
   delete: (key: string) => Promise<void>
   /**
+   * Atomic create-if-absent. Optional — see below.
+   */
+  create?: (key: string, value: unknown, options?: set.Options) => Promise<boolean>
+  /**
    * Atomic read-and-delete. Optional — see below.
    */
   take?: <value = unknown>(key: string) => Promise<value | undefined>
@@ -174,14 +178,26 @@ type set.Options = {
 }
 ```
 
+### `create(key, value, options?)` (optional)
+
+Atomic create-if-absent. Returns `true` when the value was written, or `false` when a non-expired value already exists.
+
+Backends with a linearizable create primitive should implement this so consumers can reject duplicates atomically. Consumers may fall back to `get` then `set` when strict atomicity is not required.
+
+| Adapter            | `create` implemented?                                                        |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `Kv.memory`        | ✅ atomic in-process                                                         |
+| `Kv.durableObject` | ✅ linearizable                                                              |
+| `Kv.cloudflare`    | ❌ (eventually consistent — see [`Kv.cloudflare`](#kv-cloudflare-namespace)) |
+
 ### `take(key)` (optional)
 
 Atomic read-and-delete. Returns the value if present, `undefined` if missing or expired. Across concurrent callers, exactly one observer receives a non-`undefined` return for a given key, and the key is removed exactly once.
 
 Required for one-time-consume semantics (e.g. SIWE challenge nonces). Backends without a linearizable read+delete primitive (e.g. eventually-consistent stores like Cloudflare KV) should leave this undefined; the consuming handler will refuse to accept the store at construction time and fall back to a different backend (e.g. a Durable Object).
 
-| Adapter            | `take` implemented? |
-| ------------------ | ------------------- |
-| `Kv.memory`        | ✅ atomic in-process |
-| `Kv.durableObject` | ✅ linearizable      |
+| Adapter            | `take` implemented?                                                          |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `Kv.memory`        | ✅ atomic in-process                                                         |
+| `Kv.durableObject` | ✅ linearizable                                                              |
 | `Kv.cloudflare`    | ❌ (eventually consistent — see [`Kv.cloudflare`](#kv-cloudflare-namespace)) |

--- a/src/server/Kv.ts
+++ b/src/server/Kv.ts
@@ -20,10 +20,10 @@ export type Kv = {
    * Atomic create-if-absent. Returns `true` when the value was written,
    * `false` when a non-expired value already exists.
    *
-   * Optional. Required for unique-key semantics (e.g. WebAuthn credential
-   * registration). Backends without a linearizable create primitive (e.g.
-   * eventually-consistent stores like Cloudflare KV) should leave this
-   * undefined; consumers that require uniqueness will refuse the store.
+   * Optional. Backends with a linearizable create primitive should
+   * implement this so consumers can atomically reject duplicates.
+   * Consumers may fall back to `get` then `set` when strict atomicity is
+   * not required.
    */
   create?: (key: string, value: unknown, options?: set.Options | undefined) => Promise<boolean>
   /**
@@ -61,11 +61,10 @@ export function from<kv extends Kv>(kv: kv): kv {
  * Cloudflare KV's minimum TTL is 60 seconds; the platform enforces its own
  * minimum independent of what's passed here.
  *
- * **Not safe for one-time-consume semantics.** Cloudflare KV is eventually
- * consistent across data centers — concurrent read+delete races can let
- * the same key be "consumed" twice. `take` is intentionally NOT
- * implemented. Use a Durable Object (or another linearizable backend)
- * for the SIWE challenge nonce store.
+ * **Not safe for one-time-consume or unique-key semantics.**
+ * Cloudflare KV is eventually consistent across data centers, so `take`
+ * and `create` are intentionally NOT implemented. Use a Durable Object
+ * (or another linearizable backend) for the SIWE challenge nonce store.
  */
 export function cloudflare(kv: cloudflare.Parameters): Kv {
   return from({
@@ -94,10 +93,11 @@ export declare namespace cloudflare {
 
 /**
  * Adapt a Cloudflare Durable Object namespace into a `Kv` with atomic
- * `take`. Unlike `Kv.cloudflare`, a Durable Object's storage is
- * single-actor and linearizable — `take` (read+delete) is guaranteed
- * atomic across concurrent callers, which makes this the recommended
- * backend for SIWE challenge nonce storage on Cloudflare Workers.
+ * `take` and `create`. Unlike `Kv.cloudflare`, a Durable Object's
+ * storage is single-actor and linearizable, so `take` (read+delete) and
+ * `create` (create-if-absent) are guaranteed atomic across concurrent
+ * callers. This makes it the recommended backend for SIWE challenge
+ * nonce storage on Cloudflare Workers.
  *
  * Pair with `Kv.NonceStorage` (or your own DO class implementing the
  * same fetch protocol).

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -68,7 +68,7 @@ describe('POST /register', () => {
 })
 
 describe('kv', () => {
-  test('store without atomic create is rejected', () => {
+  test('store without atomic create is accepted', () => {
     const kv: Kv.Kv = {
       async get() {
         return undefined
@@ -83,9 +83,7 @@ describe('kv', () => {
         origin: 'http://localhost',
         rpId: 'localhost',
       }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: \`webAuthn({ kv })\` requires a Kv with atomic \`create\` support]`,
-    )
+    ).not.toThrow()
   })
 })
 

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -20,6 +20,17 @@ const defaults = {
 
 const sessionKey = (token: string) => `session:${token}`
 
+async function createCredential(
+  kv: Kv.Kv,
+  key: string,
+  value: { publicKey: string; userId?: string | undefined },
+) {
+  if (kv.create) return await kv.create(key, value)
+  if (await kv.get(key)) return false
+  await kv.set(key, value)
+  return true
+}
+
 /**
  * Session payload persisted in the session store and surfaced via
  * `getSession`. Mirrors the shape of the WebAuthn login response so
@@ -89,8 +100,6 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
     ...rest
   } = options
   const origin = options.origin as string | string[]
-  if (!kv.create) throw new Error('`webAuthn({ kv })` requires a Kv with atomic `create` support')
-  const create = kv.create.bind(kv)
 
   const router = from(rest)
 
@@ -151,7 +160,7 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const userId = stored.userId
         ? Base64.fromBytes(Bytes.fromString(stored.userId), { pad: false, url: true })
         : undefined
-      const created = await create(`credential:${credentialId}`, {
+      const created = await createCredential(kv, `credential:${credentialId}`, {
         publicKey,
         ...(userId ? { userId } : {}),
       })
@@ -398,7 +407,12 @@ export declare namespace webAuthn {
     cookie?: boolean | undefined
     /** Cookie name for the session token. @default "accounts_webauthn" */
     cookieName?: string | undefined
-    /** Key-value store for challenges, credentials, and sessions. */
+    /**
+     * Key-value store for challenges, credentials, and sessions. When
+     * `create` is available, credential registration uses it to reject
+     * duplicates atomically. Otherwise, registration falls back to
+     * best-effort `get` then `set` storage.
+     */
     kv: Kv.Kv
     /** Called after a successful registration. The returned response is merged onto the default JSON response. */
     onRegister?: (parameters: {


### PR DESCRIPTION
`Handler.webAuthn` now keeps the user-bound credential fix while accepting `Kv` adapters that do not expose atomic `create`. Registration uses `create` when available and falls back to best-effort `get`/`set`, so Cloudflare KV-backed handlers can mount again.

The `Kv` reference docs and changeset now describe `create` as optional atomic behavior. Validated with focused WebAuthn/KV tests, SDK lint/format on touched files, and `tsc -b --noEmit`; full example typecheck still fails on unrelated workspace env typing.