### PR TITLE
fix: forward dialog auth capability

### DIFF
--- a/.changeset/dialog-auth-capability.md
+++ b/.changeset/dialog-auth-capability.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed dialog auth capability handling to forward returned auth tokens through wallet connection account results.

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -201,6 +201,8 @@ export declare namespace createAccount {
     email?: string | null | undefined
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
+    /** Server Authentication result, if the auth capability was requested. */
+    auth?: { token?: string | undefined } | undefined
     /**
      * Echo of the `personalSign` request, present iff the caller supplied
      * `personalSign`. The signature lives on the top-level `signature`
@@ -257,6 +259,8 @@ export declare namespace loadAccounts {
     email?: string | null | undefined
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
+    /** Server Authentication result, if the auth capability was requested. */
+    auth?: { token?: string | undefined } | undefined
     /**
      * Echo of the `personalSign` request, present iff the caller supplied
      * `personalSign`. The signature lives on the top-level `signature`

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -602,56 +602,61 @@ export function create(options: create.Options = {}): create.ReturnType {
                       ? { message: auth.message }
                       : capabilities?.personalSign
 
-                    const { keyAuthorization, accounts, email, personalSign, signature, username } =
-                      await (async () => {
-                        if (capabilities?.method === 'register') {
-                          // If a stored account already has this label, sign in
-                          // with its credential instead of creating a new one.
-                          const existing = capabilities.name
-                            ? store
-                                .getState()
-                                .accounts.find(
-                                  (a) =>
-                                    'credential' in a &&
-                                    a.label?.toLowerCase() === capabilities.name!.toLowerCase(),
-                                )
-                            : undefined
-                          if (existing && 'credential' in existing)
-                            return await actions.loadAccounts(
-                              {
-                                credentialId: existing.credential?.id,
-                                digest: capabilities.digest,
-                                authorizeAccessKey,
-                                ...(personalSign_request
-                                  ? { personalSign: personalSign_request }
-                                  : {}),
-                              },
-                              request,
-                            )
-                          return await actions.createAccount(
+                    const {
+                      accounts,
+                      auth: auth_capability,
+                      email,
+                      keyAuthorization,
+                      personalSign,
+                      signature,
+                      username,
+                    } = await (async () => {
+                      if (capabilities?.method === 'register') {
+                        // If a stored account already has this label, sign in
+                        // with its credential instead of creating a new one.
+                        const existing = capabilities.name
+                          ? store
+                              .getState()
+                              .accounts.find(
+                                (a) =>
+                                  'credential' in a &&
+                                  a.label?.toLowerCase() === capabilities.name!.toLowerCase(),
+                              )
+                          : undefined
+                        if (existing && 'credential' in existing)
+                          return await actions.loadAccounts(
                             {
+                              credentialId: existing.credential?.id,
                               digest: capabilities.digest,
                               authorizeAccessKey,
-                              name: capabilities.name ?? 'default',
-                              userId: capabilities.userId ?? Hex.random(16),
                               ...(personalSign_request
                                 ? { personalSign: personalSign_request }
                                 : {}),
                             },
                             request,
                           )
-                        }
-                        return await actions.loadAccounts(
+                        return await actions.createAccount(
                           {
-                            credentialId: capabilities?.credentialId,
-                            digest: capabilities?.digest,
+                            digest: capabilities.digest,
                             authorizeAccessKey,
-                            selectAccount: capabilities?.selectAccount,
+                            name: capabilities.name ?? 'default',
+                            userId: capabilities.userId ?? Hex.random(16),
                             ...(personalSign_request ? { personalSign: personalSign_request } : {}),
                           },
                           request,
                         )
-                      })()
+                      }
+                      return await actions.loadAccounts(
+                        {
+                          credentialId: capabilities?.credentialId,
+                          digest: capabilities?.digest,
+                          authorizeAccessKey,
+                          selectAccount: capabilities?.selectAccount,
+                          ...(personalSign_request ? { personalSign: personalSign_request } : {}),
+                        },
+                        request,
+                      )
+                    })()
 
                     store.setState({
                       accounts: resolveAccounts(accounts),
@@ -712,7 +717,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                                   : {}),
                                 ...(email !== undefined ? { email } : {}),
                                 ...(username !== undefined ? { username } : {}),
-                                ...(auth_result ? { auth: auth_result } : {}),
+                                ...((auth_result ?? auth_capability)
+                                  ? { auth: auth_result ?? auth_capability }
+                                  : {}),
                                 ...(personalSign
                                   ? { personalSign: { message: personalSign.message } }
                                   : {}),

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -92,6 +92,72 @@ describe('dialog', () => {
     expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
   })
 
+  test('behavior: loadAccounts forwards auth capabilities returned by the dialog', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+    const request = {
+      method: 'wallet_connect' as const,
+      params: [
+        {
+          capabilities: {
+            auth: {
+              url: 'https://app.example/auth',
+              returnToken: true,
+            },
+          },
+          chainId: '0x1079' as const,
+        },
+      ] as const,
+    }
+
+    const promise = adapter.actions.loadAccounts(undefined, request)
+
+    await vi.waitFor(() => {
+      if (!store.getState().requestQueue[0]) throw new Error('request not queued')
+    })
+
+    const queued = store.getState().requestQueue[0]!
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: {
+            accounts: [
+              {
+                address,
+                capabilities: {
+                  auth: { token: 'test-token' },
+                },
+              },
+            ],
+          },
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchInlineSnapshot(`
+      {
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "auth": {
+          "token": "test-token",
+        },
+      }
+    `)
+  })
+
   test('behavior: sendTransaction falls through when no access key is selected', async () => {
     const storage = Storage.memory()
     const store = Store.create({ chainId: tempoLocalnet.id, storage })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -194,20 +194,18 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           })
 
           const address = accounts[0]?.address
-          const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
+          const capabilities = accounts[0]?.capabilities
+          const keyAuthorization = capabilities?.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
             saveAccessKey(address, keyAuthorization, accessKey.keyPair)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
+            ...(capabilities?.auth ? { auth: capabilities.auth } : {}),
             ...(keyAuthorization ? { keyAuthorization } : {}),
-            ...(accounts[0]?.capabilities.signature
-              ? { signature: accounts[0].capabilities.signature }
-              : {}),
-            ...(accounts[0]?.capabilities.personalSign
-              ? { personalSign: accounts[0].capabilities.personalSign }
-              : {}),
+            ...(capabilities?.signature ? { signature: capabilities.signature } : {}),
+            ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
           }
         },
 
@@ -235,20 +233,18 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           })
 
           const address = accounts[0]?.address
-          const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
+          const capabilities = accounts[0]?.capabilities
+          const keyAuthorization = capabilities?.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
             saveAccessKey(address, keyAuthorization, accessKey.keyPair)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
+            ...(capabilities?.auth ? { auth: capabilities.auth } : {}),
             ...(keyAuthorization ? { keyAuthorization } : {}),
-            ...(accounts[0]?.capabilities.signature
-              ? { signature: accounts[0].capabilities.signature }
-              : {}),
-            ...(accounts[0]?.capabilities.personalSign
-              ? { personalSign: accounts[0].capabilities.personalSign }
-              : {}),
+            ...(capabilities?.signature ? { signature: capabilities.signature } : {}),
+            ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
           }
         },
 


### PR DESCRIPTION
## Summary
- forward auth returned by dialog wallet_connect responses through adapter results
- include forwarded auth in final wallet_connect account capabilities when the dapp-side provider skips local auth verification
- add a regression test for dialog loadAccounts preserving auth tokens

## Test plan
- PATH=/home/agent/.local/bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0VEXXPN:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm vp test src/core/adapters/dialog.test.ts
- PATH=/home/agent/.local/bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0VEXXPN:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm check:types
- PATH=/home/agent/.local/bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0VEXXPN:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm check