### PR TITLE
fix: allow deferred strict remote search validation

### DIFF
--- a/.changeset/remote-validate-search-strict-option.md
+++ b/.changeset/remote-validate-search-strict-option.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added a `strict` option to `Remote.validateSearch` to let trusted wallet routes defer access-key policy validation.

--- a/src/core/Remote.test.ts
+++ b/src/core/Remote.test.ts
@@ -185,6 +185,43 @@ describe('validateSearch', () => {
     expect(remote.rejectAll).toHaveBeenCalledOnce()
   })
 
+  test('strict false: validates wallet_connect with authorizeAccessKey missing policy', () => {
+    const remote = createMockRemote()
+    const result = Remote.validateSearch(
+      remote,
+      {
+        method: 'wallet_connect',
+        id: 6,
+        jsonrpc: '2.0',
+        params: [
+          {
+            capabilities: {
+              method: 'register',
+              authorizeAccessKey: { expiry: 100 },
+            },
+          },
+        ],
+      },
+      { method: 'wallet_connect', strict: false },
+    )
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_connect",
+        "params": [
+          {
+            "capabilities": {
+              "authorizeAccessKey": {
+                "expiry": 100,
+              },
+              "method": "register",
+            },
+          },
+        ],
+      }
+    `)
+    expect(remote.rejectAll).not.toHaveBeenCalled()
+  })
+
   test('strict: passes wallet_connect without authorizeAccessKey', () => {
     const remote = createMockRemote()
     const result = Remote.validateSearch(
@@ -220,6 +257,31 @@ describe('validateSearch', () => {
   - scopes: Invalid input]`,
     )
     expect(remote.rejectAll).toHaveBeenCalledOnce()
+  })
+
+  test('strict false: validates wallet_authorizeAccessKey without policy', () => {
+    const remote = createMockRemote()
+    const result = Remote.validateSearch(
+      remote,
+      {
+        method: 'wallet_authorizeAccessKey',
+        id: 8,
+        jsonrpc: '2.0',
+        params: [{ expiry: 100 }],
+      },
+      { method: 'wallet_authorizeAccessKey', strict: false },
+    )
+    expect(result._decoded).toMatchInlineSnapshot(`
+      {
+        "method": "wallet_authorizeAccessKey",
+        "params": [
+          {
+            "expiry": 100,
+          },
+        ],
+      }
+    `)
+    expect(remote.rejectAll).not.toHaveBeenCalled()
   })
 
   test('strict: rejects wallet_authorizeAccessKey with malformed scope', () => {

--- a/src/core/Remote.ts
+++ b/src/core/Remote.ts
@@ -331,13 +331,14 @@ export function noop(): Remote {
  *
  * Parses against the `Schema.Request` discriminated union, checks the
  * method matches, and enforces strict parameter schemas (e.g. required
- * `limits`). On failure, rejects all pending requests via the messenger
- * and re-throws so the router can handle the error boundary.
+ * `limits`) unless `strict` is false. On failure, rejects all pending
+ * requests via the messenger and re-throws so the router can handle the
+ * error boundary.
  */
 export function validateSearch<const method extends Schema.Request['method']>(
   remote: Remote,
   search: Record<string, unknown>,
-  parameters: { method: method },
+  parameters: validateSearch.Options<method>,
 ): validateSearch.ReturnType<method> {
   const { method } = parameters
   try {
@@ -350,13 +351,14 @@ export function validateSearch<const method extends Schema.Request['method']>(
       throw new RpcResponse.InvalidParamsError({
         message: `Method mismatch: expected "${method}" but got "${result.data.method}".`,
       })
-    const strict = Rpc.strictParameters[method as keyof typeof Rpc.strictParameters]
+    const strict = parameters.strict ?? true
+    const schema_strict = Rpc.strictParameters[method as keyof typeof Rpc.strictParameters]
     const params = (search.params as readonly unknown[] | undefined)?.[0]
-    if (strict && params !== undefined) {
-      const strictResult = strict.safeParse(params)
-      if (!strictResult.success)
+    if (strict && schema_strict && params !== undefined) {
+      const result_strict = schema_strict.safeParse(params)
+      if (!result_strict.success)
         throw new RpcResponse.InvalidParamsError({
-          message: formatZodErrors(method, strictResult.error),
+          message: formatZodErrors(method, result_strict.error),
         })
     }
     return {
@@ -372,6 +374,13 @@ export function validateSearch<const method extends Schema.Request['method']>(
 }
 
 export declare namespace validateSearch {
+  type Options<method extends Schema.Request['method']> = {
+    /** Expected RPC method for this route. */
+    method: method
+    /** Whether to apply strict parameter policy validation. */
+    strict?: boolean | undefined
+  }
+
   type ReturnType<method extends Schema.Request['method']> = Extract<
     Schema.Request,
     { method: method }


### PR DESCRIPTION
`Remote.validateSearch` now accepts `strict: false` while keeping strict parameter validation enabled by default. This lets dialog routes parse valid RPC search payloads and defer policy checks to route-level validation when the caller is trusted.

The SDK test coverage now exercises the relaxed path for `wallet_connect` and `wallet_authorizeAccessKey`, preserving existing strict rejection behavior for default callers.