### PR TITLE
fix: isolate iframe themes

### DIFF
--- a/.changeset/isolate-wallet-iframe-themes.md
+++ b/.changeset/isolate-wallet-iframe-themes.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed iframe dialog theme isolation between SDK callers.

--- a/site/src/pages/docs/api/dialog.iframe.mdx
+++ b/site/src/pages/docs/api/dialog.iframe.mdx
@@ -7,7 +7,7 @@ description: Embed the Tempo Wallet auth UI in an iframe dialog element.
 
 Creates an iframe dialog that embeds the auth app in a `<dialog>` element. This is the default on most browsers in secure (HTTPS) contexts.
 
-The instance is a **host-keyed singleton** — calling `Dialog.iframe()` repeatedly with the same `host` returns the cached instance and swaps in the latest store/theme rather than re-mounting the iframe. Switching to a different host tears down the previous iframe and creates a fresh one.
+The instance is a **host-and-theme-keyed singleton** — calling `Dialog.iframe()` repeatedly with the same `host` and theme returns the cached instance and swaps in the latest store rather than re-mounting the iframe. Switching to a different host or theme tears down the previous iframe and creates a fresh one.
 
 Visual appearance is configured via [`Dialog.Theme`](/docs/api/dialogs#dialogtheme), passed through the [`dialog`](/docs/api/dialog) adapter.
 

--- a/src/core/Dialog.browser.test.ts
+++ b/src/core/Dialog.browser.test.ts
@@ -6,15 +6,21 @@ import * as Store from './Store.js'
 
 const host = 'https://wallet-next.tempo.xyz/remote'
 
-function setup() {
+function setup(options: setup.Options = {}) {
   const store = Store.create({
     chainId: 1,
     storage: Storage.memory({ key: 'dialog-test' }),
   })
   const dialog = Dialog.iframe()
-  const handle = dialog({ host, store })
+  const handle = dialog({ host, store, theme: options.theme })
   lastHandle = handle
   return { handle, store }
+}
+
+declare namespace setup {
+  type Options = {
+    theme?: Dialog.Theme | undefined
+  }
 }
 
 let lastHandle: Dialog.Instance | undefined
@@ -43,6 +49,19 @@ describe('Dialog.iframe', () => {
     expect(b).toBe(c)
     const dialogs = document.querySelectorAll('dialog[data-tempo-wallet]')
     expect(dialogs.length).toBe(1)
+  })
+
+  test('behavior: different themes use isolated iframes', () => {
+    const { handle: a } = setup({ theme: { accent: '#ff007a', radius: 'full' } })
+    const iframe_a = document.querySelector('dialog[data-tempo-wallet] iframe') as HTMLIFrameElement
+
+    const { handle: b } = setup({ theme: { radius: 'none' } })
+    const iframe_b = document.querySelector('dialog[data-tempo-wallet] iframe') as HTMLIFrameElement
+
+    expect(a === b).toMatchInlineSnapshot(`false`)
+    expect(iframe_a.isConnected).toMatchInlineSnapshot(`false`)
+    expect(new URL(iframe_b.src).searchParams.get('radius')).toMatchInlineSnapshot(`"none"`)
+    expect(new URL(iframe_b.src).searchParams.has('accent')).toMatchInlineSnapshot(`false`)
   })
 
   test('behavior: iframe has correct sandbox attributes', () => {

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -81,8 +81,8 @@ export function isSafari(): boolean {
   return ua.includes('safari') && !ua.includes('chrome')
 }
 
-/** Cached iframe singleton — keyed by host, reused across setup calls. */
-let cached: { host: string; instance: Instance } | undefined
+/** Cached iframe singleton keyed by host and theme, reused across matching setup calls. */
+let cached: { instance: Instance; key: string } | undefined
 
 /** Mutable refs swapped on re-entry so the singleton always uses the latest caller's state. */
 let store: Store.Store | undefined
@@ -96,9 +96,10 @@ export function iframe(): Dialog {
 
   return define({ name: 'iframe' }, (parameters) => {
     const { host } = parameters
+    const key = getCacheKey(parameters)
 
-    // Reuse existing iframe if the host matches — just swap the store/fallback refs.
-    if (cached && cached.host === host) {
+    // Reuse existing iframe if host and theme match, and swap the store/fallback refs.
+    if (cached && cached.key === key) {
       const oldStore = store
       store = parameters.store
 
@@ -112,7 +113,7 @@ export function iframe(): Dialog {
       return cached.instance
     }
 
-    // Different host — tear down old iframe and create fresh.
+    // Different host or theme: tear down old iframe and create fresh.
     cached?.instance.destroy()
 
     store = parameters.store
@@ -399,8 +400,19 @@ export function iframe(): Dialog {
       },
     }
 
-    cached = { host, instance }
+    cached = { instance, key }
     return instance
+  })
+}
+
+function getCacheKey(parameters: SetupFn.Parameters) {
+  return JSON.stringify({
+    host: parameters.host,
+    theme: {
+      accent: parameters.theme?.accent ?? null,
+      radius: parameters.theme?.radius ?? null,
+      scheme: parameters.theme?.scheme ?? null,
+    },
   })
 }
 


### PR DESCRIPTION
Dialog iframe reuse now keys cached instances by both host and theme. This prevents a themed docs prompt from sharing its iframe with another SDK caller that expects a different or unthemed wallet prompt.

The API docs now describe the updated reuse behavior, and the changeset records the patch-level SDK fix.