### PR TITLE
docs(site): refine landing demo flows

### DIFF
--- a/site/src/landing/demo/Demo.tsx
+++ b/site/src/landing/demo/Demo.tsx
@@ -18,7 +18,6 @@ import type {
   Adapter,
   DemoKind,
   DemoResult,
-  SetupStatus,
   Status,
 } from "./types";
 
@@ -40,8 +39,6 @@ type Connected = {
 const ACTION_TIMEOUT_MS = 20_000;
 const DEPOSIT_BALANCE_ATTEMPTS = 40;
 const DEPOSIT_BALANCE_INTERVAL_MS = 1500;
-const FUNDING_BALANCE_ATTEMPTS = 20;
-const FUNDING_BALANCE_INTERVAL_MS = 1500;
 
 /** Scale when the demo box first enters from the bottom of the viewport. */
 const SCROLL_START_SCALE = 0.92;
@@ -132,8 +129,7 @@ export default function Demo() {
 
   const [demo, setDemo] = useState<DemoKind>("Log In");
   const [status, setStatus] = useState<Status>("idle");
-  const [setupStatus, setSetupStatus] = useState<SetupStatus>("idle");
-  const [setupError, setSetupError] = useState<string | null>(null);
+  const [signInStatus, setSignInStatus] = useState<Status>("idle");
   const [result, setResult] = useState<DemoResult | null>(null);
   const [lastVariant, setLastVariant] = useState<string | null>(null);
   const [connected, setConnected] = useState<Connected | null>(null);
@@ -152,8 +148,7 @@ export default function Demo() {
     depositWatchRef.current += 1;
     setDemo(next);
     setStatus("idle");
-    setSetupStatus("idle");
-    setSetupError(null);
+    setSignInStatus("idle");
     setResult(null);
     setLastVariant(null);
   };
@@ -208,8 +203,7 @@ export default function Demo() {
     setConnected(null);
     setAccountStatus("disconnected");
     setStatus("idle");
-    setSetupStatus("idle");
-    setSetupError(null);
+    setSignInStatus("idle");
     setResult(null);
     setLastVariant(null);
   };
@@ -301,6 +295,25 @@ export default function Demo() {
   const handleDemo = (next: DemoKind) => {
     if (next === demo) return;
     selectDemo(next);
+  };
+
+  const onSignIn = async () => {
+    if (signInStatus === "running") return;
+    setSignInStatus("running");
+    try {
+      const provider = await getProvider();
+      const address = await connectWallet(provider);
+      if (!address) return;
+      await refreshBalance(provider, address, {
+        chainId: balanceChainIdForDemo(activeDemoRef.current),
+      });
+      setAccountStatus("connected");
+    } catch {
+      cancelPendingRequests(providerRef.current);
+      if (!connected) setAccountStatus("disconnected");
+    } finally {
+      setSignInStatus("idle");
+    }
   };
 
   const onAction = async (variant?: string) => {
@@ -468,81 +481,6 @@ export default function Demo() {
     }
   };
 
-  const onSetupConnect = async () => {
-    if (setupStatus !== "idle") return;
-    setSetupError(null);
-    setSetupStatus("connecting");
-    try {
-      const provider = await getProvider();
-      const connectedAddr = await Promise.race([
-        connectWallet(provider).then((addr) => ({ addr })),
-        timeout(ACTION_TIMEOUT_MS),
-      ]);
-      if ("__timeout" in connectedAddr) {
-        cancelPendingRequests(provider);
-        throw new Error("Connect timed out.");
-      }
-      const addr = connectedAddr.addr;
-      if (addr) {
-        await refreshBalance(provider, addr);
-        setAccountStatus("connected");
-      } else {
-        setAccountStatus("disconnected");
-      }
-    } catch {
-      cancelPendingRequests(providerRef.current);
-      if (!connected) setAccountStatus("disconnected");
-      setSetupError("Could not connect. Try again.");
-    } finally {
-      setSetupStatus("idle");
-    }
-  };
-
-  const onSetupFund = async () => {
-    if (setupStatus !== "idle") return;
-    setSetupError(null);
-    setSetupStatus("funding");
-    try {
-      const provider = await getProvider();
-      let accounts = (await provider.request({
-        method: "eth_accounts",
-      })) as readonly `0x${string}`[];
-      let addr = accounts?.[0] ?? connected?.address ?? null;
-      if (!addr) {
-        const connectedAddr = await connectWallet(provider);
-        accounts = (await provider.request({
-          method: "eth_accounts",
-        })) as readonly `0x${string}`[];
-        addr = accounts?.[0] ?? connectedAddr;
-      }
-      if (!addr) {
-        setAccountStatus("disconnected");
-        setSetupError("Connect first, then request funds.");
-        return;
-      }
-      await provider.request({
-        method: "tempo_fundAddress",
-        params: [addr],
-      } as Parameters<typeof provider.request>[0]);
-      let next = await refreshBalance(provider, addr);
-      for (
-        let i = 0;
-        i < FUNDING_BALANCE_ATTEMPTS && next.balance <= 0n;
-        i += 1
-      ) {
-        await sleep(FUNDING_BALANCE_INTERVAL_MS);
-        next = await refreshBalance(provider, addr);
-      }
-      setAccountStatus("connected");
-      if (next.balance <= 0n)
-        setSetupError("Funds requested. Balance is still updating.");
-    } catch {
-      setSetupError("Could not request funds. Try again.");
-    } finally {
-      setSetupStatus("idle");
-    }
-  };
-
   const def = DEMOS[demo];
 
   return (
@@ -552,16 +490,14 @@ export default function Demo() {
           demo={demo}
           def={def}
           status={status}
-          setupStatus={setupStatus}
-          setupError={setupError}
+          signInStatus={signInStatus}
           result={result}
           adapter={adapter}
           lastVariant={lastVariant}
           connected={connected}
           accountStatus={accountStatus}
           onAction={onAction}
-          onSetupConnect={onSetupConnect}
-          onSetupFund={onSetupFund}
+          onSignIn={onSignIn}
           onChangeDemo={handleDemo}
           onDisconnect={onDisconnect}
         />

--- a/site/src/landing/demo/bodies/FeeSponsorship.tsx
+++ b/site/src/landing/demo/bodies/FeeSponsorship.tsx
@@ -2,7 +2,7 @@
 
 import { shorten } from "../sdk";
 import type { DemoBodyProps } from "../types";
-import { FundingOverlay, PrimaryButton, useBodyAnimation } from "./shared";
+import { PrimaryButton, useBodyAnimation } from "./shared";
 
 export function FeeSponsorshipBody(props: DemoBodyProps) {
   const { delay, onAction, result, status } = props;
@@ -10,10 +10,10 @@ export function FeeSponsorshipBody(props: DemoBodyProps) {
   const done = status === "done";
   const buttonLabel =
     status === "running"
-      ? "Sending…"
+      ? "Sending..."
       : done
         ? "Sponsored transfer sent"
-        : "Send sponsored transfer";
+        : "Send without fees";
 
   return (
     <div
@@ -23,7 +23,7 @@ export function FeeSponsorshipBody(props: DemoBodyProps) {
     >
       <div className="flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <p className="text-[13px] text-foreground-muted">Sponsored Transfer</p>
+          <p className="text-[13px] text-foreground-muted">No-fee transfer</p>
           <p className="font-mono text-[28px] leading-none text-foreground">
             $1.00
           </p>
@@ -35,11 +35,11 @@ export function FeeSponsorshipBody(props: DemoBodyProps) {
 
       <div className="grid gap-2">
         <div className="flex items-center justify-between bg-panel-3 px-4 py-3">
-          <span className="text-[12px] text-foreground-muted">User sends</span>
+          <span className="text-[12px] text-foreground-muted">You send</span>
           <span className="font-mono text-[12px] text-foreground">$1.00</span>
         </div>
         <div className="flex items-center justify-between bg-panel-3 px-4 py-3">
-          <span className="text-[12px] text-foreground-muted">App covers</span>
+          <span className="text-[12px] text-foreground-muted">Wisselbank covers</span>
           <span className="font-mono text-[12px] text-foreground">
             {result?.sponsoredFee ?? "network fee"}
           </span>
@@ -82,7 +82,6 @@ export function FeeSponsorshipBody(props: DemoBodyProps) {
           </p>
         )
       ) : null}
-      <FundingOverlay {...props} />
     </div>
   );
 }

--- a/site/src/landing/demo/bodies/LogIn.tsx
+++ b/site/src/landing/demo/bodies/LogIn.tsx
@@ -23,7 +23,7 @@ export function LogInBody({
       ? "Sign in with an on-device passkey — no popup, no third-party host."
       : adapter === "privy"
         ? "Sign in via Privy. The SDK manages access keys after authentication."
-        : "Continue with your Tempo wallet — passkeys and access keys handled by the SDK.";
+        : "Use a passkey to create or sign in to a stablecoin account.";
 
   const connected = status === "done" && Boolean(result?.summary);
   const accountLabel = connected ? result?.summary : "Not connected";
@@ -35,7 +35,7 @@ export function LogInBody({
       style={body.style}
     >
       <div className="flex flex-col gap-1.5">
-        <p className="text-[18px] text-foreground">Sign in to your account</p>
+        <p className="text-[18px] text-foreground">Create your Tempo account</p>
         <p className="text-[13px] text-foreground-muted">{description}</p>
       </div>
 

--- a/site/src/landing/demo/bodies/OnRamp.tsx
+++ b/site/src/landing/demo/bodies/OnRamp.tsx
@@ -25,12 +25,11 @@ export function OnRampBody({
         </p>
       </div>
       <p className="text-[13px] text-foreground-muted">
-        The wallet renders the full deposit UI (cards, Apple Pay, crypto, X
-        verification) — your app just calls{" "}
-        <span className="font-mono text-foreground">wallet_deposit</span>.
+        Open the wallet deposit flow with cards, Apple Pay, crypto, and X
+        verification.
       </p>
       <PrimaryButton
-        label="Deposit funds"
+        label="Add funds"
         status={status}
         onClick={onAction}
         className="h-11 w-full"

--- a/site/src/landing/demo/bodies/PayOnce.tsx
+++ b/site/src/landing/demo/bodies/PayOnce.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import type { DemoBodyProps } from "../types";
-import { FundingOverlay, PrimaryButton, useBodyAnimation } from "./shared";
+import { PrimaryButton, useBodyAnimation } from "./shared";
 
 export function PayOnceBody(props: DemoBodyProps) {
   const { status, result, onAction, delay } = props;
   const body = useBodyAnimation(delay);
   const done = status === "done";
-  const buttonLabel = done ? "Payment sent" : "Complete purchase";
+  const buttonLabel = done ? "Transfer sent" : "Send transfer";
 
   return (
     <div
@@ -16,10 +16,24 @@ export function PayOnceBody(props: DemoBodyProps) {
       style={body.style}
     >
       <div className="flex flex-col gap-1">
-        <p className="text-[13px] text-foreground-muted">Pro Plan</p>
+        <p className="text-[13px] text-foreground-muted">Transfer</p>
         <p className="font-mono text-[32px] leading-none text-foreground sm:text-[36px]">
           $240
         </p>
+      </div>
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between bg-panel-3 px-4 py-3">
+          <span className="text-[12px] text-foreground-muted">Recipient</span>
+          <span className="font-mono text-[12px] text-foreground">
+            Main account
+          </span>
+        </div>
+        <div className="flex items-center justify-between bg-panel-3 px-4 py-3">
+          <span className="text-[12px] text-foreground-muted">Memo</span>
+          <span className="font-mono text-[12px] text-foreground">
+            Monthly transfer
+          </span>
+        </div>
       </div>
       <PrimaryButton
         label={buttonLabel}
@@ -45,7 +59,6 @@ export function PayOnceBody(props: DemoBodyProps) {
           <p className="font-mono text-[10px] text-foreground-subtle">{result.summary}</p>
         )
       ) : null}
-      <FundingOverlay {...props} />
     </div>
   );
 }

--- a/site/src/landing/demo/bodies/SpendPermissions.tsx
+++ b/site/src/landing/demo/bodies/SpendPermissions.tsx
@@ -5,7 +5,6 @@ import { useLayoutEffect, useRef } from "react";
 import { springs } from "../../animation";
 import type { DemoBodyProps } from "../types";
 import {
-  FundingOverlay,
   PrimaryButton,
   SecondaryButton,
   useBodyAnimation,
@@ -58,12 +57,12 @@ export function SpendPermissionsBody(props: DemoBodyProps) {
   const buttonLabel = (() => {
     if (status === "running")
       return lastVariant?.startsWith("spend") || lastVariant === "again"
-        ? "Paying…"
-        : "Authorizing…";
+        ? "Paying..."
+        : "Approving...";
     if (canSend) return "Pay $0.01";
     if (done) return "Limit reached";
-    if (removedPermission) return "Authorize access key again";
-    return "Sign in and authorize key";
+    if (removedPermission) return "Approve rule again";
+    return "Approve spending rule";
   })();
 
   return (
@@ -75,7 +74,7 @@ export function SpendPermissionsBody(props: DemoBodyProps) {
       <div className="flex items-end justify-between">
         <div className="flex flex-col gap-1">
           <p className="text-[13px] text-foreground-muted">
-            Access-key payments
+            Micro-payments
           </p>
           <p className="font-mono text-[28px] tabular-nums text-foreground">
             {used.toLocaleString()}
@@ -97,8 +96,8 @@ export function SpendPermissionsBody(props: DemoBodyProps) {
       </div>
 
       <p className="text-[13px] text-foreground-muted">
-        Authorize a scoped access key once. Matching payments can run without
-        another prompt until the cap or expiry is reached.
+        Set a spending limit once. Matching payments can run in the background
+        until the limit or expiry is reached.
       </p>
 
       {activePermission ? (
@@ -139,8 +138,8 @@ export function SpendPermissionsBody(props: DemoBodyProps) {
         <SecondaryButton
           label={
             status === "running" && lastVariant === "revoke"
-              ? "Removing…"
-              : "Revoke access key"
+              ? "Removing..."
+              : "Revoke rule"
           }
           status={status === "running" ? "running" : "idle"}
           onClick={() => onAction("revoke")}
@@ -170,7 +169,6 @@ export function SpendPermissionsBody(props: DemoBodyProps) {
           </div>
         </div>
       ) : null}
-      <FundingOverlay {...props} />
     </div>
   );
 }

--- a/site/src/landing/demo/bodies/Subscribe.tsx
+++ b/site/src/landing/demo/bodies/Subscribe.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { shorten } from "../sdk";
 import type { DemoBodyProps } from "../types";
-import { FundingOverlay, PrimaryButton, useBodyAnimation } from "./shared";
+import { PrimaryButton, useBodyAnimation } from "./shared";
 
 export function SubscribeBody(props: DemoBodyProps) {
   const { status, result, onAction, lastVariant, delay } = props;
@@ -26,11 +26,11 @@ export function SubscribeBody(props: DemoBodyProps) {
     secondsUntilCollect > 0;
   const canCollect = Boolean(subscriptionId) && !cancelled && !waiting;
   const buttonLabel = (() => {
-    if (status === "running" && lastVariant === "cancel") return "Cancelling…";
-    if (status === "running" && !subscriptionId) return "Subscribing…";
+    if (status === "running" && lastVariant === "cancel") return "Cancelling...";
+    if (status === "running" && !subscriptionId) return "Subscribing...";
     if (cancelled) return "Subscription cancelled";
     if (subscriptionId) return "Cancel subscription";
-    return "Subscribe";
+    return "Start subscription";
   })();
 
   useEffect(() => {
@@ -67,8 +67,8 @@ export function SubscribeBody(props: DemoBodyProps) {
       </div>
 
       <p className="text-[12px] text-foreground-muted">
-        The server gates access with an MPP subscription and collects the next
-        period automatically from the approved plan.
+        Approve once. Wisselbank can collect each period automatically while
+        the subscription stays active.
       </p>
 
       {subscriptionId ? (
@@ -137,7 +137,6 @@ export function SubscribeBody(props: DemoBodyProps) {
           </div>
         </div>
       ) : null}
-      <FundingOverlay {...props} />
     </div>
   );
 }

--- a/site/src/landing/demo/bodies/Trade.tsx
+++ b/site/src/landing/demo/bodies/Trade.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { DemoBodyProps } from "../types";
-import { FundingOverlay, PrimaryButton, useBodyAnimation } from "./shared";
+import { PrimaryButton, useBodyAnimation } from "./shared";
 
 function SwapArrow() {
   return (
@@ -53,10 +53,10 @@ export function TradeBody(props: DemoBodyProps) {
   const done = status === "done";
   const buttonLabel =
     status === "running"
-      ? "Reviewing…"
+      ? "Reviewing..."
       : done
         ? "Exchange submitted"
-        : "Exchange $1.00";
+        : "Review exchange";
 
   return (
     <div
@@ -64,11 +64,11 @@ export function TradeBody(props: DemoBodyProps) {
       className="relative flex w-full max-w-[420px] flex-col gap-3 overflow-hidden bg-panel-2 p-6"
       style={body.style}
     >
-      <TokenRow label="From" amount="1.00" token="pathUSD" />
+      <TokenRow label="You sell" amount="1.00" token="pathUSD" />
       <div className="flex items-center justify-center py-2 text-foreground-muted">
         <SwapArrow />
       </div>
-      <TokenRow label="Receive" amount="1.00" token="alphaUSD" />
+      <TokenRow label="You receive" amount="1.00" token="alphaUSD" />
 
       <div className="grid gap-2">
         <div className="flex items-center justify-between bg-panel-3 px-4 py-3">
@@ -109,7 +109,6 @@ export function TradeBody(props: DemoBodyProps) {
           </p>
         )
       ) : null}
-      <FundingOverlay {...props} />
     </div>
   );
 }

--- a/site/src/landing/demo/bodies/shared.tsx
+++ b/site/src/landing/demo/bodies/shared.tsx
@@ -8,7 +8,7 @@ import {
   type CSSProperties,
 } from "react";
 import { springs } from "../../animation";
-import type { SetupStatus, Status } from "../types";
+import type { Status } from "../types";
 
 const bodyInitialStyle = {
   opacity: 0,
@@ -85,66 +85,6 @@ export function PrimaryButton({
       ) : null}
       <span className="text-[14px] text-on-accent">{label}</span>
     </button>
-  );
-}
-
-export function FundingOverlay({
-  connectedBalance,
-  needsFunding,
-  onSetupConnect,
-  onSetupFund,
-  setupError,
-  setupStatus,
-}: {
-  connectedBalance: string | null;
-  needsFunding: boolean;
-  onSetupConnect: () => void;
-  onSetupFund: () => void;
-  setupError: string | null;
-  setupStatus: SetupStatus;
-}) {
-  if (!needsFunding) return null;
-
-  const busy = setupStatus !== "idle";
-  const connected = connectedBalance !== null;
-  const connectLabel = setupStatus === "connecting" ? "Connecting…" : "Connect";
-  const fundLabel = setupStatus === "funding" ? "Requesting…" : "Request funds";
-
-  return (
-    <div className="absolute inset-0 z-10 flex flex-col justify-center gap-4 bg-panel-2/95 p-6 backdrop-blur-sm">
-      <div className="flex flex-col gap-1">
-        <p className="text-[16px] text-foreground">Add funds to continue</p>
-        <p className="text-[13px] text-foreground-muted">
-          {connected
-            ? `Current balance is ${connectedBalance}.`
-            : "Connect, then request faucet funds to try this demo."}
-        </p>
-        {setupError ? (
-          <p className="text-[12px] text-danger">{setupError}</p>
-        ) : null}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {connected ? (
-          <button
-            type="button"
-            onClick={onSetupFund}
-            disabled={busy}
-            className="h-8 bg-accent px-2.5 font-mono text-[11px] text-on-accent outline-none enabled:hover:bg-accent-hover enabled:active:bg-accent-active focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-info focus-visible:outline-offset-2 disabled:cursor-default disabled:opacity-80"
-          >
-            {fundLabel}
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onSetupConnect}
-            disabled={busy}
-            className="h-8 bg-accent px-2.5 font-mono text-[11px] text-on-accent outline-none enabled:hover:bg-accent-hover enabled:active:bg-accent-active focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-info focus-visible:outline-offset-2 disabled:cursor-default disabled:opacity-80"
-          >
-            {connectLabel}
-          </button>
-        )}
-      </div>
-    </div>
   );
 }
 

--- a/site/src/landing/demo/components/BrowserMockup.tsx
+++ b/site/src/landing/demo/components/BrowserMockup.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import { springs } from "../../animation";
 import { LockIcon, TempoLogo } from "../../icons";
-import { useBodyAnimation } from "../bodies/shared";
+import { PrimaryButton, useBodyAnimation } from "../bodies/shared";
 import { DEMOS, DEMO_STEPS } from "../config";
 import type {
   AccountStatus,
@@ -20,7 +20,6 @@ import type {
   DemoGuide,
   DemoKind,
   DemoResult,
-  SetupStatus,
   Status,
 } from "../types";
 import { shorten } from "../sdk";
@@ -201,6 +200,50 @@ function NextDemoMessage({
   );
 }
 
+function SignInGate({
+  accountStatus,
+  delay,
+  onSignIn,
+  signInStatus,
+}: {
+  accountStatus: AccountStatus;
+  delay: number;
+  onSignIn: () => void;
+  signInStatus: Status;
+}) {
+  const body = useBodyAnimation(delay);
+  const checking = accountStatus === "checking";
+  const status = checking ? "running" : signInStatus;
+  const label =
+    accountStatus === "checking"
+      ? "Checking..."
+      : signInStatus === "running"
+        ? "Signing in..."
+        : "Sign in";
+
+  return (
+    <div
+      ref={body.ref}
+      className="flex w-full max-w-[366px] flex-col gap-4 bg-panel-2 p-6"
+      style={body.style}
+    >
+      <div className="flex flex-col gap-1">
+        <p className="text-[16px] text-foreground">Sign in to continue</p>
+        <p className="text-[13px] text-foreground-muted">
+          Connect your Tempo account to try this example.
+        </p>
+      </div>
+      <PrimaryButton
+        label={label}
+        status={status}
+        disabled={checking}
+        onClick={onSignIn}
+        className="h-11 w-full"
+      />
+    </div>
+  );
+}
+
 export type ConnectedSession = {
   address: `0x${string}`;
   balanceDisplay: string;
@@ -211,32 +254,28 @@ export function BrowserMockup({
   demo,
   def,
   status,
-  setupStatus,
-  setupError,
+  signInStatus,
   result,
   adapter,
   lastVariant,
   connected,
   accountStatus,
   onAction,
-  onSetupConnect,
-  onSetupFund,
+  onSignIn,
   onChangeDemo,
   onDisconnect,
 }: {
   demo: DemoKind;
   def: DemoDef;
   status: Status;
-  setupStatus: SetupStatus;
-  setupError: string | null;
+  signInStatus: Status;
   result: DemoResult | null;
   adapter: Adapter;
   lastVariant: string | null;
   connected: ConnectedSession | null;
   accountStatus: AccountStatus;
   onAction: (variant?: string) => void;
-  onSetupConnect: () => void;
-  onSetupFund: () => void;
+  onSignIn: () => void;
   onChangeDemo: (d: DemoKind) => void;
   onDisconnect: () => void;
 }) {
@@ -284,11 +323,7 @@ export function BrowserMockup({
         : "Next example";
   const messageStyle =
     animatedMessagesDemo === demo ? undefined : messageInitialStyle;
-  const needsFunding =
-    demo !== "Log In" &&
-    demo !== "Add Funds" &&
-    accountStatus !== "checking" &&
-    (!connected || connected.balance <= 0n);
+  const needsSignIn = demo !== "Log In" && !connected;
   const changeDemo = (d: DemoKind) => {
     onChangeDemo(d);
     if (!window.matchMedia("(min-width: 640px)").matches)
@@ -506,24 +541,29 @@ export function BrowserMockup({
                   ))}
                 </div>
               ) : null}
-              <Body
-                key={`${demo}-body`}
-                status={status}
-                result={result}
-                lastVariant={lastVariant}
-                onAction={onAction}
-                onNextDemo={goNextDemo}
-                nextCtaLabel={nextCtaLabel}
-                setupStatus={setupStatus}
-                setupError={setupError}
-                needsFunding={needsFunding}
-                onSetupConnect={onSetupConnect}
-                onSetupFund={onSetupFund}
-                onDisconnect={onDisconnect}
-                delay={bodyDelay}
-                adapter={adapter}
-                connectedBalance={connected?.balanceDisplay ?? null}
-              />
+              {needsSignIn ? (
+                <SignInGate
+                  key={`${demo}-sign-in`}
+                  accountStatus={accountStatus}
+                  delay={bodyDelay}
+                  onSignIn={onSignIn}
+                  signInStatus={signInStatus}
+                />
+              ) : (
+                <Body
+                  key={`${demo}-body`}
+                  status={status}
+                  result={result}
+                  lastVariant={lastVariant}
+                  onAction={onAction}
+                  onNextDemo={goNextDemo}
+                  nextCtaLabel={nextCtaLabel}
+                  onDisconnect={onDisconnect}
+                  delay={bodyDelay}
+                  adapter={adapter}
+                  connectedBalance={connected?.balanceDisplay ?? null}
+                />
+              )}
               {status === "done" && result?.complete !== false ? (
                 <NextDemoMessage
                   key={`${demo}-next-message`}

--- a/site/src/landing/demo/config.ts
+++ b/site/src/landing/demo/config.ts
@@ -404,9 +404,9 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         "Referencing accounts.tempo.xyz/docs/guides/connect-accounts, add account sign-in to my app with the Tempo Accounts SDK.",
     },
     prelude: [
-      "Looks like you're new here",
-      "We'll set up an account with a passkey on your device",
-      "No password, no seed phrase",
+      "Welcome to Wisselbank",
+      "Create a stablecoin account with a passkey",
+      "No password, seed phrase, or extension needed",
     ],
     Body: LogInBody,
     async run(provider, ctx) {
@@ -431,7 +431,10 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       prompt:
         "Referencing accounts.tempo.xyz/docs/guides/deposits, add deposits to my app with the Tempo Accounts SDK.",
     },
-    prelude: ["Top up your account"],
+    prelude: [
+      "Add money to your Tempo account",
+      "Choose a deposit method in the wallet",
+    ],
     Body: OnRampBody,
     async run(provider) {
       // wallet_deposit opens the wallet's native Deposit dialog
@@ -453,15 +456,15 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
   "Pay Once": {
     url: "wisselbank.xyz",
     guide: {
-      label: "Transfers",
+      label: "Transfer",
       href: "/docs/guides/transfers",
       prompt:
-        "Referencing accounts.tempo.xyz/docs/guides/transfers, add one-time transfers to my app with the Tempo Accounts SDK.",
+        "Referencing accounts.tempo.xyz/docs/guides/transfers, add transfers to my app with the Tempo Accounts SDK.",
     },
     prelude: [
-      "We are processing your request to upgrade your dev account",
-      "Fetching plans....",
-      "Plan found",
+      "Start a transfer",
+      "Checking recipient details",
+      "Ready to send",
     ],
     Body: PayOnceBody,
     async run(provider) {
@@ -489,7 +492,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         | undefined;
       const tx = result?.receipt?.transactionHash;
       return {
-        summary: tx ? "Payment sent ·" : "Payment sent",
+        summary: tx ? "Transfer sent ·" : "Transfer sent",
         href: tx
           ? `${tempoModerato.blockExplorers.default.url}/tx/${tx}`
           : undefined,
@@ -507,8 +510,8 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         "Referencing accounts.tempo.xyz/docs/guides/spend-permissions, add spend permissions for per-use payments to my app with the Tempo Accounts SDK.",
     },
     prelude: [
-      "Authorize a scoped access key once",
-      "Matching transfers use that key without another prompt",
+      "Approve a payment rule once",
+      "Let Wisselbank make matching micro-payments",
     ],
     Body: SpendPermissionsBody,
     async run(provider, ctx) {
@@ -603,9 +606,9 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         "Referencing accounts.tempo.xyz/docs/guides/subscriptions, add subscriptions to my app with the Tempo Accounts SDK.",
     },
     prelude: [
-      "Checking subscription status",
+      "Check membership status",
       {
-        before: "Your server will request a recurring payment authorization via ",
+        before: "Approve recurring access with ",
         label: "MPP",
         href: "https://mpp.dev",
       },
@@ -691,8 +694,8 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         "Referencing accounts.tempo.xyz/docs/guides/fee-sponsorship, add fee sponsorship to my app with the Tempo Accounts SDK.",
     },
     prelude: [
-      "Checking sponsorship policy",
-      "Approved actions can use your app's fee payer",
+      "Check fee policy",
+      "Wisselbank covers the network fee",
     ],
     Body: FeeSponsorshipBody,
     async run(provider) {
@@ -718,7 +721,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
       prompt:
         "Referencing accounts.tempo.xyz/docs/guides/swaps, add currency exchange to my app with the Tempo Accounts SDK.",
     },
-    prelude: ["Fetching best route", "Preparing a pathUSD to alphaUSD quote"],
+    prelude: ["Find the best stablecoin route", "Quote pathUSD to alphaUSD"],
     Body: TradeBody,
     async run(provider) {
       await requireConnectedAccount(provider);

--- a/site/src/landing/demo/sdk.ts
+++ b/site/src/landing/demo/sdk.ts
@@ -84,6 +84,21 @@ type AuthorizeAccessKey =
   | ReturnType<typeof defaultAuthorizeAccessKey>
   | ReturnType<typeof spendPermissionAuthorizeAccessKey>;
 
+type ShowDeposit =
+  | boolean
+  | {
+      amount?: string | undefined;
+      displayName?: string | undefined;
+      on?: "login" | "register" | undefined;
+      token?: `0x${string}` | string | undefined;
+    };
+
+type ConnectWalletOptions = {
+  authorizeAccessKey?: AuthorizeAccessKey | undefined;
+  authorizeDefaultAccessKey?: boolean | undefined;
+  showDeposit?: ShowDeposit | undefined;
+};
+
 export const landingDemoWagmiConfig: Config = createConfig({
   chains: [tempoModerato, tempo],
   connectors: [
@@ -113,12 +128,16 @@ export async function getDemoProvider() {
 export function connectCapabilities(options: {
   authorizeAccessKey?: AuthorizeAccessKey | undefined;
   authorizeDefaultAccessKey?: boolean | undefined;
+  showDeposit?: ShowDeposit | undefined;
 } = {}) {
   const capabilities: Record<string, unknown> = {};
   if (options.authorizeAccessKey) {
     capabilities.authorizeAccessKey = options.authorizeAccessKey;
   } else if (options.authorizeDefaultAccessKey !== false) {
     capabilities.authorizeAccessKey = defaultAuthorizeAccessKey();
+  }
+  if (options.showDeposit !== undefined) {
+    capabilities.showDeposit = options.showDeposit;
   }
   return capabilities;
 }
@@ -139,10 +158,7 @@ type WalletConnectResult = {
 /** Opens the wallet sign-in flow and returns the raw wallet_connect result. */
 export async function connectWalletResult(
   provider: AccountsProvider,
-  options: {
-    authorizeAccessKey?: AuthorizeAccessKey | undefined;
-    authorizeDefaultAccessKey?: boolean | undefined;
-  } = {},
+  options: ConnectWalletOptions = {},
 ) {
   // Lazy access-key co-signing: every normal connect grants a scoped
   // session key unless the caller supplies a specialized permission.
@@ -158,10 +174,7 @@ export async function connectWalletResult(
 /** Opens the wallet sign-in flow and returns the connected account address. */
 export async function connectWallet(
   provider: AccountsProvider,
-  options: {
-    authorizeAccessKey?: AuthorizeAccessKey | undefined;
-    authorizeDefaultAccessKey?: boolean | undefined;
-  } = {},
+  options: ConnectWalletOptions = {},
 ) {
   const result = await connectWalletResult(provider, options);
   return result?.accounts?.[0]?.address ?? null;

--- a/site/src/landing/demo/types.ts
+++ b/site/src/landing/demo/types.ts
@@ -17,9 +17,6 @@ export type Status = "idle" | "running" | "done";
 /** Current account lookup state for the shared demo session. */
 export type AccountStatus = "checking" | "disconnected" | "connected";
 
-/** Status for the setup controls. Kept separate from demo action state. */
-export type SetupStatus = "idle" | "connecting" | "funding";
-
 export type AccountsProvider = ReturnType<typeof Provider.create>;
 
 export type DemoResult = {
@@ -110,16 +107,6 @@ export type DemoBodyProps = {
   onNextDemo: () => void;
   /** Label for the explicit next-step CTA after a demo completes. */
   nextCtaLabel?: string | undefined;
-  /** Status for setup actions that are separate from the demo action. */
-  setupStatus: SetupStatus;
-  /** Setup error shown in the funding overlay. */
-  setupError: string | null;
-  /** Whether this demo should block on account funding before its main action. */
-  needsFunding: boolean;
-  /** Connects the account used by the demo. */
-  onSetupConnect: () => void;
-  /** Adds funds for the demo account. */
-  onSetupFund: () => void;
   /** Disconnects the current account. */
   onDisconnect?: (() => void) | undefined;
   /** The variant string passed to the most recent `onAction` call, or null. */

--- a/site/src/landing/sections/Accounts.tsx
+++ b/site/src/landing/sections/Accounts.tsx
@@ -85,11 +85,6 @@ export default function Accounts() {
           lastVariant={null}
           connectedBalance={null}
           onNextDemo={noop}
-          setupStatus="idle"
-          setupError={null}
-          needsFunding={false}
-          onSetupConnect={noop}
-          onSetupFund={noop}
         />
       }
     />

--- a/site/src/landing/sections/LocalPayments.tsx
+++ b/site/src/landing/sections/LocalPayments.tsx
@@ -114,11 +114,6 @@ export default function LocalPayments() {
           onSelectAmount={setAmountId}
           methodLabel={INFO[method].title}
           onNextDemo={noop}
-          setupStatus="idle"
-          setupError={null}
-          needsFunding={false}
-          onSetupConnect={noop}
-          onSetupFund={noop}
         />
       }
     />

--- a/site/src/landing/sections/SendReceive.tsx
+++ b/site/src/landing/sections/SendReceive.tsx
@@ -105,11 +105,6 @@ export default function SendReceive() {
             selectedId={destId}
             onSelect={setDestId}
             onNextDemo={noop}
-            setupStatus="idle"
-            setupError={null}
-            needsFunding={false}
-            onSetupConnect={noop}
-            onSetupFund={noop}
           />
         ) : (
           <ReceiveBody address={receiveAddress} delay={120} />


### PR DESCRIPTION
Updates the landing demo so examples ask users to sign in before running protected actions and rely on the wallet-owned deposit flow instead of a manual request-funds gate.

The demo copy now reads like product flows across authentication, transfers, spend permissions, subscriptions, fee sponsorship, swaps, and deposits. Authentication uses a plain connect flow while deposit guidance remains in the docs where it belongs.