### PR TITLE
fix: use access keys for MPP sessions

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -257,6 +257,58 @@ describe('markPublished', () => {
   })
 })
 
+describe('selectMppKey', () => {
+  test('behavior: selects a locally signable key matching the authorization intent', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const scopes = [
+      {
+        address: '0x0000000000000000000000000000000000000001' as const,
+        selector: 'transfer(address,uint256)',
+      },
+    ]
+    const keyAuthorization = createKeyAuthorization(accessKey.accessKeyAddress, { scopes })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization,
+      keyPair,
+      state: 'signed',
+      store,
+    })
+
+    const result = AccessKey.selectMppKey({
+      account: rootAddress,
+      authorizeAccessKey: { keyType: 'p256', scopes },
+      chainId: 1,
+      store,
+    })
+
+    expect(result?.accessKey === accessKey.accessKeyAddress).toMatchInlineSnapshot(`true`)
+  })
+
+  test('default: does not select arbitrary keys without an authorization intent', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      state: 'signed',
+      store,
+    })
+
+    const result = AccessKey.selectMppKey({
+      account: rootAddress,
+      chainId: 1,
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
 describe('create invalidation', () => {
   async function setup(options: { other?: boolean | undefined } = {}) {
     const store = createStore()
@@ -280,7 +332,7 @@ describe('create invalidation', () => {
       state: 'signed',
       store,
     })
-    return { account_other, store }
+    return { account, account_other, store }
   }
 
   test('behavior: removes matching access key for stale-key errors', async () => {
@@ -345,6 +397,41 @@ describe('create invalidation', () => {
       transaction?.fill({ chainId: 1, from: rootAddress }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: network failed]`)
     expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
+  })
+
+  test('behavior: selects an explicit access key by address', async () => {
+    const { account_other, store } = await setup({ other: true })
+    const { client, requests } = createFillClient(account_other.accessKeyAddress)
+
+    const transaction = await AccessKeyTransaction.create({
+      accessKey: account_other.accessKeyAddress,
+      address: rootAddress,
+      chainId: 1,
+      client: client as never,
+      store,
+    })
+    await transaction?.fill({ chainId: 1, from: rootAddress })
+
+    const request = requests[0] as {
+      params: readonly [{ keyAuthorization?: { keyId?: string | undefined } | undefined }]
+    }
+    expect(request.params[0].keyAuthorization?.keyId).toBe(account_other.accessKeyAddress)
+  })
+
+  test('error: explicit access key does not fall back to another key', async () => {
+    const { store } = await setup()
+
+    await expect(
+      AccessKeyTransaction.create({
+        accessKey: '0x0000000000000000000000000000000000000099',
+        address: rootAddress,
+        chainId: 1,
+        client: createMissingClient() as never,
+        store,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Access key 0x0000000000000000000000000000000000000099 is not available for account 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266.]`,
+    )
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -90,6 +90,8 @@ type StatusQuery = {
 type SelectQuery = {
   /** Root account address. */
   account: Address.Address
+  /** Specific access key address to select. */
+  accessKey?: Address.Address | undefined
   /** Calls to match against access key scopes. */
   calls?: readonly Call[] | undefined
   /** Chain ID the access key must be authorized on. */
@@ -126,7 +128,7 @@ type ListQuery = {
 }
 
 /** Selected access key for an intent. */
-type Selection = {
+export type Selection = {
   /** Hydrated locally-signable access key account. */
   account: TempoAccount.AccessKeyAccount
   /** Access key address. */
@@ -305,9 +307,9 @@ export async function getStatus(options: StatusQuery): Promise<Status> {
 
 /** Selects a locally-signable access key for an intent. */
 export async function select(options: SelectQuery): Promise<Selection | undefined> {
-  const { account, calls, chainId, client, store } = options
+  const { accessKey, account, calls, chainId, client, store } = options
   const now = options.now ?? Date.now() / 1000
-  const records = list({ account, chainId, store })
+  const records = list({ account, ...(accessKey ? { accessKey } : {}), chainId, store })
 
   for (const record of records) {
     if (!scopesMatch(record, { calls })) continue
@@ -343,6 +345,57 @@ export async function select(options: SelectQuery): Promise<Selection | undefine
       ...(authorization ? { authorization } : {}),
       record,
     }
+  }
+}
+
+/** Selects a locally-signable access key to use as the MPP session signer. */
+export function selectMppKey(options: selectMppKey.Options): selectMppKey.ReturnType {
+  const { account, chainId, store } = options
+  const now = options.now ?? Date.now() / 1000
+  const records = list({ account, chainId, store })
+
+  for (const record of records) {
+    if (isExpired(record.expiry, now)) continue
+    if (!matchesAuthorization(record, options.authorizeAccessKey)) continue
+
+    const account_accessKey = hydrate(record)
+    if (!account_accessKey) continue
+
+    return {
+      account: account_accessKey,
+      accessKey: record.address,
+      ...(record.keyAuthorization ? { authorization: record.keyAuthorization } : {}),
+      record,
+    }
+  }
+}
+
+export declare namespace selectMppKey {
+  /** Options for {@link selectMppKey}. */
+  type Options = {
+    /** Root account address. */
+    account: Address.Address
+    /** Access key authorization intent used to identify MPP-compatible keys. */
+    authorizeAccessKey?: AuthorizationShape | undefined
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
+    /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
+    now?: number | undefined
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Selected MPP access key, if one is available. */
+  type ReturnType = Selection | undefined
+
+  /** Access key authorization fields used for MPP signer matching. */
+  type AuthorizationShape = {
+    /** Key type requested by the app. */
+    keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
+    /** TIP-20 spending limits requested by the app. */
+    limits?: readonly KeyAuthorization.TokenLimit[] | undefined
+    /** Call scopes requested by the app. */
+    scopes?: readonly KeyAuthorization.Scope[] | undefined
   }
 }
 
@@ -479,6 +532,73 @@ function scopesMatch(
       return scope.recipients.some((address) => address.toLowerCase() === recipient.toLowerCase())
     })
   })
+}
+
+function matchesAuthorization(
+  record: AccessKey,
+  authorization: selectMppKey.AuthorizationShape | undefined,
+): boolean {
+  if (!authorization) return false
+  if (authorization.keyType && record.keyType !== authorization.keyType) return false
+  if (!limitsEqual(record.limits, authorization.limits)) return false
+  if (!scopesEqual(record.scopes, authorization.scopes)) return false
+  return true
+}
+
+function limitsEqual(
+  a: AccessKey['limits'],
+  b: selectMppKey.AuthorizationShape['limits'],
+): boolean {
+  if (!a || a.length === 0) return !b || b.length === 0
+  if (!b || a.length !== b.length) return false
+  return a.every((limit, index) => {
+    const other = b[index]
+    if (!other) return false
+    if (limit.token.toLowerCase() !== other.token.toLowerCase()) return false
+    if (limit.limit !== other.limit) return false
+    if (limit.period !== other.period) return false
+    return true
+  })
+}
+
+function scopesEqual(
+  a: AccessKey['scopes'],
+  b: selectMppKey.AuthorizationShape['scopes'],
+): boolean {
+  if (!a || a.length === 0) return !b || b.length === 0
+  if (!b || a.length !== b.length) return false
+  return a.every((scope, index) => {
+    const other = b[index]
+    if (!other) return false
+    if (scope.address.toLowerCase() !== other.address.toLowerCase()) return false
+    if (!selectorsEqual(scope.selector, other.selector)) return false
+
+    const recipients = scope.recipients
+    const recipients_other = other.recipients
+    if (!recipients || recipients.length === 0)
+      return !recipients_other || recipients_other.length === 0
+    if (!recipients_other || recipients.length !== recipients_other.length) return false
+    return recipients.every(
+      (recipient, i) => recipient.toLowerCase() === recipients_other[i]?.toLowerCase(),
+    )
+  })
+}
+
+function selectorsEqual(a: Hex.Hex | string | undefined, b: Hex.Hex | string | undefined) {
+  if (!a || !b) return a === b
+  return selectorFrom(a) === selectorFrom(b)
+}
+
+function selectorFrom(selector: Hex.Hex | string) {
+  try {
+    return (
+      selector.startsWith('0x') && selector.length === 10
+        ? selector
+        : AbiFunction.getSelector(selector)
+    ).toLowerCase()
+  } catch {
+    return selector.toLowerCase()
+  }
 }
 
 function isScope(scope: unknown): scope is NonNullable<AccessKey['scopes']>[number] {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,7 +1,16 @@
 import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
-import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
+import { KeyAuthorization } from 'ox/tempo'
+import {
+  createWalletClient,
+  custom,
+  http,
+  parseUnits,
+  type Chain,
+  type Client as ViemClient,
+  type Transport,
+} from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
@@ -309,6 +318,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             : undefined)
                         const transaction = await AccessKeyTransaction.create({
                           address,
+                          accessKey: parameters.keyId,
                           calls,
                           chainId: parameters.chainId ?? state.chainId,
                           client,
@@ -322,7 +332,8 @@ export function create(options: create.Options = {}): create.ReturnType {
                               from: parameters.from ?? address,
                               ...(feePayer ? { feePayer: true } : {}),
                             })
-                          } catch {
+                          } catch (error) {
+                            if (parameters.keyId) throw error
                             return await fill(parameters)
                           }
                       }
@@ -397,7 +408,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     try {
                       assertConnected()
                       const decoded = request._decoded.params?.[0]
-                      const { calls = [], capabilities, chainId, from } = decoded ?? {}
+                      const { calls = [], capabilities, chainId, from, keyId } = decoded ?? {}
                       const sync = capabilities?.sync
                       const feePayer = resolveFeePayer(
                         capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
@@ -407,6 +418,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         calls,
                         chainId,
                         from: from ?? state.accounts[state.activeAccount]?.address,
+                        ...(keyId ? { keyId } : {}),
                         ...(feePayer ? { feePayer } : {}),
                       }
                       if (!sync) {
@@ -1049,15 +1061,69 @@ export function create(options: create.Options = {}): create.ReturnType {
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
+    const signers_mpp = new Map<
+      string,
+      { root: Address.Address; selection?: AccessKey.Selection | undefined }
+    >()
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
-      const client = provider.getClient({ chainId })
+      const client_base = provider.getClient({ chainId })
+      const request = client_base.request.bind(client_base) as (
+        request: unknown,
+      ) => Promise<unknown>
       const account = store.getState().accounts[store.getState().activeAccount]
       if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
-      return Object.assign(client, {
-        account: {
-          address: account.address,
-          type: 'json-rpc' as const,
-        },
+      const chainId_resolved = chainId ?? store.getState().chainId
+      const key = `${account.address.toLowerCase()}:${chainId_resolved}`
+      const signer =
+        signers_mpp.get(key) ??
+        (() => {
+          const selection = AccessKey.selectMppKey({
+            account: account.address,
+            authorizeAccessKey: options.authorizeAccessKey?.(),
+            chainId: chainId_resolved,
+            store,
+          })
+          const signer = { root: account.address, ...(selection ? { selection } : {}) }
+          signers_mpp.set(key, signer)
+          return signer
+        })()
+      return createWalletClient({
+        account: signer.selection
+          ? createMppAccount({ selection: signer.selection, store })
+          : signer.root,
+        chain: client_base.chain,
+        pollingInterval: client_base.pollingInterval,
+        transport: custom({
+          async request(parameters_request: unknown) {
+            if (!signer.selection) return await request(parameters_request)
+            if (!isTransactionRequest(parameters_request)) return await request(parameters_request)
+            const [parameters] = parameters_request.params
+            const keyType =
+              signer.selection.record.keyType === 'webCrypto'
+                ? 'p256'
+                : signer.selection.record.keyType
+            const keyAuthorization =
+              parameters_request.method === 'eth_estimateGas' &&
+              signer.selection.authorization &&
+              !parameters.keyAuthorization
+                ? {
+                    address: signer.selection.authorization.address,
+                    ...KeyAuthorization.toRpc(signer.selection.authorization),
+                  }
+                : undefined
+            return await request({
+              ...parameters_request,
+              params: [
+                {
+                  ...parameters,
+                  ...(!parameters.keyId ? { keyId: signer.selection.accessKey } : {}),
+                  ...(!parameters.keyType ? { keyType } : {}),
+                  ...(keyAuthorization ? { keyAuthorization } : {}),
+                },
+              ],
+            } as never)
+          },
+        }),
       })
     }
     Mppx.create({
@@ -1077,6 +1143,54 @@ export function create(options: create.Options = {}): create.ReturnType {
 const defaultIcon =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>' as const
 const sendCallsMagic = Hash.keccak256(Hex.fromString('TEMPO_5792'))
+
+function isTransactionRequest(request: unknown): request is {
+  method:
+    | 'eth_estimateGas'
+    | 'eth_fillTransaction'
+    | 'eth_sendTransaction'
+    | 'eth_sendTransactionSync'
+    | 'eth_signTransaction'
+    | 'wallet_sendCalls'
+  params: [Record<string, unknown>]
+} {
+  if (!request || typeof request !== 'object') return false
+  const value = request as { method?: unknown; params?: unknown }
+  if (
+    value.method !== 'eth_fillTransaction' &&
+    value.method !== 'eth_estimateGas' &&
+    value.method !== 'eth_sendTransaction' &&
+    value.method !== 'eth_sendTransactionSync' &&
+    value.method !== 'eth_signTransaction' &&
+    value.method !== 'wallet_sendCalls'
+  )
+    return false
+  if (!Array.isArray(value.params)) return false
+  const parameters = value.params[0]
+  if (!parameters || typeof parameters !== 'object') return false
+  return true
+}
+
+function createMppAccount(options: {
+  selection: AccessKey.Selection
+  store: Store.Store
+}): AccessKey.Selection['account'] {
+  const { selection, store } = options
+  return {
+    ...selection.account,
+    async signTransaction(...parameters) {
+      const signed = await selection.account.signTransaction(...parameters)
+      if (selection.authorization)
+        AccessKey.markPending({
+          accessKey: selection.accessKey,
+          account: selection.record.access,
+          chainId: selection.record.chainId,
+          store,
+        })
+      return signed
+    },
+  }
+}
 
 export declare namespace create {
   type Options = {

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -253,6 +253,48 @@ describe('dialog', () => {
     expect(lookups).toMatchInlineSnapshot(`[]`)
   })
 
+  test('error: explicit keyId failures do not fall through to dialog', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    vi.spyOn(AccessKeyTransaction, 'create').mockResolvedValue({
+      fill: async () => ({ capabilities: { sponsored: false }, tx: {} }),
+      prepare: async () => {
+        throw new Error('explicit key unavailable')
+      },
+    } as never)
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+
+    await expect(
+      adapter.actions.sendTransaction(
+        {
+          calls: [{ data: '0x12345678', to: recipient }],
+          chainId: 1,
+          from: address,
+          keyId: recipient,
+        },
+        {
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              calls: [{ data: '0x12345678' as const, to: recipient }],
+              chainId: '0x1' as const,
+              from: address,
+              keyId: recipient,
+            },
+          ] as const,
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: explicit key unavailable]`)
+    expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
+  })
+
   test('behavior: revokeAccessKey clears the forwarded key from local state', async () => {
     const storage = Storage.memory()
     const store = Store.create({ chainId: tempoLocalnet.id, storage })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -271,6 +271,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -285,6 +286,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.sign()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }
@@ -312,6 +314,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -326,6 +329,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.send()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }
@@ -349,6 +353,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -363,6 +368,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.sendSync()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -48,6 +48,7 @@ export function local(options: local.Options): Adapter.Adapter {
       const transaction = address
         ? await AccessKeyTransaction.create({
             address,
+            accessKey: parameters.keyId,
             calls: parameters.calls,
             chainId: parameters.chainId ?? state.chainId,
             client,
@@ -57,7 +58,9 @@ export function local(options: local.Options): Adapter.Adapter {
       if (transaction) {
         try {
           return await transaction.prepare(request)
-        } catch {}
+        } catch (error) {
+          if (parameters.keyId) throw error
+        }
       }
 
       const account = getAccount({

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -418,6 +418,7 @@ export function privy<const client extends privy.Client>(
       const transaction = address
         ? await AccessKeyTransaction.create({
             address,
+            accessKey: parameters.keyId,
             calls: parameters.calls,
             chainId: parameters.chainId ?? state.chainId,
             client: viemClient,
@@ -431,7 +432,9 @@ export function privy<const client extends privy.Client>(
             ...rest,
             ...(feePayer ? { feePayer: true } : {}),
           })
-        } catch {}
+        } catch (error) {
+          if (parameters.keyId) throw error
+        }
       }
 
       async function sign() {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -462,6 +462,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -475,7 +476,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.sign()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           return await signTransaction(parameters)
         },
@@ -503,6 +506,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -516,7 +520,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.send()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           const signed = await signTransaction(parameters)
           return await viemClient.request({
@@ -535,6 +541,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -548,7 +555,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.sendSync()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           const signed = await signTransaction(parameters)
           return await viemClient.request({

--- a/src/core/internal/AccessKeyTransaction.ts
+++ b/src/core/internal/AccessKeyTransaction.ts
@@ -29,14 +29,17 @@ const removalErrorNames = new Set([
 
 /** Creates a lifecycle-aware access-key transaction when a matching key is available. */
 export async function create(options: create.Options): Promise<create.ReturnType> {
-  const { address, calls, chainId, client, store } = options
+  const { accessKey, address, calls, chainId, client, store } = options
   const selection = await AccessKey.select({
+    ...(accessKey ? { accessKey } : {}),
     account: address,
     calls,
     chainId,
     client,
     store,
   })
+  if (!selection && accessKey)
+    throw new Error(`Access key ${accessKey} is not available for account ${address}.`)
   if (!selection) return undefined
   return createTransaction({ client, selection, store })
 }
@@ -46,6 +49,8 @@ export declare namespace create {
   type Options = {
     /** Root account address. */
     address: Address.Address
+    /** Exact access key address to use for signing. */
+    accessKey?: Address.Address | undefined
     /** Calls to match against access key scopes. */
     calls?: readonly Call[] | undefined
     /** Chain ID the access key must be authorized on. */

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -67,8 +67,10 @@ describe('mppx integration', () => {
   })
 
   test('pull mode publishes a pending access key authorization', async () => {
+    const authorizeAccessKey = { expiry: Expiry.days(1) }
     const provider = Provider.create({
       adapter: headlessWebAuthn(),
+      authorizeAccessKey: () => authorizeAccessKey,
       chains: [chain],
       mpp: { mode: 'pull' },
     })
@@ -77,7 +79,7 @@ describe('mppx integration', () => {
 
     await provider.request({
       method: 'wallet_authorizeAccessKey',
-      params: [{ expiry: Expiry.days(1) }],
+      params: [authorizeAccessKey],
     })
 
     const key = provider.store.getState().accessKeys[0]!
@@ -85,6 +87,7 @@ describe('mppx integration', () => {
 
     const res = await fetch(`${server.url}/fortune`)
     expect(res.status).toBe(200)
+    expect(res.headers.get('Authorization')).toMatchInlineSnapshot(`null`)
 
     const status = await provider.getAccessKeyStatus({ accessKey: key.address })
     expect(status).toMatchInlineSnapshot(`"published"`)

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -265,6 +265,7 @@ export namespace wallet_sendCalls {
             capabilities: sendCallsCapabilities,
             chainId: z.optional(u.number()),
             from: z.optional(u.address()),
+            keyId: z.optional(u.address()),
             version: z.optional(z.string()),
           }),
         ]),


### PR DESCRIPTION
## Summary
Use eligible local access keys as the signer for MPP sessions while keeping transactions scoped to the root account.

## Motivation
MPP sessions need a stable authorized signer. Accounts already owns access-key authorization and lifecycle state, so MPP should snapshot an eligible access key when the MPP client is first used instead of pushing dynamic key selection into MPPX.

## Changes
- Add `AccessKey.selectMppKey` to pick a locally signable key that matches `authorizeAccessKey` intent.
- Thread exact `keyId` selection through access-key transaction creation and adapters.
- Build MPP clients with a real viem/tempo access-key account when available, while preserving provider-backed RPC transport.
- Attach pending `keyAuthorization` during MPP gas estimation and mark MPP-signed keys pending after local signing.

## Testing
- `pnpm test src/core/mppx.localnet.test.ts`
- `pnpm test src/core/AccessKey.test.ts src/core/adapters/dialog.test.ts src/core/mppx.localnet.test.ts`
- `pnpm check:types`
- `pnpm check` (passes with existing unused warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`)
- `git diff --check`
