### PR TITLE
feat: add mpp_authorize support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,4 @@
 - **CLI auth example URL inputs** — the example CLI flow is expected to support both `--url` and `AUTH_URL`-based defaults, and should avoid hardcoded personal hostnames in source.
 - **Test RPC port selection should auto-fallback** — localnet test setup should start from `VITE_RPC_PORT` (or `8545`) and select the next available port to avoid `EADDRINUSE` collisions.
 - **Turnkey adapter stays structurally typed** — avoid importing `@turnkey/core` directly from the root SDK adapter so non-Turnkey consumers do not inherit a hard dependency; accept an app-provided client with the minimal client shape instead.
+- **Cloudflare/Vite empty POSTs can look body-bearing** — in the web playground Worker, empty POST session-management calls may be classified as content requests. Use HEAD for MPP session voucher/close management calls when the request should return 204 + `Payment-Receipt` instead of serving a content stream.

--- a/docs/spikes/mpp_authorize.md
+++ b/docs/spikes/mpp_authorize.md
@@ -1,0 +1,76 @@
+# mpp_authorize spike
+
+Source: https://gist.github.com/deodad/55d5343e0abe27fc1f2788b2548f7de2
+
+## Implemented shape
+
+- Added `mpp_authorize` to the core RPC schema.
+- Added `mpp` capability discovery through `wallet_getCapabilities`.
+- Routed `mpp_authorize` through the active adapter via `authorizeMpp`.
+- Reused `mppx` challenge parsing and credential creation through shared MPP helpers that wrap raw challenge strings in a synthetic 402 `Response`.
+- Rejected empty challenge lists, non-Tempo challenges, multi-challenge session continuation, and session continuation against non-session challenges.
+- Added a shared `MppAuthorization.authorize` flow that selects a locally managed access key when available, then falls back to the adapter-provided root account.
+- Each adapter supplies only account lookup functions: `getRootAccount(address)` and `getAccessKeyAccount({ accessKey, chainId, root })`.
+- Local adapters resolve the active/root account with `getAccount({ signable: true })`; Turnkey resolves the selected Turnkey wallet to a `viem/tempo` account; Privy wraps the embedded wallet provider as a local viem account backed by `secp256k1_sign`; dialog uses viem's simple JSON-RPC account wrapper for the active root address with requests routed through the dialog provider.
+- For `session.action = "voucher"` or `"close"`, hydrated `session.authorizedSigner` from locally managed access keys when it is not the active root account. Root-authorized continuations pass the root signer directly.
+- Added playground coverage for both paths:
+  - direct JSON-RPC `mpp_authorize` probes that fetch a raw 402 challenge, call the provider RPC, and retry with `Authorization`;
+  - the existing MPPX client session manager path, which still routes credential creation through wallet `mpp_authorize` when available.
+
+## Request flow
+
+1. The app or MPPX client receives a 402 response with `WWW-Authenticate`.
+2. The caller invokes `provider.request({ method: "mpp_authorize", params: [{ challenges, session? }] })`.
+3. `Provider.ts` validates the request, checks that MPP support is enabled, and dispatches the decoded params to `actions.authorizeMpp`.
+4. `MppAuthorization.authorize` validates the Tempo challenge and resolves the concrete signer through the active adapter:
+   - local/secp256k1/WebAuthn: matching access key first, then `getAccount({ signable: true })`;
+   - Turnkey: matching access key first, then the fetched Turnkey wallet as a Tempo account;
+   - Privy: matching access key first, then a local viem account wrapper over the embedded wallet provider;
+   - dialog: matching local access key first, then a JSON-RPC account for the active root address.
+5. The helper builds a synthetic 402 `Response` and calls request-local `Mppx.create(...).createCredential(response, context)`.
+6. MPPX fulfills the selected Tempo charge/session/subscription method using the supplied account and the adapter's normal viem client.
+7. The provider returns `{ authorization }`; the caller retries the original request with that credential.
+
+## Capability discovery
+
+Wallets advertise support through EIP-5792 `wallet_getCapabilities` using the
+`mpp` capability:
+
+```ts
+type Response = Record<
+  Hex,
+  {
+    /** MPP authorization support. */
+    mpp?: { status: 'supported' | 'unsupported' }
+  }
+>
+```
+
+Example:
+
+```json
+{
+  "0xa5bf": {
+    "mpp": {
+      "status": "supported"
+    }
+  }
+}
+```
+
+If `wallet_getCapabilities` is unsupported, or no `mpp.status === "supported"`
+capability appears for the relevant chain, MPP clients should fall back to
+existing signing and transaction flows.
+
+## Challenges and ambiguities
+
+- Challenge selection is delegated to `mppx` ordering. The gist says the wallet chooses between charge and session, but does not define a ranking policy or how caller preference should be expressed.
+- Opening a new session still depends on the provider's `mpp` session configuration. Without `deposit`, `maxDeposit`, or a server `suggestedDeposit`, the current `mppx` session method cannot choose a deposit amount.
+- Session continuation assumes `session.authorizedSigner` is either the active root account or a locally managed access key for the challenge chain. Dialog's root fallback can ask the remote host to sign, but delegated signers that are neither the root nor locally stored access keys remain unsupported.
+- Access-key selection for new charge/open credentials can infer transfer/open calls well enough for stored scopes, but pending `keyAuthorization` is still awkward because MPPX owns the transaction construction. A matching unpublished access key may fail and fall back to the root/dialog path unless MPPX exposes a way to attach the pending authorization.
+- `session.channelId` can be checked against `challenge.request.methodDetails.channelId` when present. Other possible conflicts, such as payer, payee, token, escrow, or chain mismatch, are not fully specified by the gist.
+- `session.cumulativeAmount` is treated as a raw decimal base-unit string because the examples use `"2500000"`. The spec should clarify whether this is always raw units or should use the payment method's display decimals.
+- The `mppx` push-charge path currently goes through viem `sendCallsSync`. The old recursive JSON-RPC-account bridge exposed a viem fallback bug where provider-internal authorization failures could be masked as `Cannot read properties of undefined (reading 'toLowerCase')`; the direct-account architecture removes that bridge from adapter-side `mpp_authorize`.
+- In the playground, the secp256k1 adapter creates a fresh local account. Pay Push needs that account to hold the requested token balance; MPP fee-payer support only covers execution fees, not the payment amount.
+- Session opens in the playground should not rely on the server fee-payer account unless that account is explicitly funded on the target network. The session routes now set `feePayer: false` and the session method uses `waitForConfirmation: false` so Moderato finality does not block UI testing.
+- Cloudflare/Vite can classify empty POST session-management requests as body-bearing content requests. Direct RPC voucher/close retries and the playground MPPX session-manager fetch shim use `HEAD` for management calls so the server returns the expected 204 + `Payment-Receipt` instead of starting a second content stream.

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { Credential } from 'mppx'
 import { tempo as mppx_tempo } from 'mppx/client'
 import { Hex, Json } from 'ox'
 import {
@@ -9,7 +10,7 @@ import {
   useState,
 } from 'react'
 import { Button as RegenButton } from 'regen-ui'
-import { formatUnits, parseUnits } from 'viem'
+import { type Address, formatUnits, isAddress, parseUnits } from 'viem'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
 import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
@@ -2060,11 +2061,26 @@ type MppScenarioResult = {
 }
 
 type MppSseEvent = { data: unknown; event: string }
+type MppTraceRow = {
+  action: string
+  channelId?: string | undefined
+  cumulative?: string | undefined
+  detail?: string | undefined
+  remaining?: string | undefined
+  spent?: string | undefined
+  step: string
+}
 type MppSessionState = {
   lastAction?: string | undefined
   remaining?: string | undefined
   spent?: string | undefined
   status: 'active' | 'closed' | 'idle' | 'open'
+}
+type MppAuthorizeSession = {
+  action: 'close' | 'voucher'
+  authorizedSigner: Address
+  channelId: Hex.Hex
+  cumulativeAmount: string
 }
 type MppSubscriptionState = {
   status: 'active' | 'canceled' | 'missing' | 'renewal due'
@@ -2084,6 +2100,7 @@ function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }
 
   return (
     <>
+      <MppRpcAuthorize />
       <MppOneTimeCharges applyMode={applyMode} />
       <MppSessions adapterType={adapterType} mode={mode} />
       <MppSubscriptions />
@@ -2124,6 +2141,36 @@ function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void> 
   )
 }
 
+function MppRpcAuthorize() {
+  const request = useMppRequest()
+
+  async function run(label: string, fn: () => Promise<MppScenarioResult>) {
+    await request.execute(label, fn)
+  }
+
+  return (
+    <MppPanel
+      title="mpp_authorize (RPC)"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <Button
+        disabled={request.pending}
+        onClick={() => run('RPC paid charge', () => runMppRpcCharge('RPC paid charge'))}
+      >
+        Paid Charge
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('RPC stream session', () => runMppRpcSse('RPC stream session'))}
+      >
+        Stream Session
+      </Button>
+    </MppPanel>
+  )
+}
+
 function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
   const { adapterType, mode } = props
   const request = useMppRequest()
@@ -2146,6 +2193,13 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
     await request.execute('Reset local session', () => runMppLocalResult('Reset local session'))
   }
 
+  async function streamChunks() {
+    const next = createMppSessionManager()
+    setManager(next)
+    setSession({ status: 'idle' })
+    await run('Stream chunks', () => runMppManagedSse('Stream chunks', next), 'voucher')
+  }
+
   return (
     <MppPanel
       title="Sessions"
@@ -2160,8 +2214,11 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
           run(
             'Start session',
             () =>
-              runMppManagedRequest('Start session', '/mpp/session/content', () =>
-                manager.fetch('/mpp/session/content'),
+              runMppManagedRequest(
+                'Start session',
+                '/mpp/session/content',
+                () => manager.fetch('/mpp/session/content'),
+                manager.trace,
               ),
             'open',
           )
@@ -2175,8 +2232,11 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
           run(
             'Pay another',
             () =>
-              runMppManagedRequest('Pay another', '/mpp/session/content', () =>
-                manager.fetch('/mpp/session/content'),
+              runMppManagedRequest(
+                'Pay another',
+                '/mpp/session/content',
+                () => manager.fetch('/mpp/session/content'),
+                manager.trace,
               ),
             'voucher',
           )
@@ -2184,12 +2244,7 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
       >
         Pay Another
       </Button>
-      <Button
-        disabled={request.pending || session.status === 'closed'}
-        onClick={() =>
-          run('Stream chunks', () => runMppManagedSse('Stream chunks', manager), 'voucher')
-        }
-      >
+      <Button disabled={request.pending || session.status === 'closed'} onClick={streamChunks}>
         Stream Chunks
       </Button>
       <Button
@@ -2320,10 +2375,57 @@ function MppPanel(props: {
       </header>
       <div className="method-body">{children}</div>
       {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {result && <MppPaymentTrace result={result} />}
       {display !== undefined && (
         <pre className="method-result">{Json.stringify(display, null, 2)}</pre>
       )}
     </article>
+  )
+}
+
+function MppPaymentTrace(props: { result: MppScenarioResult }) {
+  const rows = getMppTraceRows(props.result)
+  if (rows.length === 0) return null
+
+  return (
+    <div className="events-table-wrap">
+      <table className="events-table mpp-trace-table">
+        <thead>
+          <tr>
+            <th>Step</th>
+            <th>Event</th>
+            <th>Cumulative</th>
+            <th>Spent</th>
+            <th>Remaining</th>
+            <th>Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.step}>
+              <td>{row.step}</td>
+              <td>{row.action}</td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.cumulative)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.spent)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.remaining)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">
+                  {[row.detail, row.channelId ? `channel ${shortMppHex(row.channelId)}` : undefined]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </code>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 
@@ -2332,7 +2434,11 @@ function MppSummary(props: { children: ReactNode }) {
 }
 
 function createMppSessionManager() {
-  return mppx_tempo.session({
+  const trace: MppSseEvent[] = []
+  const manager = mppx_tempo.session({
+    fetch(input, init) {
+      return mppSessionFetch(input, init, trace)
+    },
     getClient(options: { chainId?: number | undefined } = {}) {
       const client = provider.getClient({ chainId: options.chainId })
       const account = provider.getAccount()
@@ -2340,6 +2446,45 @@ function createMppSessionManager() {
     },
     maxDeposit: '0.05',
   })
+  return Object.assign(manager, { trace })
+}
+
+async function mppSessionFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit | undefined,
+  trace?: MppSseEvent[] | undefined,
+) {
+  const headers = new Headers(init?.headers)
+  const authorization = headers.get('Authorization')
+  const hasBody = init?.body !== undefined && init.body !== null
+  if (authorization)
+    trace?.push({
+      data: summarizeMppAuthorizationHeader(authorization),
+      event: 'payment-authorization',
+    })
+
+  // Cloudflare/Vite can expose an empty POST body as non-null, so use HEAD for
+  // voucher management calls that should not serve content. Close is already
+  // classified by credential action server-side, so keep it as POST.
+  if (init?.method === 'POST' && authorization && !hasBody) {
+    const summary = summarizeMppAuthorizationHeader(authorization)
+    if ('action' in summary && summary.action === 'close') return getRawFetch()(input, init)
+
+    const response = await getRawFetch()(input, {
+      ...init,
+      method: 'HEAD',
+    })
+    trace?.push({
+      data: {
+        receipt: decodePaymentReceipt(response.headers.get('Payment-Receipt')) ?? null,
+        status: response.status,
+      },
+      event: 'payment-management-response',
+    })
+    return response
+  }
+
+  return getRawFetch()(input, init)
 }
 
 async function runMppRequest(
@@ -2374,20 +2519,24 @@ async function runMppManagedRequest(
   label: string,
   path: string,
   fetcher: () => Promise<Response & { receipt?: unknown | null | undefined }>,
+  trace?: MppSseEvent[] | undefined,
 ): Promise<MppScenarioResult> {
+  const traceStart = trace?.length ?? 0
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
   const response = await fetcher()
   const elapsedMs = Math.round(performance.now() - started)
   const body = await readResponseBody(response)
+  const events = trace?.slice(traceStart)
   const receipt = response.receipt ?? decodePaymentReceipt(response.headers.get('Payment-Receipt'))
   const inspection = await readInspection(receipt)
   const balanceAfter = await getPathUsdBalance()
   return {
     balanceAfter,
     balanceBefore,
-    body,
+    body: events?.length ? { response: body, trace: events } : body,
     elapsedMs,
+    events: events?.length ? events : undefined,
     headers: readPaymentHeaders(response),
     inspection,
     label,
@@ -2404,6 +2553,7 @@ async function runMppManagedSse(
 ): Promise<MppScenarioResult> {
   const receipts: unknown[] = []
   const chunks: string[] = []
+  const traceStart = manager.trace.length
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
   const stream = await manager.sse('/mpp/session/stream', {
@@ -2415,14 +2565,16 @@ async function runMppManagedSse(
   for await (const chunk of stream) chunks.push(chunk)
 
   const elapsedMs = Math.round(performance.now() - started)
+  const trace = manager.trace.slice(traceStart)
   const receipt = receipts.at(-1)
   const inspection = await readInspection(receipt)
   return {
     balanceAfter: await getPathUsdBalance(),
     balanceBefore,
-    body: { chunks },
+    body: { chunks, trace },
     elapsedMs,
     events: [
+      ...trace,
       ...chunks.map((chunk) => ({ data: chunk, event: 'message' })),
       ...receipts.map((item) => ({ data: item, event: 'payment-receipt' })),
     ],
@@ -2436,20 +2588,201 @@ async function runMppManagedSse(
   }
 }
 
-async function runMppSessionClose(
-  label: string,
-  manager: ReturnType<typeof createMppSessionManager>,
-): Promise<MppScenarioResult> {
+async function runMppRpcCharge(label: string): Promise<MppScenarioResult> {
+  const path = '/mpp/charge/paid'
+  const rawFetch = getRawFetch()
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
-  const receipt = await manager.close()
+  const probe = await rawFetch(path)
+  const challenge = await readMppChallenge(probe, path)
+  const authorization = await authorizeMpp(challenge)
+  const response = await rawFetch(path, {
+    headers: { Authorization: authorization },
+  })
   const elapsedMs = Math.round(performance.now() - started)
+  const body = await readResponseBody(response)
+  const receipt = decodePaymentReceipt(response.headers.get('Payment-Receipt'))
   const inspection = await readInspection(receipt)
   return {
     balanceAfter: await getPathUsdBalance(),
     balanceBefore,
-    body: receipt ? { closed: true } : { closed: false },
+    body: {
+      authorization: summarizeMppAuthorization(authorization),
+      response: body,
+    },
     elapsedMs,
+    headers: readPaymentHeaders(response),
+    inspection,
+    label,
+    ok: response.ok,
+    receipt,
+    status: response.status,
+    url: path,
+  }
+}
+
+async function runMppRpcSse(label: string): Promise<MppScenarioResult> {
+  const path = '/mpp/session/stream'
+  const rawFetch = getRawFetch()
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 45_000)
+  const events: MppSseEvent[] = []
+  const authorizations: unknown[] = []
+  const chunks: string[] = []
+
+  try {
+    const probe = await rawFetch(path, {
+      headers: { Accept: 'text/event-stream' },
+      signal: controller.signal,
+    })
+    const challenge = await readMppChallenge(probe, path)
+    const openAuthorization = await authorizeMpp(challenge)
+    const open = readMppOpenAuthorization(openAuthorization)
+    authorizations.push(open.summary)
+
+    const response = await rawFetch(path, {
+      headers: {
+        Accept: 'text/event-stream',
+        Authorization: openAuthorization,
+      },
+      signal: controller.signal,
+    })
+    if (!response.ok) throw await mppResponseError('Stream open failed', response)
+
+    let latestReceipt: unknown
+    let latestCumulative = open.cumulativeAmount
+
+    for await (const event of readMppSse(response)) {
+      events.push(event)
+
+      if (event.event === 'message') {
+        if (typeof event.data === 'string') chunks.push(event.data)
+        continue
+      }
+
+      if (event.event === 'payment-receipt') {
+        latestReceipt = event.data
+        const spent = readStringProperty(event.data, 'spent')
+        if (spent) latestCumulative = spent
+        continue
+      }
+
+      if (event.event !== 'payment-need-voucher') continue
+
+      const voucher = readMppNeedVoucher(event.data)
+      latestCumulative = voucher.requiredCumulative
+      const authorization = await authorizeMpp(challenge, {
+        action: 'voucher',
+        authorizedSigner: open.authorizedSigner,
+        channelId: voucher.channelId,
+        cumulativeAmount: voucher.requiredCumulative,
+      })
+      authorizations.push(summarizeMppAuthorization(authorization))
+      const voucherResponse = await rawFetch(path, {
+        method: 'HEAD',
+        headers: { Authorization: authorization },
+        signal: controller.signal,
+      })
+      const voucherReceipt = decodePaymentReceipt(voucherResponse.headers.get('Payment-Receipt'))
+      events.push({
+        data: {
+          receipt: voucherReceipt ?? null,
+          status: voucherResponse.status,
+        },
+        event: 'payment-voucher-response',
+      })
+      if (!voucherResponse.ok)
+        throw await mppResponseError('Voucher request failed', voucherResponse)
+    }
+
+    const closeAuthorization = await authorizeMpp(challenge, {
+      action: 'close',
+      authorizedSigner: open.authorizedSigner,
+      channelId: open.channelId,
+      cumulativeAmount: latestCumulative,
+    })
+    authorizations.push(summarizeMppAuthorization(closeAuthorization))
+    const closeResponse = await rawFetch(path, {
+      method: 'HEAD',
+      headers: { Authorization: closeAuthorization },
+      signal: controller.signal,
+    })
+    const closeReceipt = decodePaymentReceipt(closeResponse.headers.get('Payment-Receipt'))
+    events.push({
+      data: {
+        receipt: closeReceipt ?? null,
+        status: closeResponse.status,
+      },
+      event: 'payment-close-response',
+    })
+    if (!closeResponse.ok) throw await mppResponseError('Close request failed', closeResponse)
+
+    const elapsedMs = Math.round(performance.now() - started)
+    const receipt = closeReceipt ?? latestReceipt
+    const inspection = await readInspection(receipt)
+    return {
+      balanceAfter: await getPathUsdBalance(),
+      balanceBefore,
+      body: {
+        authorizations,
+        chunks,
+      },
+      elapsedMs,
+      events,
+      headers: readPaymentHeaders(response),
+      inspection,
+      label,
+      ok: true,
+      receipt,
+      status: response.status,
+      url: path,
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) throw error
+    return {
+      balanceAfter: await getPathUsdBalance(),
+      balanceBefore,
+      body: {
+        authorizations,
+        chunks,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      elapsedMs: Math.round(performance.now() - started),
+      events,
+      headers: {
+        'content-type': null,
+        'payment-receipt': null,
+        'www-authenticate': null,
+      },
+      label,
+      ok: false,
+      status: 499,
+      url: path,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function runMppSessionClose(
+  label: string,
+  manager: ReturnType<typeof createMppSessionManager>,
+): Promise<MppScenarioResult> {
+  const traceStart = manager.trace.length
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const receipt = await manager.close()
+  const elapsedMs = Math.round(performance.now() - started)
+  const trace = manager.trace.slice(traceStart)
+  const inspection = await readInspection(receipt)
+  return {
+    balanceAfter: await getPathUsdBalance(),
+    balanceBefore,
+    body: receipt ? { closed: true, trace } : { closed: false, trace },
+    elapsedMs,
+    events: trace.length ? trace : undefined,
     headers: {},
     inspection,
     label,
@@ -2508,6 +2841,166 @@ function readPaymentHeaders(response: Response) {
   }
 }
 
+async function mppResponseError(label: string, response: Response) {
+  const body = await readResponseBody(response).catch(() => null)
+  const challenge = response.headers.get('WWW-Authenticate')
+  return new Error(
+    `${label} with status ${response.status}.${body ? ` ${Json.stringify(body)}` : ''}${challenge ? ` WWW-Authenticate: ${challenge}` : ''}`,
+  )
+}
+
+async function readMppChallenge(response: Response, path: string) {
+  if (response.status !== 402) {
+    const body = await readResponseBody(response).catch(() => null)
+    throw new Error(
+      `Expected ${path} to return a payment challenge, received ${response.status}.${body ? ` ${Json.stringify(body)}` : ''}`,
+    )
+  }
+
+  const challenge = response.headers.get('WWW-Authenticate')
+  if (!challenge) throw new Error(`${path} did not return WWW-Authenticate.`)
+  return challenge
+}
+
+async function authorizeMpp(challenge: string, session?: MppAuthorizeSession | undefined) {
+  const result = await provider.request({
+    method: 'mpp_authorize',
+    params: [
+      {
+        challenges: [challenge],
+        ...(session ? { session } : {}),
+      },
+    ],
+  })
+  return result.authorization
+}
+
+async function* readMppSse(response: Response): AsyncGenerator<MppSseEvent> {
+  if (!response.body) throw new Error('Stream response has no body.')
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const parts = buffer.split('\n\n')
+      buffer = parts.pop()!
+
+      for (const part of parts) {
+        const event = parseMppSseEvent(part)
+        if (event) yield event
+      }
+    }
+
+    const tail = parseMppSseEvent(buffer)
+    if (tail) yield tail
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function parseMppSseEvent(raw: string): MppSseEvent | undefined {
+  if (!raw.trim()) return undefined
+
+  let event = 'message'
+  const data: string[] = []
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event: ')) event = line.slice(7).trim()
+    else if (line.startsWith('data: ')) data.push(line.slice(6))
+    else if (line === 'data:') data.push('')
+  }
+  if (data.length === 0) return undefined
+
+  const value = data.join('\n')
+  if (event.startsWith('payment-')) {
+    try {
+      return { data: JSON.parse(value), event }
+    } catch {
+      return { data: value, event }
+    }
+  }
+
+  return { data: value, event }
+}
+
+function readMppOpenAuthorization(authorization: string) {
+  const summary = summarizeMppAuthorization(authorization)
+  if (summary.action !== 'open') throw new Error('Expected an open session credential.')
+  if (!summary.authorizedSigner)
+    throw new Error('Open session credential missing authorizedSigner.')
+  if (!summary.channelId) throw new Error('Open session credential missing channelId.')
+  if (!summary.cumulativeAmount)
+    throw new Error('Open session credential missing cumulativeAmount.')
+
+  return {
+    authorizedSigner: asAddress(summary.authorizedSigner, 'authorizedSigner'),
+    channelId: asHex(summary.channelId, 'channelId'),
+    cumulativeAmount: summary.cumulativeAmount,
+    summary,
+  }
+}
+
+function summarizeMppAuthorization(authorization: string) {
+  const credential = Credential.deserialize(authorization)
+  const payload = isRecord(credential.payload) ? credential.payload : {}
+  return {
+    action: stringValue(payload.action),
+    authorizedSigner: stringValue(payload.authorizedSigner),
+    channelId: stringValue(payload.channelId),
+    cumulativeAmount: stringValue(payload.cumulativeAmount),
+    type: stringValue(payload.type) ?? (payload.action ? 'voucher' : undefined),
+  }
+}
+
+function summarizeMppAuthorizationHeader(authorization: string) {
+  try {
+    return summarizeMppAuthorization(authorization)
+  } catch {
+    return { raw: authorization }
+  }
+}
+
+function readMppNeedVoucher(value: unknown) {
+  const channelId = readStringProperty(value, 'channelId')
+  const requiredCumulative = readStringProperty(value, 'requiredCumulative')
+  if (!channelId) throw new Error('payment-need-voucher missing channelId.')
+  if (!requiredCumulative) throw new Error('payment-need-voucher missing requiredCumulative.')
+  return {
+    channelId: asHex(channelId, 'channelId'),
+    requiredCumulative,
+  }
+}
+
+function readStringProperty(value: unknown, key: string) {
+  if (!isRecord(value)) return undefined
+  return stringValue(value[key])
+}
+
+function asAddress(value: string, label: string): Address {
+  if (!isAddress(value)) throw new Error(`${label} is not an address.`)
+  return value
+}
+
+function asHex(value: string, label: string): Hex.Hex {
+  if (!Hex.validate(value)) throw new Error(`${label} is not hex.`)
+  return value as Hex.Hex
+}
+
+function getRawFetch() {
+  const mppxFetchWrapper = Symbol.for('mppx.fetch.wrapper')
+  let current = globalThis.fetch as typeof globalThis.fetch &
+    Record<symbol, typeof globalThis.fetch | undefined>
+  while (current[mppxFetchWrapper])
+    current = current[mppxFetchWrapper] as typeof globalThis.fetch &
+      Record<symbol, typeof globalThis.fetch | undefined>
+  return current
+}
+
 function summarizeMppResult(result: MppScenarioResult) {
   return {
     balance: {
@@ -2528,6 +3021,163 @@ function summarizeMppResult(result: MppScenarioResult) {
     status: result.status,
     url: result.url,
   }
+}
+
+function getMppTraceRows(result: MppScenarioResult) {
+  const rows: MppTraceRow[] = []
+  let receiptSeen = false
+
+  function push(row: Omit<MppTraceRow, 'step'>) {
+    rows.push({ ...row, step: String(rows.length + 1) })
+  }
+
+  function pushAuthorization(value: unknown) {
+    if (!isRecord(value)) return
+    const action = readStringProperty(value, 'action') ?? readStringProperty(value, 'type')
+    const raw = readStringProperty(value, 'raw')
+    push({
+      action: `authorize ${action ?? 'payment'}`,
+      channelId: readStringProperty(value, 'channelId'),
+      cumulative: readStringProperty(value, 'cumulativeAmount'),
+      detail: raw ? 'unreadable credential' : readStringProperty(value, 'type'),
+    })
+  }
+
+  function pushReceipt(action: string, value: unknown, detail?: string | undefined) {
+    const receipt = readMppTraceReceipt(value)
+    if (!receipt) return false
+    const cumulative = readStringProperty(receipt, 'acceptedCumulative')
+    const spent = readStringProperty(receipt, 'spent')
+    receiptSeen = true
+    push({
+      action,
+      channelId: readMppTraceReference(receipt),
+      cumulative,
+      detail,
+      remaining: subtractMppAmounts(cumulative, spent),
+      spent,
+    })
+    return true
+  }
+
+  const events = result.events ?? []
+  const eventHasAuthorization = events.some((event) => event.event === 'payment-authorization')
+  const authorizations =
+    isRecord(result.body) && Array.isArray(result.body.authorizations)
+      ? result.body.authorizations
+      : []
+  let authorizationIndex = 0
+
+  if (isRecord(result.body)) {
+    const authorization = result.body.authorization
+    if (authorization) pushAuthorization(authorization)
+  }
+
+  if (authorizations.length > 0) {
+    if (events.length === 0 || eventHasAuthorization)
+      for (const item of authorizations) pushAuthorization(item)
+    else pushAuthorization(authorizations[authorizationIndex++])
+  }
+
+  for (const event of events) {
+    if (event.event === 'message') {
+      push({
+        action: 'chunk',
+        detail: typeof event.data === 'string' ? event.data : formatEventValue(event.data),
+      })
+      continue
+    }
+
+    if (event.event === 'payment-authorization') {
+      pushAuthorization(event.data)
+      continue
+    }
+
+    if (event.event === 'payment-need-voucher') {
+      const cumulative = readStringProperty(event.data, 'requiredCumulative')
+      const spent = readStringProperty(event.data, 'spent')
+      const accepted = readStringProperty(event.data, 'acceptedCumulative')
+      push({
+        action: 'need voucher',
+        channelId: readStringProperty(event.data, 'channelId'),
+        cumulative,
+        detail: accepted ? `accepted ${formatMppAmount(accepted)}` : undefined,
+        remaining: subtractMppAmounts(cumulative, spent),
+        spent,
+      })
+      if (!eventHasAuthorization && authorizationIndex < authorizations.length)
+        pushAuthorization(authorizations[authorizationIndex++])
+      continue
+    }
+
+    if (event.event === 'payment-voucher-response') {
+      if (!pushReceipt('voucher accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'voucher accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-close-response') {
+      if (!eventHasAuthorization && authorizationIndex < authorizations.length)
+        pushAuthorization(authorizations[authorizationIndex++])
+      if (!pushReceipt('close accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'close accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-management-response') {
+      if (!pushReceipt('management accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'management accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-receipt') {
+      pushReceipt('receipt', event.data)
+      continue
+    }
+
+    if (event.event.startsWith('payment-')) {
+      push({
+        action: event.event.replace(/^payment-/, ''),
+        detail: formatEventValue(event.data),
+      })
+    }
+  }
+
+  while (!eventHasAuthorization && authorizationIndex < authorizations.length)
+    pushAuthorization(authorizations[authorizationIndex++])
+
+  if (result.receipt && !receiptSeen) pushReceipt('receipt', result.receipt, 'response receipt')
+  return rows
+}
+
+function readMppTraceReceipt(value: unknown) {
+  if (!isRecord(value)) return undefined
+  if ('receipt' in value) return isRecord(value.receipt) ? value.receipt : undefined
+  return value
+}
+
+function readMppTraceReference(value: Record<string, unknown>) {
+  return (
+    readStringProperty(value, 'channelId') ??
+    readStringProperty(value, 'reference') ??
+    readStringProperty(value, 'subscriptionId')
+  )
+}
+
+function readMppTraceStatus(value: unknown) {
+  if (!isRecord(value)) return undefined
+  const status = value.status
+  if (typeof status !== 'number' && typeof status !== 'string') return undefined
+  return `status ${status}`
+}
+
+function formatMppTraceAmount(value: string | undefined) {
+  if (!value) return ''
+  return formatMppAmount(value)
+}
+
+function shortMppHex(value: string) {
+  return value.length > 18 ? `${value.slice(0, 10)}...${value.slice(-6)}` : value
 }
 
 function readMppSessionState(result: MppScenarioResult, actionFallback?: string | undefined) {

--- a/playgrounds/web/src/index.css
+++ b/playgrounds/web/src/index.css
@@ -425,6 +425,19 @@ html {
   width: 100%;
 }
 
+.mpp-trace-table {
+  min-width: 760px;
+}
+
+.mpp-trace-table th {
+  text-align: left;
+}
+
+.mpp-trace-table th,
+.mpp-trace-table td {
+  vertical-align: top;
+}
+
 .events-table th,
 .events-table td {
   font-size: 13px;

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -9,6 +9,7 @@ import {
   local,
   privy,
   Provider,
+  Storage,
   turnkey,
   webAuthn,
 } from 'accounts'
@@ -75,10 +76,14 @@ export const host =
 export let dialogMode: DialogMode = 'iframe'
 export let mppMode: MppMode = 'push'
 export let theme: DialogNs.Theme | undefined
+const mppxFetchWrapper = Symbol.for('mppx.fetch.wrapper')
+restoreMppx()
 export let provider: ProviderValue = createProvider('tempoWallet')
 let turnkeyClient: TurnkeyClient | undefined
 let privyClient: Privy | undefined
 let privyIframeReady: Promise<void> | undefined
+let secp256k1Account: ReturnType<typeof Account.fromSecp256k1> | undefined
+type ProviderState = ReturnType<ProviderValue['store']['getState']>
 
 function mpp() {
   return {
@@ -158,37 +163,56 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
     })
   }
 
-  const privateKey = generatePrivateKey()
-  const account = Account.fromSecp256k1(privateKey)
+  const account = getSecp256k1Account()
   return Provider.create({
     adapter: local({
       loadAccounts: async () => ({ accounts: [account] }),
       createAccount: async () => {
         const key = generatePrivateKey()
         const newAccount = Account.fromSecp256k1(key)
+        secp256k1Account = newAccount
         return { accounts: [newAccount] }
       },
     }),
     mpp: mpp(),
+    storage: Storage.memory(),
     testnet,
   })
 }
 
+function getSecp256k1Account() {
+  secp256k1Account ??= Account.fromSecp256k1(generatePrivateKey())
+  return secp256k1Account
+}
+
 export function switchAdapter(adapterType: AdapterType) {
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
 }
 
 export function switchDialogMode(mode: DialogMode, adapterType: AdapterType = 'tempoWallet') {
   dialogMode = mode
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
 }
 
 export function switchMppMode(mode: MppMode, adapterType: AdapterType = 'tempoWallet') {
+  const state = provider.store.getState()
   mppMode = mode
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
+  restoreProviderState(state)
+}
+
+function restoreProviderState(state: ProviderState) {
+  provider.store.setState({
+    accessKeys: state.accessKeys,
+    accounts: state.accounts,
+    activeAccount: state.activeAccount,
+    ...(state.auth ? { auth: state.auth } : {}),
+    chainId: state.chainId,
+    requestQueue: [],
+  })
 }
 
 function getTurnkeyAdapterClient() {
@@ -262,6 +286,16 @@ export function switchTheme(
   adapterType: AdapterType = 'tempoWallet',
 ) {
   theme = next
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
+}
+
+function restoreMppx() {
+  Mppx.restore()
+  let current = globalThis.fetch as typeof globalThis.fetch &
+    Record<symbol, typeof globalThis.fetch | undefined>
+  while (current[mppxFetchWrapper])
+    current = current[mppxFetchWrapper] as typeof globalThis.fetch &
+      Record<symbol, typeof globalThis.fetch | undefined>
+  globalThis.fetch = current
 }

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -148,11 +148,12 @@ export default {
       return charge(request, { amount: '0', description: 'Free proof' })
 
     if (url.pathname === '/mpp/charge/paid')
-      return charge(request, { amount: '0.01', description: 'Paid fortune' })
+      return charge(request, { amount: '0.01', description: 'Paid fortune', feePayer: false })
 
     if (url.pathname === '/mpp/session/content') {
       const result = await payment.tempo.session({
         amount: '0.01',
+        feePayer: false,
         suggestedDeposit: '0.03',
         unitType: 'request',
       })(request)
@@ -167,6 +168,7 @@ export default {
     if (url.pathname === '/mpp/session/stream') {
       const result = await payment.tempo.session({
         amount: '0.005',
+        feePayer: false,
         suggestedDeposit: '0.05',
         unitType: 'chunk',
       })(request)

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -177,6 +177,72 @@ describe('add', () => {
   })
 })
 
+describe('getSigner', () => {
+  test('default: hydrates locally signable access key material', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const keyAuthorization = createKeyAuthorization(accessKey.accessKeyAddress)
+
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization,
+      keyPair,
+      state: 'signed',
+      store,
+    })
+
+    const signer = AccessKey.getSigner({
+      account: rootAddress,
+      accessKey: accessKey.accessKeyAddress,
+      chainId: 1,
+      store,
+    })
+
+    expect({
+      accessKeyMatches: signer?.accessKeyAddress === accessKey.accessKeyAddress,
+      found: Boolean(signer),
+      rootMatches: signer?.address === rootAddress,
+    }).toMatchInlineSnapshot(`
+      {
+        "accessKeyMatches": true,
+        "found": true,
+        "rootMatches": true,
+      }
+    `)
+  })
+
+  test('behavior: removes expired access keys', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const keyAuthorization = createKeyAuthorization(accessKey.accessKeyAddress, { expiry: 1 })
+
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization,
+      keyPair,
+      state: 'signed',
+      store,
+    })
+
+    const signer = AccessKey.getSigner({
+      account: rootAddress,
+      accessKey: accessKey.accessKeyAddress,
+      chainId: 1,
+      now: 2,
+      store,
+    })
+
+    expect({ remaining: store.getState().accessKeys.length, signer }).toMatchInlineSnapshot(`
+      {
+        "remaining": 0,
+        "signer": undefined,
+      }
+    `)
+  })
+})
+
 describe('markPublished', () => {
   test('default: clears key authorization from access key', async () => {
     const store = createStore()

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -346,6 +346,38 @@ export async function select(options: SelectQuery): Promise<Selection | undefine
   }
 }
 
+/** Returns a locally signable access key account by address. */
+export function getSigner(options: getSigner.Options): getSigner.ReturnType {
+  const { accessKey, account, chainId, store } = options
+  const now = options.now ?? Date.now() / 1000
+  const record = list({ accessKey, account, chainId, store })[0]
+  if (!record) return undefined
+  if (isExpired(record.expiry, now)) {
+    remove({ accessKey, account, chainId, store })
+    return undefined
+  }
+  return hydrate(record)
+}
+
+export declare namespace getSigner {
+  /** Options for {@link getSigner}. */
+  type Options = {
+    /** Root account address that owns the access key. */
+    account: Address.Address
+    /** Access key address to hydrate. */
+    accessKey: Address.Address
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
+    /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
+    now?: number | undefined
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  /** Locally signable access key account, if the key material is available. */
+  type ReturnType = TempoAccount.AccessKeyAccount | undefined
+}
+
 /** Adds a signed access key authorization. */
 export function add(options: add.Options): add.ReturnType {
   const { account, authorization, keyPair, privateKey, store } = options

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -1,3 +1,4 @@
+import type { tempo as mppx_tempo } from 'mppx/client'
 import type { KeyAuthorization } from 'ox/tempo'
 import type { Client, Hex, Transport } from 'viem'
 import type { Address } from 'viem/accounts'
@@ -34,6 +35,13 @@ export type Meta = {
 export type Instance = {
   /** Adapter actions dispatched by the provider's `request()` method. */
   actions: {
+    /** Authorize Machine Payment Protocol challenges. */
+    authorizeMpp?:
+      | ((
+          params: authorizeMpp.Parameters,
+          request: EncodedRequest<Rpc.mpp_authorize.Encoded>,
+        ) => Promise<authorizeMpp.ReturnType>)
+      | undefined
     /** Grant an access key for the active account. */
     authorizeAccessKey?:
       | ((
@@ -147,6 +155,10 @@ export declare namespace SetupFn {
     getAccount: Account.Find
     /** Get the viem client for a given chain ID. Defaults to the active chain. */
     getClient: (options?: getClient.Options | undefined) => Client<Transport, typeof tempo>
+    /** MPP client configuration when MPP support is enabled. */
+    mpp?: mpp.Options | undefined
+    /** Routes an RPC request through the owning provider. Present in Provider-managed adapters. */
+    request?: ((request: { method: string; params?: unknown }) => Promise<unknown>) | undefined
     /** Storage adapter used by the provider. */
     storage: Storage.Storage
     /** Reactive state store. */
@@ -174,6 +186,13 @@ export declare namespace getClient {
     chainId?: number | undefined
     /** Fee payer service URL, or `false` to opt out of fee payers for this transaction if set globally. */
     feePayer?: string | false | undefined
+  }
+}
+
+export declare namespace mpp {
+  type Options = Omit<mppx_tempo.Parameters, 'account' | 'getClient'> & {
+    /** Whether to polyfill `globalThis.fetch` with the payment-aware wrapper. */
+    polyfill?: boolean | undefined
   }
 }
 
@@ -335,6 +354,11 @@ export declare namespace authorizeAccessKey {
     keyAuthorization: KeyAuthorization.Rpc
     rootAddress: Address
   }
+}
+
+export declare namespace authorizeMpp {
+  type Parameters = ActionRequest<typeof Rpc.mpp_authorize.schema>
+  type ReturnType = Rpc.mpp_authorize.Encoded['returns']
 }
 
 export declare namespace revokeAccessKey {

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -1,6 +1,6 @@
 import type { tempo as mppx_tempo } from 'mppx/client'
 import type { KeyAuthorization } from 'ox/tempo'
-import type { Client, Hex, Transport } from 'viem'
+import type { Account as viem_Account, Client, Hex, Transport, WalletClient } from 'viem'
 import type { Address } from 'viem/accounts'
 import type { tempo } from 'viem/tempo/chains'
 
@@ -155,6 +155,10 @@ export declare namespace SetupFn {
     getAccount: Account.Find
     /** Get the viem client for a given chain ID. Defaults to the active chain. */
     getClient: (options?: getClient.Options | undefined) => Client<Transport, typeof tempo>
+    /** Create a viem wallet client bound to an account. */
+    createWalletClient: (
+      options: createWalletClient.Options,
+    ) => WalletClient<Transport, typeof tempo, viem_Account>
     /** MPP client configuration when MPP support is enabled. */
     mpp?: mpp.Options | undefined
     /** Routes an RPC request through the owning provider. Present in Provider-managed adapters. */
@@ -186,6 +190,15 @@ export declare namespace getClient {
     chainId?: number | undefined
     /** Fee payer service URL, or `false` to opt out of fee payers for this transaction if set globally. */
     feePayer?: string | false | undefined
+  }
+}
+
+export declare namespace createWalletClient {
+  type Options = getClient.Options & {
+    /** Account to bind to the wallet client. */
+    account: viem_Account
+    /** Optional transport override for provider-backed JSON-RPC accounts. */
+    transport?: Transport | undefined
   }
 }
 

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -1,11 +1,14 @@
 import { type Provider as ox_Provider } from 'ox'
 import {
+  type Account,
   type Chain,
   createClient,
+  createWalletClient as viem_createWalletClient,
   type Client,
   type EIP1193RequestFn,
   http,
   type Transport,
+  type WalletClient,
 } from 'viem'
 import { Transaction } from 'viem/tempo'
 import type { tempo } from 'viem/tempo/chains'
@@ -20,7 +23,7 @@ export function fromChainId(
   chainId: number | undefined,
   options: fromChainId.Options,
 ): Client<Transport, typeof tempo> {
-  const { chains, feePayer: feePayerOption, provider, store, transports } = options
+  const { feePayer: feePayerOption, provider, store, transports } = options
   const feePayerUrl = (() => {
     if (feePayerOption === false) return undefined
     if (typeof feePayerOption === 'string') return normalizeFeePayerUrl(feePayerOption)
@@ -51,12 +54,11 @@ export function fromChainId(
   })()
   let client = cache.get(key)
   if (!client) {
-    const chain = chains.find((c) => c.id === id) ?? chains[0]!
-    const base = transports?.[id] ?? http()
-    const transport_base = provider ? providerTransport(provider, base) : base
-    const transport = feePayerUrl
-      ? feePayerTransport(transport_base, feePayerUrl, precedence)
-      : transport_base
+    const { chain, transport } = getClientParameters(id, {
+      ...options,
+      feePayerUrl,
+      precedence,
+    })
     client = createClient({ chain, transport, pollingInterval: 1000 })
     cache.set(key, client)
   }
@@ -85,6 +87,63 @@ export declare namespace fromChainId {
     /** Per-chain transports keyed by chain ID. When omitted, defaults to `http()` (uses the chain's default RPC URL). */
     transports?: Record<number, Transport> | undefined
   }
+}
+
+/** Creates a viem Wallet Client for a given account and chain ID. */
+export function createWalletClient(
+  chainId: number | undefined,
+  options: createWalletClient.Options,
+): WalletClient<Transport, typeof tempo, Account> {
+  const id = chainId ?? options.store.getState().chainId
+  const feePayerUrl = (() => {
+    const option = options.feePayer
+    if (option === false) return undefined
+    if (typeof option === 'string') return normalizeFeePayerUrl(option)
+    if (option?.url) return normalizeFeePayerUrl(option.url)
+    return undefined
+  })()
+  const precedence = (() => {
+    const option = options.feePayer
+    if (typeof option === 'object' && option !== null) return option.precedence ?? 'fee-payer-first'
+    return 'fee-payer-first'
+  })()
+  const { chain, transport } = getClientParameters(id, {
+    ...options,
+    feePayerUrl,
+    precedence,
+  })
+  return viem_createWalletClient({
+    account: options.account,
+    chain,
+    transport: options.transport ?? transport,
+  }) as never
+}
+
+export declare namespace createWalletClient {
+  type Options = fromChainId.Options & {
+    /** Account bound to the wallet client. */
+    account: Account
+    /** Optional transport override for JSON-RPC accounts backed by wallet providers. */
+    transport?: Transport | undefined
+  }
+}
+
+function getClientParameters(
+  id: number,
+  options: fromChainId.Options & {
+    feePayerUrl?: string | undefined
+    precedence: 'fee-payer-first' | 'user-first'
+  },
+) {
+  const { chains, feePayer, feePayerUrl, precedence, provider, transports } = options
+  const chain = chains.find((c) => c.id === id) ?? chains[0]!
+  const base = transports?.[id] ?? http()
+  const transport_base = provider ? providerTransport(provider, base) : base
+  const transport =
+    feePayer !== false && feePayerUrl
+      ? feePayerTransport(transport_base, feePayerUrl, precedence)
+      : transport_base
+  return { chain, transport }
 }
 
 /**

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1275,32 +1275,41 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const result = await provider.request({ method: 'wallet_getCapabilities' })
       expect(result).toMatchInlineSnapshot(`
-      	{
-      	  "0x1079": {
-      	    "accessKeys": {
-      	      "status": "supported",
-      	    },
-      	    "atomic": {
-      	      "status": "supported",
-      	    },
-      	  },
-      	  "0x7a56": {
-      	    "accessKeys": {
-      	      "status": "supported",
-      	    },
-      	    "atomic": {
-      	      "status": "supported",
-      	    },
-      	  },
-      	  "0xa5bf": {
-      	    "accessKeys": {
-      	      "status": "supported",
-      	    },
-      	    "atomic": {
-      	      "status": "supported",
-      	    },
-      	  },
-      	}
+        {
+          "0x1079": {
+            "accessKeys": {
+              "status": "supported",
+            },
+            "atomic": {
+              "status": "supported",
+            },
+            "mpp": {
+              "status": "supported",
+            },
+          },
+          "0x7a56": {
+            "accessKeys": {
+              "status": "supported",
+            },
+            "atomic": {
+              "status": "supported",
+            },
+            "mpp": {
+              "status": "supported",
+            },
+          },
+          "0xa5bf": {
+            "accessKeys": {
+              "status": "supported",
+            },
+            "atomic": {
+              "status": "supported",
+            },
+            "mpp": {
+              "status": "supported",
+            },
+          },
+        }
       `)
     })
 
@@ -1320,6 +1329,9 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
               "status": "supported",
             },
             "atomic": {
+              "status": "supported",
+            },
+            "mpp": {
               "status": "supported",
             },
           },
@@ -1382,6 +1394,13 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const result = await provider.request({ method: 'wallet_getCapabilities' })
       expect(result[Hex.fromNumber(tempo.id)]!.feePayer).toBeUndefined()
+    })
+
+    test('behavior: excludes mpp when disabled', async () => {
+      const provider = Provider.create({ adapter: adapter(), mpp: false })
+
+      const result = await provider.request({ method: 'wallet_getCapabilities' })
+      expect(result[Hex.fromNumber(tempo.id)]!.mpp).toBeUndefined()
     })
   })
 

--- a/src/core/Provider.mpp.test.ts
+++ b/src/core/Provider.mpp.test.ts
@@ -2,6 +2,8 @@ import { Challenge, Credential } from 'mppx'
 import { Mppx } from 'mppx/client'
 import { Hex } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { custom } from 'viem'
+import { toAccount } from 'viem/accounts'
 import { Account as TempoAccount, Addresses } from 'viem/tempo'
 import { tempoLocalnet } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test } from 'vp/test'
@@ -9,8 +11,9 @@ import { afterEach, describe, expect, test } from 'vp/test'
 import { accounts, privateKeys } from '../../test/config.js'
 import * as AccessKey from './AccessKey.js'
 import type * as Account from './Account.js'
-import type * as Adapter from './Adapter.js'
+import * as Adapter from './Adapter.js'
 import { local } from './adapters/local.js'
+import * as MppAuthorization from './internal/MppAuthorization.js'
 import * as Provider from './Provider.js'
 import * as Storage from './Storage.js'
 
@@ -182,6 +185,262 @@ describe('mpp_authorize', () => {
         "source": "did:pkh:eip155:1337:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       }
     `)
+  })
+
+  test('error: rejects root signer mismatch', async () => {
+    const provider = createProvider({
+      adapter: Adapter.define({}, ({ getClient, mpp, store }) => ({
+        actions: {
+          async authorizeMpp(parameters) {
+            if (!mpp) throw new Error('mpp not configured')
+            return await MppAuthorization.authorize({
+              createWalletClient: (() => {
+                throw new Error('unexpected wallet client')
+              }) as never,
+              getClient,
+              getRootAccount: async () => TempoAccount.fromSecp256k1(privateKeys[1]!),
+              mpp,
+              parameters,
+              store,
+            })
+          },
+          createAccount: async () => ({ accounts: [] }),
+          async loadAccounts() {
+            return { accounts: [] }
+          },
+          sendTransaction: async () => {
+            throw new Error('unexpected sendTransaction')
+          },
+          sendTransactionSync: async () => {
+            throw new Error('unexpected sendTransactionSync')
+          },
+          signPersonalMessage: async () => {
+            throw new Error('unexpected signPersonalMessage')
+          },
+          signTransaction: async () => {
+            throw new Error('unexpected signTransaction')
+          },
+          signTypedData: async () => {
+            throw new Error('unexpected signTypedData')
+          },
+        },
+      })),
+      account: { address: rootAddress },
+    })
+    const channelId = Hex.padLeft('0x01', 32)
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [
+              createChallenge({
+                intent: 'session',
+                method: 'tempo',
+                request: {
+                  amount: '1',
+                  currency: Addresses.pathUsd,
+                  methodDetails: {
+                    chainId: tempoLocalnet.id,
+                    channelId,
+                    escrowContract: accounts[2]!.address,
+                  },
+                  recipient: accounts[1]!.address,
+                },
+              }),
+            ],
+            session: {
+              action: 'voucher',
+              authorizedSigner: rootAddress,
+              channelId,
+              cumulativeAmount: '1',
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Root account does not match the authorized signer.]`,
+    )
+  })
+
+  test('behavior: forwards JSON-RPC root account with native mpp_authorize support', async () => {
+    const requests: { method: string; params?: unknown }[] = []
+    const remote = {
+      async request(request: { method: string; params?: unknown }) {
+        requests.push(request)
+        if (request.method === 'wallet_getCapabilities')
+          return {
+            [Hex.fromNumber(tempoLocalnet.id)]: {
+              atomic: { status: 'supported' },
+              mpp: { status: 'supported' },
+            },
+          }
+        if (request.method === 'mpp_authorize') return { authorization: 'forwarded' }
+        throw new Error(`unexpected request ${request.method}`)
+      },
+    }
+    const provider = createProvider({
+      adapter: Adapter.define({}, ({ getClient, mpp, store }) => ({
+        actions: {
+          async authorizeMpp(parameters) {
+            if (!mpp) throw new Error('mpp not configured')
+            return await MppAuthorization.authorize({
+              createWalletClient: (() => {
+                throw new Error('unexpected wallet client')
+              }) as never,
+              getClient,
+              getRootAccount: async (address) => ({
+                account: toAccount(address),
+                provider: remote as never,
+                transport: custom(remote as never),
+              }),
+              mpp,
+              parameters,
+              store,
+            })
+          },
+          createAccount: async () => ({ accounts: [] }),
+          async loadAccounts() {
+            return { accounts: [] }
+          },
+          sendTransaction: async () => {
+            throw new Error('unexpected sendTransaction')
+          },
+          sendTransactionSync: async () => {
+            throw new Error('unexpected sendTransactionSync')
+          },
+          signPersonalMessage: async () => {
+            throw new Error('unexpected signPersonalMessage')
+          },
+          signTransaction: async () => {
+            throw new Error('unexpected signTransaction')
+          },
+          signTypedData: async () => {
+            throw new Error('unexpected signTypedData')
+          },
+        },
+      })),
+      account: { address: rootAddress },
+    })
+
+    const result = await provider.request({
+      method: 'mpp_authorize',
+      params: [
+        {
+          challenges: [
+            createChallenge({
+              intent: 'charge',
+              method: 'tempo',
+              request: {
+                amount: '1',
+                currency: Addresses.pathUsd,
+                methodDetails: { chainId: tempoLocalnet.id },
+                recipient: accounts[1]!.address,
+              },
+            }),
+          ],
+        },
+      ],
+    })
+
+    const forwarded = requests[1]?.params as readonly [{ challenges: readonly string[] }]
+    expect({
+      challenge: forwarded[0].challenges[0],
+      methods: requests.map((request) => request.method),
+      result,
+    }).toMatchInlineSnapshot(`
+      {
+        "challenge": "Payment id="tempo-charge", realm="example.test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJtZXRob2REZXRhaWxzIjp7ImNoYWluSWQiOjEzMzd9LCJyZWNpcGllbnQiOiIweDhDOGQzNTQyOUY3NGVjMjQ1RjhFZjJmNEZkMWU1NTFjRkY5N2Q2NTAifQ"",
+        "methods": [
+          "wallet_getCapabilities",
+          "mpp_authorize",
+        ],
+        "result": {
+          "authorization": "forwarded",
+        },
+      }
+    `)
+  })
+
+  test('behavior: signs with JSON-RPC account when native mpp_authorize is unsupported', async () => {
+    const remote = {
+      async request(request: { method: string }) {
+        if (request.method === 'wallet_getCapabilities')
+          return {
+            [Hex.fromNumber(tempoLocalnet.id)]: {
+              atomic: { status: 'supported' },
+              mpp: { status: 'unsupported' },
+            },
+          }
+        throw new Error(`unexpected request ${request.method}`)
+      },
+    }
+    const provider = createProvider({
+      adapter: Adapter.define({}, ({ getClient, mpp, store }) => ({
+        actions: {
+          async authorizeMpp(parameters) {
+            if (!mpp) throw new Error('mpp not configured')
+            return await MppAuthorization.authorize({
+              createWalletClient: (() => {
+                throw new Error('fallback signing')
+              }) as never,
+              getClient,
+              getRootAccount: async (address) => ({
+                account: toAccount(address),
+                provider: remote as never,
+                transport: custom(remote as never),
+              }),
+              mpp,
+              parameters,
+              store,
+            })
+          },
+          createAccount: async () => ({ accounts: [] }),
+          async loadAccounts() {
+            return { accounts: [] }
+          },
+          sendTransaction: async () => {
+            throw new Error('unexpected sendTransaction')
+          },
+          sendTransactionSync: async () => {
+            throw new Error('unexpected sendTransactionSync')
+          },
+          signPersonalMessage: async () => {
+            throw new Error('unexpected signPersonalMessage')
+          },
+          signTransaction: async () => {
+            throw new Error('unexpected signTransaction')
+          },
+          signTypedData: async () => {
+            throw new Error('unexpected signTypedData')
+          },
+        },
+      })),
+      account: { address: rootAddress },
+    })
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [
+              createChallenge({
+                intent: 'charge',
+                method: 'tempo',
+                request: {
+                  amount: '1',
+                  currency: Addresses.pathUsd,
+                  methodDetails: { chainId: tempoLocalnet.id },
+                  recipient: accounts[1]!.address,
+                },
+              }),
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[RpcResponse.InternalError: fallback signing]`)
   })
 
   test('behavior: authorizes with access key before root signer', async () => {

--- a/src/core/Provider.mpp.test.ts
+++ b/src/core/Provider.mpp.test.ts
@@ -1,0 +1,303 @@
+import { Challenge, Credential } from 'mppx'
+import { Mppx } from 'mppx/client'
+import { Hex } from 'ox'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { Account as TempoAccount, Addresses } from 'viem/tempo'
+import { tempoLocalnet } from 'viem/tempo/chains'
+import { afterEach, describe, expect, test } from 'vp/test'
+
+import { accounts, privateKeys } from '../../test/config.js'
+import * as AccessKey from './AccessKey.js'
+import type * as Account from './Account.js'
+import type * as Adapter from './Adapter.js'
+import { local } from './adapters/local.js'
+import * as Provider from './Provider.js'
+import * as Storage from './Storage.js'
+
+const rootAddress = accounts[0]!.address
+
+afterEach(() => Mppx.restore())
+
+describe('mpp_authorize', () => {
+  test('error: rejects non-Tempo challenges', async () => {
+    const provider = createProvider()
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [createChallenge({ intent: 'charge', method: 'stripe' })],
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Only Tempo payment challenges are supported.]`,
+    )
+  })
+
+  test('error: rejects session continuation with multiple challenges', async () => {
+    const provider = createProvider()
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [
+              createChallenge({ intent: 'session', method: 'tempo' }),
+              createChallenge({ intent: 'session', method: 'tempo' }),
+            ],
+            session: {
+              action: 'voucher',
+              authorizedSigner: rootAddress,
+              channelId: '0x01',
+              cumulativeAmount: '1',
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`session\` can only be used with one challenge.]`,
+    )
+  })
+
+  test('error: rejects session channel mismatch', async () => {
+    const provider = createProvider()
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [
+              createChallenge({
+                intent: 'session',
+                method: 'tempo',
+                request: { methodDetails: { channelId: '0x02' } },
+              }),
+            ],
+            session: {
+              action: 'close',
+              authorizedSigner: rootAddress,
+              channelId: '0x01',
+              cumulativeAmount: '1',
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`session.channelId\` conflicts with the payment challenge.]`,
+    )
+  })
+
+  test('behavior: authorizes charge without recursive mpp_authorize', async () => {
+    const provider = createProvider({ account: accounts[0]! })
+    const result = await provider.request({
+      method: 'mpp_authorize',
+      params: [
+        {
+          challenges: [
+            createChallenge({
+              intent: 'charge',
+              method: 'tempo',
+              request: {
+                amount: '0',
+                currency: Addresses.pathUsd,
+                methodDetails: { chainId: tempoLocalnet.id },
+                recipient: accounts[1]!.address,
+              },
+            }),
+          ],
+        },
+      ],
+    })
+
+    const credential = Credential.deserialize(result.authorization)
+    const payload = credential.payload as { type?: string | undefined }
+    expect({
+      challenge: credential.challenge.id,
+      payloadType: payload.type,
+      source: credential.source,
+    }).toMatchInlineSnapshot(`
+      {
+        "challenge": "tempo-charge",
+        "payloadType": "proof",
+        "source": "did:pkh:eip155:1337:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      }
+    `)
+  })
+
+  test('behavior: authorizes session continuation with root signer', async () => {
+    const provider = createProvider({ account: accounts[0]! })
+    const channelId = Hex.padLeft('0x01', 32)
+    const result = await provider.request({
+      method: 'mpp_authorize',
+      params: [
+        {
+          challenges: [
+            createChallenge({
+              intent: 'session',
+              method: 'tempo',
+              request: {
+                amount: '1',
+                currency: Addresses.pathUsd,
+                methodDetails: {
+                  chainId: tempoLocalnet.id,
+                  channelId,
+                  escrowContract: accounts[2]!.address,
+                },
+                recipient: accounts[1]!.address,
+              },
+            }),
+          ],
+          session: {
+            action: 'voucher',
+            authorizedSigner: rootAddress,
+            channelId,
+            cumulativeAmount: '1',
+          },
+        },
+      ],
+    })
+
+    const credential = Credential.deserialize(result.authorization)
+    const payload = credential.payload as {
+      action?: string | undefined
+      channelId?: string | undefined
+      cumulativeAmount?: string | undefined
+      signature?: string | undefined
+    }
+    const { signature: _signature, ...payload_ } = payload
+    expect({
+      payload: payload_,
+      source: credential.source,
+    }).toMatchInlineSnapshot(`
+      {
+        "payload": {
+          "action": "voucher",
+          "channelId": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "cumulativeAmount": "1",
+        },
+        "source": "did:pkh:eip155:1337:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      }
+    `)
+  })
+
+  test('behavior: authorizes with access key before root signer', async () => {
+    const provider = createProvider({
+      account: { address: rootAddress },
+    })
+    const account = TempoAccount.fromSecp256k1(privateKeys[2]!, { access: rootAddress })
+    const keyAuthorization = KeyAuthorization.from({
+      address: account.accessKeyAddress,
+      chainId: BigInt(tempoLocalnet.id),
+      signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`),
+      type: 'secp256k1',
+    })
+    AccessKey.add({
+      account: rootAddress,
+      authorization: keyAuthorization,
+      privateKey: privateKeys[2]!,
+      store: provider.store,
+    })
+
+    const result = await provider.request({
+      method: 'mpp_authorize',
+      params: [
+        {
+          challenges: [
+            createChallenge({
+              intent: 'charge',
+              method: 'tempo',
+              request: {
+                amount: '0',
+                currency: Addresses.pathUsd,
+                methodDetails: { chainId: tempoLocalnet.id },
+                recipient: accounts[1]!.address,
+              },
+            }),
+          ],
+        },
+      ],
+    })
+
+    const credential = Credential.deserialize(result.authorization)
+    const payload = credential.payload as { type?: string | undefined }
+    expect({
+      payloadType: payload.type,
+      source: credential.source,
+    }).toMatchInlineSnapshot(`
+      {
+        "payloadType": "proof",
+        "source": "did:pkh:eip155:1337:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      }
+    `)
+  })
+
+  test('error: requires a concrete signable account', async () => {
+    const provider = createProvider({
+      account: { address: rootAddress },
+    })
+
+    await expect(
+      provider.request({
+        method: 'mpp_authorize',
+        params: [
+          {
+            challenges: [
+              createChallenge({
+                intent: 'charge',
+                method: 'tempo',
+                request: {
+                  amount: '1',
+                  currency: Addresses.pathUsd,
+                  methodDetails: { chainId: tempoLocalnet.id },
+                  recipient: accounts[1]!.address,
+                },
+              }),
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Provider.UnauthorizedError: Account "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" cannot sign.]`,
+    )
+  })
+})
+
+function createProvider(
+  options: { account?: Account.Store | undefined; adapter?: Adapter.Adapter | undefined } = {},
+) {
+  const provider = Provider.create({
+    adapter:
+      options.adapter ??
+      local({
+        loadAccounts: async () => ({ accounts: [] }),
+      }),
+    mpp: { polyfill: false },
+    storage: Storage.memory(),
+  })
+  provider.store.setState({
+    accounts: [options.account ?? { address: rootAddress }],
+    activeAccount: 0,
+  })
+  return provider
+}
+
+function createChallenge(options: {
+  intent: string
+  method: string
+  request?: Record<string, unknown> | undefined
+}) {
+  const { intent, method, request = {} } = options
+  return Challenge.serialize(
+    Challenge.from({
+      id: `${method}-${intent}`,
+      intent,
+      method,
+      realm: 'example.test',
+      request,
+    }),
+  )
+}

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -48,6 +48,12 @@ describe('request', () => {
     expectTypeOf<Result<'wallet_disconnect'>>().toEqualTypeOf<undefined>()
   })
 
+  test('mpp_authorize', () => {
+    expectTypeOf<Result<'mpp_authorize'>>().toEqualTypeOf<{
+      authorization: string
+    }>()
+  })
+
   test('wallet_swap', () => {
     expectTypeOf<Result<'wallet_swap'>>().toMatchTypeOf<{
       receipt: { transactionHash: `0x${string}` }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,7 +1,15 @@
 import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
-import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
+import {
+  http,
+  parseUnits,
+  type Account as viem_Account,
+  type Chain,
+  type Client as ViemClient,
+  type Transport,
+  type WalletClient,
+} from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
@@ -37,6 +45,13 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
       chainId?: number | undefined
       feePayer?: string | undefined
     }): ViemClient<Transport, typeof tempo>
+    /** Returns a viem Wallet Client for the given account and chain ID. */
+    createWalletClient(options: {
+      account: viem_Account
+      chainId?: number | undefined
+      feePayer?: string | false | undefined
+      transport?: Transport | undefined
+    }): WalletClient<Transport, typeof tempo, viem_Account>
     /** Reactive state store. */
     store: Store.Store
   }
@@ -128,7 +143,24 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
+  function createWalletClient(options: Adapter.createWalletClient.Options) {
+    const { account, chainId, feePayer, transport } = options
+    return Client.createWalletClient(chainId, {
+      account,
+      chains,
+      feePayer: (() => {
+        if (feePayer === false) return false
+        if (feePayer) return { url: feePayer, precedence: feePayerConfig?.precedence }
+        return undefined
+      })(),
+      store,
+      ...(transport ? { transport } : {}),
+      transports,
+    })
+  }
+
   const instance = adapter({
+    createWalletClient,
     getAccount,
     getClient,
     ...(mpp ? { mpp } : {}),
@@ -1052,6 +1084,23 @@ export function create(options: create.Options = {}): create.ReturnType {
           feePayer,
           provider: providerRef,
           store,
+          transports,
+        })
+      },
+      createWalletClient(options: {
+        account: viem_Account
+        chainId?: number | undefined
+        feePayer?: string | false | undefined
+        transport?: Transport | undefined
+      }) {
+        const { account, chainId, feePayer, transport } = options
+        return Client.createWalletClient(chainId, {
+          account,
+          chains,
+          feePayer,
+          provider: providerRef,
+          store,
+          ...(transport ? { transport } : {}),
           transports,
         })
       },

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -101,6 +101,16 @@ export function create(options: create.Options = {}): create.ReturnType {
   // Lazy reference — assigned after the provider is created so the client
   // transport can route provider methods (wallet_connect, etc.) through it.
   let providerRef: ox_Provider.Provider | undefined
+  let payments:
+    | {
+        createCredential(response: Response, context?: unknown): Promise<string>
+      }
+    | undefined
+  const mpp = (() => {
+    if (options.mpp === false) return undefined
+    if (typeof options.mpp === 'object') return options.mpp
+    return {}
+  })()
 
   function getClient(
     options: { chainId?: number | undefined; feePayer?: string | false | undefined } = {},
@@ -118,7 +128,17 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
-  const instance = adapter({ getAccount, getClient, storage, store })
+  const instance = adapter({
+    getAccount,
+    getClient,
+    ...(mpp ? { mpp } : {}),
+    async request(request) {
+      if (!providerRef) throw new ox_Provider.DisconnectedError({ message: 'Provider not ready.' })
+      return await providerRef.request(request as never)
+    },
+    storage,
+    store,
+  })
   const { actions } = instance
 
   const emitter = ox_Provider.createEmitter()
@@ -534,6 +554,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' }
                         atomic: { status: 'supported' }
                         feePayer?: { status: 'supported' } | undefined
+                        mpp?: { status: 'supported' } | undefined
                       }
                     > = {}
                     for (const chain of filtered)
@@ -541,8 +562,25 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' },
                         atomic: { status: 'supported' },
                         ...(feePayerConfig ? { feePayer: { status: 'supported' } } : {}),
+                        ...(payments && actions.authorizeMpp
+                          ? { mpp: { status: 'supported' } }
+                          : {}),
                       }
                     return result as Rpc.wallet_getCapabilities.Encoded['returns']
+                  }
+
+                  case 'mpp_authorize': {
+                    assertConnected()
+                    if (!payments || !actions.authorizeMpp)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`mpp` not enabled.',
+                      })
+
+                    const [decoded] = request._decoded.params
+                    return await actions.authorizeMpp(decoded, {
+                      method: 'mpp_authorize',
+                      params: request.params,
+                    })
                   }
 
                   case 'wallet_connect': {
@@ -1039,11 +1077,6 @@ export function create(options: create.Options = {}): create.ReturnType {
     }
   }
 
-  const mpp = (() => {
-    if (options.mpp === false) return undefined
-    if (typeof options.mpp === 'object') return options.mpp
-    return {}
-  })()
   if (mpp) {
     const { mode = 'push', polyfill: polyfill_option, ...methodOptions } = mpp
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
@@ -1060,7 +1093,7 @@ export function create(options: create.Options = {}): create.ReturnType {
         },
       })
     }
-    Mppx.create({
+    payments = Mppx.create({
       methods: [
         mppx_tempo({ ...methodOptions, getClient, mode }),
         mppx_tempo.subscription({ getClient }),

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -138,6 +138,37 @@ describe('Encoded', () => {
     )
   })
 
+  test('wallet_getCapabilities: mpp', () => {
+    expectTypeOf<Rpc.wallet_getCapabilities.Encoded['returns']>().toMatchTypeOf<
+      Record<
+        Hex,
+        {
+          mpp?: { status: 'supported' | 'unsupported' } | undefined
+        }
+      >
+    >()
+  })
+
+  test('mpp_authorize', () => {
+    expectTypeOf<Rpc.mpp_authorize.Encoded>().toMatchTypeOf<{
+      method: 'mpp_authorize'
+      params: readonly [
+        {
+          challenges: readonly string[]
+          session?:
+            | {
+                action: 'voucher' | 'close'
+                authorizedSigner: Hex
+                channelId: Hex
+                cumulativeAmount: string
+              }
+            | undefined
+        },
+      ]
+      returns: { authorization: string }
+    }>()
+  })
+
   test('wallet_disconnect', () => {
     expectTypeOf<Rpc.wallet_disconnect.Encoded>().toEqualTypeOf<{
       method: 'wallet_disconnect'
@@ -237,7 +268,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[21]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[22]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -257,6 +288,7 @@ describe('Request', () => {
       | 'wallet_disconnect'
       | 'wallet_getCallsStatus'
       | 'wallet_getCapabilities'
+      | 'mpp_authorize'
       | 'wallet_sendCalls'
       | 'wallet_switchEthereumChain'
       | 'wallet_authorizeAccessKey'

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -93,6 +93,7 @@ export const schema = from([
   Rpc.wallet_getBalances.schema,
   Rpc.wallet_getCallsStatus.schema,
   Rpc.wallet_getCapabilities.schema,
+  Rpc.mpp_authorize.schema,
   Rpc.wallet_revokeAccessKey.schema,
   Rpc.wallet_transfer.schema,
   Rpc.wallet_sendCalls.schema,

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -39,6 +39,8 @@ function setup() {
       if (options?.signable) throw new ox_Provider.UnauthorizedError({ message: 'No signer.' })
       return { address, type: 'json-rpc' } as never
     },
+    createWalletClient: (() => ({})) as never,
+
     getClient: () => ({}) as never,
     storage,
     store,
@@ -85,6 +87,8 @@ describe('dialog', () => {
       getAccount: () => {
         throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
       },
+      createWalletClient: (() => ({})) as never,
+
       getClient: () =>
         ({
           chain: { id: tempoLocalnet.id },
@@ -141,6 +145,8 @@ describe('dialog', () => {
       getAccount: () => {
         throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
       },
+      createWalletClient: (() => ({})) as never,
+
       getClient: () => ({}) as never,
       storage,
       store,
@@ -210,6 +216,8 @@ describe('dialog', () => {
         lookups.push(options)
         throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
       },
+      createWalletClient: (() => ({})) as never,
+
       getClient: () => ({}) as never,
       storage,
       store,
@@ -270,6 +278,8 @@ describe('dialog', () => {
       getAccount: () => {
         throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
       },
+      createWalletClient: (() => ({})) as never,
+
       getClient: () => ({}) as never,
       storage,
       store,
@@ -465,6 +475,8 @@ describe('dialog', () => {
       getAccount: () => {
         throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
       },
+      createWalletClient: (() => ({})) as never,
+
       getClient: () => ({}) as never,
       storage,
       store,

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -1,11 +1,14 @@
 import { Address, Provider as ox_Provider, RpcRequest as ox_RpcRequest, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
+import { createWalletClient, custom } from 'viem'
+import { toAccount } from 'viem/accounts'
 import { z } from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
 import * as Dialog from '../Dialog.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as MppAuthorization from '../internal/MppAuthorization.js'
 import * as Schema from '../Schema.js'
 import type * as Store from '../Store.js'
 import * as Rpc from '../zod/rpc.js'
@@ -42,7 +45,9 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       'due to lack of WebAuthn passkey support in non-secure contexts.',
     )
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, (config) => {
+    const { getAccount, getClient, store } = config
+    const mpp = config.mpp
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()
     const requestStore = ox_RpcRequest.createStore()
 
@@ -105,6 +110,21 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       },
       { schema: Schema.ox },
     )
+
+    function getDialogAccount(address: Address.Address) {
+      const account = toAccount(address)
+      return {
+        account,
+        getClient: (options) => {
+          const client = getClient(options)
+          return createWalletClient({
+            account,
+            chain: client.chain,
+            transport: custom(provider as never),
+          }) as never
+        },
+      } satisfies MppAuthorization.authorize.Account
+    }
 
     /**
      * Prepares a local key pair when `authorizeAccessKey` is requested without
@@ -175,6 +195,28 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       },
       forwardsAuth: true,
       actions: {
+        ...(mpp
+          ? {
+              async authorizeMpp(parameters) {
+                return await MppAuthorization.authorize({
+                  accounts: {
+                    getRootAccount: async (address) => getDialogAccount(address),
+                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
+                      AccessKey.getSigner({
+                        accessKey,
+                        account: root,
+                        chainId,
+                        store,
+                      }),
+                  },
+                  mpp,
+                  getClient,
+                  parameters,
+                  store,
+                })
+              },
+            }
+          : {}),
         async createAccount(parameters, request) {
           const accessKey = await generateAccessKey(parameters.authorizeAccessKey)
 

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -1,6 +1,6 @@
 import { Address, Provider as ox_Provider, RpcRequest as ox_RpcRequest, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { createWalletClient, custom } from 'viem'
+import { custom } from 'viem'
 import { toAccount } from 'viem/accounts'
 import { z } from 'zod/mini'
 
@@ -46,8 +46,16 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     )
 
   return Adapter.define({ icon, name, rdns }, (config) => {
-    const { getAccount, getClient, store } = config
+    const { createWalletClient, getAccount, getClient, store } = config
     const mpp = config.mpp
+    const authorize = mpp
+      ? MppAuthorization.create({
+          createWalletClient,
+          getClient,
+          mpp,
+          store,
+        })
+      : undefined
     const listeners = new Set<(requestQueue: readonly Store.QueuedRequest[]) => void>()
     const requestStore = ox_RpcRequest.createStore()
 
@@ -112,18 +120,11 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     )
 
     function getDialogAccount(address: Address.Address) {
-      const account = toAccount(address)
       return {
-        account,
-        getClient: (options) => {
-          const client = getClient(options)
-          return createWalletClient({
-            account,
-            chain: client.chain,
-            transport: custom(provider as never),
-          }) as never
-        },
-      } satisfies MppAuthorization.authorize.Account
+        account: toAccount(address),
+        provider,
+        transport: custom(provider as never),
+      }
     }
 
     /**
@@ -195,24 +196,12 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       },
       forwardsAuth: true,
       actions: {
-        ...(mpp
+        ...(authorize
           ? {
               async authorizeMpp(parameters) {
-                return await MppAuthorization.authorize({
-                  accounts: {
-                    getRootAccount: async (address) => getDialogAccount(address),
-                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
-                      AccessKey.getSigner({
-                        accessKey,
-                        account: root,
-                        chainId,
-                        store,
-                      }),
-                  },
-                  mpp,
-                  getClient,
+                return await authorize({
+                  getRootAccount: async (address) => getDialogAccount(address),
                   parameters,
-                  store,
                 })
               },
             }

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -306,6 +306,8 @@ function setup(overrides: Partial<local.Options> = {}) {
     ...overrides,
   })({
     getAccount: (options) => Account.find({ ...options, signable: true, store }),
+    createWalletClient: (() => ({})) as never,
+
     getClient: () => getClient({ chain: tempoLocalnet }) as never,
     storage,
     store,

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -30,8 +30,16 @@ export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
   return Adapter.define({ icon, name, rdns }, (config) => {
-    const { getAccount, getClient, store } = config
+    const { createWalletClient, getAccount, getClient, store } = config
     const mpp = config.mpp
+    const authorize = mpp
+      ? MppAuthorization.create({
+          createWalletClient,
+          getClient,
+          mpp,
+          store,
+        })
+      : undefined
 
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const { feePayer, ...rest } = parameters
@@ -99,24 +107,12 @@ export function local(options: local.Options): Adapter.Adapter {
 
     return {
       actions: {
-        ...(mpp
+        ...(authorize
           ? {
               async authorizeMpp(parameters) {
-                return await MppAuthorization.authorize({
-                  accounts: {
-                    getRootAccount: async (address) => getAccount({ address, signable: true }),
-                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
-                      AccessKey.getSigner({
-                        accessKey,
-                        account: root,
-                        chainId,
-                        store,
-                      }),
-                  },
-                  mpp,
-                  getClient,
+                return await authorize({
+                  getRootAccount: async (address) => getAccount({ address, signable: true }),
                   parameters,
-                  store,
                 })
               },
             }

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -8,6 +8,7 @@ import * as AccessKey from '../AccessKey.js'
 import * as Account from '../Account.js'
 import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as MppAuthorization from '../internal/MppAuthorization.js'
 
 /**
  * Creates a local adapter where the app manages keys and signing in-process.
@@ -28,7 +29,10 @@ import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, (config) => {
+    const { getAccount, getClient, store } = config
+    const mpp = config.mpp
+
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const { feePayer, ...rest } = parameters
       const client = getClient({
@@ -95,6 +99,28 @@ export function local(options: local.Options): Adapter.Adapter {
 
     return {
       actions: {
+        ...(mpp
+          ? {
+              async authorizeMpp(parameters) {
+                return await MppAuthorization.authorize({
+                  accounts: {
+                    getRootAccount: async (address) => getAccount({ address, signable: true }),
+                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
+                      AccessKey.getSigner({
+                        accessKey,
+                        account: root,
+                        chainId,
+                        store,
+                      }),
+                  },
+                  mpp,
+                  getClient,
+                  parameters,
+                  store,
+                })
+              },
+            }
+          : {}),
         async createAccount(parameters) {
           if (!createAccount)
             throw new ox_Provider.UnsupportedMethodError({

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -514,6 +514,8 @@ function setup(options: setup.Options = {}) {
     getAccount: (() => {
       throw new Error('not implemented')
     }) as never,
+    createWalletClient: (() => ({})) as never,
+
     getClient: (() => ({
       chain: { id: 1 },
       sendTransaction: async (parameters: unknown) => {

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -9,8 +9,8 @@ import {
   WebCryptoP256,
 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
-import type { Address, LocalAccount } from 'viem/accounts'
+import { custom, hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
+import { toAccount, type Address, type LocalAccount } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
 import { Actions, Transaction as TempoTransaction } from 'viem/tempo'
 
@@ -78,8 +78,16 @@ export function privy<const client extends privy.Client>(
   const { icon, name = 'Privy', rdns = 'io.privy' } = options
 
   return Adapter.define({ icon, name, rdns }, (config) => {
-    const { getClient, store } = config
+    const { createWalletClient, getClient, store } = config
     const mpp = config.mpp
+    const authorize = mpp
+      ? MppAuthorization.create({
+          createWalletClient,
+          getClient,
+          mpp,
+          store,
+        })
+      : undefined
 
     let privyClient_promise: Promise<client> | undefined
     let restore_promise: Promise<void> | undefined
@@ -413,31 +421,11 @@ export function privy<const client extends privy.Client>(
 
     async function getMppAccount(options: { address?: Address | undefined } = {}) {
       const account = await accountForSigning(options.address)
-      const account_tempo = {
-        address: core_Address.from(account.address),
-        source: 'privy',
-        sign: async (parameters: { hash: Hex.Hex }) =>
-          await signPayload({
-            payload: parameters.hash,
-            walletAccount: account,
-          }),
-        signMessage: async (parameters: Parameters<LocalAccount['signMessage']>[0]) =>
-          await signPayload({
-            payload: hashMessage(parameters.message),
-            walletAccount: account,
-          }),
-        signTransaction: async (request: Parameters<LocalAccount['signTransaction']>[0]) =>
-          await signPreparedTransaction(account, request),
-        signTypedData: async (parameters: unknown) =>
-          await signPayload({
-            payload: hashTypedData(parameters as never),
-            walletAccount: account,
-          }),
-        type: 'local',
-      } satisfies Omit<LocalAccount<'privy'>, 'publicKey' | 'signTypedData'> & {
-        signTypedData: (parameters: unknown) => Promise<Hex.Hex>
+      return {
+        account: toAccount(core_Address.from(account.address)),
+        provider: account.provider as never,
+        transport: custom(account.provider as never),
       }
-      return account_tempo as LocalAccount<'privy'>
     }
 
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
@@ -544,24 +532,12 @@ export function privy<const client extends privy.Client>(
     return {
       cleanup() {},
       actions: {
-        ...(mpp
+        ...(authorize
           ? {
               async authorizeMpp(parameters) {
-                return await MppAuthorization.authorize({
-                  accounts: {
-                    getRootAccount: async (address) => await getMppAccount({ address }),
-                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
-                      AccessKey.getSigner({
-                        accessKey,
-                        account: root,
-                        chainId,
-                        store,
-                      }),
-                  },
-                  mpp,
-                  getClient,
+                return await authorize({
+                  getRootAccount: async (address) => await getMppAccount({ address }),
                   parameters,
-                  store,
                 })
               },
             }

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -17,6 +17,7 @@ import { Actions, Transaction as TempoTransaction } from 'viem/tempo'
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as MppAuthorization from '../internal/MppAuthorization.js'
 import * as Store from '../Store.js'
 
 const privySessionErrorCodes = new Set([
@@ -76,7 +77,10 @@ export function privy<const client extends privy.Client>(
 ): Adapter.Adapter {
   const { icon, name = 'Privy', rdns = 'io.privy' } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, (config) => {
+    const { getClient, store } = config
+    const mpp = config.mpp
+
     let privyClient_promise: Promise<client> | undefined
     let restore_promise: Promise<void> | undefined
     let walletAccounts: readonly privy.EmbeddedWallet[] = []
@@ -407,6 +411,35 @@ export function privy<const client extends privy.Client>(
       )
     }
 
+    async function getMppAccount(options: { address?: Address | undefined } = {}) {
+      const account = await accountForSigning(options.address)
+      const account_tempo = {
+        address: core_Address.from(account.address),
+        source: 'privy',
+        sign: async (parameters: { hash: Hex.Hex }) =>
+          await signPayload({
+            payload: parameters.hash,
+            walletAccount: account,
+          }),
+        signMessage: async (parameters: Parameters<LocalAccount['signMessage']>[0]) =>
+          await signPayload({
+            payload: hashMessage(parameters.message),
+            walletAccount: account,
+          }),
+        signTransaction: async (request: Parameters<LocalAccount['signTransaction']>[0]) =>
+          await signPreparedTransaction(account, request),
+        signTypedData: async (parameters: unknown) =>
+          await signPayload({
+            payload: hashTypedData(parameters as never),
+            walletAccount: account,
+          }),
+        type: 'local',
+      } satisfies Omit<LocalAccount<'privy'>, 'publicKey' | 'signTypedData'> & {
+        signTypedData: (parameters: unknown) => Promise<Hex.Hex>
+      }
+      return account_tempo as LocalAccount<'privy'>
+    }
+
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const viemClient = getClient({
         chainId: parameters.chainId,
@@ -511,6 +544,28 @@ export function privy<const client extends privy.Client>(
     return {
       cleanup() {},
       actions: {
+        ...(mpp
+          ? {
+              async authorizeMpp(parameters) {
+                return await MppAuthorization.authorize({
+                  accounts: {
+                    getRootAccount: async (address) => await getMppAccount({ address }),
+                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
+                      AccessKey.getSigner({
+                        accessKey,
+                        account: root,
+                        chainId,
+                        store,
+                      }),
+                  },
+                  mpp,
+                  getClient,
+                  parameters,
+                  store,
+                })
+              },
+            }
+          : {}),
         async createAccount(parameters) {
           const { authorizeAccessKey, personalSign } = parameters
           if (personalSign && parameters.digest)

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -557,6 +557,8 @@ function setup(options: setup.Options = {}) {
     getAccount: (() => {
       throw new Error('not implemented')
     }) as never,
+    createWalletClient: (() => ({})) as never,
+
     getClient: (() => ({
       chain: { id: 1 },
       sendTransaction: async (parameters: unknown) => {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -15,6 +15,7 @@ import { Account as TempoAccount, Actions } from 'viem/tempo'
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as MppAuthorization from '../internal/MppAuthorization.js'
 import * as Store from '../Store.js'
 
 const turnkeySessionErrorCodes = new Set([
@@ -70,7 +71,10 @@ export function turnkey<const client extends turnkey.Client>(
 ): Adapter.Adapter {
   const { icon, name = 'Turnkey', rdns = 'com.turnkey', sessionSkewMs = 10_000 } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, (config) => {
+    const { getClient, store } = config
+    const mpp = config.mpp
+
     let turnkeyClient_promise: Promise<client> | undefined
     let expiry_timeout: ReturnType<typeof setTimeout> | undefined
     let restore_promise: Promise<void> | undefined
@@ -324,6 +328,28 @@ export function turnkey<const client extends turnkey.Client>(
         if (expiry_timeout) clearTimeout(expiry_timeout)
       },
       actions: {
+        ...(mpp
+          ? {
+              async authorizeMpp(parameters) {
+                return await MppAuthorization.authorize({
+                  accounts: {
+                    getRootAccount: async (address) => await getTurnkeyAccount(address),
+                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
+                      AccessKey.getSigner({
+                        accessKey,
+                        account: root,
+                        chainId,
+                        store,
+                      }),
+                  },
+                  mpp,
+                  getClient,
+                  parameters,
+                  store,
+                })
+              },
+            }
+          : {}),
         async createAccount(parameters) {
           const { authorizeAccessKey, personalSign } = parameters
           if (personalSign && parameters.digest)

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -72,8 +72,16 @@ export function turnkey<const client extends turnkey.Client>(
   const { icon, name = 'Turnkey', rdns = 'com.turnkey', sessionSkewMs = 10_000 } = options
 
   return Adapter.define({ icon, name, rdns }, (config) => {
-    const { getClient, store } = config
+    const { createWalletClient, getClient, store } = config
     const mpp = config.mpp
+    const authorize = mpp
+      ? MppAuthorization.create({
+          createWalletClient,
+          getClient,
+          mpp,
+          store,
+        })
+      : undefined
 
     let turnkeyClient_promise: Promise<client> | undefined
     let expiry_timeout: ReturnType<typeof setTimeout> | undefined
@@ -328,24 +336,12 @@ export function turnkey<const client extends turnkey.Client>(
         if (expiry_timeout) clearTimeout(expiry_timeout)
       },
       actions: {
-        ...(mpp
+        ...(authorize
           ? {
               async authorizeMpp(parameters) {
-                return await MppAuthorization.authorize({
-                  accounts: {
-                    getRootAccount: async (address) => await getTurnkeyAccount(address),
-                    getAccessKeyAccount: async ({ accessKey, chainId, root }) =>
-                      AccessKey.getSigner({
-                        accessKey,
-                        account: root,
-                        chainId,
-                        store,
-                      }),
-                  },
-                  mpp,
-                  getClient,
+                return await authorize({
+                  getRootAccount: async (address) => await getTurnkeyAccount(address),
                   parameters,
-                  store,
                 })
               },
             }

--- a/src/core/internal/Mpp.ts
+++ b/src/core/internal/Mpp.ts
@@ -1,0 +1,257 @@
+import { Challenge as mpp_Challenge } from 'mppx'
+import { Address, Hex, RpcResponse } from 'ox'
+import { encodeFunctionData } from 'viem'
+import { Abis, Actions } from 'viem/tempo'
+
+import type * as Adapter from '../Adapter.js'
+
+/** Parsed Machine Payment Protocol challenge. */
+export type Challenge = mpp_Challenge.Challenge
+
+/** Transaction call metadata used to match access-key scopes. */
+export type Call = {
+  /** Calldata for the target call. */
+  data?: Hex.Hex | undefined
+  /** Target contract address. */
+  to?: Address.Address | undefined
+}
+
+/** Parses and validates an `mpp_authorize` request. */
+export function parseAuthorization(
+  parameters: Adapter.authorizeMpp.Parameters,
+): parseAuthorization.ReturnType {
+  const challenges = parameters.challenges.map(parseChallenge)
+  for (const challenge of challenges) {
+    if (challenge.method !== 'tempo')
+      throw new RpcResponse.InvalidParamsError({
+        message: 'Only Tempo payment challenges are supported.',
+      })
+  }
+
+  if (parameters.session && challenges.length !== 1)
+    throw new RpcResponse.InvalidParamsError({
+      message: '`session` can only be used with one challenge.',
+    })
+
+  const challenge = challenges[0]!
+  if (parameters.session && challenge.intent !== 'session')
+    throw new RpcResponse.InvalidParamsError({
+      message: '`session` can only be used with a session challenge.',
+    })
+
+  return { challenge, challenges }
+}
+
+export declare namespace parseAuthorization {
+  /** Parsed and validated authorization request. */
+  type ReturnType = {
+    /** First parsed challenge. */
+    challenge: Challenge
+    /** All parsed challenges from the request. */
+    challenges: readonly Challenge[]
+  }
+}
+
+/** Parses a serialized MPP challenge. */
+export function parseChallenge(value: string): Challenge {
+  try {
+    return mpp_Challenge.deserialize(value)
+  } catch (error) {
+    throw new RpcResponse.InvalidParamsError({
+      message: error instanceof Error ? error.message : 'Invalid payment challenge.',
+    })
+  }
+}
+
+/** Creates the synthetic HTTP 402 response consumed by `mppx`. */
+export function createResponse(challenges: readonly string[]): Response {
+  return new Response(null, {
+    headers: { 'WWW-Authenticate': challenges.join(', ') },
+    status: 402,
+  })
+}
+
+/** Builds additional credential context for a validated MPP challenge. */
+export function getContext(
+  parameters: Adapter.authorizeMpp.Parameters,
+  challenge: Challenge,
+): Record<string, unknown> {
+  const { session } = parameters
+  if (!session) return {}
+
+  const details = getMethodDetails(challenge)
+  const channelId = typeof details?.channelId === 'string' ? details.channelId : undefined
+  if (channelId && channelId.toLowerCase() !== session.channelId.toLowerCase())
+    throw new RpcResponse.InvalidParamsError({
+      message: '`session.channelId` conflicts with the payment challenge.',
+    })
+
+  return {
+    action: session.action,
+    authorizedSigner: session.authorizedSigner,
+    channelId: session.channelId,
+    cumulativeAmountRaw: session.cumulativeAmount,
+  }
+}
+
+/** Infers payment-related calls for access-key scope matching. */
+export function getCalls(challenge: Challenge, options: getCalls.Options): getCalls.ReturnType {
+  try {
+    if (challenge.intent === 'charge') return getChargeCalls(challenge)
+    if (challenge.intent === 'session') return getSessionCalls(challenge, options)
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+export declare namespace getCalls {
+  /** Options for {@link getCalls}. */
+  type Options = {
+    /** MPP adapter options. */
+    mpp: Adapter.mpp.Options
+  }
+
+  /** Inferred calls, or `undefined` when the challenge cannot map to concrete calls. */
+  type ReturnType = readonly Call[] | undefined
+}
+
+/** Gets the MPP challenge chain ID, falling back to the active chain. */
+export function getChainId(challenge: Challenge, fallback: number): number {
+  const details = getMethodDetails(challenge)
+  return typeof details?.chainId === 'number' ? details.chainId : fallback
+}
+
+/** Extracts Tempo method details from an MPP challenge. */
+export function getMethodDetails(challenge: Challenge): Record<string, unknown> | undefined {
+  const value = challenge.request.methodDetails
+  if (!value || typeof value !== 'object') return undefined
+  return value as Record<string, unknown>
+}
+
+function getChargeCalls(challenge: Challenge) {
+  const request = challenge.request as { amount?: unknown; currency?: unknown; recipient?: unknown }
+  if (
+    typeof request.amount !== 'string' ||
+    typeof request.currency !== 'string' ||
+    typeof request.recipient !== 'string'
+  )
+    return undefined
+
+  const currency = Address.from(request.currency)
+  const recipient = Address.from(request.recipient)
+  return getTransfers({
+    amount: request.amount,
+    details: getMethodDetails(challenge),
+    recipient,
+  }).map((transfer) =>
+    Actions.token.transfer.call({
+      amount: BigInt(transfer.amount),
+      ...(transfer.memo ? { memo: transfer.memo } : {}),
+      to: transfer.recipient,
+      token: currency,
+    }),
+  )
+}
+
+function getSessionCalls(challenge: Challenge, options: getCalls.Options) {
+  const request = challenge.request as { currency?: unknown; recipient?: unknown }
+  const details = getMethodDetails(challenge)
+  const escrow = typeof details?.escrowContract === 'string' ? details.escrowContract : undefined
+  const escrow_ = escrow ?? options.mpp.escrowContract
+  if (
+    typeof request.currency !== 'string' ||
+    typeof request.recipient !== 'string' ||
+    typeof escrow_ !== 'string'
+  )
+    return undefined
+
+  const currency = Address.from(request.currency)
+  const recipient = Address.from(request.recipient)
+  const escrowContract = Address.from(escrow_)
+  return [
+    {
+      to: currency,
+      data: encodeFunctionData({
+        abi: Abis.tip20,
+        functionName: 'approve',
+        args: [escrowContract, 0n],
+      }),
+    },
+    {
+      to: escrowContract,
+      data: encodeFunctionData({
+        abi: mppEscrowAbi,
+        functionName: 'open',
+        args: [recipient, currency, 0n, Hex.padLeft('0x00', 32), recipient],
+      }),
+    },
+  ]
+}
+
+function getTransfers(options: {
+  amount: string
+  details?: Record<string, unknown> | undefined
+  recipient: Address.Address
+}) {
+  const total = BigInt(options.amount)
+  const splits = getSplits(options.details)
+  const split_total = splits.reduce((sum, split) => sum + BigInt(split.amount), 0n)
+  if (split_total >= total) return []
+
+  const primary = total - split_total
+  if (primary <= 0n) return []
+
+  return [
+    {
+      amount: primary.toString(),
+      ...(typeof options.details?.memo === 'string' && Hex.validate(options.details.memo)
+        ? { memo: options.details.memo as Hex.Hex }
+        : {}),
+      recipient: options.recipient,
+    },
+    ...splits,
+  ].map((transfer) => ({
+    amount: transfer.amount,
+    ...(typeof transfer.memo === 'string' && Hex.validate(transfer.memo)
+      ? { memo: transfer.memo as Hex.Hex }
+      : {}),
+    recipient: transfer.recipient,
+  }))
+}
+
+function getSplits(
+  details?: Record<string, unknown> | undefined,
+): readonly { amount: string; memo?: Hex.Hex | undefined; recipient: Address.Address }[] {
+  if (!Array.isArray(details?.splits)) return []
+  return details.splits.flatMap((split) => {
+    if (!split || typeof split !== 'object') return []
+    const value = split as { amount?: unknown; memo?: unknown; recipient?: unknown }
+    if (typeof value.amount !== 'string' || typeof value.recipient !== 'string') return []
+    return [
+      {
+        amount: value.amount,
+        ...(typeof value.memo === 'string' && Hex.validate(value.memo)
+          ? { memo: value.memo as Hex.Hex }
+          : {}),
+        recipient: Address.from(value.recipient),
+      },
+    ]
+  })
+}
+
+const mppEscrowAbi = [
+  {
+    type: 'function',
+    name: 'open',
+    inputs: [
+      { name: 'payee', type: 'address' },
+      { name: 'token', type: 'address' },
+      { name: 'deposit', type: 'uint128' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'authorizedSigner', type: 'address' },
+    ],
+    outputs: [{ name: 'channelId', type: 'bytes32' }],
+    stateMutability: 'nonpayable',
+  },
+] as const

--- a/src/core/internal/MppAuthorization.ts
+++ b/src/core/internal/MppAuthorization.ts
@@ -1,0 +1,169 @@
+import { Mppx, tempo as mppx_tempo } from 'mppx/client'
+import { Address, Provider as ox_Provider, RpcResponse } from 'ox'
+import type { Account as viem_Account } from 'viem'
+
+import * as AccessKey from '../AccessKey.js'
+import type * as Adapter from '../Adapter.js'
+import * as Mpp from './Mpp.js'
+
+/**
+ * Authorizes an MPP challenge with an access key when available, falling back
+ * to the adapter's root account.
+ */
+export async function authorize(options: authorize.Options): Promise<authorize.ReturnType> {
+  const { accounts, getClient, mpp, parameters, store } = options
+  const { challenge } = Mpp.parseAuthorization(parameters)
+  const state = store.getState()
+  const root = state.accounts[state.activeAccount]?.address
+  if (!root) throw new ox_Provider.DisconnectedError({ message: 'No accounts connected.' })
+
+  const chainId = Mpp.getChainId(challenge, state.chainId)
+  const base = Mpp.getContext(parameters, challenge)
+
+  if (parameters.session) {
+    if (parameters.session.authorizedSigner.toLowerCase() !== root.toLowerCase()) {
+      const account = await accounts.getAccessKeyAccount({
+        accessKey: parameters.session.authorizedSigner,
+        chainId,
+        root,
+      })
+      if (!account)
+        throw new RpcResponse.InvalidParamsError({
+          message: '`session.authorizedSigner` is not available to the wallet.',
+        })
+
+      return await createCredential({
+        credential: account,
+        base,
+        getClient,
+        mpp,
+        parameters,
+      })
+    }
+
+    return await createCredential({
+      credential: await accounts.getRootAccount(root),
+      base,
+      getClient,
+      mpp,
+      parameters,
+    })
+  }
+
+  const selection = await selectMppAccessKey({
+    challenge,
+    chainId,
+    getClient,
+    mpp,
+    root,
+    store,
+  })
+  if (selection)
+    try {
+      return await createCredential({
+        credential: selection.account,
+        base,
+        getClient,
+        mpp,
+        parameters,
+      })
+    } catch {}
+
+  return await createCredential({
+    credential: await accounts.getRootAccount(root),
+    base,
+    getClient,
+    mpp,
+    parameters,
+  })
+}
+
+export declare namespace authorize {
+  /** Adapter-specific account lookup hooks for MPP authorization. */
+  type Accounts = {
+    /** Returns the root account for the active address. */
+    getRootAccount: (address: Address.Address) => Promise<Account>
+    /** Returns a locally available access-key account, if present. */
+    getAccessKeyAccount: (options: {
+      /** Access-key signer address requested by the challenge/session. */
+      accessKey: Address.Address
+      /** Chain the access key must be authorized on. */
+      chainId: number
+      /** Root account that owns the access key. */
+      root: Address.Address
+    }) => Promise<Account | undefined>
+  }
+
+  /** Resolved account and optional client override used to create an MPP credential. */
+  type Account =
+    | viem_Account
+    | {
+        /** Account to use for signing or JSON-RPC wallet actions. */
+        account: viem_Account
+        /** Optional client resolver for accounts backed by a different provider. */
+        getClient?: Adapter.SetupFn.Parameters['getClient'] | undefined
+      }
+
+  /** Options for authorizing an MPP request. */
+  type Options = {
+    /** Adapter-specific root and access-key account lookup hooks. */
+    accounts: Accounts
+    /** Provider client resolver. */
+    getClient: Adapter.SetupFn.Parameters['getClient']
+    /** MPP adapter options. */
+    mpp: Adapter.mpp.Options
+    /** `mpp_authorize` request parameters. */
+    parameters: Adapter.authorizeMpp.Parameters
+    /** Provider store. */
+    store: Adapter.SetupFn.Parameters['store']
+  }
+
+  /** Result returned to the JSON-RPC caller. */
+  type ReturnType = Adapter.authorizeMpp.ReturnType
+}
+
+async function createCredential(options: {
+  credential: authorize.Account
+  base: Record<string, unknown>
+  getClient: Adapter.SetupFn.Parameters['getClient']
+  mpp: Adapter.mpp.Options
+  parameters: Adapter.authorizeMpp.Parameters
+}) {
+  const { base, credential, mpp: mppOptions, parameters } = options
+  const { account, getClient = options.getClient } =
+    'account' in credential ? credential : { account: credential }
+  const { mode = 'push', polyfill: _polyfill, ...methodOptions } = mppOptions
+  const mpp = Mppx.create({
+    methods: [
+      mppx_tempo({ ...methodOptions, account, getClient, mode } as never),
+      mppx_tempo.subscription({ account, getClient }),
+    ],
+    polyfill: false,
+  })
+  return {
+    authorization: await mpp.createCredential(Mpp.createResponse(parameters.challenges), {
+      ...base,
+      account,
+    }),
+  }
+}
+
+async function selectMppAccessKey(options: {
+  challenge: Mpp.Challenge
+  chainId: number
+  getClient: Adapter.SetupFn.Parameters['getClient']
+  mpp: Adapter.mpp.Options
+  root: Address.Address
+  store: Adapter.SetupFn.Parameters['store']
+}) {
+  const { challenge, chainId, getClient, mpp, root, store } = options
+  const calls = Mpp.getCalls(challenge, { mpp })
+  if (!calls) return undefined
+  return await AccessKey.select({
+    account: root,
+    calls,
+    chainId,
+    client: getClient({ chainId }),
+    store,
+  })
+}

--- a/src/core/internal/MppAuthorization.ts
+++ b/src/core/internal/MppAuthorization.ts
@@ -1,17 +1,53 @@
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
-import { Address, Provider as ox_Provider, RpcResponse } from 'ox'
-import type { Account as viem_Account } from 'viem'
+import { Address, Hex, Provider as ox_Provider, RpcResponse } from 'ox'
+import type { Account as viem_Account, Transport } from 'viem'
 
 import * as AccessKey from '../AccessKey.js'
 import type * as Adapter from '../Adapter.js'
 import * as Mpp from './Mpp.js'
 
 /**
+ * Creates an MPP authorizer bound to provider-level dependencies.
+ */
+export function create(options: create.Options): create.ReturnType {
+  return async (parameters) =>
+    await authorize({
+      ...options,
+      ...parameters,
+    })
+}
+
+export declare namespace create {
+  /** Options for creating a bound MPP authorizer. */
+  type Options = {
+    /** Wallet client factory for account-bound MPP actions. */
+    createWalletClient: Adapter.SetupFn.Parameters['createWalletClient']
+    /** Provider client resolver. */
+    getClient: Adapter.SetupFn.Parameters['getClient']
+    /** MPP adapter options. */
+    mpp: Adapter.mpp.Options
+    /** Provider store. */
+    store: Adapter.SetupFn.Parameters['store']
+  }
+
+  /** Parameters for a single MPP authorization request. */
+  type Parameters = {
+    /** Returns the adapter-specific root account for the active address. */
+    getRootAccount: (address: Address.Address) => Promise<authorize.Account>
+    /** `mpp_authorize` request parameters. */
+    parameters: Adapter.authorizeMpp.Parameters
+  }
+
+  /** Bound MPP authorization function. */
+  type ReturnType = (parameters: Parameters) => Promise<authorize.ReturnType>
+}
+
+/**
  * Authorizes an MPP challenge with an access key when available, falling back
  * to the adapter's root account.
  */
 export async function authorize(options: authorize.Options): Promise<authorize.ReturnType> {
-  const { accounts, getClient, mpp, parameters, store } = options
+  const { createWalletClient, getClient, getRootAccount, mpp, parameters, store } = options
   const { challenge } = Mpp.parseAuthorization(parameters)
   const state = store.getState()
   const root = state.accounts[state.activeAccount]?.address
@@ -22,29 +58,34 @@ export async function authorize(options: authorize.Options): Promise<authorize.R
 
   if (parameters.session) {
     if (parameters.session.authorizedSigner.toLowerCase() !== root.toLowerCase()) {
-      const account = await accounts.getAccessKeyAccount({
+      const account = await AccessKey.getSigner({
         accessKey: parameters.session.authorizedSigner,
+        account: root,
         chainId,
-        root,
+        store,
       })
       if (!account)
         throw new RpcResponse.InvalidParamsError({
           message: '`session.authorizedSigner` is not available to the wallet.',
         })
 
-      return await createCredential({
+      return await authorizeCredential({
         credential: account,
         base,
-        getClient,
+        chainId,
+        createWalletClient,
         mpp,
         parameters,
       })
     }
 
-    return await createCredential({
-      credential: await accounts.getRootAccount(root),
+    const credential = await getRootAccount(root)
+    assertRootAccount(credential, parameters.session.authorizedSigner)
+    return await authorizeCredential({
+      credential,
       base,
-      getClient,
+      chainId,
+      createWalletClient,
       mpp,
       parameters,
     })
@@ -60,83 +101,79 @@ export async function authorize(options: authorize.Options): Promise<authorize.R
   })
   if (selection)
     try {
-      return await createCredential({
+      return await authorizeCredential({
         credential: selection.account,
         base,
-        getClient,
+        chainId,
+        createWalletClient,
         mpp,
         parameters,
       })
     } catch {}
 
-  return await createCredential({
-    credential: await accounts.getRootAccount(root),
+  const credential = await getRootAccount(root)
+  assertRootAccount(credential, root)
+  return await authorizeCredential({
+    credential,
     base,
-    getClient,
+    chainId,
+    createWalletClient,
     mpp,
     parameters,
   })
 }
 
 export declare namespace authorize {
-  /** Adapter-specific account lookup hooks for MPP authorization. */
-  type Accounts = {
-    /** Returns the root account for the active address. */
-    getRootAccount: (address: Address.Address) => Promise<Account>
-    /** Returns a locally available access-key account, if present. */
-    getAccessKeyAccount: (options: {
-      /** Access-key signer address requested by the challenge/session. */
-      accessKey: Address.Address
-      /** Chain the access key must be authorized on. */
-      chainId: number
-      /** Root account that owns the access key. */
-      root: Address.Address
-    }) => Promise<Account | undefined>
-  }
-
   /** Resolved account and optional client override used to create an MPP credential. */
   type Account =
     | viem_Account
     | {
         /** Account to use for signing or JSON-RPC wallet actions. */
         account: viem_Account
-        /** Optional client resolver for accounts backed by a different provider. */
-        getClient?: Adapter.SetupFn.Parameters['getClient'] | undefined
+        /** Optional transport for JSON-RPC accounts backed by wallet providers. */
+        transport?: Transport | undefined
+        /** Optional provider for forwarding native JSON-RPC authorization. */
+        provider?: ox_Provider.Provider | undefined
       }
 
   /** Options for authorizing an MPP request. */
-  type Options = {
-    /** Adapter-specific root and access-key account lookup hooks. */
-    accounts: Accounts
-    /** Provider client resolver. */
-    getClient: Adapter.SetupFn.Parameters['getClient']
-    /** MPP adapter options. */
-    mpp: Adapter.mpp.Options
-    /** `mpp_authorize` request parameters. */
-    parameters: Adapter.authorizeMpp.Parameters
-    /** Provider store. */
-    store: Adapter.SetupFn.Parameters['store']
-  }
+  type Options = create.Options & create.Parameters
 
   /** Result returned to the JSON-RPC caller. */
   type ReturnType = Adapter.authorizeMpp.ReturnType
 }
 
-async function createCredential(options: {
+function assertRootAccount(credential: authorize.Account, address: Address.Address) {
+  const account = getAccount(credential)
+  if (account.address.toLowerCase() === address.toLowerCase()) return
+  throw new RpcResponse.InvalidParamsError({
+    message: 'Root account does not match the authorized signer.',
+  })
+}
+
+async function authorizeCredential(options: {
   credential: authorize.Account
   base: Record<string, unknown>
-  getClient: Adapter.SetupFn.Parameters['getClient']
+  chainId: number
+  createWalletClient: Adapter.SetupFn.Parameters['createWalletClient']
   mpp: Adapter.mpp.Options
   parameters: Adapter.authorizeMpp.Parameters
 }) {
-  const { base, credential, mpp: mppOptions, parameters } = options
-  const { account, getClient = options.getClient } =
-    'account' in credential ? credential : { account: credential }
+  const { base, chainId, createWalletClient, credential, mpp: mppOptions, parameters } = options
+  const forwarded = await forwardJsonRpcAuthorization({ chainId, credential, parameters })
+  if (forwarded) return forwarded
+
+  const account = getAccount(credential)
+  const client = createWalletClient({
+    account,
+    chainId,
+    ...('account' in credential && credential.transport ? { transport: credential.transport } : {}),
+  })
   const { mode = 'push', polyfill: _polyfill, ...methodOptions } = mppOptions
   const mpp = Mppx.create({
     methods: [
-      mppx_tempo({ ...methodOptions, account, getClient, mode } as never),
-      mppx_tempo.subscription({ account, getClient }),
+      mppx_tempo({ ...methodOptions, account, getClient: () => client, mode } as never),
+      mppx_tempo.subscription({ account, getClient: () => client }),
     ],
     polyfill: false,
   })
@@ -146,6 +183,59 @@ async function createCredential(options: {
       account,
     }),
   }
+}
+
+async function forwardJsonRpcAuthorization(options: {
+  chainId: number
+  credential: authorize.Account
+  parameters: Adapter.authorizeMpp.Parameters
+}) {
+  const { chainId, credential, parameters } = options
+  const account = getAccount(credential)
+  if (!('account' in credential) || !credential.provider) return undefined
+
+  const supported = await supportsMppAuthorization({
+    account,
+    chainId,
+    provider: credential.provider,
+  })
+  if (!supported) return undefined
+
+  return (await credential.provider.request({
+    method: 'mpp_authorize',
+    params: [parameters],
+  } as never)) as authorize.ReturnType
+}
+
+function getAccount(credential: authorize.Account) {
+  return 'account' in credential ? credential.account : credential
+}
+
+async function supportsMppAuthorization(options: {
+  account: viem_Account
+  chainId: number
+  provider: ox_Provider.Provider
+}) {
+  const { account, chainId, provider } = options
+  try {
+    const capabilities = await provider.request({
+      method: 'wallet_getCapabilities',
+      params: [account.address, [Hex.fromNumber(chainId)]],
+    } as never)
+    return getMppStatus(capabilities, chainId) === 'supported'
+  } catch {
+    return false
+  }
+}
+
+function getMppStatus(capabilities: unknown, chainId: number) {
+  if (typeof capabilities !== 'object' || capabilities === null) return undefined
+  const chain = (capabilities as Record<string, unknown>)[Hex.fromNumber(chainId)]
+  if (typeof chain !== 'object' || chain === null) return undefined
+  const mpp = (chain as Record<string, unknown>).mpp
+  if (typeof mpp !== 'object' || mpp === null) return undefined
+  const status = (mpp as Record<string, unknown>).status
+  return status === 'supported' ? status : undefined
 }
 
 async function selectMppAccessKey(options: {

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -3,6 +3,103 @@ import * as z from 'zod/mini'
 
 import * as Rpc from './rpc.js'
 
+describe('mpp_authorize.parameters', () => {
+  test('accepts challenge-only requests', () => {
+    expect(
+      z.parse(Rpc.mpp_authorize.parameters, {
+        challenges: [
+          'Payment id="1", realm="example.test", method="tempo", intent="charge", request="e30"',
+        ],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "challenges": [
+          "Payment id="1", realm="example.test", method="tempo", intent="charge", request="e30"",
+        ],
+      }
+    `)
+  })
+
+  test('accepts manual session requests', () => {
+    expect(
+      z.parse(Rpc.mpp_authorize.parameters, {
+        challenges: [
+          'Payment id="1", realm="example.test", method="tempo", intent="session", request="e30"',
+        ],
+        session: {
+          action: 'voucher',
+          authorizedSigner: '0x0000000000000000000000000000000000000001',
+          channelId: '0x1234',
+          cumulativeAmount: '2500000',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "challenges": [
+          "Payment id="1", realm="example.test", method="tempo", intent="session", request="e30"",
+        ],
+        "session": {
+          "action": "voucher",
+          "authorizedSigner": "0x0000000000000000000000000000000000000001",
+          "channelId": "0x1234",
+          "cumulativeAmount": "2500000",
+        },
+      }
+    `)
+  })
+
+  test('rejects empty challenges', () => {
+    expect(() =>
+      z.parse(Rpc.mpp_authorize.parameters, {
+        challenges: [],
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [$ZodError: [
+        {
+          "origin": "array",
+          "code": "too_small",
+          "minimum": 1,
+          "inclusive": true,
+          "path": [
+            "challenges"
+          ],
+          "message": "Invalid input"
+        }
+      ]]
+    `)
+  })
+
+  test('rejects non-decimal cumulative amount', () => {
+    expect(() =>
+      z.parse(Rpc.mpp_authorize.parameters, {
+        challenges: [
+          'Payment id="1", realm="example.test", method="tempo", intent="session", request="e30"',
+        ],
+        session: {
+          action: 'close',
+          authorizedSigner: '0x0000000000000000000000000000000000000001',
+          channelId: '0x1234',
+          cumulativeAmount: '0x1234',
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [$ZodError: [
+        {
+          "origin": "string",
+          "code": "invalid_format",
+          "format": "regex",
+          "pattern": "/^\\\\d+$/",
+          "path": [
+            "session",
+            "cumulativeAmount"
+          ],
+          "message": "Invalid input"
+        }
+      ]]
+    `)
+  })
+})
+
 describe('wallet_connect.capabilities.request: auth', () => {
   test('accepts string shorthand', () => {
     expect(

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -339,8 +339,44 @@ export namespace wallet_getCapabilities {
             status: z.union([z.literal('supported'), z.literal('unsupported')]),
           }),
         ),
+        mpp: z.optional(
+          z.object({
+            status: z.union([z.literal('supported'), z.literal('unsupported')]),
+          }),
+        ),
       }),
     ),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
+export namespace mpp_authorize {
+  export const parameters = z.object({
+    /** Raw `WWW-Authenticate` Payment challenge values. */
+    challenges: z.readonly(z.array(z.string()).check(z.minLength(1))),
+    /** Existing session parameters for voucher or close credentials. */
+    session: z.optional(
+      z.object({
+        /** Session action to authorize. */
+        action: z.union([z.literal('voucher'), z.literal('close')]),
+        /** Authorized signer for the session channel. */
+        authorizedSigner: u.address(),
+        /** Existing session channel id. */
+        channelId: u.hex(),
+        /** Raw cumulative amount in token base units. */
+        cumulativeAmount: z.string().check(z.regex(/^\d+$/)),
+      }),
+    ),
+  })
+
+  export const schema = Schema.defineItem({
+    method: z.literal('mpp_authorize'),
+    params: z.readonly(z.tuple([parameters])),
+    returns: z.object({
+      /** Complete HTTP Authorization header value. */
+      authorization: z.string(),
+    }),
   })
   export type Encoded = Schema.Encoded<typeof schema>
   export type Decoded = Schema.Decoded<typeof schema>

--- a/test/config.ts
+++ b/test/config.ts
@@ -59,14 +59,12 @@ export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
 } as const
 
-type TempoTestChain = typeof tempoLocalnet | typeof tempoModerato
-
-export const chain: TempoTestChain = (() => {
+export const chain = (() => {
   if (nodeEnv === 'testnet') return tempoModerato
   return defineChain({
     ...tempoLocalnet,
     rpcUrls: { default: { http: [rpcUrl] } },
-  }) as typeof tempoLocalnet
+  })
 })()
 
 export const chainId = (() => {
@@ -81,7 +79,7 @@ export const fetchOptions = {
   },
 } as const
 
-export const http = (url = rpcUrl): Transport =>
+export const http = (url = rpcUrl) =>
   viem_http(url, {
     ...debugOptions({
       rpcUrl: url,

--- a/test/config.ts
+++ b/test/config.ts
@@ -59,12 +59,14 @@ export const addresses = {
   alphaUsd: '0x20c0000000000000000000000000000000000001',
 } as const
 
-export const chain = (() => {
+type TempoTestChain = typeof tempoLocalnet | typeof tempoModerato
+
+export const chain: TempoTestChain = (() => {
   if (nodeEnv === 'testnet') return tempoModerato
   return defineChain({
     ...tempoLocalnet,
     rpcUrls: { default: { http: [rpcUrl] } },
-  })
+  }) as typeof tempoLocalnet
 })()
 
 export const chainId = (() => {
@@ -79,7 +81,7 @@ export const fetchOptions = {
   },
 } as const
 
-export const http = (url = rpcUrl) =>
+export const http = (url = rpcUrl): Transport =>
   viem_http(url, {
     ...debugOptions({
       rpcUrl: url,


### PR DESCRIPTION
## Summary
Add wallet-native `mpp_authorize` support and playground coverage for direct RPC and MPPX client flows.

## Motivation
Apps need an adapter-owned path for fulfilling MPP challenges without constructing recursive JSON-RPC provider bridges. The provider should advertise MPP capability, dispatch `mpp_authorize` to the active adapter, and let adapters resolve access-key or root accounts before passing a real viem wallet client into MPPX.

## Changes
- Add `mpp_authorize` schema/provider dispatch in `src/core/Provider.ts` and `src/core/zod/rpc.ts`.
- Add shared MPP helpers in `src/core/internal/Mpp.ts` and `src/core/internal/MppAuthorization.ts` for parsing challenges, selecting access keys, validating root signers, and creating credentials.
- Add provider-owned wallet-client creation in `src/core/Client.ts` / `src/core/Provider.ts` so MPPX gets a real viem client with an account.
- Wire local, dialog, Turnkey, and Privy adapters through access-key/root account lookup callbacks, with dialog and Privy using JSON-RPC account transports for remote signers.
- Expand playground MPP controls in `playgrounds/web/src/App.tsx` to test JSON-RPC `mpp_authorize` and MPPX client paths.

## Testing
- `pnpm check` via pre-commit: passed with two existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`.
- `docker compose exec -T playground pnpm exec tsc --noEmit --pretty false`: passed.
- `docker compose exec -T playground pnpm check:types`: passed.
- `docker compose exec -T playground pnpm test src/core/Provider.mpp.test.ts`: passed, 8 tests.
- `docker compose exec -T playground pnpm test src/core/Provider.localnet.test.ts -- -t mpp`: failed before tests ran during localnet setup, HTTP 400 on `eth_getTransactionCount` while minting AMM liquidity.
- `docker compose exec -T playground pnpm exec vp lint --fix ...` and `vp fmt ...`: failed in the container with `Cannot find binary path for command node`; host pre-commit `pnpm check` ran lint/fmt successfully.