### PR TITLE
chore: add generated Privy adapter changeset

### DIFF
--- a/.changeset/early-crews-enter.md
+++ b/.changeset/early-crews-enter.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added a Privy adapter for connecting and signing with app-provided Privy embedded wallet accounts.


### PR DESCRIPTION
## Summary

Adds a generated patch changeset for the Privy adapter release note.

## Motivation

The Privy adapter addition needs release-note coverage in the next `accounts` release, matching the language used for the Turnkey adapter addition.

## Changes

- Generated `.changeset/early-crews-enter.md` with the Changesets CLI.
- Added a patch bump for `accounts` describing the Privy embedded-wallet adapter.

## Testing

- `pnpm exec changeset add --message "Added a Privy adapter for connecting and signing with app-provided Privy embedded wallet accounts."`
- `pnpm exec changeset status --since origin/main`