### PR TITLE
fix: use selected access keys for mppx

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -280,7 +280,7 @@ describe('create invalidation', () => {
       state: 'signed',
       store,
     })
-    return { account_other, store }
+    return { account, account_other, store }
   }
 
   test('behavior: removes matching access key for stale-key errors', async () => {
@@ -345,6 +345,41 @@ describe('create invalidation', () => {
       transaction?.fill({ chainId: 1, from: rootAddress }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: network failed]`)
     expect(store.getState().accessKeys.length).toMatchInlineSnapshot(`1`)
+  })
+
+  test('behavior: selects an explicit access key by address', async () => {
+    const { account_other, store } = await setup({ other: true })
+    const { client, requests } = createFillClient(account_other.accessKeyAddress)
+
+    const transaction = await AccessKeyTransaction.create({
+      accessKey: account_other.accessKeyAddress,
+      address: rootAddress,
+      chainId: 1,
+      client: client as never,
+      store,
+    })
+    await transaction?.fill({ chainId: 1, from: rootAddress })
+
+    const request = requests[0] as {
+      params: readonly [{ keyAuthorization?: { keyId?: string | undefined } | undefined }]
+    }
+    expect(request.params[0].keyAuthorization?.keyId).toBe(account_other.accessKeyAddress)
+  })
+
+  test('error: explicit access key does not fall back to another key', async () => {
+    const { store } = await setup()
+
+    await expect(
+      AccessKeyTransaction.create({
+        accessKey: '0x0000000000000000000000000000000000000099',
+        address: rootAddress,
+        chainId: 1,
+        client: createMissingClient() as never,
+        store,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Access key 0x0000000000000000000000000000000000000099 is not available for account 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266.]`,
+    )
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -90,6 +90,8 @@ type StatusQuery = {
 type SelectQuery = {
   /** Root account address. */
   account: Address.Address
+  /** Specific access key address to select. */
+  accessKey?: Address.Address | undefined
   /** Calls to match against access key scopes. */
   calls?: readonly Call[] | undefined
   /** Chain ID the access key must be authorized on. */
@@ -305,9 +307,9 @@ export async function getStatus(options: StatusQuery): Promise<Status> {
 
 /** Selects a locally-signable access key for an intent. */
 export async function select(options: SelectQuery): Promise<Selection | undefined> {
-  const { account, calls, chainId, client, store } = options
+  const { accessKey, account, calls, chainId, client, store } = options
   const now = options.now ?? Date.now() / 1000
-  const records = list({ account, chainId, store })
+  const records = list({ account, ...(accessKey ? { accessKey } : {}), chainId, store })
 
   for (const record of records) {
     if (!scopesMatch(record, { calls })) continue

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1047,26 +1047,40 @@ export function create(options: create.Options = {}): create.ReturnType {
     return {}
   })()
   if (mpp) {
-    const { mode = 'push', polyfill: polyfill_option, ...methodOptions } = mpp
+    const { mode, polyfill: polyfill_option, ...methodOptions } = mpp
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
-    const getClient = ({ chainId }: { chainId?: number | undefined }) => {
-      const client = provider.getClient({ chainId })
-      const account = store.getState().accounts[store.getState().activeAccount]
+    const getClient = async ({ chainId }: { chainId?: number | undefined }) => {
+      const state = store.getState()
+      const chainId_ = chainId ?? state.chainId
+      const account = state.accounts[state.activeAccount]
       if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
-      return Object.assign(client, {
-        account: {
-          address: account.address,
-          type: 'json-rpc' as const,
-        },
+
+      const client = provider.getClient({ chainId: chainId_ })
+      const selection = await AccessKey.select({
+        account: account.address,
+        chainId: chainId_,
+        client,
+        store,
+      })
+      return Object.assign({}, client, {
+        account:
+          selection && !selection.authorization
+            ? selection.account
+            : {
+                address: account.address,
+                type: 'json-rpc' as const,
+              },
       })
     }
+    const options_tempo = {
+      ...methodOptions,
+      getClient,
+      ...(mode ? { mode } : {}),
+    }
     Mppx.create({
-      methods: [
-        mppx_tempo({ ...methodOptions, getClient, mode }),
-        mppx_tempo.subscription({ getClient }),
-      ],
+      methods: [mppx_tempo(options_tempo), mppx_tempo.subscription({ getClient })],
       polyfill,
     })
   }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -309,6 +309,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             : undefined)
                         const transaction = await AccessKeyTransaction.create({
                           address,
+                          accessKey: parameters.keyId,
                           calls,
                           chainId: parameters.chainId ?? state.chainId,
                           client,
@@ -322,7 +323,8 @@ export function create(options: create.Options = {}): create.ReturnType {
                               from: parameters.from ?? address,
                               ...(feePayer ? { feePayer: true } : {}),
                             })
-                          } catch {
+                          } catch (error) {
+                            if (parameters.keyId) throw error
                             return await fill(parameters)
                           }
                       }

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -253,6 +253,48 @@ describe('dialog', () => {
     expect(lookups).toMatchInlineSnapshot(`[]`)
   })
 
+  test('error: explicit keyId failures do not fall through to dialog', async () => {
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: tempoLocalnet.id, storage })
+    vi.spyOn(AccessKeyTransaction, 'create').mockResolvedValue({
+      fill: async () => ({ capabilities: { sponsored: false }, tx: {} }),
+      prepare: async () => {
+        throw new Error('explicit key unavailable')
+      },
+    } as never)
+    const adapter = dialog({ dialog: Dialog.noop() })({
+      getAccount: () => {
+        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
+      },
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+
+    await expect(
+      adapter.actions.sendTransaction(
+        {
+          calls: [{ data: '0x12345678', to: recipient }],
+          chainId: 1,
+          from: address,
+          keyId: recipient,
+        },
+        {
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              calls: [{ data: '0x12345678' as const, to: recipient }],
+              chainId: '0x1' as const,
+              from: address,
+              keyId: recipient,
+            },
+          ] as const,
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: explicit key unavailable]`)
+    expect(store.getState().requestQueue).toMatchInlineSnapshot(`[]`)
+  })
+
   test('behavior: revokeAccessKey clears the forwarded key from local state', async () => {
     const storage = Storage.memory()
     const store = Store.create({ chainId: tempoLocalnet.id, storage })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -271,6 +271,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -285,6 +286,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.sign()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }
@@ -312,6 +314,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -326,6 +329,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.send()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }
@@ -349,6 +353,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             parameters.from && typeof parameters.chainId !== 'undefined'
               ? await AccessKeyTransaction.create({
                   address: parameters.from,
+                  accessKey: parameters.keyId,
                   calls: parameters.calls,
                   chainId: parameters.chainId,
                   client,
@@ -363,6 +368,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
               })
               return await prepared.sendSync()
             } catch (error) {
+              if (parameters.keyId) throw error
               console.warn('[accounts] access key sign failed, falling through to dialog:', error)
             }
           }

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -48,6 +48,7 @@ export function local(options: local.Options): Adapter.Adapter {
       const transaction = address
         ? await AccessKeyTransaction.create({
             address,
+            accessKey: parameters.keyId,
             calls: parameters.calls,
             chainId: parameters.chainId ?? state.chainId,
             client,
@@ -57,7 +58,9 @@ export function local(options: local.Options): Adapter.Adapter {
       if (transaction) {
         try {
           return await transaction.prepare(request)
-        } catch {}
+        } catch (error) {
+          if (parameters.keyId) throw error
+        }
       }
 
       const account = getAccount({

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -418,6 +418,7 @@ export function privy<const client extends privy.Client>(
       const transaction = address
         ? await AccessKeyTransaction.create({
             address,
+            accessKey: parameters.keyId,
             calls: parameters.calls,
             chainId: parameters.chainId ?? state.chainId,
             client: viemClient,
@@ -431,7 +432,9 @@ export function privy<const client extends privy.Client>(
             ...rest,
             ...(feePayer ? { feePayer: true } : {}),
           })
-        } catch {}
+        } catch (error) {
+          if (parameters.keyId) throw error
+        }
       }
 
       async function sign() {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -462,6 +462,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -475,7 +476,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.sign()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           return await signTransaction(parameters)
         },
@@ -503,6 +506,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -516,7 +520,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.send()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           const signed = await signTransaction(parameters)
           return await viemClient.request({
@@ -535,6 +541,7 @@ export function turnkey<const client extends turnkey.Client>(
           const transaction = address
             ? await AccessKeyTransaction.create({
                 address,
+                accessKey: parameters.keyId,
                 calls: parameters.calls,
                 chainId: parameters.chainId ?? state.chainId,
                 client: viemClient,
@@ -548,7 +555,9 @@ export function turnkey<const client extends turnkey.Client>(
                 ...(feePayer ? { feePayer: true } : {}),
               })
               return await prepared.sendSync()
-            } catch {}
+            } catch (error) {
+              if (parameters.keyId) throw error
+            }
           }
           const signed = await signTransaction(parameters)
           return await viemClient.request({

--- a/src/core/internal/AccessKeyTransaction.ts
+++ b/src/core/internal/AccessKeyTransaction.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from 'ox'
+import { Address, Hex, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import type { Client, Transport } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
@@ -29,14 +29,19 @@ const removalErrorNames = new Set([
 
 /** Creates a lifecycle-aware access-key transaction when a matching key is available. */
 export async function create(options: create.Options): Promise<create.ReturnType> {
-  const { address, calls, chainId, client, store } = options
+  const { accessKey, address, calls, chainId, client, store } = options
   const selection = await AccessKey.select({
+    ...(accessKey ? { accessKey } : {}),
     account: address,
     calls,
     chainId,
     client,
     store,
   })
+  if (!selection && accessKey)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Access key ${accessKey} is not available for account ${address}.`,
+    })
   if (!selection) return undefined
   return createTransaction({ client, selection, store })
 }
@@ -46,6 +51,8 @@ export declare namespace create {
   type Options = {
     /** Root account address. */
     address: Address.Address
+    /** Exact access key address to use for signing. */
+    accessKey?: Address.Address | undefined
     /** Calls to match against access key scopes. */
     calls?: readonly Call[] | undefined
     /** Chain ID the access key must be authorized on. */

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -3,7 +3,7 @@ import { Mppx as ServerMppx, tempo } from 'mppx/server'
 import { parseUnits } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Actions } from 'viem/tempo'
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vp/test'
 
 import { headlessWebAuthn } from '../../test/adapters.js'
 import { accounts, chain, getClient } from '../../test/config.js'
@@ -95,6 +95,43 @@ describe('mppx integration', () => {
       accessKey: key.address,
     })
     expect(metadata.isRevoked).toMatchInlineSnapshot(`false`)
+  })
+
+  test('default mode snapshots a local access key account lazily', async () => {
+    const provider = Provider.create({
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: true,
+    })
+    const address = await connect(provider)
+    await fund(address)
+
+    await provider.request({
+      method: 'wallet_authorizeAccessKey',
+      params: [{ expiry: Expiry.days(1) }],
+    })
+    const key = provider.store.getState().accessKeys[0]!
+
+    const methods: string[] = []
+    const request = provider.request.bind(provider)
+    vi.spyOn(provider, 'request').mockImplementation((async (
+      args: Parameters<typeof provider.request>[0],
+    ) => {
+      methods.push(args.method)
+      return await request(args)
+    }) as never)
+
+    const first = await fetch(`${server.url}/fortune`)
+    expect(first.status).toMatchInlineSnapshot(`200`)
+
+    const status = await provider.getAccessKeyStatus({ accessKey: key.address })
+    expect(status).toMatchInlineSnapshot(`"published"`)
+
+    methods.length = 0
+    const second = await fetch(`${server.url}/fortune`)
+    expect(second.status).toMatchInlineSnapshot(`200`)
+    expect(methods).toContain('eth_fillTransaction')
+    expect(methods).not.toContain('wallet_sendCalls')
   })
 
   test('pull mode keeps access key authorization pending after failed verification', async () => {


### PR DESCRIPTION
## Summary
Respect explicit access-key selection and let MPPX use published local access-key accounts.

## Motivation
Transaction requests can carry `keyId`, but access-key selection could still pick another eligible key or fall back to root/dialog signing. MPPX also only received a root JSON-RPC account, so it could not use a published local access key directly when creating payment credentials.

## Changes
- Add exact access-key filtering to `AccessKey.select`.
- Pass `keyId` through `AccessKeyTransaction.create` and adapter transaction paths.
- Stop fallback behavior when an explicit `keyId` cannot be used.
- Snapshot a published local access-key account for MPPX at payment time; pending keys still use the provider path so their authorization can publish first.

## Testing
- `pnpm test src/core/AccessKey.test.ts src/core/adapters/dialog.test.ts`
- `pnpm test src/core/mppx.localnet.test.ts`
- `pnpm check:types`
- `pnpm check` (passes with existing unused warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`)
- `git diff --check`
