### PR TITLE
feat: add `showDeposit#on`

### DIFF
--- a/.changeset/show-deposit-on-filter.md
+++ b/.changeset/show-deposit-on-filter.md
@@ -2,4 +2,4 @@
 'accounts': patch
 ---
 
-Added an `on` filter to the `wallet_connect` `showDeposit` capability.
+Added an `on` filter to the `wallet_connect` `showDeposit` capability to direct if the deposit screen should be shown on login or register.

--- a/.changeset/show-deposit-on-filter.md
+++ b/.changeset/show-deposit-on-filter.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+**Added:** Added an `on` filter to the `wallet_connect` `showDeposit` capability.

--- a/.changeset/show-deposit-on-filter.md
+++ b/.changeset/show-deposit-on-filter.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
-**Added:** Added an `on` filter to the `wallet_connect` `showDeposit` capability.
+Added an `on` filter to the `wallet_connect` `showDeposit` capability.

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -108,9 +108,7 @@ export default function App() {
       setError(null)
       let result = await provider.request({
         method: 'wallet_connect',
-        ...(showDeposit
-          ? { params: [{ capabilities: { method: 'register', showDeposit: true } }] }
-          : {}),
+        ...(showDeposit ? { params: [{ capabilities: { showDeposit: true } }] } : {}),
       })
 
       const addr = result.accounts[0]?.address

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -808,6 +808,7 @@ function WalletConnect(props: { adapterType: AdapterType }) {
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
             ...(auth ? { auth } : {}),
+            ...(showDepositEnabled ? { showDeposit: true } : {}),
           }
 
     execute(() =>

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -793,6 +793,7 @@ function WalletConnect(props: { adapterType: AdapterType }) {
     // Server Authentication: the SDK absolutizes relative URLs against
     // the dapp's origin before forwarding to the wallet host.
     const auth = authEnabled ? '/auth' : undefined
+    const showDeposit = showDepositEnabled ? buildShowDeposit(form) : undefined
 
     const capabilities =
       method === 'register'
@@ -802,13 +803,13 @@ function WalletConnect(props: { adapterType: AdapterType }) {
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
             ...(auth ? { auth } : {}),
-            ...(showDepositEnabled ? { showDeposit: true } : {}),
+            ...(showDeposit ? { showDeposit } : {}),
           } as const)
         : {
             ...(digest ? { digest } : {}),
             ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
             ...(auth ? { auth } : {}),
-            ...(showDepositEnabled ? { showDeposit: true } : {}),
+            ...(showDeposit ? { showDeposit } : {}),
           }
 
     execute(() =>
@@ -982,6 +983,38 @@ function WalletConnect(props: { adapterType: AdapterType }) {
               Show Deposit
             </label>
           </legend>
+          {showDepositEnabled && (
+            <div style={{ display: 'grid', gap: 8 }}>
+              <div
+                style={{
+                  display: 'grid',
+                  gap: 8,
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+                }}
+              >
+                <label style={{ display: 'grid', gap: 4 }}>
+                  <span>Amount</span>
+                  <input name="showDepositAmount" placeholder="50" />
+                </label>
+                <label style={{ display: 'grid', gap: 4 }}>
+                  <span>Token</span>
+                  <input name="showDepositToken" placeholder="USDC or 0x…" />
+                </label>
+                <label style={{ display: 'grid', gap: 4 }}>
+                  <span>Display name</span>
+                  <input name="showDepositDisplayName" placeholder="example.com" />
+                </label>
+                <label style={{ display: 'grid', gap: 4 }}>
+                  <span>On</span>
+                  <select name="showDepositOn" defaultValue="">
+                    <option value="">Login and register</option>
+                    <option value="login">Login</option>
+                    <option value="register">Register</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+          )}
         </fieldset>
         <Button type="submit" value="login">
           Login
@@ -992,6 +1025,33 @@ function WalletConnect(props: { adapterType: AdapterType }) {
       </form>
     </Method>
   )
+}
+
+function buildShowDeposit(
+  form: FormData,
+): true | {
+  amount?: string | undefined
+  displayName?: string | undefined
+  on?: 'login' | 'register' | undefined
+  token?: string | undefined
+} {
+  const amount = String(form.get('showDepositAmount') ?? '').trim()
+  const displayName = String(form.get('showDepositDisplayName') ?? '').trim()
+  const on = getShowDepositOn(form.get('showDepositOn'))
+  const token = String(form.get('showDepositToken') ?? '').trim()
+  const showDeposit = {
+    ...(amount ? { amount } : {}),
+    ...(displayName ? { displayName } : {}),
+    ...(on ? { on } : {}),
+    ...(token ? { token } : {}),
+  }
+  if (Object.keys(showDeposit).length === 0) return true
+  return showDeposit
+}
+
+function getShowDepositOn(value: FormDataEntryValue | null): 'login' | 'register' | undefined {
+  if (value === 'login' || value === 'register') return value
+  return undefined
 }
 
 function EthRequestAccounts() {

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -984,32 +984,27 @@ function WalletConnect(props: { adapterType: AdapterType }) {
             </label>
           </legend>
           {showDepositEnabled && (
-            <div style={{ display: 'grid', gap: 8 }}>
+            <div style={{ display: 'grid', gap: 12 }}>
               <div
                 style={{
                   display: 'grid',
-                  gap: 8,
-                  gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+                  gap: 12,
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
                 }}
               >
-                <label style={{ display: 'grid', gap: 4 }}>
+                <label style={{ display: 'grid', gap: 6 }}>
                   <span>Amount</span>
                   <input name="showDepositAmount" placeholder="50" />
                 </label>
-                <label style={{ display: 'grid', gap: 4 }}>
+                <label style={{ display: 'grid', gap: 6 }}>
                   <span>Token</span>
-                  <input name="showDepositToken" placeholder="USDC or 0x…" />
-                </label>
-                <label style={{ display: 'grid', gap: 4 }}>
-                  <span>Display name</span>
-                  <input name="showDepositDisplayName" placeholder="example.com" />
-                </label>
-                <label style={{ display: 'grid', gap: 4 }}>
-                  <span>On</span>
-                  <select name="showDepositOn" defaultValue="">
-                    <option value="">Login and register</option>
-                    <option value="login">Login</option>
-                    <option value="register">Register</option>
+                  <select name="showDepositToken" defaultValue="">
+                    <option value="" />
+                    {tokenlist.map((t) => (
+                      <option key={t.address} value={t.address}>
+                        {t.symbol}
+                      </option>
+                    ))}
                   </select>
                 </label>
               </div>
@@ -1031,27 +1026,16 @@ function buildShowDeposit(
   form: FormData,
 ): true | {
   amount?: string | undefined
-  displayName?: string | undefined
-  on?: 'login' | 'register' | undefined
   token?: string | undefined
 } {
   const amount = String(form.get('showDepositAmount') ?? '').trim()
-  const displayName = String(form.get('showDepositDisplayName') ?? '').trim()
-  const on = getShowDepositOn(form.get('showDepositOn'))
   const token = String(form.get('showDepositToken') ?? '').trim()
   const showDeposit = {
     ...(amount ? { amount } : {}),
-    ...(displayName ? { displayName } : {}),
-    ...(on ? { on } : {}),
     ...(token ? { token } : {}),
   }
   if (Object.keys(showDeposit).length === 0) return true
   return showDeposit
-}
-
-function getShowDepositOn(value: FormDataEntryValue | null): 'login' | 'register' | undefined {
-  if (value === 'login' || value === 'register') return value
-  return undefined
 }
 
 function EthRequestAccounts() {

--- a/site/src/pages/docs/guides/connect-accounts.mdx
+++ b/site/src/pages/docs/guides/connect-accounts.mdx
@@ -178,13 +178,10 @@ When you're ready to go live, follow the [Deploying to Production](/docs/product
 
 ### Prompt for Funds
 
-If users should have a chance to fund a new account immediately, pass the
-`showDeposit` capability on a registration connect request. The wallet shows the
-standard deposit picker after registration succeeds. The prompt is optional, so
-the user can continue without depositing.
-
-`showDeposit` only applies to registration. Existing users who sign in with a
-saved account skip the deposit prompt.
+If users should have a chance to fund their account immediately after connecting,
+pass the `showDeposit` capability. The wallet shows the standard deposit picker
+after connect succeeds. The prompt is optional, so the user can continue without
+depositing.
 
 ```tsx twoslash [Example.tsx]
 // @noErrors
@@ -200,7 +197,6 @@ export function Example() {
         connect.connect({
           connector,
           capabilities: { // [!code focus]
-            method: 'register', // [!code focus]
             showDeposit: true, // [!code focus]
           }, // [!code focus]
         })
@@ -215,17 +211,18 @@ export function Example() {
 :::tip
 
 Use the object form when you want to pre-fill deposit details. The deposit target
-is always the newly connected account on the active connect chain.
+is always the newly connected account on the active connect chain. Add
+`on: 'register'` when the prompt should only appear after sign up.
 
 ```tsx twoslash [Example.tsx]
 // @noErrors
 connect.connect({
   connector,
   capabilities: { // [!code focus]
-    method: 'register', // [!code focus]
     showDeposit: { // [!code focus]
       amount: '50', // [!code focus]
       displayName: 'Example', // [!code focus]
+      on: 'register', // [!code focus]
       token: 'USDC', // [!code focus]
     }, // [!code focus]
   }, // [!code focus]

--- a/site/src/pages/docs/rpc/wallet_connect.mdx
+++ b/site/src/pages/docs/rpc/wallet_connect.mdx
@@ -7,15 +7,15 @@ description: Connect account(s) with optional capabilities like access key autho
 
 Requests to connect account(s) with optional capabilities.
 
-Set register `capabilities.showDeposit` to `true` or funding hints to show an
-optional deposit prompt after a new account connects. The deposit target is
-always the connected account on the active connect chain.
+Set `capabilities.showDeposit` to `true` or funding hints to show an optional
+deposit prompt after an account connects. The deposit target is always the
+connected account on the active connect chain.
 
 ## Request
 
 `capabilities` is a discriminated union over `method` — `'register'` or
-`'login'`. Both branches share the `digest`, `authorizeAccessKey`, `auth`, and
-`personalSign` fields. The register branch also accepts `showDeposit`.
+`'login'`. Both branches share the `digest`, `authorizeAccessKey`, `auth`,
+`personalSign`, and `showDeposit` fields.
 
 ```ts
 type Request = {
@@ -59,6 +59,8 @@ type ConnectLoginCapabilities = {
   auth?: Auth
   /** Sign an EIP-191 message in the same passkey ceremony. */
   personalSign?: { message: string }
+  /** Show an optional deposit prompt after the account connects. */
+  showDeposit?: ShowDeposit
   /** Show an account picker before authenticating. */
   selectAccount?: boolean
 }
@@ -68,6 +70,8 @@ type ShowDeposit = boolean | {
   amount?: string
   /** Display name shown in the deposit UI (e.g. the app name). */
   displayName?: string
+  /** Connect method that should show the deposit prompt. Defaults to both methods. */
+  on?: 'login' | 'register'
   /** Token contract address or supported token symbol to pre-fill. */
   token?: `0x${string}` | string
 }

--- a/src/cli/Provider.localnet.test.ts
+++ b/src/cli/Provider.localnet.test.ts
@@ -56,10 +56,11 @@ function connectRequest(
   options: {
     accessKey?: typeof accessKey | undefined
     expiry?: number | undefined
+    method?: 'login' | 'register' | undefined
     showDeposit?: z.output<typeof CliAuth.createRequest>['showDeposit'] | undefined
   } = {},
 ) {
-  const { accessKey: key = accessKey, expiry: expiry_ = expiry, showDeposit } = options
+  const { accessKey: key = accessKey, expiry: expiry_ = expiry, method, showDeposit } = options
 
   return {
     method: 'wallet_connect',
@@ -71,7 +72,8 @@ function connectRequest(
             keyType: key.keyType,
             publicKey: key.publicKey,
           },
-          ...(showDeposit !== undefined ? { method: 'register' as const, showDeposit } : {}),
+          ...(method ? { method } : {}),
+          ...(showDeposit !== undefined ? { showDeposit } : {}),
         },
       },
     ],
@@ -237,9 +239,11 @@ describe('Provider.create', () => {
 
       await provider.request(
         connectRequest({
+          method: 'register',
           showDeposit: {
             amount: '50',
             displayName: 'DoorDash',
+            on: 'register',
             token: 'USDC',
           },
         }),
@@ -250,8 +254,48 @@ describe('Provider.create', () => {
           {
             "amount": "50",
             "displayName": "DoorDash",
+            "on": "register",
             "token": "USDC",
           },
+        ]
+      `)
+    } finally {
+      await server.closeAsync()
+    }
+  })
+
+  test('behavior: forwards showDeposit through login device-code requests', async () => {
+    const handler = createHandler()
+    const server = await createServer(handler.listener)
+    const pendingShowDeposit: z.output<typeof CliAuth.pendingResponse>['showDeposit'][] = []
+
+    try {
+      const provider = Provider.create({
+        chains: [chain],
+        open: async (url) => {
+          const code = new URL(url).searchParams.get('code')!
+          const response = await fetch(`${server.url}/cli-auth/pending/${code}`)
+          const pending = z.decode(CliAuth.pendingResponse, (await response.json()) as never)
+          pendingShowDeposit.push(pending.showDeposit)
+          await fetch(`${server.url}/cli-auth`, {
+            body: JSON.stringify(await authorizePending(server.url, code)),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          })
+        },
+        host: `${server.url}/cli-auth`,
+      })
+
+      await provider.request(
+        connectRequest({
+          method: 'login',
+          showDeposit: true,
+        }),
+      )
+
+      expect(pendingShowDeposit).toMatchInlineSnapshot(`
+        [
+          true,
         ]
       `)
     } finally {

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -245,7 +245,7 @@ export declare namespace loadAccounts {
   type Capabilities = NonNullable<
     NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']
   >
-  type ShowDeposit = Extract<Capabilities, { method: 'register' }>['showDeposit']
+  type ShowDeposit = Extract<Capabilities, { method?: 'login' | undefined }>['showDeposit']
 
   type Parameters = {
     /** Grant an access key during the ceremony. */
@@ -263,7 +263,7 @@ export declare namespace loadAccounts {
     personalSign?: { message: string } | undefined
     /** When `true`, prompts the user to pick from all available credentials instead of using the last-used one. */
     selectAccount?: boolean | undefined
-    /** Show the deposit flow after a register ceremony signs in to an existing account. */
+    /** Show the deposit flow after the connect ceremony succeeds. */
     showDeposit?: ShowDeposit | undefined
   }
   type ReturnType = {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -664,6 +664,9 @@ export function create(options: create.Options = {}): create.ReturnType {
                           authorizeAccessKey,
                           selectAccount: capabilities?.selectAccount,
                           ...(personalSign_request ? { personalSign: personalSign_request } : {}),
+                          ...(capabilities?.showDeposit !== undefined
+                            ? { showDeposit: capabilities.showDeposit }
+                            : {}),
                         },
                         request,
                       )

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -105,6 +105,7 @@ describe('Encoded', () => {
     type Register = Extract<Capabilities, { method: 'register' }>
     type Login = Extract<Capabilities, { method?: 'login' | undefined }>
     type ShowDeposit = Register['showDeposit']
+    type LoginShowDeposit = Login['showDeposit']
     type ShowDepositObject = Exclude<Exclude<ShowDeposit, boolean | undefined>, undefined>
 
     expectTypeOf<ShowDeposit>().toMatchTypeOf<
@@ -112,11 +113,12 @@ describe('Encoded', () => {
       | {
           amount?: string | undefined
           displayName?: string | undefined
+          on?: 'login' | 'register' | undefined
           token?: string | undefined
         }
       | undefined
     >()
-    expectTypeOf<Login>().not.toHaveProperty('showDeposit')
+    expectTypeOf<LoginShowDeposit>().toEqualTypeOf<ShowDeposit>()
     expectTypeOf<ShowDepositObject>().not.toHaveProperty('address')
     expectTypeOf<ShowDepositObject>().not.toHaveProperty('chainId')
   })

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -213,6 +213,18 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
     })
   })
 
+  test('accepts true on the login branch', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        showDeposit: true,
+      }),
+    ).toEqual({
+      method: 'login',
+      showDeposit: true,
+    })
+  })
+
   test('accepts false on the register branch', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
@@ -225,6 +237,18 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
     })
   })
 
+  test('accepts false on the login branch', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        showDeposit: false,
+      }),
+    ).toEqual({
+      method: 'login',
+      showDeposit: false,
+    })
+  })
+
   test('accepts deposit parameters on the register branch', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
@@ -232,6 +256,7 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
         showDeposit: {
           amount: '50',
           displayName: 'DoorDash',
+          on: 'register',
           token: 'USDC',
         },
       }),
@@ -240,19 +265,29 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
       showDeposit: {
         amount: '50',
         displayName: 'DoorDash',
+        on: 'register',
         token: 'USDC',
       },
     })
   })
 
-  test('ignores showDeposit on the login branch', () => {
+  test('accepts deposit parameters on the login branch', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'login',
-        showDeposit: true,
+        showDeposit: {
+          amount: '25',
+          on: 'login',
+          token: 'USDC',
+        },
       }),
     ).toEqual({
       method: 'login',
+      showDeposit: {
+        amount: '25',
+        on: 'login',
+        token: 'USDC',
+      },
     })
   })
 
@@ -261,6 +296,15 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'register',
         showDeposit: { amount: 50 },
+      }),
+    ).toThrow()
+  })
+
+  test('rejects invalid showDeposit event filters', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'register',
+        showDeposit: { on: 'connect' },
       }),
     ).toThrow()
   })
@@ -324,6 +368,22 @@ describe('wallet_connect_strict.parameters: showDeposit', () => {
     })
   })
 
+  test('accepts true on the login branch', () => {
+    expect(
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: {
+          method: 'login',
+          showDeposit: true,
+        },
+      }),
+    ).toEqual({
+      capabilities: {
+        method: 'login',
+        showDeposit: true,
+      },
+    })
+  })
+
   test('accepts false on the register branch', () => {
     expect(
       z.parse(Rpc.wallet_connect_strict.parameters, {
@@ -340,6 +400,22 @@ describe('wallet_connect_strict.parameters: showDeposit', () => {
     })
   })
 
+  test('accepts false on the login branch', () => {
+    expect(
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: {
+          method: 'login',
+          showDeposit: false,
+        },
+      }),
+    ).toEqual({
+      capabilities: {
+        method: 'login',
+        showDeposit: false,
+      },
+    })
+  })
+
   test('accepts deposit parameters on the register branch', () => {
     expect(
       z.parse(Rpc.wallet_connect_strict.parameters, {
@@ -348,6 +424,7 @@ describe('wallet_connect_strict.parameters: showDeposit', () => {
           showDeposit: {
             amount: '100',
             displayName: 'DoorDash',
+            on: 'register',
             token: 'USDC',
           },
         },
@@ -358,23 +435,33 @@ describe('wallet_connect_strict.parameters: showDeposit', () => {
         showDeposit: {
           amount: '100',
           displayName: 'DoorDash',
+          on: 'register',
           token: 'USDC',
         },
       },
     })
   })
 
-  test('ignores showDeposit on the login branch', () => {
+  test('accepts deposit parameters on the login branch', () => {
     expect(
       z.parse(Rpc.wallet_connect_strict.parameters, {
         capabilities: {
           method: 'login',
-          showDeposit: true,
+          showDeposit: {
+            amount: '25',
+            on: 'login',
+            token: 'USDC',
+          },
         },
       }),
     ).toEqual({
       capabilities: {
         method: 'login',
+        showDeposit: {
+          amount: '25',
+          on: 'login',
+          token: 'USDC',
+        },
       },
     })
   })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -428,11 +428,12 @@ export namespace wallet_connect {
   export const authorizeAccessKey = z.optional(wallet_authorizeAccessKey.parameters)
 
   /**
-   * Shows an optional funding prompt after `wallet_connect` registration succeeds.
+   * Shows an optional funding prompt after `wallet_connect` succeeds.
    *
-   * `true` uses the connected account as the deposit target. Object form
-   * pre-fills deposit UI hints. The deposit chain comes from the surrounding
-   * `wallet_connect` chain context.
+   * `true` prompts after both registration and login. Object form pre-fills
+   * deposit UI hints and can scope the prompt to a specific connect method
+   * with `on`. The deposit chain comes from the surrounding `wallet_connect`
+   * chain context.
    */
   export const showDeposit = z.optional(
     z.union([
@@ -442,6 +443,8 @@ export namespace wallet_connect {
         amount: z.optional(z.string()),
         /** Display name shown in the deposit UI (e.g. the app name). */
         displayName: z.optional(z.string()),
+        /** Connect method that should show the deposit prompt. Defaults to both methods. */
+        on: z.optional(z.union([z.literal('login'), z.literal('register')])),
         /**
          * Token to pre-fill, accepted as either a contract address or a
          * supported deposit token symbol (case-insensitive, e.g. `"USDC"`).
@@ -519,6 +522,7 @@ export namespace wallet_connect {
           method: z.optional(z.literal('login')),
           personalSign,
           selectAccount: z.optional(z.boolean()),
+          showDeposit,
         }),
       ]),
     ),
@@ -606,6 +610,7 @@ export namespace wallet_connect_strict {
           method: z.optional(z.literal('login')),
           personalSign,
           selectAccount: z.optional(z.boolean()),
+          showDeposit,
         }),
       ]),
     ),

--- a/src/react-native/Provider.localnet.test.ts
+++ b/src/react-native/Provider.localnet.test.ts
@@ -139,6 +139,29 @@ describe('create', () => {
     )
   })
 
+  test('behavior: forwards showDeposit boolean to the mobile auth URL for login', async () => {
+    const browser = createOpen()
+    const provider = Provider.create({
+      authorizeAccessKey: () => ({
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+      }),
+      chains: [chain],
+      host: 'https://wallet-next.tempo.xyz',
+      open: browser.open,
+      redirectUri: 'accounts-playground://auth',
+      secureStorage: Storage.memory(),
+    })
+
+    await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login', showDeposit: true } }],
+    })
+
+    expect(new URL(browser.urls()[0]!).searchParams.get('showDeposit')).toMatchInlineSnapshot(
+      `"true"`,
+    )
+  })
+
   test('behavior: forwards showDeposit params to the mobile auth URL for registration', async () => {
     const browser = createOpen()
     const provider = Provider.create({
@@ -161,6 +184,7 @@ describe('create', () => {
             showDeposit: {
               amount: '50',
               displayName: 'DoorDash',
+              on: 'register',
               token: 'USDC',
             },
           },
@@ -173,6 +197,7 @@ describe('create', () => {
       {
         "amount": "50",
         "displayName": "DoorDash",
+        "on": "register",
         "token": "USDC",
       }
     `)

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -348,6 +348,9 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           const result = await authorize({
             authorizeAccessKey: parameters?.authorizeAccessKey,
             method: 'wallet_connect',
+            ...(parameters?.showDeposit !== undefined
+              ? { showDeposit: parameters.showDeposit }
+              : {}),
           })
 
           return {

--- a/src/server/CliAuth.test-d.ts
+++ b/src/server/CliAuth.test-d.ts
@@ -18,6 +18,7 @@ describe('createRequest', () => {
         | {
             amount?: string | undefined
             displayName?: string | undefined
+            on?: 'login' | 'register' | undefined
             token?: string | undefined
           }
         | undefined
@@ -64,6 +65,7 @@ describe('pendingResponse', () => {
         | {
             amount?: string | undefined
             displayName?: string | undefined
+            on?: 'login' | 'register' | undefined
             token?: string | undefined
           }
         | undefined

--- a/src/server/CliAuth.test.ts
+++ b/src/server/CliAuth.test.ts
@@ -679,6 +679,7 @@ describe('pending', () => {
       showDeposit: {
         amount: '50',
         displayName: 'DoorDash',
+        on: 'register',
         token: 'USDC',
       },
     })
@@ -711,6 +712,7 @@ describe('pending', () => {
         "showDeposit": {
           "amount": "50",
           "displayName": "DoorDash",
+          "on": "register",
           "token": "USDC",
         },
         "status": "pending",

--- a/src/server/CliAuth.ts
+++ b/src/server/CliAuth.ts
@@ -18,6 +18,7 @@ const showDeposit = z.optional(
     z.object({
       amount: z.optional(z.string()),
       displayName: z.optional(z.string()),
+      on: z.optional(z.union([z.literal('login'), z.literal('register')])),
       token: z.optional(z.union([u.address(), z.string()])),
     }),
   ]),


### PR DESCRIPTION
Modifies `showDeposit` capability to add an `on` property to direct if the deposit screen should be shown after login or registration or both.