### PR TITLE
docs: rename sdk references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<p align="center"><b>Accounts SDK for Apps and Wallets building on Tempo.</b></p>
+<p align="center"><b>Tempo Accounts SDK for Apps and Wallets building on Tempo.</b></p>
 
 <p align="center">
   <a href="#quick-prompt">Quick Prompt</a> · <a href="#install">Install</a> · <a href="#documentation">Documentation</a> · <a href="#examples">Examples</a> · <a href="#development">Development</a> · <a href="#license">License</a>
@@ -42,7 +42,7 @@ For documentation and guides, visit [docs.tempo.xyz/accounts](https://docs.tempo
 
 ## Getting Help
 
-Have questions or building something cool with the Accounts SDK?
+Have questions or building something cool with the Tempo Accounts SDK?
 
 Join the Telegram group to chat with the team and other devs: [@mpp_devs](https://t.me/mpp_devs)
 

--- a/examples/mpp/README.md
+++ b/examples/mpp/README.md
@@ -1,11 +1,11 @@
 # MPP Example
 
 Demonstrates [Machine Payment Protocol (MPP)](https://mpp.dev) integration with
-the Accounts SDK. The browser auto-pays HTTP `402 Payment Required` challenges
+the Tempo Accounts SDK. The browser auto-pays HTTP `402 Payment Required` challenges
 served by a [Hono](https://hono.dev/) server using the
 [`mppx/hono`](https://github.com/wevm/mppx) middleware.
 
-MPP support is enabled by default on the Accounts SDK provider — no extra
+MPP support is enabled by default on the Tempo Accounts SDK provider — no extra
 client-side configuration is required.
 
 ## Intents

--- a/examples/mpp/src/App.tsx
+++ b/examples/mpp/src/App.tsx
@@ -12,8 +12,8 @@ export default function App() {
     <div>
       <h1>MPP Example</h1>
       <p>
-        Demonstrates the Accounts SDK auto-paying HTTP <code>402 Payment Required</code> responses
-        served by a Hono server using <code>mppx/hono</code> middleware.
+        Demonstrates the Tempo Accounts SDK auto-paying HTTP <code>402 Payment Required</code>{' '}
+        responses served by a Hono server using <code>mppx/hono</code> middleware.
       </p>
 
       <h2>Connection</h2>

--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -26,7 +26,7 @@ some pathUSD, then click **GET /api/articles** to subscribe.
 `GET /api/articles` is gated by `mppx.subscription({})` from the
 [`mppx/hono`](https://github.com/wevm/mppx) middleware. The first request
 responds with a `402 Payment Required` challenge describing the subscription
-plan (amount, currency, recipient, period, expiry). The Accounts SDK
+plan (amount, currency, recipient, period, expiry). The Tempo Accounts SDK
 automatically:
 
 1. Asks the wallet to authorize a recurring access key bound to the plan via

--- a/examples/transfers/README.md
+++ b/examples/transfers/README.md
@@ -1,6 +1,6 @@
 # Transfers Example
 
-Two ways to transfer from a Tempo account using the Accounts SDK:
+Two ways to transfer from a Tempo account using the Tempo Accounts SDK:
 
 | Category                       | Mechanism                       | What it does                                                                                                   |
 | ------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
@@ -36,7 +36,7 @@ See `src/App.tsx` for the client-side implementation.
 ### Server-initiated transfers
 
 `GET /api/transfer` responds with HTTP `402 Payment Required` and a challenge
-describing the amount, currency, and recipient. The Accounts SDK automatically
+describing the amount, currency, and recipient. The Tempo Accounts SDK automatically
 intercepts the 402 response, signs and broadcasts a pathUSD transfer with the
 connected account, and retries the original request with the credential
 attached — no extra client-side wiring required.

--- a/site/src/landing/customize.tsx
+++ b/site/src/landing/customize.tsx
@@ -683,7 +683,7 @@ export default function Customize() {
           Customize to <br className="sm:hidden" /> match your app
         </h2>
         <p className="max-w-[600px] text-[16px] text-foreground-muted sm:text-[18px]">
-          The Accounts SDK ships with full control on customizability to allow
+          Tempo Accounts SDK ships with full control on customizability to allow
           you to design embed like your native styles.
         </p>
         <div className="mt-5">

--- a/site/src/landing/demo/config.ts
+++ b/site/src/landing/demo/config.ts
@@ -401,7 +401,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Authentication",
       href: "/docs/guides/connect-accounts",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/connect-accounts, add account sign-in to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/connect-accounts, add account sign-in to my app with the Tempo Accounts SDK.",
     },
     prelude: [
       "Looks like you're new here",
@@ -429,7 +429,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Deposits",
       href: "/docs/guides/deposits",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/deposits, add deposits to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/deposits, add deposits to my app with the Tempo Accounts SDK.",
     },
     prelude: ["Top up your account"],
     Body: OnRampBody,
@@ -456,7 +456,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Transfers",
       href: "/docs/guides/transfers",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/transfers, add one-time transfers to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/transfers, add one-time transfers to my app with the Tempo Accounts SDK.",
     },
     prelude: [
       "We are processing your request to upgrade your dev account",
@@ -504,7 +504,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Spend Permissions",
       href: "/docs/guides/spend-permissions",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/spend-permissions, add spend permissions for per-use payments to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/spend-permissions, add spend permissions for per-use payments to my app with the Tempo Accounts SDK.",
     },
     prelude: [
       "Authorize a scoped access key once",
@@ -600,7 +600,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Subscriptions",
       href: "/docs/guides/subscriptions",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/subscriptions, add subscriptions to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/subscriptions, add subscriptions to my app with the Tempo Accounts SDK.",
     },
     prelude: [
       "Checking subscription status",
@@ -688,7 +688,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Fee Sponsorship",
       href: "/docs/guides/fee-sponsorship",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/fee-sponsorship, add fee sponsorship to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/fee-sponsorship, add fee sponsorship to my app with the Tempo Accounts SDK.",
     },
     prelude: [
       "Checking sponsorship policy",
@@ -716,7 +716,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       label: "Exchange Currencies",
       href: "/docs/guides/swaps",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/swaps, add currency exchange to my app with the Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/swaps, add currency exchange to my app with the Tempo Accounts SDK.",
     },
     prelude: ["Fetching best route", "Preparing a pathUSD to alphaUSD quote"],
     Body: TradeBody,

--- a/site/src/landing/demo/sdk.ts
+++ b/site/src/landing/demo/sdk.ts
@@ -93,7 +93,7 @@ export const landingDemoWagmiConfig: Config = createConfig({
       storage: accountsStorage,
       testnet: true,
       theme: { radius: "none" },
-      name: "Accounts SDK",
+      name: "Tempo Accounts SDK",
     }),
   ],
   multiInjectedProviderDiscovery: false,

--- a/site/src/landing/hero.tsx
+++ b/site/src/landing/hero.tsx
@@ -75,12 +75,12 @@ const adapterInfo: Record<Adapter, { title: string; description: string }> = {
   privy: {
     title: "Privy Adapter",
     description:
-      "Bring your own auth: route sign-in through Privy's embedded wallets while keeping the Accounts SDK's wagmi-compatible surface. Falls back to the Tempo dialog when Privy is unavailable.",
+      "Bring your own auth: route sign-in through Privy's embedded wallets while keeping the Tempo Accounts SDK's wagmi-compatible surface. Falls back to the Tempo dialog when Privy is unavailable.",
   },
   turnkey: {
     title: "Turnkey Adapter",
     description:
-      "Bring your own signing infrastructure: delegate key management and approvals to Turnkey while the Accounts SDK exposes the same wagmi-compatible surface to your app.",
+      "Bring your own signing infrastructure: delegate key management and approvals to Turnkey while the Tempo Accounts SDK exposes the same wagmi-compatible surface to your app.",
   },
 };
 
@@ -349,7 +349,7 @@ function HeroIntro({
           style={staggerStyle}
           className="text-[32px] leading-[1.1] tracking-[-0.02em] text-foreground sm:text-5xl sm:whitespace-nowrap"
         >
-          The Accounts SDK
+          Tempo Accounts SDK
         </h1>
         <p
           data-hero-stagger
@@ -813,7 +813,7 @@ function DemoSplit() {
           className="max-w-[520px] text-[16px] text-foreground-muted sm:text-[20px]"
           style={{ animation: `fadeUp 600ms ${easeOut} 80ms both` }}
         >
-          Accounts SDK is provider-agnostic. Bring your own wallet. Keep the same SDK.
+          Tempo Accounts SDK is provider-agnostic. Bring your own wallet. Keep the same SDK.
         </p>
       </div>
       <div

--- a/site/src/pages/_api/relay.ts
+++ b/site/src/pages/_api/relay.ts
@@ -10,7 +10,7 @@ const privateKey =
 const relay = Handler.relay({
   feePayer: {
     account: privateKeyToAccount(privateKey as `0x${string}`),
-    name: 'Accounts SDK Demo',
+    name: 'Tempo Accounts SDK Demo',
     url: 'https://accounts.tempo.xyz',
     validate: (request) => {
       const calls = request.calls

--- a/site/src/pages/docs/adapters/custom.mdx
+++ b/site/src/pages/docs/adapters/custom.mdx
@@ -7,7 +7,7 @@ import { Cards, Card } from 'vocs'
 
 # Custom Adapter
 
-The Accounts SDK exposes a low-level `Adapter.define` API for authoring custom adapters. Use it when none of the built-in adapters ([`tempoWallet`](/docs/adapters/tempo-wallet), [`webAuthn`](/docs/adapters/webauthn), [`turnkey`](/docs/adapters/turnkey), [`privy`](/docs/adapters/privy), [`secp256k1`](/docs/adapters/private-key)) match your custody model.
+The Tempo Accounts SDK exposes a low-level `Adapter.define` API for authoring custom adapters. Use it when none of the built-in adapters ([`tempoWallet`](/docs/adapters/tempo-wallet), [`webAuthn`](/docs/adapters/webauthn), [`turnkey`](/docs/adapters/turnkey), [`privy`](/docs/adapters/privy), [`secp256k1`](/docs/adapters/private-key)) match your custody model.
 
 Use it when you want:
 

--- a/site/src/pages/docs/adapters/index.mdx
+++ b/site/src/pages/docs/adapters/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adapters
-description: Choose the signing adapter for your Accounts SDK integration.
+description: Choose the signing adapter for your Tempo Accounts SDK integration.
 ---
 
 import { Cards, Card } from 'vocs'
@@ -9,7 +9,7 @@ import { Cards, Card } from 'vocs'
 
 ## Overview
 
-Adapters decide where keys live, who runs authentication, and how account requests are approved. Your app talks to the Accounts SDK through one provider surface while the adapter handles signing.
+Adapters decide where keys live, who runs authentication, and how account requests are approved. Your app talks to the Tempo Accounts SDK through one provider surface while the adapter handles signing.
 
 | Adapter                                     | Who owns auth       | Best for                                                                            |
 | ------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------- |
@@ -23,7 +23,7 @@ Adapters decide where keys live, who runs authentication, and how account reques
 ```mermaid
 sequenceDiagram
     participant App
-    participant SDK as Accounts SDK
+    participant SDK as Tempo Accounts SDK
     participant Adapter
     participant Signer
 

--- a/site/src/pages/docs/adapters/webauthn.mdx
+++ b/site/src/pages/docs/adapters/webauthn.mdx
@@ -7,7 +7,7 @@ import { Cards, Card } from 'vocs'
 
 # WebAuthn Adapter
 
-The WebAuthn adapter is for apps and enterprises that want account keys bound to their own domain. Your app owns the passkey ceremony and the Accounts SDK plugs those signatures into Tempo account flows.
+The WebAuthn adapter is for apps and enterprises that want account keys bound to their own domain. Your app owns the passkey ceremony and the Tempo Accounts SDK plugs those signatures into Tempo account flows.
 
 Use it when you want:
 

--- a/site/src/pages/docs/enterprise/bring-your-auth/aws-kms.mdx
+++ b/site/src/pages/docs/enterprise/bring-your-auth/aws-kms.mdx
@@ -1,6 +1,6 @@
 ---
 title: AWS KMS
-description: Stub for integrating AWS KMS-backed signing with the Accounts SDK.
+description: Stub for integrating AWS KMS-backed signing with the Tempo Accounts SDK.
 ---
 
 # AWS KMS

--- a/site/src/pages/docs/enterprise/bring-your-auth/index.mdx
+++ b/site/src/pages/docs/enterprise/bring-your-auth/index.mdx
@@ -5,7 +5,7 @@ description: Connect enterprise auth and signing systems to Tempo accounts.
 
 # Bring Your Auth
 
-Bring your own authentication and signing infrastructure, then expose it to app code through an Accounts SDK adapter.
+Bring your own authentication and signing infrastructure, then expose it to app code through a Tempo Accounts SDK adapter.
 
 This path is for teams that already have user identity, compliance, custody, or signing requirements that should remain outside Tempo Wallet.
 
@@ -23,7 +23,7 @@ This path is for teams that already have user identity, compliance, custody, or 
 ```mermaid
 flowchart LR
     App["App"]
-    SDK["Accounts SDK"]
+    SDK["Tempo Accounts SDK"]
     Adapter["Custom adapter"]
     Auth["Auth/session system"]
     Signer["Signer infrastructure"]

--- a/site/src/pages/docs/enterprise/bring-your-auth/privy.mdx
+++ b/site/src/pages/docs/enterprise/bring-your-auth/privy.mdx
@@ -1,11 +1,11 @@
 ---
 title: Privy
-description: Enterprise notes for integrating Privy-backed auth with the Accounts SDK.
+description: Enterprise notes for integrating Privy-backed auth with the Tempo Accounts SDK.
 ---
 
 # Privy
 
-Use the built-in [Privy adapter](/docs/adapters/privy) when Privy owns authentication, session state, and embedded wallets while the app still wants Tempo account features through the Accounts SDK.
+Use the built-in [Privy adapter](/docs/adapters/privy) when Privy owns authentication, session state, and embedded wallets while the app still wants Tempo account features through the Tempo Accounts SDK.
 
 ## Demo
 

--- a/site/src/pages/docs/enterprise/bring-your-auth/turnkey.mdx
+++ b/site/src/pages/docs/enterprise/bring-your-auth/turnkey.mdx
@@ -1,11 +1,11 @@
 ---
 title: Turnkey
-description: Stub for integrating Turnkey-backed signing with the Accounts SDK.
+description: Stub for integrating Turnkey-backed signing with the Tempo Accounts SDK.
 ---
 
 # Turnkey
 
-Use a custom adapter when Turnkey owns signer infrastructure and the app wants to expose Tempo account operations through the Accounts SDK.
+Use a custom adapter when Turnkey owns signer infrastructure and the app wants to expose Tempo account operations through the Tempo Accounts SDK.
 
 ## Demo
 
@@ -19,7 +19,7 @@ This page needs a real Turnkey-backed adapter example before publishing. Keep th
 
 - Accept an app-provided Turnkey client shape.
 - Keep Turnkey-specific dependencies out of the root SDK path.
-- Map Turnkey signing responses into Accounts SDK responses.
+- Map Turnkey signing responses into Tempo Accounts SDK responses.
 - Test connect, payment, and spend-permission flows.
 
 ## Next Steps

--- a/site/src/pages/docs/enterprise/hosted-universal-wallets.mdx
+++ b/site/src/pages/docs/enterprise/hosted-universal-wallets.mdx
@@ -14,7 +14,7 @@ Use this path when you want the portability of a wallet surface but need to own 
 ```mermaid
 flowchart LR
     App["Partner app"]
-    SDK["Accounts SDK"]
+    SDK["Tempo Accounts SDK"]
     Adapter["Hosted wallet adapter"]
     Wallet["Wallet domain"]
     Signer["Signer service"]

--- a/site/src/pages/docs/guides/connect-accounts.mdx
+++ b/site/src/pages/docs/guides/connect-accounts.mdx
@@ -11,7 +11,7 @@ import { Demo, DemoReset } from '../../../components/Demo'
 
 Connect a Tempo account in your application using the [Tempo Accounts SDK](/docs) and [Wagmi](https://wagmi.sh).
 
-The Accounts SDK ships several signing adapters — [Tempo Wallet](/docs/adapters/tempo-wallet), [domain-bound Passkeys](/docs/adapters/webauthn), [Turnkey](/docs/adapters/turnkey), [Privy](/docs/adapters/privy), and more. Each adapter exposes the same Wagmi connector surface, so the integration code in this guide is the same regardless of which adapter you pick. Choose an adapter once in your Wagmi config; the rest of your app stays adapter-agnostic.
+The Tempo Accounts SDK ships several signing adapters — [Tempo Wallet](/docs/adapters/tempo-wallet), [domain-bound Passkeys](/docs/adapters/webauthn), [Turnkey](/docs/adapters/turnkey), [Privy](/docs/adapters/privy), and more. Each adapter exposes the same Wagmi connector surface, so the integration code in this guide is the same regardless of which adapter you pick. Choose an adapter once in your Wagmi config; the rest of your app stays adapter-agnostic.
 
 :::info[Which adapter should I use?]
 

--- a/site/src/pages/docs/guides/subscriptions.mdx
+++ b/site/src/pages/docs/guides/subscriptions.mdx
@@ -12,7 +12,7 @@ import * as Steps from '../../../components/Steps'
 
 # Subscriptions
 
-Subscriptions let your server charge a recurring amount after the user approves the plan once. The first request returns an HTTP `402 Payment Required` challenge, and the Accounts SDK fulfills it from the connected account.
+Subscriptions let your server charge a recurring amount after the user approves the plan once. The first request returns an HTTP `402 Payment Required` challenge, and the Tempo Accounts SDK fulfills it from the connected account.
 
 After activation, your server can serve requests during the current billing period without asking for another confirmation. When the next period is due, a worker, cron job, or request handler can collect the next payment.
 
@@ -134,7 +134,7 @@ For local testing, set `periodCount: 10` and `periodUnit: 'dev_second'`. Product
 
 ### Call the Route from the Client
 
-Use `fetch` normally. The Accounts SDK handles the `402`, asks the user to approve the subscription, and retries the request with the signed credential.
+Use `fetch` normally. The Tempo Accounts SDK handles the `402`, asks the user to approve the subscription, and retries the request with the signed credential.
 
 ```tsx twoslash [Articles.tsx]
 // @noErrors

--- a/site/src/pages/docs/guides/transfers.mdx
+++ b/site/src/pages/docs/guides/transfers.mdx
@@ -17,7 +17,7 @@ Send stablecoin transfers from a connected Tempo account using the [Tempo Accoun
 There are two common ways to move value out of a connected account:
 
 - **User-initiated transfers**: your UI calls `wallet_transfer` and the connected account signs and broadcasts a stablecoin transfer.
-- **Server-initiated transfers**: your server responds with HTTP `402 Payment Required` using the [Machine Payments Protocol (MPP)](https://mpp.dev) [charge method](https://mpp.dev/payment-methods/tempo/charge), describing the amount, currency, and recipient. The Accounts SDK auto-fulfills the challenge from the connected account and retries the request, so your client code stays a plain `fetch`.
+- **Server-initiated transfers**: your server responds with HTTP `402 Payment Required` using the [Machine Payments Protocol (MPP)](https://mpp.dev) [charge method](https://mpp.dev/payment-methods/tempo/charge), describing the amount, currency, and recipient. The Tempo Accounts SDK auto-fulfills the challenge from the connected account and retries the request, so your client code stays a plain `fetch`.
 
 <Tabs stateKey="transfer-mode">
 
@@ -241,7 +241,7 @@ export default app
 
 ### Call It from the Client
 
-No extra client code is required. Use `fetch` (or any HTTP client) the same way you would for any other endpoint. The Accounts SDK transparently handles the `402`, signs a transfer with the connected account, and replays the request.
+No extra client code is required. Use `fetch` (or any HTTP client) the same way you would for any other endpoint. The Tempo Accounts SDK transparently handles the `402`, signs a transfer with the connected account, and replays the request.
 
 ```tsx twoslash [Charge.tsx]
 // @noErrors

--- a/site/src/pages/docs/index.mdx
+++ b/site/src/pages/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Accounts SDK - Getting Started
+title: Tempo Accounts SDK - Getting Started
 description: Set up the Tempo Accounts SDK to create, manage, and interact with accounts on Tempo.
 ---
 
@@ -17,7 +17,7 @@ The Tempo Accounts SDK is a TypeScript library for applications and wallets to c
 
 ### Demo
 
-Below is a live example of the Tempo Wallet adapter from the Accounts SDK — connect a Tempo account and send a payment to see the end-to-end flow.
+Below is a live example of the Tempo Wallet adapter from the Tempo Accounts SDK — connect a Tempo account and send a payment to see the end-to-end flow.
 
 <Demo
   title="Make a Payment"
@@ -34,7 +34,7 @@ Below is a live example of the Tempo Wallet adapter from the Accounts SDK — co
 
 ### Quick Prompt
 
-You can integrate the Accounts SDK, and achieve a flow like the demo above by prompting your agent:
+You can integrate the Tempo Accounts SDK, and achieve a flow like the demo above by prompting your agent:
 
 ```
 Read accounts.tempo.xyz/docs and integrate Tempo accounts into my application
@@ -42,7 +42,7 @@ Read accounts.tempo.xyz/docs and integrate Tempo accounts into my application
 
 ### Adapters
 
-The Accounts SDK ships with several signing adapters. Pick the one that matches how you want to custody your Tempo account.
+The Tempo Accounts SDK ships with several signing adapters. Pick the one that matches how you want to custody your Tempo account.
 
 <Cards>
   <Card
@@ -326,6 +326,6 @@ export default defineConfig({
 
 ## Getting Help
 
-Have questions or building something cool with the Accounts SDK?
+Have questions or building something cool with the Tempo Accounts SDK?
 
 Join the Telegram group to chat with the team and other devs: [@mpp_devs](https://t.me/mpp_devs)

--- a/site/src/pages/docs/server/hc.mdx
+++ b/site/src/pages/docs/server/hc.mdx
@@ -1,6 +1,6 @@
 ---
 title: hc
-description: Typed RPC client for handlers built with the Accounts SDK.
+description: Typed RPC client for handlers built with the Tempo Accounts SDK.
 ---
 
 # `hc`

--- a/site/src/pages/index.mdx
+++ b/site/src/pages/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Accounts SDK
+title: Tempo Accounts SDK
 description: The fastest way to add stablecoins to your application.
 layout: blank
 ---

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -32,7 +32,7 @@ const config: Config = defineConfig({
   sidebar: {
     '/': [
       {
-        text: 'Accounts SDK',
+        text: 'Tempo Accounts SDK',
         items: [
           { text: 'Getting Started', link: '/docs' },
           { text: 'Deploying to Production', link: '/docs/production' },
@@ -214,8 +214,8 @@ const config: Config = defineConfig({
       link: 'https://github.com/tempoxyz/accounts',
     },
   ],
-  title: 'Accounts SDK',
-  titleTemplate: '%s | Accounts SDK',
+  title: 'Tempo Accounts SDK',
+  titleTemplate: '%s | Tempo Accounts SDK',
   topNav: [
     { text: 'Docs', link: '/docs' },
     { text: 'Examples', link: 'https://github.com/tempoxyz/accounts/tree/main/examples' },


### PR DESCRIPTION
Updates the README, examples, landing page, and docs copy to consistently refer to the product as Tempo Accounts SDK.

This keeps package and import names unchanged while aligning visible documentation and example text with the preferred product name.
