### PR TITLE
fix(adapters): revoke Turnkey and Privy access keys

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -1,6 +1,6 @@
 import { Hex, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { encodeErrorResult, encodeFunctionResult } from 'viem'
+import { BaseError, encodeErrorResult, encodeFunctionResult } from 'viem'
 import { Abis, Account as TempoAccount } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
@@ -345,6 +345,27 @@ describe('create invalidation', () => {
       transaction?.fill({ chainId: 1, from: rootAddress }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: network failed]`)
     expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
+  })
+})
+
+describe('isUnavailableError', () => {
+  test('default: recognizes unavailable key revert errors', () => {
+    expect(AccessKey.isUnavailableError(createRevert('KeyNotFound'))).toMatchInlineSnapshot(`true`)
+    expect(AccessKey.isUnavailableError(createRevert('KeyAlreadyRevoked'))).toMatchInlineSnapshot(
+      `true`,
+    )
+    expect(AccessKey.isUnavailableError(createRevert('SpendingLimitExceeded')))
+      .toMatchInlineSnapshot(`false`)
+  })
+
+  test('behavior: recognizes nested viem error data', () => {
+    const error = new BaseError('revoke failed', {
+      cause: Object.assign(new Error('execution reverted'), {
+        data: { errorName: 'KeyAlreadyRevoked' },
+      }),
+    })
+
+    expect(AccessKey.isUnavailableError(error)).toMatchInlineSnapshot(`true`)
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -1,6 +1,6 @@
 import { AbiFunction, Address, Hex, PublicKey, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import type { Client, Transport } from 'viem'
+import { BaseError, type Client, type Transport } from 'viem'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 
 import type { OneOf } from '../internal/types.js'
@@ -17,6 +17,8 @@ const status = {
   /** A matching key exists but is past its expiry. */
   expired: 'expired',
 } as const
+
+const unavailableErrorNames = new Set(['KeyAlreadyRevoked', 'KeyNotFound'])
 
 type Status = (typeof status)[keyof typeof status]
 
@@ -421,6 +423,20 @@ export function remove(options: Key): void {
   }))
 }
 
+/** Returns whether an error means an access key is already unavailable on-chain. */
+export function isUnavailableError(error: unknown): boolean {
+  if (error instanceof BaseError) {
+    const found = error.walk((e) => {
+      const errorName = (e as { data?: { errorName?: string } }).data?.errorName
+      return !!errorName && unavailableErrorNames.has(errorName)
+    })
+    if (found) return true
+  }
+
+  if (!(error instanceof Error)) return false
+  return unavailableErrorNames.has(ExecutionError.parse(error).errorName)
+}
+
 function scopesMatch(
   key: AccessKey,
   options: {
@@ -517,10 +533,7 @@ async function getPublishedStatus(
     if (metadata.expiry > 0n && metadata.expiry < BigInt(Math.floor(now))) return status.expired
     return status.published
   } catch (error) {
-    if (!(error instanceof Error)) throw error
-    const parsed = ExecutionError.parse(error)
-    if (parsed.errorName === 'KeyNotFound' || parsed.errorName === 'KeyAlreadyRevoked')
-      return status.missing
+    if (isUnavailableError(error)) return status.missing
     throw error
   }
 }

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -145,6 +145,56 @@ describe('dialog', () => {
     expect(lookups).toMatchInlineSnapshot(`[]`)
   })
 
+  test('behavior: revokeAccessKey clears the forwarded key from local state', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    store.setState({
+      accessKeys: [
+        {
+          access: address,
+          address: recipient,
+          chainId: tempoLocalnet.id,
+          keyType: 'p256',
+        } as never,
+      ],
+    })
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+    const request = {
+      method: 'wallet_revokeAccessKey' as const,
+      params: [{ accessKeyAddress: recipient, address }] as const,
+    }
+
+    const promise = adapter.actions.revokeAccessKey!(
+      { accessKeyAddress: recipient, address },
+      request,
+    )
+
+    await vi.waitFor(() => {
+      if (!store.getState().requestQueue[0]) throw new Error('request not queued')
+    })
+
+    const queued = store.getState().requestQueue[0]!
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: undefined,
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchInlineSnapshot(`undefined`)
+    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
+  })
+
   test('error: wallet validation errors keep their RPC code', async () => {
     const storage = Storage.memory()
     const store = Store.create({ chainId: tempoLocalnet.id, storage })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -392,8 +392,14 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           return result
         },
 
-        async revokeAccessKey(_params, request) {
+        async revokeAccessKey(params, request) {
           await provider.request(request)
+          AccessKey.remove({
+            accessKey: params.accessKeyAddress,
+            account: params.address,
+            chainId: store.getState().chainId,
+            store,
+          })
         },
 
         async deposit(_params, request) {

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,6 +1,6 @@
 import { Provider as ox_Provider } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { BaseError, hashMessage } from 'viem'
+import { hashMessage } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
 import { Actions } from 'viem/tempo'
 
@@ -248,20 +248,16 @@ export function local(options: local.Options): Adapter.Adapter {
             await Actions.accessKey.revoke(client, {
               account,
               accessKey: parameters.accessKeyAddress,
-            } as never)
+            })
           } catch (error) {
-            const isKeyNotFound =
-              error instanceof BaseError &&
-              !!error.walk(
-                (e) => (e as { data?: { errorName?: string } }).data?.errorName === 'KeyNotFound',
-              )
-            if (!isKeyNotFound) throw error
+            if (!AccessKey.isUnavailableError(error)) throw error
           }
-          store.setState((state) => ({
-            accessKeys: state.accessKeys.filter(
-              (a) => a.address?.toLowerCase() !== parameters.accessKeyAddress.toLowerCase(),
-            ),
-          }))
+          AccessKey.remove({
+            accessKey: parameters.accessKeyAddress,
+            account: account.address,
+            chainId: client.chain.id,
+            store,
+          })
         },
         async signPersonalMessage({ data, address }) {
           const account = getAccount({ address, signable: true })

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -1,4 +1,7 @@
 import { Address as core_Address, Hex, Secp256k1, Signature } from 'ox'
+import { decodeFunctionData } from 'viem'
+import type { Address } from 'viem/accounts'
+import { Abis } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import * as Storage from '../Storage.js'
@@ -174,6 +177,54 @@ describe('privy', () => {
     	  "rootAddress": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
     	}
     `)
+  })
+
+  test('default: revokeAccessKey revokes with the connected Privy account', async () => {
+    const { adapter, client, store } = setup()
+    store.setState({
+      accounts: [{ address }],
+      activeAccount: 0,
+      accessKeys: [
+        {
+          access: address,
+          address: other,
+          chainId: 1,
+          keyType: 'secp256k1',
+        } as never,
+      ],
+    })
+
+    await adapter.actions.revokeAccessKey!(
+      { accessKeyAddress: other, address },
+      { method: 'wallet_revokeAccessKey', params: [{ accessKeyAddress: other, address }] },
+    )
+
+    const transaction = client.transactions[0] as
+      | { account: { address: Address }; data: Hex.Hex; to: Address }
+      | undefined
+    const decoded = transaction
+      ? decodeFunctionData({ abi: Abis.accountKeychain, data: transaction.data })
+      : undefined
+    expect(
+      transaction &&
+        decoded && {
+          account: transaction.account.address,
+          args: decoded.args,
+          functionName: decoded.functionName,
+          to: transaction.to,
+        },
+    )
+      .toMatchInlineSnapshot(`
+        {
+          "account": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+          "args": [
+            "0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+          ],
+          "functionName": "revokeKey",
+          "to": "0xaAAAaaAA00000000000000000000000000000000",
+        }
+      `)
+    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
   })
 
   test('behavior: signing silently restores wallet accounts via the Privy SDK', async () => {
@@ -450,7 +501,13 @@ function setup(options: setup.Options = {}) {
     getAccount: (() => {
       throw new Error('not implemented')
     }) as never,
-    getClient: (() => ({ chain: { id: 1 } })) as never,
+    getClient: (() => ({
+      chain: { id: 1 },
+      sendTransaction: async (parameters: unknown) => {
+        client.transactions.push(parameters)
+        return Hex.padLeft('0x1', 32)
+      },
+    })) as never,
     storage,
     store,
   })
@@ -481,6 +538,7 @@ type MockClient = privy.Client & {
   restoreCalls: number
   signPayloads: Hex.Hex[]
   signWith: string[]
+  transactions: unknown[]
   wallets: privy.EmbeddedWallet[]
   makeWallet: (address: string) => privy.EmbeddedWallet
   addWallet: (address: string) => void
@@ -496,6 +554,7 @@ function createClient(options: setup.Options = {}) {
     restoreCalls: 0,
     signPayloads: [] as Hex.Hex[],
     signWith: [] as string[],
+    transactions: [] as unknown[],
     wallets: [] as privy.EmbeddedWallet[],
     makeWallet(address: string): privy.EmbeddedWallet {
       return {

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -9,9 +9,9 @@ import {
 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
-import type { Address } from 'viem/accounts'
+import type { Address, LocalAccount } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Transaction as TempoTransaction } from 'viem/tempo'
+import { Actions, Transaction as TempoTransaction } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
@@ -75,7 +75,7 @@ export function privy<const client extends privy.Client>(
 ): Adapter.Adapter {
   const { icon, name = 'Privy', rdns = 'io.privy' } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, ({ getClient, store }) => {
     let privyClient_promise: Promise<client> | undefined
     let restore_promise: Promise<void> | undefined
     let walletAccounts: readonly privy.EmbeddedWallet[] = []
@@ -375,8 +375,17 @@ export function privy<const client extends privy.Client>(
         ...(feePayer ? { feePayer: true } : {}),
         type: 'tempo',
       } as never)
+      return await signPreparedTransaction(account, prepared)
+    }
+
+    async function signPreparedTransaction(account: privy.EmbeddedWallet, prepared: unknown) {
       const presign = (() => {
-        if ('feePayerSignature' in prepared && prepared.feePayerSignature)
+        if (
+          prepared &&
+          typeof prepared === 'object' &&
+          'feePayerSignature' in prepared &&
+          prepared.feePayerSignature
+        )
           return { ...prepared, feePayerSignature: null }
         return prepared
       })()
@@ -591,6 +600,35 @@ export function privy<const client extends privy.Client>(
           const account = await accountForSigning(undefined)
           const keyAuthorization = await authorizeAccessKeyFor(account, parameters)
           return { keyAuthorization, rootAddress: core_Address.from(account.address) }
+        },
+        async revokeAccessKey(parameters) {
+          const account = await accountForSigning(parameters.address)
+          const account_tempo = {
+            address: core_Address.from(account.address),
+            source: 'privy',
+            signTransaction: async (request: unknown) =>
+              await signPreparedTransaction(account, request),
+            type: 'local',
+          } satisfies {
+            address: Address
+            signTransaction: (request: unknown) => Promise<Hex.Hex>
+            source: 'privy'
+            type: 'local'
+          }
+          try {
+            await Actions.accessKey.revoke(getClient(), {
+              account: account_tempo as LocalAccount<'privy'>,
+              accessKey: parameters.accessKeyAddress,
+            })
+          } catch (error) {
+            if (!AccessKey.isUnavailableError(error)) throw error
+          }
+          AccessKey.remove({
+            accessKey: parameters.accessKeyAddress,
+            account: core_Address.from(account.address),
+            chainId: store.getState().chainId,
+            store,
+          })
         },
         async signPersonalMessage(parameters) {
           const account = await accountForSigning(parameters.address)

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -1,5 +1,7 @@
 import { Hex, PublicKey } from 'ox'
+import { decodeFunctionData } from 'viem'
 import type { Address } from 'viem/accounts'
+import { Abis } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { accounts } from '../../../test/config.js'
@@ -292,6 +294,54 @@ describe('turnkey', () => {
     `)
   })
 
+  test('default: revokeAccessKey revokes with the connected Turnkey account', async () => {
+    const { adapter, client, store } = setup()
+    store.setState({
+      accounts: [{ address }],
+      activeAccount: 0,
+      accessKeys: [
+        {
+          access: address,
+          address: other,
+          chainId: 1,
+          keyType: 'secp256k1',
+        } as never,
+      ],
+    })
+
+    await adapter.actions.revokeAccessKey!(
+      { accessKeyAddress: other, address },
+      { method: 'wallet_revokeAccessKey', params: [{ accessKeyAddress: other, address }] },
+    )
+
+    const transaction = client.transactions[0] as
+      | { account: { address: Address }; data: Hex.Hex; to: Address }
+      | undefined
+    const decoded = transaction
+      ? decodeFunctionData({ abi: Abis.accountKeychain, data: transaction.data })
+      : undefined
+    expect(
+      transaction &&
+        decoded && {
+          account: transaction.account.address,
+          args: decoded.args,
+          functionName: decoded.functionName,
+          to: transaction.to,
+        },
+    )
+      .toMatchInlineSnapshot(`
+        {
+          "account": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "args": [
+            "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+          ],
+          "functionName": "revokeKey",
+          "to": "0xaAAAaaAA00000000000000000000000000000000",
+        }
+      `)
+    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
+  })
+
   test('behavior: signing silently restores wallet accounts from an existing session', async () => {
     const { adapter, client, store } = setup()
     store.setState({ accounts: [{ address }], activeAccount: 0 })
@@ -508,7 +558,13 @@ function setup(options: setup.Options = {}) {
     getAccount: (() => {
       throw new Error('not implemented')
     }) as never,
-    getClient: (() => ({ chain: { id: 1 } })) as never,
+    getClient: (() => ({
+      chain: { id: 1 },
+      sendTransaction: async (parameters: unknown) => {
+        client.transactions.push(parameters)
+        return Hex.padLeft('0x1', 32)
+      },
+    })) as never,
     storage,
     store,
   })
@@ -546,6 +602,7 @@ function createClient(options: setup.Options = {}) {
     loadCalls: 0,
     signPayloads: [] as Hex.Hex[],
     signWith: [] as string[],
+    transactions: [] as unknown[],
     wallets: [{ accounts: [toWalletAccount(account)] }] as WalletShape[],
   }
   const client = {
@@ -572,6 +629,9 @@ function createClient(options: setup.Options = {}) {
     },
     get signWith() {
       return state.signWith
+    },
+    get transactions() {
+      return state.transactions
     },
     get wallets() {
       return state.wallets
@@ -610,6 +670,7 @@ function createClient(options: setup.Options = {}) {
     loadCalls: number
     signPayloads: Hex.Hex[]
     signWith: string[]
+    transactions: unknown[]
     wallets: WalletShape[]
   }
 

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -10,7 +10,7 @@ import {
 import { hashMessage, hashTypedData, isAddressEqual } from 'viem'
 import type { Address } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Account as TempoAccount } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
@@ -426,6 +426,23 @@ export function turnkey<const client extends turnkey.Client>(
             store,
           })
           return { keyAuthorization, rootAddress: account.address }
+        },
+        async revokeAccessKey(parameters) {
+          const account = await getTurnkeyAccount(parameters.address)
+          try {
+            await Actions.accessKey.revoke(getClient(), {
+              account,
+              accessKey: parameters.accessKeyAddress,
+            })
+          } catch (error) {
+            if (!AccessKey.isUnavailableError(error)) throw error
+          }
+          AccessKey.remove({
+            accessKey: parameters.accessKeyAddress,
+            account: account.address,
+            chainId: store.getState().chainId,
+            store,
+          })
         },
         async signPersonalMessage(parameters) {
           return await (


### PR DESCRIPTION
## Summary
Add `wallet_revokeAccessKey` support for Turnkey and Privy adapters.

## Motivation
Turnkey supports access key revocation, but the SDK adapters only handled access key authorization. Turnkey and Privy sessions need to revoke keys through the SDK and clear stale local key state after successful or already-applied revocations.

## Changes
- Add `revokeAccessKey` actions in `src/core/adapters/turnkey.ts` and `src/core/adapters/privy.ts`.
- Use scoped `AccessKey.remove({ accessKey, account, chainId, store })` cleanup and shared `AccessKey.isUnavailableError()` handling.
- Treat `KeyNotFound` and `KeyAlreadyRevoked` as successful local cleanup cases.
- Add AccessKey, Turnkey, Privy, and dialog tests for revoke/unavailable-key behavior.

## Testing
- `pnpm vp lint --fix src/core/adapters/turnkey.ts src/core/adapters/local.ts src/core/adapters/privy.ts src/core/adapters/turnkey.test.ts src/core/adapters/privy.test.ts src/core/adapters/dialog.test.ts src/core/AccessKey.ts src/core/AccessKey.test.ts` - passed, 0 warnings/errors.
- `pnpm exec tsc -b --noEmit` - passed.
- `pnpm test src/core/AccessKey.test.ts src/core/adapters/turnkey.test.ts src/core/adapters/privy.test.ts src/core/adapters/dialog.test.ts` - passed, 78 tests.
- `pnpm check:types` - root SDK type build passed, then example workspace typechecks failed on existing dependency/type resolution issues (`hono`, `viem`, `process`, etc.).