### PR TITLE
fix: import `viem/tempo` inference types

### DIFF
--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1132,15 +1132,11 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           experimental_fallback: true,
           experimental_fallbackDelay: 0,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [TransactionExecutionError: An internal error was received.
-
-        Request Arguments:
-          from:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-
-        Details: plain send failure
-        Version: viem@2.49.3]
-      `)
+      ).rejects.toMatchObject({
+        name: 'TransactionExecutionError',
+        shortMessage: 'An internal error was received.',
+        details: 'plain send failure',
+      })
     })
   })
 

--- a/test/config.ts
+++ b/test/config.ts
@@ -59,7 +59,11 @@ export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
 } as const
 
-export const chain = (() => {
+type ConfiguredChain =
+  | (Omit<typeof tempoLocalnet, 'rpcUrls'> & { rpcUrls: Chain['rpcUrls'] })
+  | typeof tempoModerato
+
+export const chain: ConfiguredChain = (() => {
   if (nodeEnv === 'testnet') return tempoModerato
   return defineChain({
     ...tempoLocalnet,

--- a/test/config.ts
+++ b/test/config.ts
@@ -13,9 +13,12 @@ import {
 import { type Address, english, generateMnemonic, type JsonRpcAccount } from 'viem/accounts'
 import { tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
 import {
-  // biome-ignore lint/correctness/noUnusedImports: This is needed to ensure TypeScript can reference viem/tempo types portably
-  type z_TokenId as _,
   Account,
+  type TempoAddress,
+  type z_KeyAuthorization,
+  type z_SignatureEnvelope,
+  type z_TokenId,
+  type z_TxEnvelopeTempo,
 } from 'viem/tempo'
 
 export const id =
@@ -59,11 +62,14 @@ export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
 } as const
 
-type ConfiguredChain =
-  | (Omit<typeof tempoLocalnet, 'rpcUrls'> & { rpcUrls: Chain['rpcUrls'] })
-  | typeof tempoModerato
+type _TempoInference =
+  | TempoAddress.Address
+  | z_KeyAuthorization.Signed
+  | z_SignatureEnvelope.SignatureEnvelope
+  | z_TokenId.TokenIdOrAddress
+  | z_TxEnvelopeTempo.Call
 
-export const chain: ConfiguredChain = (() => {
+export const chain = (() => {
   if (nodeEnv === 'testnet') return tempoModerato
   return defineChain({
     ...tempoLocalnet,

--- a/test/config.ts
+++ b/test/config.ts
@@ -62,6 +62,7 @@ export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
 } as const
 
+// Remove once viem publishes portable Tempo chain inference declarations.
 type _TempoInference =
   | TempoAddress.Address
   | z_KeyAuthorization.Signed


### PR DESCRIPTION
Imports the Tempo namespaces that TypeScript needs to name the inferred test chain from `viem/tempo`, preserving chain inference while keeping declaration emit portable.

Also makes the provider fallback error test assert the stable error fields instead of snapshotting viem's version string.
