### PR TITLE
fix(docs): remove themed demo and prebundle `anser`

### DIFF
--- a/site/src/components/Demo.tsx
+++ b/site/src/components/Demo.tsx
@@ -7,12 +7,7 @@ import { useDisconnect, WagmiProvider } from 'wagmi'
 import LucideExternalLink from '~icons/lucide/external-link'
 import LucideRotateCcw from '~icons/lucide/rotate-ccw'
 
-import {
-  feeSponsorshipWagmiConfig,
-  spendPermissionsWagmiConfig,
-  themingWagmiConfig,
-  wagmiConfig,
-} from '../wagmi.js'
+import { feeSponsorshipWagmiConfig, spendPermissionsWagmiConfig, wagmiConfig } from '../wagmi.js'
 import * as Steps from './Steps.js'
 
 const queryClient = new QueryClient()
@@ -20,7 +15,6 @@ const wagmiConfigs = {
   default: wagmiConfig,
   feeSponsorship: feeSponsorshipWagmiConfig,
   spendPermissions: spendPermissionsWagmiConfig,
-  theming: themingWagmiConfig,
 }
 
 export function Demo(props: Demo.Props) {

--- a/site/src/pages/docs/guides/theming.mdx
+++ b/site/src/pages/docs/guides/theming.mdx
@@ -4,32 +4,12 @@ description: Match embedded account surfaces to your product.
 ---
 
 import { Cards, Card } from 'vocs'
-import { ConnectAccount } from '../../../components/ConnectAccount'
-import { Demo, DemoReset } from '../../../components/Demo'
-import * as Steps from '../../../components/Steps'
 
 # Theming
 
 Theming lets you tune Tempo Wallet's embedded account prompts without changing your signing adapter or account flow.
 
 Use it when your app already uses Tempo Wallet and you want the prompt to match your product's accent color, corner radius, and light or dark mode. These options apply to hosted Tempo Wallet surfaces opened by the `dialog` or `tempoWallet` adapter. App-owned buttons, forms, and custom adapter screens still use your own design system.
-
-## Demo
-
-By the end of this guide you'll configure a Uniswap-style Tempo Wallet prompt. Try the sign-in button below: it uses a hot pink accent and pill-shaped radius.
-
-<Demo
-  title="Uniswap-style Sign In"
-  githubUrl="https://github.com/tempoxyz/accounts/tree/main/examples/basic"
-  headerAction={<DemoReset />}
-  className="flex flex-col gap-3"
-  wagmiConfig="theming"
->
-  <Steps.Step
-    label="Create an account, or use an existing one."
-    action={<ConnectAccount />}
-  />
-</Demo>
 
 ## Walkthrough
 
@@ -43,11 +23,11 @@ Follow the [Connect Accounts](/docs/guides/connect-accounts) guide to set up Wag
 
 Pick the values that should travel with the hosted prompt.
 
-| Option | Values | Purpose |
-| --- | --- | --- |
-| `accent` | `'neutral'`, `'blue'`, `'red'`, `'amber'`, `'green'`, `'purple'`, or any CSS color value | Colors primary actions and emphasis states. |
-| `radius` | `'none'`, `'small'`, `'medium'`, `'large'`, or `'full'` | Controls the corner radius used inside the prompt. |
-| `scheme` | `'light'` or `'dark'` | Sets the prompt's color scheme. Omit it to follow the user's operating system setting. |
+| Option   | Values                                                                                   | Purpose                                                                                |
+| -------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `accent` | `'neutral'`, `'blue'`, `'red'`, `'amber'`, `'green'`, `'purple'`, or any CSS color value | Colors primary actions and emphasis states.                                            |
+| `radius` | `'none'`, `'small'`, `'medium'`, `'large'`, or `'full'`                                  | Controls the corner radius used inside the prompt.                                     |
+| `scheme` | `'light'` or `'dark'`                                                                    | Sets the prompt's color scheme. Omit it to follow the user's operating system setting. |
 
 ### Configure Tempo Wallet
 

--- a/site/src/wagmi.ts
+++ b/site/src/wagmi.ts
@@ -65,27 +65,6 @@ export const feeSponsorshipWagmiConfig: Config = createConfig({
   },
 })
 
-export const themingWagmiConfig: Config = createConfig({
-  chains: [tempoModerato, tempo],
-  connectors: [
-    tempoWallet({
-      mpp: true,
-      storage: accountsStorage,
-      testnet: true,
-      theme: {
-        accent: '#ff007a',
-        radius: 'full',
-      },
-    }),
-  ],
-  multiInjectedProviderDiscovery: false,
-  storage: wagmiStorage,
-  transports: {
-    [tempoModerato.id]: http(),
-    [tempo.id]: http(),
-  },
-})
-
 declare module 'wagmi' {
   interface Register {
     config: typeof wagmiConfig

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(({ command }) => {
   return {
     ...(dev ? { define: disableUserTiming } : {}),
     optimizeDeps: {
-      include: ['mermaid'],
+      include: ['mermaid', 'vocs > @codesandbox/sandpack-react > anser'],
       ...(dev
         ? {
             esbuildOptions: {


### PR DESCRIPTION
Removes the live sign-in demo from the Theming guide and deletes the docs-only Wagmi config that applied a hot pink, full-radius theme. The guide still documents the theme options, but no longer opens a themed Tempo Wallet dialog from the docs site.

The docs Vite config also prebundles Sandpack's `anser` dependency to avoid Vite serving the CommonJS module as if it exposed a default ESM export.