### PR TITLE
Attach pending key auth for CLI MPP pull payments

### DIFF
--- a/src/cli/Provider.localnet.test.ts
+++ b/src/cli/Provider.localnet.test.ts
@@ -1,6 +1,8 @@
 import { mkdtemp, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Fetch } from 'mppx/client'
+import { Mppx as ServerMppx, tempo } from 'mppx/server'
 import { Address, Hex, PublicKey } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { type Address as ViemAddress, parseUnits } from 'viem'
@@ -148,7 +150,69 @@ const transferCall = Actions.token.transfer.call({
   amount: parseUnits('1', 6),
 })
 
+const payment = ServerMppx.create({
+  methods: [
+    tempo({
+      account: accounts[3]!,
+      currency: Addresses.pathUsd,
+      getClient: () => getClient(),
+    }),
+  ],
+  realm: 'accounts-cli-test',
+  secretKey: 'test-secret-key',
+})
+
 describe('Provider.create', () => {
+  test('default: MPP pull payments attach pending access key authorization', async () => {
+    const handler = createHandler()
+    const authServer = await createServer(handler.listener)
+    const mppServer = await createServer(async (req, res) => {
+      const result = await ServerMppx.toNodeListener(
+        payment.charge({
+          amount: '1',
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+    })
+
+    try {
+      const provider = Provider.create({
+        chains: [chain],
+        host: `${authServer.url}/cli-auth`,
+        mpp: true,
+        open: async (url) => {
+          const code = new URL(url).searchParams.get('code')!
+          await fetch(`${authServer.url}/cli-auth`, {
+            body: JSON.stringify(await authorize(code)),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          })
+        },
+      })
+
+      const result = await provider.request(connectRequest())
+      const address = result.accounts[0]!.address
+      await fund(address)
+
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeDefined()
+
+      const res = await fetch(`${mppServer.url}/fortune`)
+      expect(res.status).toBe(200)
+
+      const key = provider.store.getState().accessKeys[0]!
+      expect(await provider.getAccessKeyStatus({ accessKey: key.address })).toMatchInlineSnapshot(
+        `"published"`,
+      )
+      expect(provider.store.getState().accessKeys[0]!.keyAuthorization).toBeUndefined()
+    } finally {
+      Fetch.restore()
+      await authServer.closeAsync()
+      await mppServer.closeAsync()
+    }
+  })
+
   test('default: bootstraps wallet_connect through the device-code flow', async () => {
     const handler = createHandler()
     const server = await createServer(handler.listener)

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1056,7 +1056,19 @@ export function create(options: create.Options = {}): create.ReturnType {
       return Object.assign(client, {
         account: {
           address: account.address,
-          type: 'json-rpc' as const,
+          async signTransaction(request: unknown) {
+            return (await provider.request({
+              method: 'eth_signTransaction',
+              params: [request],
+            } as never)) as Hex.Hex
+          },
+          async signTypedData(parameters: { message?: unknown }) {
+            return (await provider.request({
+              method: 'eth_signTypedData_v4',
+              params: [account.address, Json.stringify(parameters.message)],
+            } as never)) as Hex.Hex
+          },
+          type: 'local' as const,
         },
       })
     }


### PR DESCRIPTION
## Summary
- keep CLI MPP defaulting to `pull` mode
- make the MPP client account sign through the provider so pull-mode payments include pending `keyAuthorization` when needed
- add a CLI localnet regression test for default MPP pull payments publishing a pending access key

## Diagnosis
The bug is in the pull-mode signing path, not the default mode. A first payment may use an access key that is only locally authorized, so the signed Tempo transaction must carry the pending `keyAuthorization`. If the signed proof omits it, the MPP server hits `KeyNotFound`; servers that wrap that as `payment_proof_invalid` prevent the client from recovering.

The fix keeps pull mode and routes MPP transaction signing through the provider’s `eth_signTransaction` path, which already selects the managed access key and attaches pending `keyAuthorization` before signing.

## Verification
- `PATH="$PWD/node_modules/.bin:$PATH" ./node_modules/.bin/tsc -b --noEmit`
- `PATH="$PWD/node_modules/.bin:$PATH" ./node_modules/.bin/vp test src/cli/Provider.localnet.test.ts` still fails before tests run in shared localnet setup: AMM liquidity mint hits local RPC HTTP 400 on `eth_getTransactionCount`.