### PR TITLE
fix: include Privy env vars in playground deploy

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -29,6 +29,8 @@ jobs:
               VITE_ENV=mainnet
               VITE_TURNKEY_ORGANIZATION_ID=1562c50f-1a48-4b10-8f42-87df4e8ef01d
               VITE_TURNKEY_AUTH_PROXY_CONFIG_ID=eab55ad4-b2f4-414f-836b-a5e279f01ed2
+              VITE_PRIVY_APP_ID=cmixx4jol01zgl80cgjenqkps
+              VITE_PRIVY_CLIENT_ID=client-WY6TQmgzdwgp2ZkrEXJBDscCamyaXNyXrTYoVRkMYm2rk
           - name: Wagmi
             directory: playgrounds/wagmi
 


### PR DESCRIPTION
## Summary

Includes the Privy app and client IDs in the production Playground build environment.

## Motivation

Selecting the Privy adapter on accounts-pg.tempo.xyz failed because the browser bundle was built without `VITE_PRIVY_APP_ID`.

## Changes

- Added `VITE_PRIVY_APP_ID` to the Playground deploy workflow build env.
- Added `VITE_PRIVY_CLIENT_ID` to the Playground deploy workflow build env.

## Testing

- `git diff --check`
- `pnpm --filter './playgrounds/web' build`