### PR TITLE
docs: update deposit guidance

### DIFF
--- a/site/src/pages/docs/guides/connect-accounts.mdx
+++ b/site/src/pages/docs/guides/connect-accounts.mdx
@@ -176,7 +176,7 @@ When you're ready to go live, follow the [Deploying to Production](/docs/product
 
 ## Best Practices
 
-### Prompt for Funds
+### Deposit Funds
 
 If users should have a chance to fund their account immediately after connecting,
 pass the `showDeposit` capability. The wallet shows the standard deposit picker
@@ -210,9 +210,7 @@ export function Example() {
 
 :::tip
 
-Use the object form when you want to pre-fill deposit details. The deposit target
-is always the newly connected account on the active connect chain. Add
-`on: 'register'` when the prompt should only appear after sign up.
+Use the object form when you want to pre-fill deposit details.
 
 ```tsx twoslash [Example.tsx]
 // @noErrors
@@ -220,10 +218,8 @@ connect.connect({
   connector,
   capabilities: { // [!code focus]
     showDeposit: { // [!code focus]
-      amount: '50', // [!code focus]
-      displayName: 'Example', // [!code focus]
-      on: 'register', // [!code focus]
-      token: 'USDC', // [!code focus]
+      amount: '10', // [!code focus]
+      token: 'USDC.e', // [!code focus]
     }, // [!code focus]
   }, // [!code focus]
 })

--- a/site/src/pages/docs/guides/deposits.mdx
+++ b/site/src/pages/docs/guides/deposits.mdx
@@ -118,6 +118,57 @@ export function Deposit() {
 
 ::::
 
+## Best Practices
+
+### Deposit on Connection
+
+If adding funds is part of onboarding, show the deposit picker immediately after
+the user signs in.
+
+```tsx twoslash [Connect.tsx]
+// @noErrors
+import { useConnect, useConnectors } from 'wagmi'
+
+export function Connect() {
+  const connect = useConnect()
+  const [connector] = useConnectors()
+
+  return (
+    <button
+      onClick={() =>
+        connect.connect({
+          connector,
+          capabilities: { // [!code focus]
+            showDeposit: true, // [!code focus]
+          }, // [!code focus]
+        })
+      }
+    >
+      Sign up
+    </button>
+  )
+}
+```
+
+:::tip
+
+Use the object form when you want to pre-fill deposit details.
+
+```tsx twoslash [Connect.tsx]
+// @noErrors
+connect.connect({
+  connector,
+  capabilities: { // [!code focus]
+    showDeposit: { // [!code focus]
+      amount: '10', // [!code focus]
+      token: 'USDC.e', // [!code focus]
+    }, // [!code focus]
+  }, // [!code focus]
+})
+```
+
+:::
+
 ## Next Steps
 
 <Cards>


### PR DESCRIPTION
Renames the connect guide deposit best-practice section and tightens the `showDeposit` object example to use `amount: '10'` and `token: 'USDC.e'`.

Adds a deposits guide best practice for prompting deposits during connection, with boolean and object-form `showDeposit` examples so onboarding and standalone top-up flows are easier to compare.