### PR TITLE
test: label localnet setup retries

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,6 +6,7 @@ import { accounts, getClient, nodeEnv, rpcUrl, webAuthnAccounts } from './config
 
 const client = getClient()
 const localnetSetupKey = '__accounts_localnet_setup__'
+const retry_count = 8
 
 type SetupState = {
   promise?: Promise<void> | undefined
@@ -31,10 +32,11 @@ beforeAll(async () => {
       await new Promise((resolve) => setTimeout(resolve, ms))
     }
 
-    async function withRetry(fn: () => Promise<void>) {
+    async function withRetry(label: string, fn: () => Promise<void>) {
       let error: unknown
-      for (let i = 0; i < 12; i++) {
+      for (let i = 0; i < retry_count; i++) {
         try {
+          console.info(`localnet setup: ${label} (${i + 1}/${retry_count})`)
           await fn()
           return
         } catch (e) {
@@ -49,13 +51,14 @@ beforeAll(async () => {
           await wait(200 * (i + 1))
         }
       }
-      throw error
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`localnet setup failed during ${label}: ${message}`, { cause: error })
     }
 
     state.promise = (async () => {
       // Mint liquidity for fee tokens.
       for (const id of [1n, 2n, 3n])
-        await withRetry(async () => {
+        await withRetry(`mint AMM liquidity for token ${id}`, async () => {
           await Actions.amm.mintSync(client, {
             account: accounts[0],
             feeToken: Addresses.pathUsd,
@@ -67,7 +70,7 @@ beforeAll(async () => {
         })
 
       // Fund first account for provider tests.
-      await withRetry(async () => {
+      await withRetry('fund headless WebAuthn account', async () => {
         await Actions.token.transferSync(client, {
           account: accounts[0],
           feeToken: Addresses.pathUsd,


### PR DESCRIPTION
## Summary
Label localnet setup retries so CI reports which seed step failed.

## Motivation
PR 490 hit a generic Vitest hook timeout in `test/setup.ts`, which hid the localnet setup action that was actually pending or retrying. This branch is based on PR 490 and is intended to be merged/cherry-picked there.

## Changes
- Add labeled logging around each localnet setup retry in `test/setup.ts`
- Reduce setup retries from 12 to 8 so repeated RPC failures can surface before the 120s hook timeout
- Wrap exhausted retries with the setup step name and original error message

## Testing
`./node_modules/.bin/vp test ./src/core/mppx.test.ts ./src/core/adapters/secp256k1.test.ts --bail=1`

Passed: 2 files, 5 tests.