### PR TITLE
feat: support `showDeposit` on `wallet_authorizeAccessKey`

### DIFF
--- a/.changeset/show-deposit-authorize-access-key.md
+++ b/.changeset/show-deposit-authorize-access-key.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `showDeposit` support to `wallet_authorizeAccessKey` requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,4 @@
 - **CLI auth example URL inputs** — the example CLI flow is expected to support both `--url` and `AUTH_URL`-based defaults, and should avoid hardcoded personal hostnames in source.
 - **Test RPC port selection should auto-fallback** — localnet test setup should start from `VITE_RPC_PORT` (or `8545`) and select the next available port to avoid `EADDRINUSE` collisions.
 - **Turnkey adapter stays structurally typed** — avoid importing `@turnkey/core` directly from the root SDK adapter so non-Turnkey consumers do not inherit a hard dependency; accept an app-provided client with the minimal client shape instead.
+- **Standalone access-key deposit prompts have no event filter** -- `wallet_authorizeAccessKey.showDeposit` supports boolean or deposit hints and intentionally omits `on`; use `wallet_connect.capabilities.showDeposit.on` for login/register filtering.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,4 @@
 - **Test RPC port selection should auto-fallback** — localnet test setup should start from `VITE_RPC_PORT` (or `8545`) and select the next available port to avoid `EADDRINUSE` collisions.
 - **Turnkey adapter stays structurally typed** — avoid importing `@turnkey/core` directly from the root SDK adapter so non-Turnkey consumers do not inherit a hard dependency; accept an app-provided client with the minimal client shape instead.
 - **Standalone access-key deposit prompts have no event filter** -- `wallet_authorizeAccessKey.showDeposit` supports boolean or deposit hints and intentionally omits `on`; use `wallet_connect.capabilities.showDeposit.on` for login/register filtering.
+- **Connect access-key params do not carry deposit prompts** -- `wallet_connect.capabilities.authorizeAccessKey` omits `showDeposit`; connect deposit prompts belong on `wallet_connect.capabilities.showDeposit` only.

--- a/site/src/pages/docs/rpc/wallet_authorizeAccessKey.mdx
+++ b/site/src/pages/docs/rpc/wallet_authorizeAccessKey.mdx
@@ -44,11 +44,24 @@ type Request = {
       /** Allowed call recipients (e.g. `transfer(to, ...)`). */
       recipients?: Address[]
     }[]
+    /** Optional funding prompt to show after approval. */
+    showDeposit?: ShowDeposit
   }]
+}
+
+type ShowDeposit = boolean | {
+  /** Human-readable amount to pre-fill (e.g. `"50"`). */
+  amount?: string
+  /** Display name shown in the deposit UI. */
+  displayName?: string
+  /** Token symbol or contract address to pre-fill. */
+  token?: string | Address
 }
 ```
 
 Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Use the `address` field on each scope for the target contract; malformed scope entries are rejected before approval.
+
+Set `showDeposit` to `true` or funding hints to show the optional deposit picker before the wallet returns the authorization result.
 
 ## Response
 
@@ -89,14 +102,15 @@ import { Expiry } from 'accounts'
 
 const result = await provider.request({
   method: 'wallet_authorizeAccessKey',
-  params: [{
-    expiry: Expiry.days(1),
-    limits: [
-      { token: '0x20c0000000000000000000000000000000000001', limit: '0x5F5E100' },
-    ],
-    scopes: [
-      { address: '0x20c0000000000000000000000000000000000001' },
-    ],
-  }],
+  params: [
+    {
+      expiry: Expiry.days(1),
+      limits: [
+        { token: '0x20c0000000000000000000000000000000000001', limit: '0x5F5E100' },
+      ],
+      scopes: [{ address: '0x20c0000000000000000000000000000000000001' }],
+      showDeposit: { amount: '50', token: 'USDC' },
+    },
+  ],
 })
 ```

--- a/src/cli/Provider.localnet.test.ts
+++ b/src/cli/Provider.localnet.test.ts
@@ -303,6 +303,50 @@ describe('Provider.create', () => {
     }
   })
 
+  test('behavior: forwards showDeposit through wallet_authorizeAccessKey device-code requests', async () => {
+    const handler = createHandler()
+    const server = await createServer(handler.listener)
+    const pendingShowDeposit: z.output<typeof CliAuth.pendingResponse>['showDeposit'][] = []
+
+    try {
+      const provider = Provider.create({
+        chains: [chain],
+        open: async (url) => {
+          const code = new URL(url).searchParams.get('code')!
+          const response = await fetch(`${server.url}/cli-auth/pending/${code}`)
+          const pending = z.decode(CliAuth.pendingResponse, (await response.json()) as never)
+          pendingShowDeposit.push(pending.showDeposit)
+          await fetch(`${server.url}/cli-auth`, {
+            body: JSON.stringify(await authorizePending(server.url, code)),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          })
+        },
+        host: `${server.url}/cli-auth`,
+      })
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [
+          {
+            expiry,
+            keyType: accessKey.keyType,
+            publicKey: accessKey.publicKey,
+            showDeposit: true,
+          },
+        ],
+      })
+
+      expect(pendingShowDeposit).toMatchInlineSnapshot(`
+        [
+          true,
+        ]
+      `)
+    } finally {
+      await server.closeAsync()
+    }
+  })
+
   test('behavior: browser-open failures surface the URL and code', async () => {
     const handler = createHandler()
     const server = await createServer(handler.listener)

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -258,6 +258,9 @@ export function cli(options: cli.Options): Adapter.Adapter {
             ...(account ? { account } : {}),
             authorizeAccessKey: parameters,
             method: 'wallet_authorizeAccessKey',
+            ...(parameters.showDeposit !== undefined
+              ? { showDeposit: parameters.showDeposit }
+              : {}),
           })
 
           if (!account)

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -308,6 +308,10 @@ export declare namespace signTypedData {
 }
 
 export declare namespace authorizeAccessKey {
+  type ShowDeposit = NonNullable<
+    Rpc.wallet_authorizeAccessKey.Decoded['params']
+  >[number]['showDeposit']
+
   type Parameters = {
     /** Access key address. Alternative to `publicKey` when the caller already knows the derived address. */
     address?: Address | undefined
@@ -329,6 +333,8 @@ export declare namespace authorizeAccessKey {
           recipients?: readonly Address[] | undefined
         }[]
       | undefined
+    /** Show the deposit flow after the access-key authorization succeeds. */
+    showDeposit?: ShowDeposit | undefined
   }
 
   type ReturnType = {

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -123,6 +123,25 @@ describe('Encoded', () => {
     expectTypeOf<ShowDepositObject>().not.toHaveProperty('chainId')
   })
 
+  test('wallet_authorizeAccessKey: showDeposit', () => {
+    type Parameters = NonNullable<Rpc.wallet_authorizeAccessKey.Decoded['params']>[number]
+    type ShowDeposit = Parameters['showDeposit']
+    type ShowDepositObject = Exclude<Exclude<ShowDeposit, boolean | undefined>, undefined>
+
+    expectTypeOf<ShowDeposit>().toMatchTypeOf<
+      | boolean
+      | {
+          amount?: string | undefined
+          displayName?: string | undefined
+          token?: string | undefined
+        }
+      | undefined
+    >()
+    expectTypeOf<ShowDepositObject>().not.toHaveProperty('address')
+    expectTypeOf<ShowDepositObject>().not.toHaveProperty('chainId')
+    expectTypeOf<ShowDepositObject>().not.toHaveProperty('on')
+  })
+
   test('wallet_connect: returns', () => {
     expectTypeOf<Rpc.wallet_connect.Encoded['returns']>().toHaveProperty('accounts')
     expectTypeOf<

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -107,6 +107,8 @@ describe('Encoded', () => {
     type ShowDeposit = Register['showDeposit']
     type LoginShowDeposit = Login['showDeposit']
     type ShowDepositObject = Exclude<Exclude<ShowDeposit, boolean | undefined>, undefined>
+    type AuthorizeAccessKey = NonNullable<Register['authorizeAccessKey']>
+    type LoginAuthorizeAccessKey = NonNullable<Login['authorizeAccessKey']>
 
     expectTypeOf<ShowDeposit>().toMatchTypeOf<
       | boolean
@@ -121,6 +123,8 @@ describe('Encoded', () => {
     expectTypeOf<LoginShowDeposit>().toEqualTypeOf<ShowDeposit>()
     expectTypeOf<ShowDepositObject>().not.toHaveProperty('address')
     expectTypeOf<ShowDepositObject>().not.toHaveProperty('chainId')
+    expectTypeOf<LoginAuthorizeAccessKey>().toEqualTypeOf<AuthorizeAccessKey>()
+    expectTypeOf<AuthorizeAccessKey>().not.toHaveProperty('showDeposit')
   })
 
   test('wallet_authorizeAccessKey: showDeposit', () => {

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -386,6 +386,49 @@ describe('dialog', () => {
     expect('keyPair' in store.getState().accessKeys[0]!).toMatchInlineSnapshot(`true`)
   })
 
+  test('behavior: authorizeAccessKey forwards showDeposit', async () => {
+    const { adapter, store } = setup()
+    const expiry = 123
+    const showDeposit = { amount: '50', token: 'USDC' }
+    const promise = adapter.actions.authorizeAccessKey!(
+      { expiry, showDeposit },
+      { method: 'wallet_authorizeAccessKey', params: [{ expiry, showDeposit }] },
+    )
+
+    const queued = await takeRequest(store)
+    const request = queued.request as {
+      params: [
+        {
+          expiry: number
+          keyType: 'p256'
+          publicKey: Hex.Hex
+          showDeposit: typeof showDeposit
+        },
+      ]
+    }
+    const params = request.params[0]
+    store.setState({
+      requestQueue: [
+        {
+          request: queued.request,
+          result: {
+            keyAuthorization: createKeyAuthorization(params),
+            rootAddress: address,
+          },
+          status: 'success',
+        },
+      ],
+    })
+
+    await expect(promise).resolves.toMatchObject({ rootAddress: address })
+    expect(params.showDeposit).toMatchInlineSnapshot(`
+      {
+        "amount": "50",
+        "token": "USDC",
+      }
+    `)
+  })
+
   test('behavior: authorizeAccessKey generates a p256 key when requested', async () => {
     const { adapter, store } = setup()
     const expiry = 123

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -379,7 +379,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             ...request,
             params: [
               z.encode(
-                Rpc.wallet_connect.authorizeAccessKey,
+                Rpc.wallet_authorizeAccessKey.parameters,
                 accessKey ? accessKey.request : parameters,
               )!,
             ],

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -308,6 +308,25 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
       }),
     ).toThrow()
   })
+
+  test('omits nested showDeposit from authorizeAccessKey', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        authorizeAccessKey: {
+          expiry: 123,
+          showDeposit: true,
+        },
+        method: 'register',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "authorizeAccessKey": {
+          "expiry": 123,
+        },
+        "method": "register",
+      }
+    `)
+  })
 })
 
 describe('wallet_authorizeAccessKey.parameters: showDeposit', () => {
@@ -540,5 +559,41 @@ describe('wallet_connect_strict.parameters: showDeposit', () => {
         },
       },
     })
+  })
+
+  test('omits nested showDeposit from authorizeAccessKey', () => {
+    expect(
+      z.parse(Rpc.wallet_connect_strict.parameters, {
+        capabilities: {
+          authorizeAccessKey: {
+            expiry: 123,
+            limits: [{ limit: 1n, token: '0x0000000000000000000000000000000000000001' }],
+            scopes: [{ address: '0x0000000000000000000000000000000000000001' }],
+            showDeposit: true,
+          },
+          method: 'register',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "capabilities": {
+          "authorizeAccessKey": {
+            "expiry": 123,
+            "limits": [
+              {
+                "limit": 1n,
+                "token": "0x0000000000000000000000000000000000000001",
+              },
+            ],
+            "scopes": [
+              {
+                "address": "0x0000000000000000000000000000000000000001",
+              },
+            ],
+          },
+          "method": "register",
+        },
+      }
+    `)
   })
 })

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -310,6 +310,82 @@ describe('wallet_connect.capabilities.request: showDeposit', () => {
   })
 })
 
+describe('wallet_authorizeAccessKey.parameters: showDeposit', () => {
+  test('accepts true', () => {
+    expect(
+      z.parse(Rpc.wallet_authorizeAccessKey.parameters, {
+        expiry: 123,
+        showDeposit: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "expiry": 123,
+        "showDeposit": true,
+      }
+    `)
+  })
+
+  test('accepts deposit parameters', () => {
+    expect(
+      z.parse(Rpc.wallet_authorizeAccessKey.parameters, {
+        expiry: 123,
+        showDeposit: {
+          amount: '50',
+          displayName: 'DoorDash',
+          token: 'USDC',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "expiry": 123,
+        "showDeposit": {
+          "amount": "50",
+          "displayName": "DoorDash",
+          "token": "USDC",
+        },
+      }
+    `)
+  })
+
+  test('rejects invalid deposit parameters', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_authorizeAccessKey.parameters, {
+        expiry: 123,
+        showDeposit: { amount: 50 },
+      }),
+    ).toThrow()
+  })
+})
+
+describe('wallet_authorizeAccessKey_strict.parameters: showDeposit', () => {
+  test('accepts showDeposit with required access-key policy', () => {
+    expect(
+      z.parse(Rpc.wallet_authorizeAccessKey_strict.parameters, {
+        expiry: 123,
+        limits: [{ limit: 1n, token: '0x0000000000000000000000000000000000000001' }],
+        scopes: [{ address: '0x0000000000000000000000000000000000000001' }],
+        showDeposit: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "expiry": 123,
+        "limits": [
+          {
+            "limit": 1n,
+            "token": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "scopes": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "showDeposit": true,
+      }
+    `)
+  })
+})
+
 describe('wallet_connect_strict.parameters: auth', () => {
   test('accepts string shorthand', () => {
     expect(

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -347,6 +347,29 @@ export namespace wallet_getCapabilities {
 }
 
 export namespace wallet_authorizeAccessKey {
+  /**
+   * Shows an optional funding prompt after `wallet_authorizeAccessKey`
+   * succeeds.
+   *
+   * `true` prompts after approval. Object form pre-fills deposit UI hints.
+   */
+  export const showDeposit = z.optional(
+    z.union([
+      z.boolean(),
+      z.object({
+        /** Human-readable amount to pre-fill (e.g. `"50"`). */
+        amount: z.optional(z.string()),
+        /** Display name shown in the deposit UI (e.g. the app name). */
+        displayName: z.optional(z.string()),
+        /**
+         * Token to pre-fill, accepted as either a contract address or a
+         * supported deposit token symbol (case-insensitive, e.g. `"USDC"`).
+         */
+        token: z.optional(z.union([u.address(), z.string()])),
+      }),
+    ]),
+  )
+
   export const parameters = z.object({
     address: z.optional(u.address()),
     chainId: z.optional(u.bigint()),
@@ -371,6 +394,7 @@ export namespace wallet_authorizeAccessKey {
         ),
       ),
     ),
+    showDeposit,
   })
 
   export const returns = z.object({
@@ -409,6 +433,7 @@ export namespace wallet_authorizeAccessKey_strict {
         )
         .check(z.minLength(1)),
     ),
+    showDeposit: wallet_authorizeAccessKey.showDeposit,
   })
 }
 
@@ -427,14 +452,7 @@ export namespace wallet_revokeAccessKey {
 export namespace wallet_connect {
   export const authorizeAccessKey = z.optional(wallet_authorizeAccessKey.parameters)
 
-  /**
-   * Shows an optional funding prompt after `wallet_connect` succeeds.
-   *
-   * `true` prompts after both registration and login. Object form pre-fills
-   * deposit UI hints and can scope the prompt to a specific connect method
-   * with `on`. The deposit chain comes from the surrounding `wallet_connect`
-   * chain context.
-   */
+  /** Shows an optional funding prompt after `wallet_connect` succeeds. */
   export const showDeposit = z.optional(
     z.union([
       z.boolean(),
@@ -443,7 +461,7 @@ export namespace wallet_connect {
         amount: z.optional(z.string()),
         /** Display name shown in the deposit UI (e.g. the app name). */
         displayName: z.optional(z.string()),
-        /** Connect method that should show the deposit prompt. Defaults to both methods. */
+        /** Auth event that should show the deposit prompt. Defaults to any event. */
         on: z.optional(z.union([z.literal('login'), z.literal('register')])),
         /**
          * Token to pre-fill, accepted as either a contract address or a

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -450,7 +450,9 @@ export namespace wallet_revokeAccessKey {
 }
 
 export namespace wallet_connect {
-  export const authorizeAccessKey = z.optional(wallet_authorizeAccessKey.parameters)
+  export const authorizeAccessKey = z.optional(
+    z.omit(wallet_authorizeAccessKey.parameters, { showDeposit: true }),
+  )
 
   /** Shows an optional funding prompt after `wallet_connect` succeeds. */
   export const showDeposit = z.optional(
@@ -602,7 +604,9 @@ export namespace wallet_connect {
 }
 
 export namespace wallet_connect_strict {
-  const authorizeAccessKey = z.optional(wallet_authorizeAccessKey_strict.parameters)
+  const authorizeAccessKey = z.optional(
+    z.omit(wallet_authorizeAccessKey_strict.parameters, { showDeposit: true }),
+  )
   const auth = wallet_connect.auth
   const personalSign = wallet_connect.personalSign
   const showDeposit = wallet_connect.showDeposit

--- a/src/react-native/Provider.localnet.test.ts
+++ b/src/react-native/Provider.localnet.test.ts
@@ -210,6 +210,38 @@ describe('create', () => {
     `)
   })
 
+  test('behavior: forwards showDeposit params to the mobile auth URL for wallet_authorizeAccessKey', async () => {
+    const browser = createOpen()
+    const provider = Provider.create({
+      chains: [chain],
+      host: 'https://wallet-next.tempo.xyz',
+      open: browser.open,
+      redirectUri: 'accounts-playground://auth',
+      secureStorage: Storage.memory(),
+    })
+
+    await provider.request({
+      method: 'wallet_authorizeAccessKey',
+      params: [
+        {
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+          showDeposit: {
+            amount: '25',
+            token: 'USDC',
+          },
+        },
+      ],
+    })
+
+    expect(JSON.parse(new URL(browser.urls()[0]!).searchParams.get('showDeposit')!))
+      .toMatchInlineSnapshot(`
+      {
+        "amount": "25",
+        "token": "USDC",
+      }
+    `)
+  })
+
   test('behavior: forwards personalSign to the mobile auth URL and returns signature', async () => {
     const browser = createOpen()
     const provider = Provider.create({

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -308,6 +308,9 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
             ...(account ? { account } : {}),
             authorizeAccessKey: parameters,
             method: 'wallet_authorizeAccessKey',
+            ...(parameters.showDeposit !== undefined
+              ? { showDeposit: parameters.showDeposit }
+              : {}),
           })
 
           if (!account)


### PR DESCRIPTION
Adds `showDeposit` to `wallet_authorizeAccessKey` across the RPC schema, adapters, and docs.

The standalone access-key shape accepts `true` or deposit hints like `amount`, `displayName`, and `token`. Login/register filtering remains scoped to `wallet_connect.capabilities.showDeposit.on`.
