### PR TITLE
fix(provider): thread key type through transaction fills

### DIFF
--- a/.changeset/web-authn-fill-key-type.md
+++ b/.changeset/web-authn-fill-key-type.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Passed keyType through on eth_fillTransaction.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,0 +1,93 @@
+import { custom, type EIP1193Parameters } from 'viem'
+import { Addresses } from 'viem/tempo'
+import { tempoModerato } from 'viem/tempo/chains'
+import { describe, expect, test } from 'vp/test'
+
+import { privateKeys, webAuthnAccounts } from '../../test/config.js'
+import { local as core_local } from './adapters/local.js'
+import * as Provider from './Provider.js'
+import * as Storage from './Storage.js'
+
+describe('eth_fillTransaction', () => {
+  test('behavior: forwards connected WebAuthn key type for root-account gas estimation', async () => {
+    const requests: EIP1193Parameters[] = []
+    const provider = Provider.create({
+      adapter: core_local({
+        loadAccounts: async () => ({
+          accounts: [
+            {
+              address: webAuthnAccounts[0]!.address,
+              keyType: 'webAuthn_headless',
+              privateKey: privateKeys[0]!,
+              origin: 'https://example.com',
+              rpId: 'example.com',
+            },
+          ],
+        }),
+      }),
+      chains: [tempoModerato],
+      storage: Storage.memory({ key: crypto.randomUUID() }),
+      transports: {
+        [tempoModerato.id]: custom({
+          async request(parameters) {
+            requests.push(parameters)
+            if (parameters.method === 'eth_chainId') return '0x1079'
+            if (parameters.method === 'eth_fillTransaction') return { tx: { gas: '0x1' } }
+            return null
+          },
+        }),
+      },
+    })
+
+    const connect = await provider.request({ method: 'wallet_connect' })
+    await provider.request({
+      method: 'eth_fillTransaction',
+      params: [
+        {
+          calls: [
+            {
+              to: Addresses.pathUsd,
+              data: '0x',
+            },
+          ],
+          feePayer: false,
+          from: connect.accounts[0]!.address,
+        },
+      ],
+    })
+
+    const request = requests[0] as {
+      method: string
+      params: [
+        {
+          from?: unknown
+          [key: string]: unknown
+        },
+      ]
+    }
+    const { from, ...param } = request.params[0]
+
+    expect({ from: typeof from, method: request.method, param }).toMatchInlineSnapshot(`
+      {
+        "from": "string",
+        "method": "eth_fillTransaction",
+        "param": {
+          "calls": [
+            {
+              "data": "0x",
+              "to": "0x20c0000000000000000000000000000000000000",
+              "value": "0x",
+            },
+          ],
+          "chainId": "0xa5bf",
+          "data": undefined,
+          "feePayer": false,
+          "keyType": "webAuthn",
+          "to": undefined,
+          "type": "0x76",
+          "value": undefined,
+        },
+      }
+    `)
+  })
+})

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -186,6 +186,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     return url
   }
 
+  /** Converts local-only key variants to the RPC key family used for gas estimation. */
+  function toRpcKeyType(keyType: Account.Store['keyType'] | undefined) {
+    if (keyType === 'webAuthn_headless') return 'webAuthn'
+    if (keyType === 'webCrypto') return 'p256'
+    return keyType
+  }
+
   const provider = Object.assign(
     ox_Provider.from(
       {
@@ -268,6 +275,16 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const parameters = { ...decoded }
                     const chainId = parameters.chainId
                     const feePayer = resolveFeePayer(parameters.feePayer)
+                    const state = store.getState()
+                    const address = parameters.from ?? state.accounts[state.activeAccount]?.address
+                    const account = address
+                      ? state.accounts.find(
+                          (a) => a.address.toLowerCase() === address.toLowerCase(),
+                        )
+                      : undefined
+                    const keyType =
+                      parameters.keyType ??
+                      (!parameters.keyAuthorization ? toRpcKeyType(account?.keyType) : undefined)
 
                     type FillParams = z.output<typeof Rpc.transactionRequest> & {
                       keyAuthorization?: unknown
@@ -278,6 +295,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         ...params,
                         chainId: params.chainId ?? client.chain?.id,
                         ...(feePayer ? { feePayer: true } : {}),
+                        ...(keyType ? { keyType } : {}),
                       }
                       const formatter = client.chain?.formatters?.transactionRequest
                       const formatted =
@@ -293,9 +311,6 @@ export function create(options: create.Options = {}): create.ReturnType {
                     // Inject pending keyAuthorization so the node accounts for
                     // key authorization gas during estimation.
                     if (!parameters.keyAuthorization) {
-                      const state = store.getState()
-                      const address =
-                        parameters.from ?? state.accounts[state.activeAccount]?.address
                       if (address) {
                         const calls =
                           parameters.calls ??


### PR DESCRIPTION
## Summary
Thread connected account key type into root eth_fillTransaction fills.

## Motivation
WebAuthn root-account transactions could be estimated with a secp256k1 placeholder signature when callers omitted keyType, producing gas limits that were too low for the final WebAuthn envelope.

## Changes
- Add Provider eth_fillTransaction key type inference from the connected store account in src/core/Provider.ts
- Normalize local-only key variants before formatting fill requests
- Add src/core/Provider.test.ts coverage for WebAuthn self-paid fill requests
- Add a patch changeset for the SDK behavior fix

## Testing
- pnpm test src/core/Provider.test.ts
- pnpm test src/core/Provider.localnet.test.ts -t eth_fillTransaction
- pnpm exec tsc -b --noEmit
- git commit hook: vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test (passed with existing warnings in site/src/pages.gen.ts and src/server/internal/handlers/exchange.localnet.test.ts)