### PR TITLE
fix(site): pin landing demos to moderato

### DIFF
--- a/site/src/landing/demo/Demo.tsx
+++ b/site/src/landing/demo/Demo.tsx
@@ -11,6 +11,7 @@ import {
   PATH_USD,
   shorten,
   TEMPO_MAINNET_CHAIN_ID,
+  TEMPO_MODERATO_CHAIN_ID,
 } from "./sdk";
 import type {
   AccountStatus,
@@ -48,7 +49,7 @@ const SCROLL_LIFT_PX = 60;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const balanceChainIdForDemo = (demo: DemoKind) =>
-  demo === "Add Funds" ? TEMPO_MAINNET_CHAIN_ID : undefined;
+  demo === "Add Funds" ? TEMPO_MAINNET_CHAIN_ID : TEMPO_MODERATO_CHAIN_ID;
 
 const rejectPendingRequests = (provider: AccountsProvider | null) => {
   provider?.store.setState((state) => ({
@@ -461,7 +462,9 @@ export default function Demo() {
         })) as readonly `0x${string}`[];
         const addr = accounts?.[0];
         if (addr) {
-          await refreshBalance(provider, addr);
+          await refreshBalance(provider, addr, {
+            chainId: balanceChainIdForDemo(activeDemoRef.current),
+          });
           if (activeDemoRef.current === demo) setAccountStatus("connected");
         } else {
           setAccountStatus("disconnected");

--- a/site/src/landing/demo/config.ts
+++ b/site/src/landing/demo/config.ts
@@ -22,6 +22,7 @@ import {
   SPEND_PERMISSION_VALID_SECONDS,
   spendPermissionAuthorizeAccessKey,
   TEMPO_MAINNET_CHAIN_ID,
+  TEMPO_MODERATO_CHAIN_ID,
 } from "./sdk";
 import type { AccountsProvider, DemoDef, DemoKind, DemoResult } from "./types";
 
@@ -37,13 +38,6 @@ const FEE_SPONSORSHIP_RECIPIENT =
   "0x0000000000000000000000000000000000000001" as const;
 const SWAP_AMOUNT_USD = "1";
 const ALPHA_USD = "0x20c0000000000000000000000000000000000001" as const;
-
-function currentChainId(provider: AccountsProvider) {
-  const state = provider.store.getState() as unknown as {
-    chainId?: number | undefined;
-  };
-  return state.chainId ?? tempoModerato.id;
-}
 
 async function connectedAddress(provider: Parameters<DemoDef["run"]>[0]) {
   const accounts = (await provider.request({
@@ -195,6 +189,7 @@ function spendPermissionResult(options: {
 export async function connectSpendPermission(provider: AccountsProvider) {
   const result = await connectWalletResult(provider, {
     authorizeAccessKey: spendPermissionAuthorizeAccessKey(),
+    chainId: TEMPO_MODERATO_CHAIN_ID,
   });
   const account = result.accounts?.[0];
   const key = account?.capabilities?.keyAuthorization;
@@ -235,13 +230,12 @@ function findSpendPermission(
   provider: AccountsProvider,
   account: `0x${string}`,
 ) {
-  const chainId = currentChainId(provider);
   const state = provider.store.getState() as unknown as {
     accessKeys?: readonly SpendPermissionRecord[] | undefined;
   };
   return state.accessKeys?.find((key) => {
     if (key.access.toLowerCase() !== account.toLowerCase()) return false;
-    if (key.chainId !== chainId) return false;
+    if (key.chainId !== TEMPO_MODERATO_CHAIN_ID) return false;
     if (
       !key.limits?.some(
         (limit) =>
@@ -280,7 +274,7 @@ async function sendApprovedPayment(
     params: [
       {
         calls: [call],
-        chainId: currentChainId(provider),
+        chainId: TEMPO_MODERATO_CHAIN_ID,
         feeToken: PATH_USD,
         from: account,
       },
@@ -365,6 +359,7 @@ async function sendSponsoredTransfer(
     params: [
       {
         amount: FEE_SPONSORSHIP_AMOUNT_USD,
+        chainId: TEMPO_MODERATO_CHAIN_ID,
         to: FEE_SPONSORSHIP_RECIPIENT,
         token: PATH_USD,
       },
@@ -482,6 +477,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         params: [
           {
             editable: true,
+            chainId: TEMPO_MODERATO_CHAIN_ID,
             to: self,
             amount: PURCHASE_AMOUNT_USD,
             token: "pathUsd",
@@ -730,6 +726,7 @@ export const DEMOS: Record<DemoKind, DemoDef> = {
         params: [
           {
             amount: SWAP_AMOUNT_USD,
+            chainId: TEMPO_MODERATO_CHAIN_ID,
             pairToken: ALPHA_USD,
             slippage: 0.005,
             token: PATH_USD,

--- a/site/src/landing/demo/sdk.ts
+++ b/site/src/landing/demo/sdk.ts
@@ -14,6 +14,8 @@ export const PATH_USD =
   "0x20c0000000000000000000000000000000000000" as const;
 /** Tempo mainnet chain ID, used by demos that intentionally target production funds. */
 export const TEMPO_MAINNET_CHAIN_ID = tempo.id;
+/** Tempo Moderato chain ID, used by demos that rely on the public testnet sponsor. */
+export const TEMPO_MODERATO_CHAIN_ID = tempoModerato.id;
 
 const ONE_DAY = 24 * 60 * 60;
 const FIVE_USD = 5_000_000n;
@@ -96,6 +98,7 @@ type ShowDeposit =
 type ConnectWalletOptions = {
   authorizeAccessKey?: AuthorizeAccessKey | undefined;
   authorizeDefaultAccessKey?: boolean | undefined;
+  chainId?: number | undefined;
   showDeposit?: ShowDeposit | undefined;
 };
 
@@ -164,10 +167,12 @@ export async function connectWalletResult(
   // session key unless the caller supplies a specialized permission.
   return (await provider.request({
     method: "wallet_connect",
-    params: [{ capabilities: connectCapabilities(options) } as Record<
-      string,
-      unknown
-    >],
+    params: [
+      {
+        capabilities: connectCapabilities(options),
+        chainId: options.chainId ?? TEMPO_MODERATO_CHAIN_ID,
+      } as Record<string, unknown>,
+    ],
   })) as WalletConnectResult;
 }
 


### PR DESCRIPTION
Pins the landing demo's non-deposit wallet requests to Tempo Moderato so the public Moderato sponsor never receives a mainnet fill request from persisted wallet state.

Deposits stay on Tempo mainnet, and balance reads now follow the same split. Follow-up to https://github.com/tempoxyz/accounts/pull/576.