### PR TITLE
fix: relax `auth` endpoint validation

### DIFF
--- a/.changeset/fixed-auth-endpoints.md
+++ b/.changeset/fixed-auth-endpoints.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed `wallet_connect` auth handling to allow derived or forwarded auth endpoints without dropping the SIWE signature.

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -418,6 +418,22 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
       })
 
+      test('default: object-form auth with url derives challenge and verify', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { method: 'register', auth: { url: authBase } } }],
+        })
+
+        const capabilities = result.accounts[0]!.capabilities
+        expect(capabilities.auth).toEqual({ token: expect.any(String) })
+        expect(capabilities.personalSign).toEqual({
+          message: expect.stringContaining('wants you to sign in'),
+        })
+        expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+      })
+
       test('default: object-form auth with explicit endpoints uses the override URLs', async () => {
         const provider = Provider.create({ adapter: adapter() })
 
@@ -437,6 +453,32 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         })
 
         expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
+      })
+
+      test('default: forwarded auth without verify returns signature for downstream verify', async () => {
+        const provider = Provider.create({ adapter: adapter() })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [
+            {
+              capabilities: {
+                method: 'register',
+                auth: {
+                  challenge: `${authBase}/challenge`,
+                  logout: `${authBase}/logout`,
+                },
+              },
+            },
+          ],
+        })
+
+        const capabilities = result.accounts[0]!.capabilities
+        expect(capabilities.auth).toBeUndefined()
+        expect(capabilities.personalSign).toEqual({
+          message: expect.stringContaining('wants you to sign in'),
+        })
+        expect(capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
       })
 
       test('error: verify endpoint returns 401 → InternalError; user already signed', async () => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -568,6 +568,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                           auth_input as NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
                         )
                       : undefined
+                    if (auth_request && typeof auth_request === 'object' && !auth_request.challenge)
+                      throw new RpcResponse.InvalidParamsError({
+                        message:
+                          '`auth` capability must include either `url` or an explicit `challenge` endpoint.',
+                      })
                     if (auth_request && capabilities?.personalSign)
                       throw new RpcResponse.InvalidParamsError({
                         message:
@@ -712,7 +717,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                                       },
                                     }
                                   : {}),
-                                ...(signature && (!auth_request || auth_result)
+                                ...(signature && (!auth_request || auth_result || !verifyUrl)
                                   ? { signature }
                                   : {}),
                                 ...(email !== undefined ? { email } : {}),
@@ -1263,14 +1268,16 @@ function resolveAuthEndpoint(
 }
 
 /**
- * Pre-resolves the `auth` capability into its absolute, fully-explicit
- * object form. Run once at the dapp-side Provider so forwarding adapters
- * (dialog) carry absolute URLs to the wallet host — the wallet's
- * `window.location.origin` belongs to the wallet, not the dapp, and
- * cannot resolve relative paths correctly.
+ * Pre-resolves the `auth` capability into its absolute object form. Run
+ * once at the dapp-side Provider so forwarding adapters (dialog) carry
+ * absolute URLs to the wallet host — the wallet's `window.location.origin`
+ * belongs to the wallet, not the dapp, and cannot resolve relative paths
+ * correctly.
  *
- * `logout` is omitted when the input doesn't supply enough info to derive
- * one (it's optional in the protocol).
+ * Individual endpoints are omitted when the input doesn't supply enough
+ * info to derive them. `logout` is optional in the protocol; `verify` can
+ * also be omitted by wallet-host re-entry so the dapp-origin Provider runs
+ * verification and receives the session cookie.
  */
 function absolutizeAuth(
   auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
@@ -1294,10 +1301,6 @@ function absolutizeAuth(
 
 function assertSameAuthOrigin(auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>): void {
   if (typeof auth !== 'object') return
-  if (!auth.challenge || !auth.verify)
-    throw new RpcResponse.InvalidParamsError({
-      message: '`auth` requires both `challenge` and `verify` endpoints.',
-    })
   const urls = [auth.challenge, auth.verify, auth.logout].filter(
     (u): u is string => typeof u === 'string',
   )


### PR DESCRIPTION
Relaxes Server Authentication endpoint validation so `{ url }` auth config derives `challenge`, `verify`, and `logout` without hitting the partial-endpoint error. Forwarded auth payloads that intentionally omit `verify` now still return the SIWE signature for downstream verification.

Adds regressions for `{ url }` derivation and forwarded no-`verify` auth, plus a patch changeset for `accounts`.

Validated with `pnpm test src/core/Provider.localnet.test.ts -- --runInBand` and `git diff --check`.