### PR TITLE
docs(site): remove adapter demo todos

### DIFF
--- a/site/src/pages/docs/adapters/private-key.mdx
+++ b/site/src/pages/docs/adapters/private-key.mdx
@@ -19,10 +19,6 @@ Use it when you want:
 Storing keys in browser storage in plaintext is dangerous — only omit `privateKey` for development, testing, or when the threat model allows it.
 :::
 
-## Demo
-
-TODO
-
 ## Usage
 
 ```ts twoslash

--- a/site/src/pages/docs/adapters/tempo-wallet.mdx
+++ b/site/src/pages/docs/adapters/tempo-wallet.mdx
@@ -16,10 +16,6 @@ Use it when you want:
 - Tempo-managed passkey and signing infrastructure.
 - A fast path for app teams that do not need to build a wallet.
 
-## Demo
-
-TODO
-
 ## Usage
 
 :::code-group

--- a/site/src/pages/docs/adapters/turnkey.mdx
+++ b/site/src/pages/docs/adapters/turnkey.mdx
@@ -15,10 +15,6 @@ Use it when you want:
 - Passkey or other Turnkey-supported authentication on your own organization.
 - Tempo account features without managing your own signer infrastructure.
 
-## Demo
-
-TODO
-
 ## Usage
 
 ```tsx

--- a/site/src/pages/docs/adapters/webauthn.mdx
+++ b/site/src/pages/docs/adapters/webauthn.mdx
@@ -15,10 +15,6 @@ Use it when you want:
 - Your app to own registration and authentication UX.
 - Tempo account features without using the hosted Tempo Wallet surface.
 
-## Demo
-
-TODO
-
 ## Usage
 
 :::code-group


### PR DESCRIPTION
Removes empty demo placeholders from the adapter docs where the sections only contained `TODO`.

The adapter pages now flow directly from their overview into usage examples until real demos are available.