### PR TITLE
fix: supply mpp sessions with access keys

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -14,6 +14,7 @@ import type * as Adapter from './Adapter.js'
 import { dialog } from './adapters/dialog.js'
 import * as Client from './Client.js'
 import * as AccessKeyTransaction from './internal/AccessKeyTransaction.js'
+import { createMppRpcClient, createMppSessionClient } from './internal/createMppClient.js'
 import { withDedupe } from './internal/withDedupe.js'
 import * as Schema from './Schema.js'
 import * as Storage from './Storage.js'
@@ -1050,19 +1051,38 @@ export function create(options: create.Options = {}): create.ReturnType {
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
+      const state = store.getState()
       const client = provider.getClient({ chainId })
-      const account = store.getState().accounts[store.getState().activeAccount]
+      const account = state.accounts[state.activeAccount]
       if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
-      return Object.assign(client, {
-        account: {
-          address: account.address,
-          type: 'json-rpc' as const,
-        },
+      // Charge/subscription methods use the provider path so access-key
+      // selection sees the actual transaction calls.
+      return createMppRpcClient({
+        account: account.address,
+        client,
       })
     }
+    const getClient_session = async ({ chainId }: { chainId?: number | undefined }) => {
+      const state = store.getState()
+      const client = provider.getClient({ chainId })
+      const account = state.accounts[state.activeAccount]
+      if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
+      // Session methods need an access-key account up front so mppx can use
+      // `account.accessKeyAddress` as the channel's authorized signer.
+      return await createMppSessionClient({
+        account: account.address,
+        chainId: chainId ?? state.chainId,
+        client,
+        store,
+      })
+    }
+    const session = mppx_tempo({ ...methodOptions, getClient: getClient_session, mode }).find(
+      (method) => method.intent === 'session',
+    )
     Mppx.create({
       methods: [
-        mppx_tempo({ ...methodOptions, getClient, mode }),
+        mppx_tempo.charge({ ...methodOptions, getClient, mode }),
+        ...(session ? [session] : []),
         mppx_tempo.subscription({ getClient }),
       ],
       polyfill,

--- a/src/core/internal/createMppClient.ts
+++ b/src/core/internal/createMppClient.ts
@@ -1,0 +1,144 @@
+import { Address } from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
+import { createClient, custom, type Client, type Transport } from 'viem'
+
+import * as AccessKey from '../AccessKey.js'
+import type * as Store from '../Store.js'
+
+type RequestParameters = {
+  method: string
+  params?: readonly unknown[] | undefined
+}
+
+/** Creates a JSON-RPC account client for mppx charge and subscription methods. */
+export function createMppRpcClient(
+  options: createMppRpcClient.Options,
+): createMppRpcClient.ReturnType {
+  const { account, client } = options
+  return createClient({
+    account: {
+      address: account,
+      type: 'json-rpc' as const,
+    },
+    chain: client.chain,
+    pollingInterval: client.pollingInterval,
+    transport: createTransport({ client }),
+  })
+}
+
+export declare namespace createMppRpcClient {
+  /** Options for {@link createMppRpcClient}. */
+  type Options = {
+    /** Root account address. */
+    account: Address.Address
+    /** Client to decorate for mppx. */
+    client: Client<Transport>
+  }
+
+  /** Viem client decorated with a JSON-RPC root account. */
+  type ReturnType = Client<Transport>
+}
+
+/** Creates a viem client that lets mppx sessions sign with a managed access key. */
+export async function createMppSessionClient(
+  options: createMppSessionClient.Options,
+): Promise<createMppSessionClient.ReturnType> {
+  const { account, chainId, client, store } = options
+  const request = client.request.bind(client)
+  const selection = await AccessKey.select({
+    account,
+    chainId,
+    client,
+    store,
+  })
+  if (!selection)
+    return createMppRpcClient({
+      account,
+      client,
+    })
+
+  const signTransaction = selection.account.signTransaction.bind(selection.account)
+  const account_accessKey = {
+    ...selection.account,
+    accessKeyAddress: selection.accessKey,
+    address: account,
+    async signTransaction(parameters: Parameters<typeof selection.account.signTransaction>[0]) {
+      const signed = await signTransaction({
+        ...parameters,
+        ...(selection.authorization ? { keyAuthorization: selection.authorization } : {}),
+      } as never)
+
+      if (selection.authorization)
+        AccessKey.markPending({
+          accessKey: selection.accessKey,
+          account: selection.record.access,
+          chainId: selection.record.chainId,
+          store,
+        })
+
+      return signed
+    },
+  }
+
+  return createClient({
+    account: account_accessKey,
+    chain: client.chain,
+    pollingInterval: client.pollingInterval,
+    transport: createTransport({
+      client,
+      async request(parameters) {
+        if (parameters.method === 'eth_fillTransaction' && selection.authorization) {
+          const [transaction] = parameters.params ?? []
+          if (transaction && typeof transaction === 'object')
+            return await request({
+              ...parameters,
+              params: [
+                {
+                  ...transaction,
+                  keyAuthorization: {
+                    address: selection.authorization.address,
+                    ...KeyAuthorization.toRpc(selection.authorization),
+                  },
+                },
+              ],
+            } as never)
+        }
+
+        return await request(parameters as never)
+      },
+    }),
+  })
+}
+
+export declare namespace createMppSessionClient {
+  /** Options for {@link createMppSessionClient}. */
+  type Options = {
+    /** Root account address. */
+    account: Address.Address
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
+    /** Client to decorate for mppx. */
+    client: Client<Transport>
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Viem client decorated with an mppx session-ready account when a local access key is available. */
+  type ReturnType = Client<Transport>
+}
+
+function createTransport(options: createTransport.Options): Transport {
+  const { client } = options
+  const request = options.request ?? client.request.bind(client)
+
+  return custom({ request })
+}
+
+declare namespace createTransport {
+  type Options = {
+    /** Client whose transport metadata should be preserved. */
+    client: Client<Transport>
+    /** Optional request wrapper. Defaults to forwarding to `client.request`. */
+    request?: ((parameters: RequestParameters) => Promise<unknown>) | undefined
+  }
+}

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -9,6 +9,7 @@ import { headlessWebAuthn } from '../../test/adapters.js'
 import { accounts, chain, getClient } from '../../test/config.js'
 import { type Server, createServer } from '../../test/utils.js'
 import * as Expiry from './Expiry.js'
+import { createMppSessionClient } from './internal/createMppClient.js'
 import * as Provider from './Provider.js'
 
 const client = getClient()
@@ -152,6 +153,18 @@ describe('mppx integration', () => {
       params: [{ expiry: Expiry.days(1) }],
     })
     const key = provider.store.getState().accessKeys[0]!
+    const client_mpp = await createMppSessionClient({
+      account: address,
+      chainId: chain.id,
+      client: provider.getClient(),
+      store: provider.store,
+    })
+    const address_accessKey = (
+      client_mpp.account as { accessKeyAddress?: `0x${string}` | undefined }
+    ).accessKeyAddress
+    expect(address_accessKey?.toLowerCase() === key.address.toLowerCase()).toMatchInlineSnapshot(
+      `true`,
+    )
 
     const res = await fetch(`${server.url}/fortune`)
     expect(res.status).toMatchInlineSnapshot(`200`)


### PR DESCRIPTION
## Summary
Route mppx charge and session clients through account shapes that match their signing needs.

## Motivation
mppx sessions need `account.accessKeyAddress` for `authorizedSigner`, while charge/subscription flows should keep using the Provider path so scoped access-key selection sees the actual transaction calls.

## Changes
- Add `src/core/internal/createMppClient.ts` with JSON-RPC and session-specific mppx client helpers
- Use the JSON-RPC helper for mppx charge/subscription methods in `src/core/Provider.ts`
- Use the session helper for mppx session methods so pending access-key authorizations attach on first signed transaction
- Assert the session helper exposes `account.accessKeyAddress` in `src/core/mppx.localnet.test.ts`

## Testing
- `pnpm test src/core/mppx.localnet.test.ts`
- `pnpm check:types`
- `pnpm check`

`pnpm check` reports existing unrelated warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`.
