### PR TITLE
chore: add Privy adapter changeset

### DIFF
--- a/.changeset/privy-adapter.md
+++ b/.changeset/privy-adapter.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added a Privy adapter for connecting and signing with app-provided Privy embedded wallet accounts.


### PR DESCRIPTION
## Summary

Adds a patch changeset for the Privy adapter release note.

## Motivation

The Privy adapter was added without an active changeset, so the next release needed release-note coverage matching the Turnkey adapter addition wording.

## Changes

- Added `.changeset/privy-adapter.md` with a patch bump for `accounts`.
- Matched the Turnkey adapter addition language for the Privy embedded-wallet adapter.

## Testing

- `pnpm exec changeset status --since origin/main`