### PR TITLE
chore: update `viem` to 2.50.4

### DIFF
--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -17,7 +17,7 @@
     "hono": "^4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "viem": "^2.50.3",
+    "viem": "^2.50.4",
     "wagmi": "latest"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ overrides:
   accounts: workspace:*
   '@sinclair/typebox': ^0.34.0
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
-  viem: ^2.50.3
+  viem: ^2.50.4
   file-type: 22.0.1
   follow-redirects: 1.16.0
   js-yaml@^3: 3.14.2
@@ -96,7 +96,7 @@ importers:
         version: 0.0.7(typescript@5.9.3)
       mppx:
         specifier: 'catalog:'
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
       ox:
         specifier: ~0.14.18
         version: 0.14.20(typescript@5.9.3)(zod@4.3.6)
@@ -142,7 +142,7 @@ importers:
         version: 5.2.0(vite@8.0.13)
       '@wagmi/core':
         specifier: ^3.4.10
-        version: 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
+        version: 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
       elysia:
         specifier: ^1.4.28
         version: 1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -183,14 +183,14 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.3.6)
       vp:
         specifier: npm:vite-plus@~0.1.18
         version: vite-plus@0.1.18(@types/node@25.6.0)(@vitejs/devtools@0.1.15)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.13)(yaml@2.8.3)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
       zile:
         specifier: ^0.0.25
         version: 0.0.25(typescript@5.9.3)
@@ -210,11 +210,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -253,11 +253,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -305,11 +305,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -354,11 +354,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -391,8 +391,8 @@ importers:
         specifier: ~0.14.18
         version: 0.14.18(typescript@5.9.3)(zod@4.4.3)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: latest
@@ -419,11 +419,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -462,11 +462,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -514,11 +514,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -558,7 +558,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.26
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -566,11 +566,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
@@ -610,7 +610,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.26
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -618,11 +618,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
@@ -664,11 +664,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: latest
@@ -702,7 +702,7 @@ importers:
         version: 4.12.18
       mppx:
         specifier: ^0.6.26
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -710,11 +710,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ~1.33.2
@@ -759,11 +759,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: latest
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -835,8 +835,8 @@ importers:
         specifier: ~4.24.0
         version: 4.24.0(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -855,7 +855,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -863,11 +863,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: latest
@@ -898,7 +898,7 @@ importers:
     dependencies:
       '@privy-io/js-sdk-core':
         specifier: ^0.61.3
-        version: 0.61.3(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.61.3(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       '@turnkey/core':
         specifier: 1.13.0
         version: 1.13.0(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
@@ -907,7 +907,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -921,8 +921,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(react@19.2.5)
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
@@ -1020,7 +1020,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
     devDependencies:
       '@tanstack/router-plugin':
         specifier: ^1.167.20
@@ -1063,7 +1063,7 @@ importers:
         version: 11.15.0
       mppx:
         specifier: 'catalog:'
-        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       ox:
         specifier: ~0.14.18
         version: 0.14.20(typescript@5.9.3)(zod@4.4.3)
@@ -1083,8 +1083,8 @@ importers:
         specifier: 'catalog:'
         version: 4.21.0
       viem:
-        specifier: ^2.50.3
-        version: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       vite:
         specifier: 'catalog:'
         version: 8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.13))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -1093,7 +1093,7 @@ importers:
         version: https://pkg.pr.new/wevm/vocs@dc18ab3(patch_hash=0749dd43af96e1423a849f589c6b765ac71042c00b84c5d521e0af05bf159b6e)(@cfworker/json-schema@4.1.1)(@tanstack/react-router@1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(@vue/compiler-sfc@3.5.33)(mermaid@11.15.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.13))(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(waku@1.0.0-alpha.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.13))(babel-plugin-react-compiler@1.0.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+        version: 3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       waku:
         specifier: 1.0.0-alpha.10
         version: 1.0.0-alpha.10(@types/node@25.6.0)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(idb-keyval@6.2.2)(typescript@5.9.3)(vite@8.0.13))(babel-plugin-react-compiler@1.0.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -3194,13 +3194,13 @@ packages:
   '@privy-io/ethereum@0.0.11':
     resolution: {integrity: sha512-8G63lwvBGqov1stRtQvvH+PdWRz/WWrNbL2RrT7i91DXHQ+pEBwMP0HtblRoP3RStHn7LqKCH+7aT/5IQUfgZw==}
     peerDependencies:
-      viem: ^2.50.3
+      viem: ^2.50.4
 
   '@privy-io/js-sdk-core@0.61.3':
     resolution: {integrity: sha512-JsfHGACfP6C6j1HbNvl0YxeR68MOgRKvE1X60tNabrXjyMv5hRFgN3yrnc1vkJTWilzeMW/CtphriEpDTKsy4w==}
     peerDependencies:
       permissionless: ^0.2.47
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       permissionless:
         optional: true
@@ -4649,7 +4649,7 @@ packages:
       accounts: workspace:*
       porto: ~0.2.35
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -4683,7 +4683,7 @@ packages:
       accounts: workspace:*
       porto: ~0.2.35
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -4710,7 +4710,7 @@ packages:
       '@tanstack/query-core': '>=5.0.0'
       accounts: workspace:*
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -4725,7 +4725,7 @@ packages:
       '@tanstack/query-core': '>=5.0.0'
       accounts: workspace:*
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -7432,7 +7432,7 @@ packages:
       elysia: '>=1'
       express: '>=5'
       hono: '>=4.12.18'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -9207,8 +9207,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.50.3:
-    resolution: {integrity: sha512-xJ4XlnkKM2Of0A0TPS4KZNZU1YLYM8+mMirkNA+atTg6Crjg0YqWvSIckszSEmlQ4qH/5lhZ/DILgmNlepbV5A==}
+  viem@2.50.4:
+    resolution: {integrity: sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9380,7 +9380,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.5
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9391,7 +9391,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: ^19.2.5
       typescript: '>=5.7.3'
-      viem: ^2.50.3
+      viem: ^2.50.4
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11929,17 +11929,17 @@ snapshots:
     dependencies:
       '@scure/base': 1.2.6
 
-  '@privy-io/ethereum@0.0.11(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@privy-io/ethereum@0.0.11(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
 
-  '@privy-io/js-sdk-core@0.61.3(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@privy-io/js-sdk-core@0.61.3(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       '@privy-io/api-base': 1.9.0
       '@privy-io/api-types': 0.10.0
       '@privy-io/chains': 0.2.0
       '@privy-io/encoding': 0.1.3
-      '@privy-io/ethereum': 0.0.11(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+      '@privy-io/ethereum': 0.0.11(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       '@privy-io/routes': 0.0.13
       canonicalize: 2.1.0
       eventemitter3: 5.0.1
@@ -11950,7 +11950,7 @@ snapshots:
       set-cookie-parser: 2.7.2
       uuid: 9.0.1
     optionalDependencies:
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
 
   '@privy-io/routes@0.0.13':
     dependencies:
@@ -12778,7 +12778,7 @@ snapshots:
       ethers: 6.16.0
       jwt-decode: 4.0.0
       uuid: 11.1.1
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       '@react-native-async-storage/async-storage': 3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
@@ -13695,34 +13695,34 @@ snapshots:
 
   '@vue/shared@3.5.33': {}
 
-  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       accounts: 'link:'
       typescript: 5.9.3
 
-  '@wagmi/connectors@8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       accounts: 'link:'
       typescript: 5.9.3
 
-  '@wagmi/connectors@8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
-      viem: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
+      viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.10
@@ -13734,11 +13734,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.10
@@ -13749,11 +13749,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))':
+  '@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.10
@@ -13765,11 +13765,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.100.10
@@ -17330,11 +17330,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6)):
+  mppx@0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       incur: 0.4.6
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -17344,11 +17344,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)):
+  mppx@0.6.26(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.6
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -19266,7 +19266,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.50.3(typescript@5.9.3)(zod@4.3.6):
+  viem@2.50.4(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -19283,7 +19283,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.50.3(typescript@5.9.3)(zod@4.4.3):
+  viem@2.50.4(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -19613,14 +19613,14 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)):
+  wagmi@3.6.12(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19636,14 +19636,14 @@ snapshots:
       - immer
       - porto
 
-  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)):
+  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.10(react@19.2.5)
-      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19659,14 +19659,14 @@ snapshots:
       - immer
       - porto
 
-  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6)):
+  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.5))(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.100.10(react@19.2.5)
-      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
-      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19682,14 +19682,14 @@ snapshots:
       - immer
       - porto
 
-  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)):
+  wagmi@3.6.15(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.5(react@19.2.5))(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.5(react@19.2.5)
-      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
-      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.3(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.14(@wagmi/core@3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3)))(accounts@)(typescript@5.9.3)(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.4.12(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@)(immer@11.1.4)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@5.9.3)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.50.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   tsx: ^4.21.0
   typed-query-selector: ^2.12.1
   typescript: ^5.9.3
-  viem: ^2.50.3
+  viem: ^2.50.4
   vite: ^8.0.5
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1139,7 +1139,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
           from:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
         Details: plain send failure
-        Version: viem@2.49.3]
+        Version: viem@2.50.4]
       `)
     })
   })


### PR DESCRIPTION
Updates the workspace catalog and lockfile to `viem` 2.50.4, and keeps the authentication example's direct dependency aligned with the same range.

The provider error snapshot now reflects the `viem` runtime version included in fallback error messages.

Validated with `pnpm test` and `pnpm check:types`.