### PR TITLE
fix(deps): pin patched `tmp`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,7 @@ overrides:
   react: ^19.2.5
   react-dom: ^19.2.5
   tar: 7.5.15
+  tmp@<0.2.6: 0.2.6
   uuid@<11.1.1: 11.1.1
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
@@ -9219,8 +9220,8 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -20563,7 +20564,7 @@ snapshots:
       properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
-      tmp: 0.2.5
+      tmp: 0.2.6
       undici: 7.25.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -20604,7 +20605,7 @@ snapshots:
 
   tinypool@2.1.0: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ minimumReleaseAgeExclude:
   - ox
   - regen-ui
   - secretlint
+  - tmp
   - vocs
   - viem
   - vite-plus
@@ -87,6 +88,7 @@ overrides:
   react: 'catalog:'
   react-dom: 'catalog:'
   tar: '7.5.15'
+  'tmp@<0.2.6': '0.2.6'
   'uuid@<11.1.1': '11.1.1'
   vite-plus: 'catalog:'
   vp: 'catalog:'


### PR DESCRIPTION
Adds a workspace override for `tmp@<0.2.6` and refreshes the lockfile to use `tmp@0.2.6`, clearing the GitHub Actions audit failure from https://github.com/tempoxyz/accounts/actions/runs/26485102778/job/77990762965.

`tmp` is also added to the minimum-release-age exception list so the patched advisory release can install immediately.