### PR TITLE
fix(dialog): reject access key requests without key material

### DIFF
--- a/.changeset/dialog-generated-access-key-type.md
+++ b/.changeset/dialog-generated-access-key-type.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed access key authorization to reject requests that require external key material when none is provided.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -181,6 +181,8 @@ const provider = Provider.create({
 
 You can also pre-derive the access key locally by passing `publicKey` or `address` with `keyType`. The wallet still authorizes that key during `wallet_connect`; the app keeps the signing material.
 
+For `keyType: 'secp256k1'`, generate and store the private key in your app or backend, then pass either the derived `address` or the `publicKey` in `authorizeAccessKey`.
+
 ```ts twoslash
 // @noErrors
 import { Expiry, Provider } from 'accounts'

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -354,8 +354,9 @@ describe('isUnavailableError', () => {
     expect(AccessKey.isUnavailableError(createRevert('KeyAlreadyRevoked'))).toMatchInlineSnapshot(
       `true`,
     )
-    expect(AccessKey.isUnavailableError(createRevert('SpendingLimitExceeded')))
-      .toMatchInlineSnapshot(`false`)
+    expect(
+      AccessKey.isUnavailableError(createRevert('SpendingLimitExceeded')),
+    ).toMatchInlineSnapshot(`false`)
   })
 
   test('behavior: recognizes nested viem error data', () => {
@@ -370,7 +371,7 @@ describe('isUnavailableError', () => {
 })
 
 describe('generate', () => {
-  test('default: returns access key and key pair', async () => {
+  test('default: returns p256 access key and key pair', async () => {
     const result = await AccessKey.generate()
 
     expect(result.accessKey.address).toMatch(/^0x[0-9a-f]{40}$/i)
@@ -394,6 +395,22 @@ describe('prepareAuthorization', () => {
     expect(result.keyAuthorization.expiry).toMatchInlineSnapshot(`123`)
     expect(result.keyAuthorization.type).toMatchInlineSnapshot(`"p256"`)
     expect(result.keyPair).toBeDefined()
+  })
+
+  test('error: rejects secp256k1 authorization without external key material', async () => {
+    await expect(
+      AccessKey.prepareAuthorization({ chainId: 1, expiry: 123, keyType: 'secp256k1' }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`keyType: "secp256k1"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
+    )
+  })
+
+  test('error: rejects webAuthn authorization without external key material', async () => {
+    await expect(
+      AccessKey.prepareAuthorization({ chainId: 1, expiry: 123, keyType: 'webAuthn' }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`keyType: "webAuthn"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
+    )
   })
 
   test('behavior: prepares external key authorization from address', async () => {
@@ -465,6 +482,27 @@ describe('prepareAuthorization', () => {
         "limits": undefined,
         "scopes": undefined,
         "type": "p256",
+      }
+    `)
+  })
+
+  test('behavior: prepares external secp256k1 authorization from public key', async () => {
+    const result = await AccessKey.prepareAuthorization({
+      chainId: 123n,
+      expiry: 456,
+      keyType: 'secp256k1',
+      publicKey: accounts[1]!.publicKey,
+    })
+
+    expect(result.keyPair).toBeUndefined()
+    expect(result.keyAuthorization).toMatchInlineSnapshot(`
+      {
+        "address": "${accounts[1]!.address.toLowerCase()}",
+        "chainId": 123n,
+        "expiry": 456,
+        "limits": undefined,
+        "scopes": undefined,
+        "type": "secp256k1",
       }
     `)
   })

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -1,4 +1,4 @@
-import { AbiFunction, Address, Hex, PublicKey, WebCryptoP256 } from 'ox'
+import { AbiFunction, Address, Hex, PublicKey, RpcResponse, WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { BaseError, type Client, type Transport } from 'viem'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
@@ -179,6 +179,10 @@ export async function prepareAuthorization(
     })
     return { keyAuthorization }
   }
+  if (keyType && keyType !== 'p256')
+    throw new RpcResponse.InvalidParamsError({
+      message: `\`keyType: "${keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
+    })
 
   const keyPair = await WebCryptoP256.createKeyPair()
   const keyAuthorization = KeyAuthorization.from({

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -297,7 +297,7 @@ export declare namespace authorizeAccessKey {
     chainId?: bigint | undefined
     /** Unix timestamp (seconds) when the key expires. */
     expiry: number
-    /** Key type of the external public key. Required when `publicKey` or `address` is provided. */
+    /** External key type. Defaults to `secp256k1` for external keys. */
     keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
     /** TIP-20 spending limits for this key. */
     limits?: readonly { token: Address; limit: bigint; period?: number | undefined }[] | undefined

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -1,4 +1,5 @@
-import { Provider as ox_Provider } from 'ox'
+import { Address, Hex, Provider as ox_Provider, PublicKey } from 'ox'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { tempoLocalnet } from 'viem/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
@@ -10,6 +11,47 @@ import { dialog } from './dialog.js'
 
 const address = '0x0000000000000000000000000000000000000001'
 const recipient = '0x0000000000000000000000000000000000000002'
+
+function createKeyAuthorization(options: {
+  expiry: number
+  keyType: 'secp256k1' | 'p256'
+  publicKey: Hex.Hex
+}) {
+  const { expiry, keyType, publicKey } = options
+  return KeyAuthorization.toRpc(
+    KeyAuthorization.from(
+      {
+        address: Address.fromPublicKey(PublicKey.from(publicKey)),
+        chainId: BigInt(tempoLocalnet.id),
+        expiry,
+        type: keyType,
+      },
+      { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
+    ),
+  )
+}
+
+function setup() {
+  const storage = Storage.memory()
+  const store = Store.create({ chainId: tempoLocalnet.id, storage })
+  const adapter = dialog({ dialog: Dialog.noop() })({
+    getAccount: (options) => {
+      if (options?.signable) throw new ox_Provider.UnauthorizedError({ message: 'No signer.' })
+      return { address, type: 'json-rpc' } as never
+    },
+    getClient: () => ({}) as never,
+    storage,
+    store,
+  })
+  return { adapter, store }
+}
+
+async function takeRequest(store: Store.Store) {
+  await vi.waitFor(() => {
+    if (!store.getState().requestQueue[0]) throw new Error('request not queued')
+  })
+  return store.getState().requestQueue[0]!
+}
 
 describe('dialog', () => {
   afterEach(() => {
@@ -193,6 +235,160 @@ describe('dialog', () => {
 
     await expect(promise).resolves.toMatchInlineSnapshot(`undefined`)
     expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: authorizeAccessKey forwards an external secp256k1 key', async () => {
+    const { adapter, store } = setup()
+    const expiry = 123
+    const promise = adapter.actions.authorizeAccessKey!(
+      { address: recipient, expiry, keyType: 'secp256k1' },
+      {
+        method: 'wallet_authorizeAccessKey',
+        params: [{ address: recipient, expiry, keyType: 'secp256k1' }],
+      },
+    )
+
+    const queued = await takeRequest(store)
+    const request = queued.request as {
+      params: [{ address: typeof recipient; expiry: number; keyType: 'secp256k1' }]
+    }
+    const params = request.params[0]
+    const keyAuthorization = KeyAuthorization.toRpc(
+      KeyAuthorization.from(
+        {
+          address: recipient,
+          chainId: BigInt(tempoLocalnet.id),
+          expiry,
+          type: 'secp256k1',
+        },
+        { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
+      ),
+    )
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: {
+            keyAuthorization,
+            rootAddress: address,
+          },
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchObject({ rootAddress: address })
+    expect(params.keyType).toMatchInlineSnapshot(`"secp256k1"`)
+    expect(params.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000002"`)
+    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: authorizeAccessKey generates a p256 key by default', async () => {
+    const { adapter, store } = setup()
+    const expiry = 123
+    const promise = adapter.actions.authorizeAccessKey!(
+      { expiry },
+      { method: 'wallet_authorizeAccessKey', params: [{ expiry }] },
+    )
+
+    const queued = await takeRequest(store)
+    const request = queued.request as {
+      params: [{ expiry: number; keyType: 'p256'; publicKey: Hex.Hex }]
+    }
+    const params = request.params[0]
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: {
+            keyAuthorization: createKeyAuthorization(params),
+            rootAddress: address,
+          },
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchObject({ rootAddress: address })
+    expect(params.keyType).toMatchInlineSnapshot(`"p256"`)
+    expect(store.getState().accessKeys).toMatchObject([
+      {
+        access: address,
+        keyType: 'p256',
+      },
+    ])
+    expect('keyPair' in store.getState().accessKeys[0]!).toMatchInlineSnapshot(`true`)
+  })
+
+  test('behavior: authorizeAccessKey generates a p256 key when requested', async () => {
+    const { adapter, store } = setup()
+    const expiry = 123
+    const promise = adapter.actions.authorizeAccessKey!(
+      { expiry, keyType: 'p256' },
+      { method: 'wallet_authorizeAccessKey', params: [{ expiry, keyType: 'p256' }] },
+    )
+
+    const queued = await takeRequest(store)
+    const request = queued.request as {
+      params: [{ expiry: number; keyType: 'p256'; publicKey: Hex.Hex }]
+    }
+    const params = request.params[0]
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: {
+            keyAuthorization: createKeyAuthorization(params),
+            rootAddress: address,
+          },
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchObject({ rootAddress: address })
+    expect(params.keyType).toMatchInlineSnapshot(`"p256"`)
+    expect(store.getState().accessKeys).toMatchObject([
+      {
+        access: address,
+        keyType: 'p256',
+      },
+    ])
+    expect('keyPair' in store.getState().accessKeys[0]!).toMatchInlineSnapshot(`true`)
+  })
+
+  test('error: secp256k1 access key requires external key material', async () => {
+    const { adapter, store } = setup()
+
+    await expect(
+      adapter.actions.authorizeAccessKey!(
+        { expiry: 123, keyType: 'secp256k1' },
+        {
+          method: 'wallet_authorizeAccessKey',
+          params: [{ expiry: 123, keyType: 'secp256k1' }],
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`keyType: "secp256k1"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
+    )
+    expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('error: webAuthn access key requires external key material', async () => {
+    const { adapter, store } = setup()
+
+    await expect(
+      adapter.actions.authorizeAccessKey!(
+        { expiry: 123, keyType: 'webAuthn' },
+        {
+          method: 'wallet_authorizeAccessKey',
+          params: [{ expiry: 123, keyType: 'webAuthn' }],
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`keyType: "webAuthn"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
+    )
+    expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
   })
 
   test('error: wallet validation errors keep their RPC code', async () => {

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -1,4 +1,4 @@
-import { Address, Provider as ox_Provider, RpcRequest as ox_RpcRequest } from 'ox'
+import { Address, Provider as ox_Provider, RpcRequest as ox_RpcRequest, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { z } from 'zod/mini'
 
@@ -114,11 +114,16 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     async function generateAccessKey(options: Adapter.authorizeAccessKey.Parameters | undefined) {
       if (!options) return undefined
       if (options.publicKey || options.address) return undefined
+      if (options.keyType && options.keyType !== 'p256')
+        throw new RpcResponse.InvalidParamsError({
+          message: `\`keyType: "${options.keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
+        })
 
-      const { accessKey, keyPair } = await AccessKey.generate()
+      const generated = await AccessKey.generate()
+      const { accessKey } = generated
       return {
         accessKey,
-        keyPair,
+        generated,
         request: {
           ...options,
           publicKey: accessKey.publicKey,
@@ -134,13 +139,13 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     function saveAccessKey(
       address: Address.Address,
       keyAuth: KeyAuthorization.Rpc,
-      keyPair: Awaited<ReturnType<typeof AccessKey.generate>>['keyPair'],
+      generated: Awaited<ReturnType<typeof AccessKey.generate>>,
     ) {
       const keyAuthorization = KeyAuthorization.fromRpc(keyAuth)
       AccessKey.add({
         account: address,
         authorization: keyAuthorization,
-        keyPair,
+        keyPair: generated.keyPair,
         store,
       })
     }
@@ -197,7 +202,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.keyPair)
+            saveAccessKey(address, keyAuthorization, accessKey.generated)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -238,7 +243,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           const keyAuthorization = accounts[0]?.capabilities.keyAuthorization
 
           if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.keyPair)
+            saveAccessKey(address, keyAuthorization, accessKey.generated)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -386,7 +391,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
           if (accessKey) {
             const account = getAccount({ signable: false })
-            saveAccessKey(account.address, result.keyAuthorization, accessKey.keyPair)
+            saveAccessKey(account.address, result.keyAuthorization, accessKey.generated)
           }
 
           return result

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -179,6 +179,20 @@ describe('privy', () => {
     `)
   })
 
+  test('error: secp256k1 access key requires external key material', async () => {
+    const { adapter, store } = setup()
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      adapter.actions.authorizeAccessKey!(
+        { expiry: 123, keyType: 'secp256k1' },
+        { method: 'wallet_authorizeAccessKey', params: [{ expiry: 123, keyType: 'secp256k1' }] },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`keyType: "secp256k1"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
+    )
+  })
+
   test('default: revokeAccessKey revokes with the connected Privy account', async () => {
     const { adapter, client, store } = setup()
     store.setState({

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -3,6 +3,7 @@ import {
   Hex,
   Provider as ox_Provider,
   PublicKey,
+  RpcResponse,
   Secp256k1,
   Signature,
   WebCryptoP256,
@@ -328,6 +329,11 @@ export function privy<const client extends privy.Client>(
             }),
           }
         }
+
+        if (options.keyType && options.keyType !== 'p256')
+          throw new RpcResponse.InvalidParamsError({
+            message: `\`keyType: "${options.keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
+          })
 
         const keyPair = await WebCryptoP256.createKeyPair()
         const address = core_Address.fromPublicKey(PublicKey.from(keyPair.publicKey))


### PR DESCRIPTION
## Summary
Fix access-key requests so key types that require external material are not silently treated as generated P256 keys.

## Motivation
Closes #519. `wallet_authorizeAccessKey` accepted `keyType: "secp256k1"`, but generated-key flows could create P256 material and continue with the wrong key type. That made unsupported key requests look successful.

## Changes
- Keep `AccessKey.generate()` scoped to P256 key pairs.
- Preserve externally supplied access keys for `secp256k1`, `p256`, and `webAuthn` requests.
- Reject `secp256k1` and `webAuthn` requests without externally generated key material in core, dialog, and Privy paths.
- Document that secp256k1 access keys must be generated and stored by the app or backend before passing `address` or `publicKey`.

## Testing
- `CI=true pnpm test src/core/AccessKey.test.ts src/core/adapters/dialog.test.ts src/core/adapters/local.test.ts src/core/adapters/turnkey.test.ts src/core/adapters/privy.test.ts` — 97 tests passed
- `CI=true pnpm test src/core/adapters/privy.test.ts` — 24 tests passed
- `pnpm check:types`
- `pnpm check` — passed with existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`