### PR TITLE
feat: add mpp_authorize provider support

### DIFF
--- a/examples/mpp/package.json
+++ b/examples/mpp/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-query": "^5.97.0",
     "accounts": "latest",
     "hono": "^4.12.18",
-    "mppx": "^0.6.27",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "latest",

--- a/examples/subscriptions/package.json
+++ b/examples/subscriptions/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-query": "^5.97.0",
     "accounts": "latest",
     "hono": "^4.12.18",
-    "mppx": "^0.6.27",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "latest",

--- a/examples/transfers/package.json
+++ b/examples/transfers/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-query": "^5.97.0",
     "accounts": "latest",
     "hono": "^4.12.18",
-    "mppx": "^0.6.27",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "latest",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "hono": "^4.12.18",
     "idb-keyval": "^6.2.2",
     "mipd": "^0.0.7",
-    "mppx": "catalog:",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "ox": "~0.14.20",
     "webauthx": "~0.1.1",
     "zod": "^4.3.6",

--- a/playgrounds/wagmi/package.json
+++ b/playgrounds/wagmi/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "latest",
     "accounts": "workspace:*",
-    "mppx": "catalog:",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "viem": "catalog:",

--- a/playgrounds/web/package.json
+++ b/playgrounds/web/package.json
@@ -14,7 +14,7 @@
     "@privy-io/js-sdk-core": "^0.61.3",
     "@turnkey/core": "1.13.0",
     "accounts": "workspace:*",
-    "mppx": "catalog:",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "regen-ui": "^0.3.0",

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Credential } from 'mppx'
 import { tempo as mppx_tempo } from 'mppx/client'
 import { Hex, Json } from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
 import {
   type ComponentProps,
   type ReactNode,
@@ -10,10 +11,11 @@ import {
   useState,
 } from 'react'
 import { Button as RegenButton } from 'regen-ui'
-import { type Address, formatUnits, isAddress, parseUnits } from 'viem'
+import { type Address, createClient, custom, formatUnits, isAddress, parseUnits } from 'viem'
+import { generatePrivateKey } from 'viem/accounts'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
 import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
-import { Actions } from 'viem/tempo'
+import { Account, Actions } from 'viem/tempo'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/tempo/chains'
 
 import { PrivyEmailOtp } from './PrivyEmailOtp.js'
@@ -740,7 +742,7 @@ function WalletConnect(props: { adapterType: AdapterType }) {
   const [accessKeyEnabled, setAccessKeyEnabled] = useState(false)
   const [expiry, setExpiry] = useState('86400')
   const [limits, setLimits] = useState<LimitInput[]>([{ token: '', amount: '100', period: '' }])
-  const [scopeSelector, setScopeSelector] = useState('transfer(address,uint256)')
+  const [scopeSelector, setScopeSelector] = useState('')
   const [authEnabled, setAuthEnabled] = useState(false)
   const [showDepositEnabled, setShowDepositEnabled] = useState(false)
   const turnkey = adapterType === 'turnkey'
@@ -771,12 +773,15 @@ function WalletConnect(props: { adapterType: AdapterType }) {
     const name = turnkey ? undefined : (form.get('name') as string)
     const digest = form.get('digest') as Hex.Hex
     const method = (e.nativeEvent as SubmitEvent).submitter?.getAttribute('value')
+    const generated = accessKeyEnabled ? createPlaygroundSecp256k1AccessKey() : undefined
 
     const authorizeAccessKey = accessKeyEnabled
       ? (() => {
           const filledLimits = limits.filter((l) => l.token && l.amount)
           return {
             expiry: Math.floor(Date.now() / 1000) + Number(expiry || '86400'),
+            keyType: 'secp256k1',
+            publicKey: generated!.publicKey,
             ...(filledLimits.length > 0 && {
               limits: filledLimits.map((l) => ({
                 token: l.token,
@@ -813,8 +818,8 @@ function WalletConnect(props: { adapterType: AdapterType }) {
             ...(showDeposit ? { showDeposit } : {}),
           }
 
-    execute(() =>
-      provider.request({
+    execute(async () => {
+      const result = await provider.request({
         method: 'wallet_connect',
         params: [
           {
@@ -824,8 +829,17 @@ function WalletConnect(props: { adapterType: AdapterType }) {
             ),
           },
         ],
-      }),
-    )
+      })
+      const account = result.accounts[0]
+      const keyAuthorization = account?.capabilities?.keyAuthorization
+      if (generated && account && keyAuthorization)
+        savePlaygroundAccessKey({
+          keyAuthorization,
+          privateKey: generated.privateKey,
+          rootAddress: account.address,
+        })
+      return result
+    })
   }
 
   return (
@@ -1822,6 +1836,10 @@ const periodOptions = [
 const scopePresets = [
   { label: 'None', value: '' },
   { label: 'transfer(address,uint256)', value: 'transfer(address,uint256)' },
+  {
+    label: 'transferWithMemo(address,uint256,bytes32)',
+    value: 'transferWithMemo(address,uint256,bytes32)',
+  },
   { label: 'approve(address,uint256)', value: 'approve(address,uint256)' },
   {
     label: 'transferFrom(address,address,uint256)',
@@ -1836,6 +1854,43 @@ type TokenlistEntry = {
   logoURI?: string
   name: string
   symbol: string
+}
+
+function createPlaygroundSecp256k1AccessKey() {
+  const privateKey = generatePrivateKey()
+  const accessKey = Account.fromSecp256k1(privateKey)
+  return { privateKey, publicKey: accessKey.publicKey }
+}
+
+function savePlaygroundAccessKey(options: {
+  keyAuthorization: unknown
+  privateKey: Hex.Hex
+  rootAddress: Address
+}) {
+  const authorization = KeyAuthorization.fromRpc(options.keyAuthorization as never)
+  provider.store.setState((state) => ({
+    accessKeys: [
+      {
+        address: authorization.address,
+        access: options.rootAddress,
+        chainId: Number(authorization.chainId),
+        expiry: authorization.expiry ?? undefined,
+        keyAuthorization: authorization,
+        keyType: authorization.type,
+        limits: authorization.limits as never,
+        privateKey: options.privateKey,
+        scopes: authorization.scopes as never,
+      },
+      ...state.accessKeys.filter(
+        (key) =>
+          !(
+            key.access.toLowerCase() === options.rootAddress.toLowerCase() &&
+            key.address.toLowerCase() === authorization.address.toLowerCase() &&
+            key.chainId === Number(authorization.chainId)
+          ),
+      ),
+    ],
+  }))
 }
 
 type LimitInput = {
@@ -1906,8 +1961,11 @@ function WalletAuthorizeAccessKey() {
           const scopeSelector = form.get('scopeSelector') as string
 
           const filledLimits = limits.filter((l) => l.token && l.amount)
+          const generated = createPlaygroundSecp256k1AccessKey()
           const params: Record<string, unknown> = {}
           if (expiry) params.expiry = Math.floor(Date.now() / 1000) + Number(expiry)
+          params.keyType = 'secp256k1'
+          params.publicKey = generated.publicKey
           if (filledLimits.length > 0)
             params.limits = filledLimits.map((l) => ({
               token: l.token,
@@ -1917,12 +1975,18 @@ function WalletAuthorizeAccessKey() {
           if (scopeSelector && filledLimits[0])
             params.scopes = [{ address: filledLimits[0].token, selector: scopeSelector }]
 
-          execute(() =>
-            provider.request({
+          execute(async () => {
+            const result = await provider.request({
               method: 'wallet_authorizeAccessKey',
               ...(Object.keys(params).length > 0 ? { params: [params] } : {}),
-            } as never),
-          )
+            } as never)
+            savePlaygroundAccessKey({
+              keyAuthorization: result.keyAuthorization,
+              privateKey: generated.privateKey,
+              rootAddress: result.rootAddress,
+            })
+            return result
+          })
         }}
       >
         <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
@@ -1996,7 +2060,7 @@ function WalletAuthorizeAccessKey() {
 
         <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
           <label>Scope</label>
-          <select defaultValue="transfer(address,uint256)" name="scopeSelector" style={{ flex: 1 }}>
+          <select defaultValue="" name="scopeSelector" style={{ flex: 1 }}>
             {scopePresets.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
@@ -2440,7 +2504,12 @@ function createMppSessionManager() {
       return mppSessionFetch(input, init, trace)
     },
     getClient(options: { chainId?: number | undefined } = {}) {
-      const client = provider.getClient({ chainId: options.chainId })
+      const base = provider.getClient({ chainId: options.chainId })
+      const client = createClient({
+        chain: base.chain,
+        pollingInterval: base.pollingInterval,
+        transport: custom(provider),
+      })
       const account = provider.getAccount()
       return Object.assign(client, { account })
     },

--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { Credential } from 'mppx'
 import { tempo as mppx_tempo } from 'mppx/client'
 import { Hex, Json } from 'ox'
 import {
@@ -9,7 +10,7 @@ import {
   useState,
 } from 'react'
 import { Button as RegenButton } from 'regen-ui'
-import { formatUnits, parseUnits } from 'viem'
+import { type Address, formatUnits, isAddress, parseUnits } from 'viem'
 import { verifyMessage, verifyTypedData } from 'viem/actions'
 import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
@@ -1873,7 +1874,6 @@ function WalletAuthorizeAccessKey() {
   const [result, error, execute] = useRequest()
   const tokenlist = useTokenlist()
   const [limits, setLimits] = useState<LimitInput[]>([{ token: '', amount: '100', period: '' }])
-  const [showDepositEnabled, setShowDepositEnabled] = useState(false)
 
   // Once the tokenlist resolves, hydrate any unselected limit row with the first token.
   useEffect(() => {
@@ -1916,7 +1916,6 @@ function WalletAuthorizeAccessKey() {
             }))
           if (scopeSelector && filledLimits[0])
             params.scopes = [{ address: filledLimits[0].token, selector: scopeSelector }]
-          if (showDepositEnabled) params.showDeposit = true
 
           execute(() =>
             provider.request({
@@ -2005,18 +2004,6 @@ function WalletAuthorizeAccessKey() {
             ))}
           </select>
         </div>
-        <fieldset style={{ marginBottom: 8 }}>
-          <legend>
-            <label>
-              <input
-                checked={showDepositEnabled}
-                onChange={(e) => setShowDepositEnabled(e.target.checked)}
-                type="checkbox"
-              />{' '}
-              Show Deposit
-            </label>
-          </legend>
-        </fieldset>
         <Button type="submit">Authorize</Button>
       </form>
     </Method>
@@ -2074,11 +2061,26 @@ type MppScenarioResult = {
 }
 
 type MppSseEvent = { data: unknown; event: string }
+type MppTraceRow = {
+  action: string
+  channelId?: string | undefined
+  cumulative?: string | undefined
+  detail?: string | undefined
+  remaining?: string | undefined
+  spent?: string | undefined
+  step: string
+}
 type MppSessionState = {
   lastAction?: string | undefined
   remaining?: string | undefined
   spent?: string | undefined
   status: 'active' | 'closed' | 'idle' | 'open'
+}
+type MppAuthorizeSession = {
+  action: 'close' | 'voucher'
+  authorizedSigner: Address
+  channelId: Hex.Hex
+  cumulativeAmount: string
 }
 type MppSubscriptionState = {
   status: 'active' | 'canceled' | 'missing' | 'renewal due'
@@ -2098,6 +2100,7 @@ function MppPlayground(props: { adapterType: AdapterType; rerender: () => void }
 
   return (
     <>
+      <MppRpcAuthorize />
       <MppOneTimeCharges applyMode={applyMode} />
       <MppSessions adapterType={adapterType} mode={mode} />
       <MppSubscriptions />
@@ -2138,6 +2141,36 @@ function MppOneTimeCharges(props: { applyMode: (mode: MppMode) => Promise<void> 
   )
 }
 
+function MppRpcAuthorize() {
+  const request = useMppRequest()
+
+  async function run(label: string, fn: () => Promise<MppScenarioResult>) {
+    await request.execute(label, fn)
+  }
+
+  return (
+    <MppPanel
+      title="mpp_authorize (RPC)"
+      pending={request.pending}
+      result={request.result}
+      error={request.error}
+    >
+      <Button
+        disabled={request.pending}
+        onClick={() => run('RPC paid charge', () => runMppRpcCharge('RPC paid charge'))}
+      >
+        Paid Charge
+      </Button>
+      <Button
+        disabled={request.pending}
+        onClick={() => run('RPC stream session', () => runMppRpcSse('RPC stream session'))}
+      >
+        Stream Session
+      </Button>
+    </MppPanel>
+  )
+}
+
 function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
   const { adapterType, mode } = props
   const request = useMppRequest()
@@ -2160,6 +2193,13 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
     await request.execute('Reset local session', () => runMppLocalResult('Reset local session'))
   }
 
+  async function streamChunks() {
+    const next = createMppSessionManager()
+    setManager(next)
+    setSession({ status: 'idle' })
+    await run('Stream chunks', () => runMppManagedSse('Stream chunks', next), 'voucher')
+  }
+
   return (
     <MppPanel
       title="Sessions"
@@ -2174,8 +2214,11 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
           run(
             'Start session',
             () =>
-              runMppManagedRequest('Start session', '/mpp/session/content', () =>
-                manager.fetch('/mpp/session/content'),
+              runMppManagedRequest(
+                'Start session',
+                '/mpp/session/content',
+                () => manager.fetch('/mpp/session/content'),
+                manager.trace,
               ),
             'open',
           )
@@ -2189,8 +2232,11 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
           run(
             'Pay another',
             () =>
-              runMppManagedRequest('Pay another', '/mpp/session/content', () =>
-                manager.fetch('/mpp/session/content'),
+              runMppManagedRequest(
+                'Pay another',
+                '/mpp/session/content',
+                () => manager.fetch('/mpp/session/content'),
+                manager.trace,
               ),
             'voucher',
           )
@@ -2198,12 +2244,7 @@ function MppSessions(props: { adapterType: AdapterType; mode: MppMode }) {
       >
         Pay Another
       </Button>
-      <Button
-        disabled={request.pending || session.status === 'closed'}
-        onClick={() =>
-          run('Stream chunks', () => runMppManagedSse('Stream chunks', manager), 'voucher')
-        }
-      >
+      <Button disabled={request.pending || session.status === 'closed'} onClick={streamChunks}>
         Stream Chunks
       </Button>
       <Button
@@ -2334,10 +2375,57 @@ function MppPanel(props: {
       </header>
       <div className="method-body">{children}</div>
       {error && <pre className="method-error">{`${error.name}: ${error.message}`}</pre>}
+      {result && <MppPaymentTrace result={result} />}
       {display !== undefined && (
         <pre className="method-result">{Json.stringify(display, null, 2)}</pre>
       )}
     </article>
+  )
+}
+
+function MppPaymentTrace(props: { result: MppScenarioResult }) {
+  const rows = getMppTraceRows(props.result)
+  if (rows.length === 0) return null
+
+  return (
+    <div className="events-table-wrap">
+      <table className="events-table mpp-trace-table">
+        <thead>
+          <tr>
+            <th>Step</th>
+            <th>Event</th>
+            <th>Cumulative</th>
+            <th>Spent</th>
+            <th>Remaining</th>
+            <th>Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.step}>
+              <td>{row.step}</td>
+              <td>{row.action}</td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.cumulative)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.spent)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">{formatMppTraceAmount(row.remaining)}</code>
+              </td>
+              <td>
+                <code className="events-table-value">
+                  {[row.detail, row.channelId ? `channel ${shortMppHex(row.channelId)}` : undefined]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </code>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 
@@ -2346,7 +2434,11 @@ function MppSummary(props: { children: ReactNode }) {
 }
 
 function createMppSessionManager() {
-  return mppx_tempo.session({
+  const trace: MppSseEvent[] = []
+  const manager = mppx_tempo.session({
+    fetch(input, init) {
+      return mppSessionFetch(input, init, trace)
+    },
     getClient(options: { chainId?: number | undefined } = {}) {
       const client = provider.getClient({ chainId: options.chainId })
       const account = provider.getAccount()
@@ -2354,6 +2446,45 @@ function createMppSessionManager() {
     },
     maxDeposit: '0.05',
   })
+  return Object.assign(manager, { trace })
+}
+
+async function mppSessionFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit | undefined,
+  trace?: MppSseEvent[] | undefined,
+) {
+  const headers = new Headers(init?.headers)
+  const authorization = headers.get('Authorization')
+  const hasBody = init?.body !== undefined && init.body !== null
+  if (authorization)
+    trace?.push({
+      data: summarizeMppAuthorizationHeader(authorization),
+      event: 'payment-authorization',
+    })
+
+  // Cloudflare/Vite can expose an empty POST body as non-null, so use HEAD for
+  // voucher management calls that should not serve content. Close is already
+  // classified by credential action server-side, so keep it as POST.
+  if (init?.method === 'POST' && authorization && !hasBody) {
+    const summary = summarizeMppAuthorizationHeader(authorization)
+    if ('action' in summary && summary.action === 'close') return getRawFetch()(input, init)
+
+    const response = await getRawFetch()(input, {
+      ...init,
+      method: 'HEAD',
+    })
+    trace?.push({
+      data: {
+        receipt: decodePaymentReceipt(response.headers.get('Payment-Receipt')) ?? null,
+        status: response.status,
+      },
+      event: 'payment-management-response',
+    })
+    return response
+  }
+
+  return getRawFetch()(input, init)
 }
 
 async function runMppRequest(
@@ -2388,20 +2519,24 @@ async function runMppManagedRequest(
   label: string,
   path: string,
   fetcher: () => Promise<Response & { receipt?: unknown | null | undefined }>,
+  trace?: MppSseEvent[] | undefined,
 ): Promise<MppScenarioResult> {
+  const traceStart = trace?.length ?? 0
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
   const response = await fetcher()
   const elapsedMs = Math.round(performance.now() - started)
   const body = await readResponseBody(response)
+  const events = trace?.slice(traceStart)
   const receipt = response.receipt ?? decodePaymentReceipt(response.headers.get('Payment-Receipt'))
   const inspection = await readInspection(receipt)
   const balanceAfter = await getPathUsdBalance()
   return {
     balanceAfter,
     balanceBefore,
-    body,
+    body: events?.length ? { response: body, trace: events } : body,
     elapsedMs,
+    events: events?.length ? events : undefined,
     headers: readPaymentHeaders(response),
     inspection,
     label,
@@ -2418,6 +2553,7 @@ async function runMppManagedSse(
 ): Promise<MppScenarioResult> {
   const receipts: unknown[] = []
   const chunks: string[] = []
+  const traceStart = manager.trace.length
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
   const stream = await manager.sse('/mpp/session/stream', {
@@ -2429,14 +2565,16 @@ async function runMppManagedSse(
   for await (const chunk of stream) chunks.push(chunk)
 
   const elapsedMs = Math.round(performance.now() - started)
+  const trace = manager.trace.slice(traceStart)
   const receipt = receipts.at(-1)
   const inspection = await readInspection(receipt)
   return {
     balanceAfter: await getPathUsdBalance(),
     balanceBefore,
-    body: { chunks },
+    body: { chunks, trace },
     elapsedMs,
     events: [
+      ...trace,
       ...chunks.map((chunk) => ({ data: chunk, event: 'message' })),
       ...receipts.map((item) => ({ data: item, event: 'payment-receipt' })),
     ],
@@ -2450,20 +2588,201 @@ async function runMppManagedSse(
   }
 }
 
-async function runMppSessionClose(
-  label: string,
-  manager: ReturnType<typeof createMppSessionManager>,
-): Promise<MppScenarioResult> {
+async function runMppRpcCharge(label: string): Promise<MppScenarioResult> {
+  const path = '/mpp/charge/paid'
+  const rawFetch = getRawFetch()
   const balanceBefore = await getPathUsdBalance()
   const started = performance.now()
-  const receipt = await manager.close()
+  const probe = await rawFetch(path)
+  const challenge = await readMppChallenge(probe, path)
+  const authorization = await authorizeMpp(challenge)
+  const response = await rawFetch(path, {
+    headers: { Authorization: authorization },
+  })
   const elapsedMs = Math.round(performance.now() - started)
+  const body = await readResponseBody(response)
+  const receipt = decodePaymentReceipt(response.headers.get('Payment-Receipt'))
   const inspection = await readInspection(receipt)
   return {
     balanceAfter: await getPathUsdBalance(),
     balanceBefore,
-    body: receipt ? { closed: true } : { closed: false },
+    body: {
+      authorization: summarizeMppAuthorization(authorization),
+      response: body,
+    },
     elapsedMs,
+    headers: readPaymentHeaders(response),
+    inspection,
+    label,
+    ok: response.ok,
+    receipt,
+    status: response.status,
+    url: path,
+  }
+}
+
+async function runMppRpcSse(label: string): Promise<MppScenarioResult> {
+  const path = '/mpp/session/stream'
+  const rawFetch = getRawFetch()
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 45_000)
+  const events: MppSseEvent[] = []
+  const authorizations: unknown[] = []
+  const chunks: string[] = []
+
+  try {
+    const probe = await rawFetch(path, {
+      headers: { Accept: 'text/event-stream' },
+      signal: controller.signal,
+    })
+    const challenge = await readMppChallenge(probe, path)
+    const openAuthorization = await authorizeMpp(challenge)
+    const open = readMppOpenAuthorization(openAuthorization)
+    authorizations.push(open.summary)
+
+    const response = await rawFetch(path, {
+      headers: {
+        Accept: 'text/event-stream',
+        Authorization: openAuthorization,
+      },
+      signal: controller.signal,
+    })
+    if (!response.ok) throw await mppResponseError('Stream open failed', response)
+
+    let latestReceipt: unknown
+    let latestCumulative = open.cumulativeAmount
+
+    for await (const event of readMppSse(response)) {
+      events.push(event)
+
+      if (event.event === 'message') {
+        if (typeof event.data === 'string') chunks.push(event.data)
+        continue
+      }
+
+      if (event.event === 'payment-receipt') {
+        latestReceipt = event.data
+        const spent = readStringProperty(event.data, 'spent')
+        if (spent) latestCumulative = spent
+        continue
+      }
+
+      if (event.event !== 'payment-need-voucher') continue
+
+      const voucher = readMppNeedVoucher(event.data)
+      latestCumulative = voucher.requiredCumulative
+      const authorization = await authorizeMpp(challenge, {
+        action: 'voucher',
+        authorizedSigner: open.authorizedSigner,
+        channelId: voucher.channelId,
+        cumulativeAmount: voucher.requiredCumulative,
+      })
+      authorizations.push(summarizeMppAuthorization(authorization))
+      const voucherResponse = await rawFetch(path, {
+        method: 'HEAD',
+        headers: { Authorization: authorization },
+        signal: controller.signal,
+      })
+      const voucherReceipt = decodePaymentReceipt(voucherResponse.headers.get('Payment-Receipt'))
+      events.push({
+        data: {
+          receipt: voucherReceipt ?? null,
+          status: voucherResponse.status,
+        },
+        event: 'payment-voucher-response',
+      })
+      if (!voucherResponse.ok)
+        throw await mppResponseError('Voucher request failed', voucherResponse)
+    }
+
+    const closeAuthorization = await authorizeMpp(challenge, {
+      action: 'close',
+      authorizedSigner: open.authorizedSigner,
+      channelId: open.channelId,
+      cumulativeAmount: latestCumulative,
+    })
+    authorizations.push(summarizeMppAuthorization(closeAuthorization))
+    const closeResponse = await rawFetch(path, {
+      method: 'HEAD',
+      headers: { Authorization: closeAuthorization },
+      signal: controller.signal,
+    })
+    const closeReceipt = decodePaymentReceipt(closeResponse.headers.get('Payment-Receipt'))
+    events.push({
+      data: {
+        receipt: closeReceipt ?? null,
+        status: closeResponse.status,
+      },
+      event: 'payment-close-response',
+    })
+    if (!closeResponse.ok) throw await mppResponseError('Close request failed', closeResponse)
+
+    const elapsedMs = Math.round(performance.now() - started)
+    const receipt = closeReceipt ?? latestReceipt
+    const inspection = await readInspection(receipt)
+    return {
+      balanceAfter: await getPathUsdBalance(),
+      balanceBefore,
+      body: {
+        authorizations,
+        chunks,
+      },
+      elapsedMs,
+      events,
+      headers: readPaymentHeaders(response),
+      inspection,
+      label,
+      ok: true,
+      receipt,
+      status: response.status,
+      url: path,
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) throw error
+    return {
+      balanceAfter: await getPathUsdBalance(),
+      balanceBefore,
+      body: {
+        authorizations,
+        chunks,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      elapsedMs: Math.round(performance.now() - started),
+      events,
+      headers: {
+        'content-type': null,
+        'payment-receipt': null,
+        'www-authenticate': null,
+      },
+      label,
+      ok: false,
+      status: 499,
+      url: path,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function runMppSessionClose(
+  label: string,
+  manager: ReturnType<typeof createMppSessionManager>,
+): Promise<MppScenarioResult> {
+  const traceStart = manager.trace.length
+  const balanceBefore = await getPathUsdBalance()
+  const started = performance.now()
+  const receipt = await manager.close()
+  const elapsedMs = Math.round(performance.now() - started)
+  const trace = manager.trace.slice(traceStart)
+  const inspection = await readInspection(receipt)
+  return {
+    balanceAfter: await getPathUsdBalance(),
+    balanceBefore,
+    body: receipt ? { closed: true, trace } : { closed: false, trace },
+    elapsedMs,
+    events: trace.length ? trace : undefined,
     headers: {},
     inspection,
     label,
@@ -2522,6 +2841,166 @@ function readPaymentHeaders(response: Response) {
   }
 }
 
+async function mppResponseError(label: string, response: Response) {
+  const body = await readResponseBody(response).catch(() => null)
+  const challenge = response.headers.get('WWW-Authenticate')
+  return new Error(
+    `${label} with status ${response.status}.${body ? ` ${Json.stringify(body)}` : ''}${challenge ? ` WWW-Authenticate: ${challenge}` : ''}`,
+  )
+}
+
+async function readMppChallenge(response: Response, path: string) {
+  if (response.status !== 402) {
+    const body = await readResponseBody(response).catch(() => null)
+    throw new Error(
+      `Expected ${path} to return a payment challenge, received ${response.status}.${body ? ` ${Json.stringify(body)}` : ''}`,
+    )
+  }
+
+  const challenge = response.headers.get('WWW-Authenticate')
+  if (!challenge) throw new Error(`${path} did not return WWW-Authenticate.`)
+  return challenge
+}
+
+async function authorizeMpp(challenge: string, session?: MppAuthorizeSession | undefined) {
+  const result = await provider.request({
+    method: 'mpp_authorize',
+    params: [
+      {
+        challenges: [challenge],
+        ...(session ? { session } : {}),
+      },
+    ],
+  })
+  return result.authorization
+}
+
+async function* readMppSse(response: Response): AsyncGenerator<MppSseEvent> {
+  if (!response.body) throw new Error('Stream response has no body.')
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const parts = buffer.split('\n\n')
+      buffer = parts.pop()!
+
+      for (const part of parts) {
+        const event = parseMppSseEvent(part)
+        if (event) yield event
+      }
+    }
+
+    const tail = parseMppSseEvent(buffer)
+    if (tail) yield tail
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function parseMppSseEvent(raw: string): MppSseEvent | undefined {
+  if (!raw.trim()) return undefined
+
+  let event = 'message'
+  const data: string[] = []
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event: ')) event = line.slice(7).trim()
+    else if (line.startsWith('data: ')) data.push(line.slice(6))
+    else if (line === 'data:') data.push('')
+  }
+  if (data.length === 0) return undefined
+
+  const value = data.join('\n')
+  if (event.startsWith('payment-')) {
+    try {
+      return { data: JSON.parse(value), event }
+    } catch {
+      return { data: value, event }
+    }
+  }
+
+  return { data: value, event }
+}
+
+function readMppOpenAuthorization(authorization: string) {
+  const summary = summarizeMppAuthorization(authorization)
+  if (summary.action !== 'open') throw new Error('Expected an open session credential.')
+  if (!summary.authorizedSigner)
+    throw new Error('Open session credential missing authorizedSigner.')
+  if (!summary.channelId) throw new Error('Open session credential missing channelId.')
+  if (!summary.cumulativeAmount)
+    throw new Error('Open session credential missing cumulativeAmount.')
+
+  return {
+    authorizedSigner: asAddress(summary.authorizedSigner, 'authorizedSigner'),
+    channelId: asHex(summary.channelId, 'channelId'),
+    cumulativeAmount: summary.cumulativeAmount,
+    summary,
+  }
+}
+
+function summarizeMppAuthorization(authorization: string) {
+  const credential = Credential.deserialize(authorization)
+  const payload = isRecord(credential.payload) ? credential.payload : {}
+  return {
+    action: stringValue(payload.action),
+    authorizedSigner: stringValue(payload.authorizedSigner),
+    channelId: stringValue(payload.channelId),
+    cumulativeAmount: stringValue(payload.cumulativeAmount),
+    type: stringValue(payload.type) ?? (payload.action ? 'voucher' : undefined),
+  }
+}
+
+function summarizeMppAuthorizationHeader(authorization: string) {
+  try {
+    return summarizeMppAuthorization(authorization)
+  } catch {
+    return { raw: authorization }
+  }
+}
+
+function readMppNeedVoucher(value: unknown) {
+  const channelId = readStringProperty(value, 'channelId')
+  const requiredCumulative = readStringProperty(value, 'requiredCumulative')
+  if (!channelId) throw new Error('payment-need-voucher missing channelId.')
+  if (!requiredCumulative) throw new Error('payment-need-voucher missing requiredCumulative.')
+  return {
+    channelId: asHex(channelId, 'channelId'),
+    requiredCumulative,
+  }
+}
+
+function readStringProperty(value: unknown, key: string) {
+  if (!isRecord(value)) return undefined
+  return stringValue(value[key])
+}
+
+function asAddress(value: string, label: string): Address {
+  if (!isAddress(value)) throw new Error(`${label} is not an address.`)
+  return value
+}
+
+function asHex(value: string, label: string): Hex.Hex {
+  if (!Hex.validate(value)) throw new Error(`${label} is not hex.`)
+  return value as Hex.Hex
+}
+
+function getRawFetch() {
+  const mppxFetchWrapper = Symbol.for('mppx.fetch.wrapper')
+  let current = globalThis.fetch as typeof globalThis.fetch &
+    Record<symbol, typeof globalThis.fetch | undefined>
+  while (current[mppxFetchWrapper])
+    current = current[mppxFetchWrapper] as typeof globalThis.fetch &
+      Record<symbol, typeof globalThis.fetch | undefined>
+  return current
+}
+
 function summarizeMppResult(result: MppScenarioResult) {
   return {
     balance: {
@@ -2542,6 +3021,163 @@ function summarizeMppResult(result: MppScenarioResult) {
     status: result.status,
     url: result.url,
   }
+}
+
+function getMppTraceRows(result: MppScenarioResult) {
+  const rows: MppTraceRow[] = []
+  let receiptSeen = false
+
+  function push(row: Omit<MppTraceRow, 'step'>) {
+    rows.push({ ...row, step: String(rows.length + 1) })
+  }
+
+  function pushAuthorization(value: unknown) {
+    if (!isRecord(value)) return
+    const action = readStringProperty(value, 'action') ?? readStringProperty(value, 'type')
+    const raw = readStringProperty(value, 'raw')
+    push({
+      action: `authorize ${action ?? 'payment'}`,
+      channelId: readStringProperty(value, 'channelId'),
+      cumulative: readStringProperty(value, 'cumulativeAmount'),
+      detail: raw ? 'unreadable credential' : readStringProperty(value, 'type'),
+    })
+  }
+
+  function pushReceipt(action: string, value: unknown, detail?: string | undefined) {
+    const receipt = readMppTraceReceipt(value)
+    if (!receipt) return false
+    const cumulative = readStringProperty(receipt, 'acceptedCumulative')
+    const spent = readStringProperty(receipt, 'spent')
+    receiptSeen = true
+    push({
+      action,
+      channelId: readMppTraceReference(receipt),
+      cumulative,
+      detail,
+      remaining: subtractMppAmounts(cumulative, spent),
+      spent,
+    })
+    return true
+  }
+
+  const events = result.events ?? []
+  const eventHasAuthorization = events.some((event) => event.event === 'payment-authorization')
+  const authorizations =
+    isRecord(result.body) && Array.isArray(result.body.authorizations)
+      ? result.body.authorizations
+      : []
+  let authorizationIndex = 0
+
+  if (isRecord(result.body)) {
+    const authorization = result.body.authorization
+    if (authorization) pushAuthorization(authorization)
+  }
+
+  if (authorizations.length > 0) {
+    if (events.length === 0 || eventHasAuthorization)
+      for (const item of authorizations) pushAuthorization(item)
+    else pushAuthorization(authorizations[authorizationIndex++])
+  }
+
+  for (const event of events) {
+    if (event.event === 'message') {
+      push({
+        action: 'chunk',
+        detail: typeof event.data === 'string' ? event.data : formatEventValue(event.data),
+      })
+      continue
+    }
+
+    if (event.event === 'payment-authorization') {
+      pushAuthorization(event.data)
+      continue
+    }
+
+    if (event.event === 'payment-need-voucher') {
+      const cumulative = readStringProperty(event.data, 'requiredCumulative')
+      const spent = readStringProperty(event.data, 'spent')
+      const accepted = readStringProperty(event.data, 'acceptedCumulative')
+      push({
+        action: 'need voucher',
+        channelId: readStringProperty(event.data, 'channelId'),
+        cumulative,
+        detail: accepted ? `accepted ${formatMppAmount(accepted)}` : undefined,
+        remaining: subtractMppAmounts(cumulative, spent),
+        spent,
+      })
+      if (!eventHasAuthorization && authorizationIndex < authorizations.length)
+        pushAuthorization(authorizations[authorizationIndex++])
+      continue
+    }
+
+    if (event.event === 'payment-voucher-response') {
+      if (!pushReceipt('voucher accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'voucher accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-close-response') {
+      if (!eventHasAuthorization && authorizationIndex < authorizations.length)
+        pushAuthorization(authorizations[authorizationIndex++])
+      if (!pushReceipt('close accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'close accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-management-response') {
+      if (!pushReceipt('management accepted', event.data, readMppTraceStatus(event.data)))
+        push({ action: 'management accepted', detail: readMppTraceStatus(event.data) })
+      continue
+    }
+
+    if (event.event === 'payment-receipt') {
+      pushReceipt('receipt', event.data)
+      continue
+    }
+
+    if (event.event.startsWith('payment-')) {
+      push({
+        action: event.event.replace(/^payment-/, ''),
+        detail: formatEventValue(event.data),
+      })
+    }
+  }
+
+  while (!eventHasAuthorization && authorizationIndex < authorizations.length)
+    pushAuthorization(authorizations[authorizationIndex++])
+
+  if (result.receipt && !receiptSeen) pushReceipt('receipt', result.receipt, 'response receipt')
+  return rows
+}
+
+function readMppTraceReceipt(value: unknown) {
+  if (!isRecord(value)) return undefined
+  if ('receipt' in value) return isRecord(value.receipt) ? value.receipt : undefined
+  return value
+}
+
+function readMppTraceReference(value: Record<string, unknown>) {
+  return (
+    readStringProperty(value, 'channelId') ??
+    readStringProperty(value, 'reference') ??
+    readStringProperty(value, 'subscriptionId')
+  )
+}
+
+function readMppTraceStatus(value: unknown) {
+  if (!isRecord(value)) return undefined
+  const status = value.status
+  if (typeof status !== 'number' && typeof status !== 'string') return undefined
+  return `status ${status}`
+}
+
+function formatMppTraceAmount(value: string | undefined) {
+  if (!value) return ''
+  return formatMppAmount(value)
+}
+
+function shortMppHex(value: string) {
+  return value.length > 18 ? `${value.slice(0, 10)}...${value.slice(-6)}` : value
 }
 
 function readMppSessionState(result: MppScenarioResult, actionFallback?: string | undefined) {

--- a/playgrounds/web/src/index.css
+++ b/playgrounds/web/src/index.css
@@ -425,6 +425,19 @@ html {
   width: 100%;
 }
 
+.mpp-trace-table {
+  min-width: 760px;
+}
+
+.mpp-trace-table th {
+  text-align: left;
+}
+
+.mpp-trace-table th,
+.mpp-trace-table td {
+  vertical-align: top;
+}
+
 .events-table th,
 .events-table td {
   font-size: 13px;

--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -9,6 +9,7 @@ import {
   local,
   privy,
   Provider,
+  Storage,
   turnkey,
   webAuthn,
 } from 'accounts'
@@ -75,10 +76,14 @@ export const host =
 export let dialogMode: DialogMode = 'iframe'
 export let mppMode: MppMode = 'push'
 export let theme: DialogNs.Theme | undefined
+const mppxFetchWrapper = Symbol.for('mppx.fetch.wrapper')
+restoreMppx()
 export let provider: ProviderValue = createProvider('tempoWallet')
 let turnkeyClient: TurnkeyClient | undefined
 let privyClient: Privy | undefined
 let privyIframeReady: Promise<void> | undefined
+let secp256k1Account: ReturnType<typeof Account.fromSecp256k1> | undefined
+type ProviderState = ReturnType<ProviderValue['store']['getState']>
 
 function mpp() {
   return {
@@ -158,37 +163,56 @@ export function createProvider(adapterType: AdapterType): ProviderValue {
     })
   }
 
-  const privateKey = generatePrivateKey()
-  const account = Account.fromSecp256k1(privateKey)
+  const account = getSecp256k1Account()
   return Provider.create({
     adapter: local({
       loadAccounts: async () => ({ accounts: [account] }),
       createAccount: async () => {
         const key = generatePrivateKey()
         const newAccount = Account.fromSecp256k1(key)
+        secp256k1Account = newAccount
         return { accounts: [newAccount] }
       },
     }),
     mpp: mpp(),
+    storage: Storage.memory(),
     testnet,
   })
 }
 
+function getSecp256k1Account() {
+  secp256k1Account ??= Account.fromSecp256k1(generatePrivateKey())
+  return secp256k1Account
+}
+
 export function switchAdapter(adapterType: AdapterType) {
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
 }
 
 export function switchDialogMode(mode: DialogMode, adapterType: AdapterType = 'tempoWallet') {
   dialogMode = mode
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
 }
 
 export function switchMppMode(mode: MppMode, adapterType: AdapterType = 'tempoWallet') {
+  const state = provider.store.getState()
   mppMode = mode
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
+  restoreProviderState(state)
+}
+
+function restoreProviderState(state: ProviderState) {
+  provider.store.setState({
+    accessKeys: state.accessKeys,
+    accounts: state.accounts,
+    activeAccount: state.activeAccount,
+    ...(state.auth ? { auth: state.auth } : {}),
+    chainId: state.chainId,
+    requestQueue: [],
+  })
 }
 
 function getTurnkeyAdapterClient() {
@@ -262,6 +286,16 @@ export function switchTheme(
   adapterType: AdapterType = 'tempoWallet',
 ) {
   theme = next
-  Mppx.restore()
+  restoreMppx()
   provider = createProvider(adapterType)
+}
+
+function restoreMppx() {
+  Mppx.restore()
+  let current = globalThis.fetch as typeof globalThis.fetch &
+    Record<symbol, typeof globalThis.fetch | undefined>
+  while (current[mppxFetchWrapper])
+    current = current[mppxFetchWrapper] as typeof globalThis.fetch &
+      Record<symbol, typeof globalThis.fetch | undefined>
+  globalThis.fetch = current
 }

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -24,13 +24,11 @@ const payment = Mppx.create({
     tempo.charge({
       account,
       currency: pathUsd,
-      feePayer: true,
       testnet,
     }),
     tempo.session({
       account,
       currency: pathUsd,
-      feePayer: true,
       sse: { poll: true },
       store,
       suggestedDeposit: '0.03',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^5.2.0
       version: 5.2.0
-    mppx:
-      specifier: ^0.6.27
-      version: 0.6.27
     prool:
       specifier: ~0.2.4
       version: 0.2.4
@@ -98,8 +95,8 @@ importers:
         specifier: ^0.0.7
         version: 0.0.7(typescript@5.9.3)
       mppx:
-        specifier: 'catalog:'
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.3.6))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.3.6))
       ox:
         specifier: 0.14.25
         version: 0.14.25(typescript@5.9.3)(zod@4.3.6)
@@ -560,8 +557,8 @@ importers:
         specifier: ^4.12.18
         version: 4.12.18
       mppx:
-        specifier: ^0.6.27
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -612,8 +609,8 @@ importers:
         specifier: ^4.12.18
         version: 4.12.18
       mppx:
-        specifier: ^0.6.27
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -704,8 +701,8 @@ importers:
         specifier: ^4.12.18
         version: 4.12.18
       mppx:
-        specifier: ^0.6.27
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -857,8 +854,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       mppx:
-        specifier: 'catalog:'
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -909,8 +906,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       mppx:
-        specifier: 'catalog:'
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1074,8 +1071,8 @@ importers:
         specifier: ^11.14.1
         version: 11.15.0
       mppx:
-        specifier: 'catalog:'
-        version: 0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
+        specifier: file:/Users/tony/.codex/worktrees/a4fb/mppx
+        version: file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3))
       ox:
         specifier: 0.14.25
         version: 0.14.25(typescript@5.9.3)(zod@4.4.3)
@@ -7812,8 +7809,8 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.6.27:
-    resolution: {integrity: sha512-7KxM+Uau7dDcOBI9RjJYSLcDlF7glAC09eX6h64AopmQ9zZXN5gicSg7Ty8hmutXkUglEFPG/8YfWXGK4CQXSw==}
+  mppx@file:../../../.codex/worktrees/a4fb/mppx:
+    resolution: {directory: ../../../.codex/worktrees/a4fb/mppx, type: directory}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -18855,7 +18852,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.3.6)):
+  mppx@file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       incur: 0.4.6
       ox: 0.14.25(typescript@5.9.3)(zod@4.4.3)
@@ -18869,7 +18866,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3)):
+  mppx@file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.6
       ox: 0.14.25(typescript@5.9.3)(zod@4.4.3)
@@ -18883,7 +18880,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.6.27(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3)):
+  mppx@file:../../../.codex/worktrees/a4fb/mppx(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.23)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.6
       ox: 0.14.25(typescript@5.9.3)(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,6 @@ catalog:
   '@vitejs/plugin-react': ^5.2.0
   '@wagmi/core': ^3.4.12
   hono: ^4.12.18
-  mppx: ^0.6.27
   ox: 0.14.25
   prool: ~0.2.4
   react: ^19.2.5

--- a/site/package.json
+++ b/site/package.json
@@ -18,7 +18,7 @@
     "animejs": "^4.4.1",
     "cuer": "^0.0.3",
     "mermaid": "^11.14.0",
-    "mppx": "catalog:",
+    "mppx": "file:/Users/tony/.codex/worktrees/a4fb/mppx",
     "ox": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -4,7 +4,7 @@ import { BaseError, encodeErrorResult, encodeFunctionResult } from 'viem'
 import { Abis, Account as TempoAccount } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
-import { accounts } from '../../test/config.js'
+import { accounts, privateKeys } from '../../test/config.js'
 import * as AccessKey from './AccessKey.js'
 import * as AccessKeyTransaction from './internal/AccessKeyTransaction.js'
 import * as Store from './Store.js'
@@ -20,6 +20,7 @@ function createKeyAuthorization(
   options: {
     chainId?: bigint | undefined
     expiry?: number | undefined
+    keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
     limits?: { token: `0x${string}`; limit: bigint }[] | undefined
     scopes?: KeyAuthorization.Scope[] | undefined
   } = {},
@@ -31,7 +32,7 @@ function createKeyAuthorization(
       expiry: options.expiry,
       limits: options.limits,
       scopes: options.scopes,
-      type: 'p256',
+      type: options.keyType ?? 'p256',
     },
     { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
   )
@@ -552,6 +553,76 @@ describe('select', () => {
         "miss": false,
       }
     `)
+  })
+
+  test('behavior: selects a secp256k1 access key without transaction calls', async () => {
+    const store = createStore()
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accounts[1]!.address, {
+        keyType: 'secp256k1',
+      }),
+      privateKey: privateKeys[1],
+      store,
+    })
+
+    const result = await AccessKey.select({
+      account: rootAddress,
+      calls: [],
+      chainId: 1,
+      keyType: 'secp256k1',
+      store,
+    })
+
+    expect(result?.accessKeyAddress).toMatchInlineSnapshot(
+      `"0x8c8d35429f74ec245f8ef2f4fd1e551cff97d650"`,
+    )
+  })
+
+  test('behavior: skips p256 access keys when secp256k1 is required', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      store,
+    })
+
+    const result = await AccessKey.select({
+      account: rootAddress,
+      calls: [],
+      chainId: 1,
+      keyType: 'secp256k1',
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
+describe('get', () => {
+  test('behavior: skips exact access key with wrong key type', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      store,
+    })
+
+    const result = await AccessKey.get({
+      accessKey: accessKey.accessKeyAddress,
+      account: rootAddress,
+      chainId: 1,
+      keyType: 'secp256k1',
+      store,
+    })
+
+    expect(result).toMatchInlineSnapshot(`undefined`)
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -312,6 +312,36 @@ export async function select(
   }
 }
 
+/** Returns a locally-signable access key account by exact address. */
+export async function get(options: get.Options): Promise<get.ReturnType> {
+  const { accessKey, account, chainId, store } = options
+  const now = options.now ?? Date.now() / 1000
+  const record = list({ account, accessKey, chainId, store })[0]
+  if (!record) return undefined
+  if (isExpired(record.expiry, now)) {
+    remove({ accessKey: record.address, account: record.access, chainId: record.chainId, store })
+    return undefined
+  }
+  return hydrate(record, store)
+}
+
+export declare namespace get {
+  type Options = {
+    /** Root account address. */
+    account: Address.Address
+    /** Specific access key address to match. */
+    accessKey: Address.Address
+    /** Chain ID the access key must be authorized on. */
+    chainId: number
+    /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
+    now?: number | undefined
+    /** Reactive state store. */
+    store: Store.Store
+  }
+
+  type ReturnType = TempoAccount.AccessKeyAccount | undefined
+}
+
 function createKeyAuthorizationManager(store: Store.Store): KeyAuthorizationManager {
   return TempoKeyAuthorizationManager.from({
     source: {

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -96,6 +96,8 @@ type SelectQuery = {
   calls?: readonly Call[] | undefined
   /** Chain ID the access key must be authorized on. */
   chainId: number
+  /** Key type the access key must use. */
+  keyType?: AccessKey['keyType'] | undefined
   /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
   now?: number | undefined
   /** Reactive state store. */
@@ -128,7 +130,7 @@ type ManagedAccount = TempoAccount.AccessKeyAccount
 
 type KeyAuthorizationManager = TempoKeyAuthorizationManager.KeyAuthorizationManager
 
-/** Generates a P256 key pair and access key account. */
+/** Generates local key material and an access key account. */
 export async function generate(options: generate.Options = {}): Promise<generate.ReturnType> {
   const { account } = options
   const keyPair = await WebCryptoP256.createKeyPair()
@@ -294,11 +296,12 @@ export async function getStatus(options: StatusQuery): Promise<Status> {
 export async function select(
   options: SelectQuery,
 ): Promise<TempoAccount.AccessKeyAccount | undefined> {
-  const { account, calls, chainId, store } = options
+  const { account, calls, chainId, keyType, store } = options
   const now = options.now ?? Date.now() / 1000
   const records = list({ account, chainId, store })
 
   for (const record of records) {
+    if (keyType && record.keyType !== keyType) continue
     if (!scopesMatch(record, { calls })) continue
     if (isExpired(record.expiry, now)) {
       remove({ accessKey: record.address, account: record.access, chainId: record.chainId, store })
@@ -314,10 +317,11 @@ export async function select(
 
 /** Returns a locally-signable access key account by exact address. */
 export async function get(options: get.Options): Promise<get.ReturnType> {
-  const { accessKey, account, chainId, store } = options
+  const { accessKey, account, chainId, keyType, store } = options
   const now = options.now ?? Date.now() / 1000
   const record = list({ account, accessKey, chainId, store })[0]
   if (!record) return undefined
+  if (keyType && record.keyType !== keyType) return undefined
   if (isExpired(record.expiry, now)) {
     remove({ accessKey: record.address, account: record.access, chainId: record.chainId, store })
     return undefined
@@ -333,6 +337,8 @@ export declare namespace get {
     accessKey: Address.Address
     /** Chain ID the access key must be authorized on. */
     chainId: number
+    /** Key type the access key must use. */
+    keyType?: AccessKey['keyType'] | undefined
     /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
     now?: number | undefined
     /** Reactive state store. */

--- a/src/core/Account.test.ts
+++ b/src/core/Account.test.ts
@@ -1,8 +1,10 @@
-import { WebCryptoP256 } from 'viem/tempo'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { Account as TempoAccount, WebCryptoP256 } from 'viem/tempo'
 import { tempoLocalnet } from 'viem/tempo/chains'
 import { describe, expect, test } from 'vp/test'
 
 import { accounts, privateKeys } from '../../test/config.js'
+import * as AccessKey from './AccessKey.js'
 import * as Account from './Account.js'
 import * as Store from './Store.js'
 
@@ -169,5 +171,130 @@ describe('find', () => {
     expect(() => Account.find({ store })).toThrowErrorMatchingInlineSnapshot(
       `[Provider.DisconnectedError: No active account.]`,
     )
+  })
+})
+
+describe('createSignerResolver', () => {
+  function setup(storeAccounts: readonly Account.Store[] = []) {
+    const store = Store.create({ chainId: tempoLocalnet.id })
+    store.setState({ accounts: storeAccounts, activeAccount: 0 })
+    const resolveSigner = Account.createSignerResolver({
+      getFallbackAccount: (options = {}) =>
+        Account.find({ address: options.address, signable: true, store }),
+      store,
+    })
+    return { resolveSigner, store }
+  }
+
+  function createKeyAuthorization(address: `0x${string}`) {
+    return KeyAuthorization.from(
+      {
+        address,
+        chainId: BigInt(tempoLocalnet.id),
+        scopes: [
+          {
+            address: accounts[1].address,
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+        type: 'p256',
+      },
+      { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
+    )
+  }
+
+  test('default: falls back to the adapter root account', async () => {
+    const { resolveSigner } = setup([
+      { address: accounts[0].address, keyType: 'secp256k1', privateKey: privateKeys[0] },
+    ])
+
+    const result = await resolveSigner()
+
+    expect(result.address).toMatchInlineSnapshot(`"${accounts[0].address}"`)
+    expect('type' in result ? result.type : undefined).toMatchInlineSnapshot(`"local"`)
+  })
+
+  test('behavior: fallback can be a JSON-RPC root account', async () => {
+    const store = Store.create({ chainId: tempoLocalnet.id })
+    store.setState({ accounts: [{ address: accounts[0].address }], activeAccount: 0 })
+    const resolveSigner = Account.createSignerResolver({
+      getFallbackAccount: (options = {}) => Account.find({ address: options.address, store }),
+      store,
+    })
+
+    const result = await resolveSigner({
+      chainId: tempoLocalnet.id,
+      requiredSigner: accounts[1].address,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "address": "${accounts[0].address}",
+        "type": "json-rpc",
+      }
+    `)
+  })
+
+  test('behavior: resolves an exact access key signer without transaction calls', async () => {
+    const { resolveSigner, store } = setup([
+      { address: accounts[0].address, keyType: 'secp256k1', privateKey: privateKeys[0] },
+    ])
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: accounts[0].address })
+    AccessKey.add({
+      account: accounts[0].address,
+      authorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      store,
+    })
+
+    const result = await resolveSigner({
+      chainId: tempoLocalnet.id,
+      requiredSigner: accessKey.accessKeyAddress,
+    })
+
+    expect(result.address).toMatchInlineSnapshot(`"${accounts[0].address}"`)
+    expect(
+      'accessKeyAddress' in result ? result.accessKeyAddress : undefined,
+    ).toMatchInlineSnapshot(`"${accessKey.accessKeyAddress}"`)
+  })
+
+  test('behavior: falls through to scoped access key when exact signer is unavailable', async () => {
+    const { resolveSigner, store } = setup([
+      { address: accounts[0].address, keyType: 'secp256k1', privateKey: privateKeys[0] },
+    ])
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: accounts[0].address })
+    AccessKey.add({
+      account: accounts[0].address,
+      authorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      store,
+    })
+
+    const result = await resolveSigner({
+      calls: [{ to: accounts[1].address, data: '0xa9059cbb' }],
+      chainId: tempoLocalnet.id,
+      requiredSigner: accounts[2].address,
+    })
+
+    expect(result.address).toMatchInlineSnapshot(`"${accounts[0].address}"`)
+    expect(
+      'accessKeyAddress' in result ? result.accessKeyAddress : undefined,
+    ).toMatchInlineSnapshot(`"${accessKey.accessKeyAddress}"`)
+  })
+
+  test('behavior: falls back to root when exact signer is unavailable and no scoped key matches', async () => {
+    const { resolveSigner } = setup([
+      { address: accounts[0].address, keyType: 'secp256k1', privateKey: privateKeys[0] },
+    ])
+
+    const result = await resolveSigner({
+      chainId: tempoLocalnet.id,
+      requiredSigner: accounts[1].address,
+    })
+
+    expect(result.address).toMatchInlineSnapshot(`"${accounts[0].address}"`)
+    expect('type' in result ? result.type : undefined).toMatchInlineSnapshot(`"local"`)
   })
 })

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -136,6 +136,7 @@ export function createSignerResolver(
         account: account.address,
         accessKey: options.requiredSigner,
         chainId,
+        keyType: options.keyType,
         store,
       })
       if (accessKey) return accessKey
@@ -146,6 +147,7 @@ export function createSignerResolver(
         account: account.address,
         calls: options.calls,
         chainId,
+        keyType: options.keyType,
         store,
       })
       if (accessKey) return accessKey
@@ -190,6 +192,8 @@ export declare namespace resolveSigner {
     calls?: readonly { to?: Address | undefined; data?: Hex | undefined }[] | undefined
     /** Chain ID used when selecting chain-scoped access keys. Defaults to the active chain. */
     chainId?: number | undefined
+    /** Key type used when selecting access keys. */
+    keyType?: AccessKey.AccessKey['keyType'] | undefined
     /** Exact signer required by the action. */
     requiredSigner?: Address | undefined
   }

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -4,6 +4,7 @@ import type { Address, JsonRpcAccount } from 'viem/accounts'
 import { Account as TempoAccount } from 'viem/tempo'
 
 import type { OneOf } from '../internal/types.js'
+import * as AccessKey from './AccessKey.js'
 import type * as core_Store from './Store.js'
 
 /** Account stored in the provider state. */
@@ -113,4 +114,85 @@ export declare namespace hydrate {
     /** Whether to hydrate signing capability. @default false */
     signable?: boolean | undefined
   }
+}
+
+/** Creates a resolver for the signer available for a shared provider action. */
+export function createSignerResolver(
+  options: createSignerResolver.Options,
+): createSignerResolver.ReturnType {
+  const { getFallbackAccount, store } = options
+  return async function resolveSigner(options = {}) {
+    const state = store.getState()
+    const account = find({
+      address: options.address,
+      store,
+    })
+    const chainId = options.chainId ?? state.chainId
+
+    if (options.requiredSigner) {
+      if (account.address.toLowerCase() === options.requiredSigner.toLowerCase())
+        return await getFallbackAccount({ address: account.address })
+      const accessKey = await AccessKey.get({
+        account: account.address,
+        accessKey: options.requiredSigner,
+        chainId,
+        store,
+      })
+      if (accessKey) return accessKey
+    }
+
+    if (options.calls) {
+      const accessKey = await AccessKey.select({
+        account: account.address,
+        calls: options.calls,
+        chainId,
+        store,
+      })
+      if (accessKey) return accessKey
+    }
+
+    return await getFallbackAccount({ address: account.address })
+  }
+}
+
+export declare namespace createSignerResolver {
+  type Options = {
+    /** Returns the fallback account when no local access key should sign. */
+    getFallbackAccount: (
+      options?: getFallbackAccount.Options | undefined,
+    ) => getFallbackAccount.ReturnType
+    /** Reactive state store. */
+    store: core_Store.Store
+  }
+
+  type ReturnType = (
+    options?: resolveSigner.Options | undefined,
+  ) => Promise<resolveSigner.ReturnType>
+}
+
+export declare namespace getFallbackAccount {
+  type Options = {
+    /** Root account address. Defaults to the active account. */
+    address?: Address | undefined
+  }
+
+  type ReturnType =
+    | TempoAccount.Account
+    | JsonRpcAccount
+    | Promise<TempoAccount.Account | JsonRpcAccount>
+}
+
+export declare namespace resolveSigner {
+  type Options = {
+    /** Root account address. Defaults to the active account. */
+    address?: Address | undefined
+    /** Calls used to select an access key when one can satisfy the action. */
+    calls?: readonly { to?: Address | undefined; data?: Hex | undefined }[] | undefined
+    /** Chain ID used when selecting chain-scoped access keys. Defaults to the active chain. */
+    chainId?: number | undefined
+    /** Exact signer required by the action. */
+    requiredSigner?: Address | undefined
+  }
+
+  type ReturnType = TempoAccount.Account | TempoAccount.AccessKeyAccount | JsonRpcAccount
 }

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -48,6 +48,10 @@ describe('request', () => {
     expectTypeOf<Result<'wallet_disconnect'>>().toEqualTypeOf<undefined>()
   })
 
+  test('mpp_authorize', () => {
+    expectTypeOf<Result<'mpp_authorize'>>().toEqualTypeOf<{ authorization: string }>()
+  })
+
   test('wallet_swap', () => {
     expectTypeOf<Result<'wallet_swap'>>().toMatchTypeOf<{
       receipt: { transactionHash: `0x${string}` }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,9 +1,10 @@
 import { announceProvider } from 'mipd'
 import { Challenge } from 'mppx'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
+import { Charge as MppCharge, Session as MppSession } from 'mppx/tempo'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
-import type { JsonRpcAccount } from 'viem/accounts'
+import type { Account as ViemAccount, JsonRpcAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
 import { Actions } from 'viem/tempo'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/tempo/chains'
@@ -208,20 +209,15 @@ export function create(options: create.Options = {}): create.ReturnType {
       })
 
     const chainId = getMppChainId(challenge) ?? store.getState().chainId
-    const account = await resolveSigner({
-      chainId,
-      ...(session ? { requiredSigner: session.authorizedSigner } : {}),
-    })
-    const client = Object.assign(
+    const account = getAccount()
+    const client = getMppSigningClient(
       Client.fromChainId(chainId, {
         chains,
         provider: providerRef,
         store,
         transports,
       }),
-      { account },
     )
-    const client_mpp = getMppSigningClient(client)
     const {
       mode = 'push',
       polyfill: _polyfill,
@@ -230,24 +226,78 @@ export function create(options: create.Options = {}): create.ReturnType {
 
     switch (challenge.intent) {
       case 'charge': {
-        const method = mppx_tempo.charge({
-          ...methodOptions,
-          account,
-          getClient: () => client_mpp,
-          mode,
+        const filled = await MppCharge.fill(client, {
+          autoSwap: methodOptions.autoSwap,
+          challenge: challenge as MppCharge.ChargeChallenge,
+          clientId: methodOptions.clientId,
+          expectedRecipients: methodOptions.expectedRecipients,
+          payer: account.address,
         })
-        return await method.createCredential({ challenge: challenge as never, context: {} })
+        const signer = await resolveSigner({
+          chainId: filled.chainId,
+          // Proof credentials have no transaction calls, but should still use a locally
+          // authorized access key when one is available.
+          calls: filled.kind === 'calls' ? filled.calls : [],
+        })
+        return await MppCharge.createCredential(client, { filled, mode, signer })
       }
       case 'session': {
-        const method = mppx_tempo({
-          ...methodOptions,
-          account,
-          getClient: () => client_mpp,
-        })[1]
-        return await method.createCredential({
-          challenge: challenge as never,
-          context: session ? (toMppSessionContext({ account, session }) as never) : {},
+        const challenge_session = challenge as MppSession.SessionChallenge
+        if (!session) {
+          let signer = await resolveSigner({ chainId, keyType: 'secp256k1' })
+          let filled = await fillMppSessionOpen({
+            account,
+            challenge: challenge_session,
+            client,
+            options: methodOptions,
+            signer,
+          })
+          const signer_open = await resolveSigner({
+            calls: filled.calls,
+            chainId: filled.chainId,
+            keyType: 'secp256k1',
+          })
+          if (!isMppSigner(signer, signer_open)) {
+            signer = signer_open
+            filled = await fillMppSessionOpen({
+              account,
+              challenge: challenge_session,
+              client,
+              options: methodOptions,
+              signer,
+            })
+          }
+          return await MppSession.open.createCredential(client, {
+            filled,
+            signer: signer_open,
+            voucherSigner: signer,
+          })
+        }
+        const signer = await resolveSigner({
+          chainId,
+          keyType: 'secp256k1',
+          requiredSigner: session.authorizedSigner,
         })
+        switch (session.action) {
+          case 'voucher':
+            return await MppSession.voucher.createCredential(client, {
+              challenge: challenge_session,
+              channelId: session.channelId,
+              cumulativeAmount: BigInt(session.cumulativeAmount),
+              signer,
+            })
+          case 'close':
+            return await MppSession.close.createCredential(client, {
+              challenge: challenge_session,
+              channelId: session.channelId,
+              cumulativeAmount: BigInt(session.cumulativeAmount),
+              signer,
+            })
+          case 'topUp':
+            throw new ox_Provider.UnsupportedMethodError({
+              message: '`mpp_authorize` session topUp is not supported yet.',
+            })
+        }
       }
       default:
         throw new RpcResponse.InvalidParamsError({
@@ -1172,7 +1222,12 @@ export function create(options: create.Options = {}): create.ReturnType {
     const polyfill = polyfill_option ?? isFetchWritable()
 
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
-      const client = provider.getClient({ chainId })
+      const client = Client.fromChainId(chainId, {
+        chains,
+        provider,
+        store,
+        transports,
+      })
       const account = store.getState().accounts[store.getState().activeAccount]
       if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
       return Object.assign(client, {
@@ -1222,38 +1277,76 @@ const defaultIcon =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>' as const
 const sendCallsMagic = Hash.keccak256(Hex.fromString('TEMPO_5792'))
 
-function toMppSessionContext(options: toMppSessionContext.Options): toMppSessionContext.ReturnType {
-  const { account, session } = options
-  switch (session.action) {
-    case 'voucher':
-    case 'close':
-      return {
-        account,
-        action: session.action,
-        authorizedSigner: session.authorizedSigner,
-        channelId: session.channelId,
-        cumulativeAmountRaw: session.cumulativeAmount,
-      }
-    case 'topUp':
-      throw new ox_Provider.UnsupportedMethodError({
-        message: '`mpp_authorize` session topUp is not supported yet.',
-      })
+async function fillMppSessionOpen(
+  options: fillMppSessionOpen.Options,
+): Promise<MppSession.open.fill.Filled> {
+  const { account, challenge, client, options: options_mpp, signer } = options
+  return await MppSession.open.fill(client, {
+    authorizedSigner: getMppSignerAddress(signer),
+    challenge,
+    deposit: resolveMppSessionDeposit({
+      challenge,
+      options: options_mpp,
+    }),
+    escrowContract: options_mpp.escrowContract,
+    payer: account.address,
+  })
+}
+
+declare namespace fillMppSessionOpen {
+  type Options = {
+    account: { address: Address.Address }
+    challenge: MppSession.SessionChallenge
+    client: ViemClient
+    options: {
+      decimals?: number | undefined
+      deposit?: string | undefined
+      escrowContract?: Address.Address | undefined
+      maxDeposit?: string | undefined
+    }
+    signer: ViemAccount
   }
 }
 
-declare namespace toMppSessionContext {
-  type Options = {
-    account: Account.resolveSigner.ReturnType
-    session: z.output<typeof Rpc.mpp_authorize.session>
-  }
+function resolveMppSessionDeposit(options: resolveMppSessionDeposit.Options): bigint {
+  const { challenge, options: options_mpp } = options
+  const decimals = options_mpp.decimals ?? 6
+  const suggestedDeposit = challenge.request.suggestedDeposit
+    ? BigInt(challenge.request.suggestedDeposit)
+    : undefined
+  const maxDeposit =
+    options_mpp.maxDeposit !== undefined ? parseUnits(options_mpp.maxDeposit, decimals) : undefined
 
-  type ReturnType = {
-    account: Account.resolveSigner.ReturnType
-    action: 'voucher' | 'close'
-    authorizedSigner: Address.Address
-    channelId: Hex.Hex
-    cumulativeAmountRaw: string
+  if (options_mpp.deposit !== undefined) return parseUnits(options_mpp.deposit, decimals)
+  if (suggestedDeposit !== undefined && maxDeposit !== undefined)
+    return suggestedDeposit < maxDeposit ? suggestedDeposit : maxDeposit
+  if (maxDeposit !== undefined) return maxDeposit
+  if (suggestedDeposit !== undefined) return suggestedDeposit
+  throw new RpcResponse.InvalidParamsError({
+    message:
+      'No session deposit amount available. Set `mpp.deposit`, `mpp.maxDeposit`, or use a challenge with `suggestedDeposit`.',
+  })
+}
+
+declare namespace resolveMppSessionDeposit {
+  type Options = {
+    challenge: MppSession.SessionChallenge
+    options: {
+      decimals?: number | undefined
+      deposit?: string | undefined
+      maxDeposit?: string | undefined
+    }
   }
+}
+
+function getMppSignerAddress(account: ViemAccount): Address.Address {
+  if ('accessKeyAddress' in account && typeof account.accessKeyAddress === 'string')
+    return account.accessKeyAddress as Address.Address
+  return account.address
+}
+
+function isMppSigner(a: ViemAccount, b: ViemAccount): boolean {
+  return getMppSignerAddress(a).toLowerCase() === getMppSignerAddress(b).toLowerCase()
 }
 
 function getMppChainId(challenge: Challenge.Challenge) {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,4 +1,5 @@
 import { announceProvider } from 'mipd'
+import { Challenge } from 'mppx'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
@@ -120,6 +121,10 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   const instance = adapter({ getAccount, getClient, storage, store })
   const { actions } = instance
+  const resolveSigner = Account.createSignerResolver({
+    getFallbackAccount: (options = {}) => getAccount(options),
+    store,
+  })
 
   const emitter = ox_Provider.createEmitter()
 
@@ -184,6 +189,71 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (url.startsWith('http://') || url.startsWith('https://')) return url
     if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
     return url
+  }
+
+  let mppClient: Mppx.Mppx | undefined
+
+  async function authorizeMpp(options: {
+    challenges: readonly Challenge.Challenge[]
+    session?: z.output<typeof Rpc.mpp_authorize.session> | undefined
+  }): Promise<string> {
+    const { challenges, session } = options
+    const challenge = (() => {
+      if (session) return challenges[0]
+      return challenges.find((challenge) => challenge.intent === 'charge') ?? challenges[0]
+    })()
+    if (!challenge)
+      throw new RpcResponse.InvalidParamsError({
+        message: '`challenges` must include at least one challenge.',
+      })
+
+    const chainId = getMppChainId(challenge) ?? store.getState().chainId
+    const account = await resolveSigner({
+      chainId,
+      ...(session ? { requiredSigner: session.authorizedSigner } : {}),
+    })
+    const client = Object.assign(
+      Client.fromChainId(chainId, {
+        chains,
+        provider: providerRef,
+        store,
+        transports,
+      }),
+      { account },
+    )
+    const client_mpp = getMppSigningClient(client)
+    const {
+      mode = 'push',
+      polyfill: _polyfill,
+      ...methodOptions
+    } = typeof mpp === 'object' ? mpp : {}
+
+    switch (challenge.intent) {
+      case 'charge': {
+        const method = mppx_tempo.charge({
+          ...methodOptions,
+          account,
+          getClient: () => client_mpp,
+          mode,
+        })
+        return await method.createCredential({ challenge: challenge as never, context: {} })
+      }
+      case 'session': {
+        const method = mppx_tempo({
+          ...methodOptions,
+          account,
+          getClient: () => client_mpp,
+        })[1]
+        return await method.createCredential({
+          challenge: challenge as never,
+          context: session ? (toMppSessionContext({ account, session }) as never) : {},
+        })
+      }
+      default:
+        throw new RpcResponse.InvalidParamsError({
+          message: `Unsupported Tempo challenge intent "${challenge.intent}".`,
+        })
+    }
   }
 
   const provider = Object.assign(
@@ -533,6 +603,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' }
                         atomic: { status: 'supported' }
                         feePayer?: { status: 'supported' } | undefined
+                        mpp?: { status: 'supported' } | undefined
                       }
                     > = {}
                     for (const chain of filtered)
@@ -540,8 +611,59 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' },
                         atomic: { status: 'supported' },
                         ...(feePayerConfig ? { feePayer: { status: 'supported' } } : {}),
+                        ...(mppClient ? { mpp: { status: 'supported' } } : {}),
                       }
                     return result as Rpc.wallet_getCapabilities.Encoded['returns']
+                  }
+
+                  case 'mpp_authorize': {
+                    if (!mpp)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`mpp_authorize` requires `mpp` support.',
+                      })
+                    assertConnected()
+
+                    const decoded = request._decoded.params[0]
+                    const challenges = decoded.challenges.map((header) => {
+                      try {
+                        return Challenge.deserialize(header)
+                      } catch (error) {
+                        throw new RpcResponse.InvalidParamsError({
+                          message:
+                            error instanceof Error
+                              ? `Invalid Payment challenge: ${error.message}`
+                              : 'Invalid Payment challenge.',
+                        })
+                      }
+                    })
+                    if (!challenges.every((challenge) => challenge.method === 'tempo'))
+                      throw new RpcResponse.InvalidParamsError({
+                        message: 'All challenges must use method "tempo".',
+                      })
+
+                    if (decoded.session && challenges.length !== 1)
+                      throw new RpcResponse.InvalidParamsError({
+                        message: '`session` requires exactly one challenge.',
+                      })
+
+                    const selected = decoded.session ? challenges[0] : undefined
+                    if (decoded.session) {
+                      if (!selected)
+                        throw new RpcResponse.InvalidParamsError({
+                          message: '`session` requires exactly one challenge.',
+                        })
+                      if (selected.intent !== 'session')
+                        throw new RpcResponse.InvalidParamsError({
+                          message: '`session` can only be used with a Tempo session challenge.',
+                        })
+                    }
+
+                    return {
+                      authorization: await authorizeMpp({
+                        challenges,
+                        session: decoded.session,
+                      }),
+                    } satisfies Rpc.mpp_authorize.Encoded['returns']
                   }
 
                   case 'wallet_connect': {
@@ -1048,6 +1170,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
+
     const getClient = ({ chainId }: { chainId?: number | undefined }) => {
       const client = provider.getClient({ chainId })
       const account = store.getState().accounts[store.getState().activeAccount]
@@ -1059,7 +1182,8 @@ export function create(options: create.Options = {}): create.ReturnType {
         },
       })
     }
-    Mppx.create({
+
+    mppClient = Mppx.create({
       methods: [
         mppx_tempo({ ...methodOptions, getClient, mode }),
         mppx_tempo.subscription({ getClient }),
@@ -1073,9 +1197,71 @@ export function create(options: create.Options = {}): create.ReturnType {
   return provider
 }
 
+function getMppSigningClient(client: ViemClient): ViemClient {
+  const request = client.request
+  return Object.assign(client, {
+    async request(
+      parameters: { method: string; params?: unknown },
+      options?: Parameters<typeof request>[1],
+    ) {
+      const result = await request(parameters as never, options as never)
+      if (parameters.method !== 'wallet_getCapabilities') return result
+      if (!result || typeof result !== 'object') return result
+      return Object.fromEntries(
+        Object.entries(result).map(([chainId, capabilities]) => {
+          if (!capabilities || typeof capabilities !== 'object') return [chainId, capabilities]
+          const { mpp: _mpp, ...rest } = capabilities as { mpp?: unknown } & Record<string, unknown>
+          return [chainId, rest]
+        }),
+      ) as never
+    },
+  }) as never
+}
+
 const defaultIcon =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>' as const
 const sendCallsMagic = Hash.keccak256(Hex.fromString('TEMPO_5792'))
+
+function toMppSessionContext(options: toMppSessionContext.Options): toMppSessionContext.ReturnType {
+  const { account, session } = options
+  switch (session.action) {
+    case 'voucher':
+    case 'close':
+      return {
+        account,
+        action: session.action,
+        authorizedSigner: session.authorizedSigner,
+        channelId: session.channelId,
+        cumulativeAmountRaw: session.cumulativeAmount,
+      }
+    case 'topUp':
+      throw new ox_Provider.UnsupportedMethodError({
+        message: '`mpp_authorize` session topUp is not supported yet.',
+      })
+  }
+}
+
+declare namespace toMppSessionContext {
+  type Options = {
+    account: Account.resolveSigner.ReturnType
+    session: z.output<typeof Rpc.mpp_authorize.session>
+  }
+
+  type ReturnType = {
+    account: Account.resolveSigner.ReturnType
+    action: 'voucher' | 'close'
+    authorizedSigner: Address.Address
+    channelId: Hex.Hex
+    cumulativeAmountRaw: string
+  }
+}
+
+function getMppChainId(challenge: Challenge.Challenge) {
+  const methodDetails = challenge.request.methodDetails as
+    | { chainId?: number | undefined }
+    | undefined
+  return methodDetails?.chainId
+}
 
 export declare namespace create {
   type Options = {

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -169,6 +169,38 @@ describe('Encoded', () => {
     }>()
   })
 
+  test('mpp_authorize', () => {
+    expectTypeOf<Rpc.mpp_authorize.Encoded>().toMatchTypeOf<{
+      method: 'mpp_authorize'
+      params: readonly [
+        {
+          challenges: readonly string[]
+          session?:
+            | {
+                action: 'voucher'
+                authorizedSigner: Hex
+                channelId: Hex
+                cumulativeAmount: string
+              }
+            | {
+                action: 'topUp'
+                additionalDeposit: string
+                authorizedSigner: Hex
+                channelId: Hex
+              }
+            | {
+                action: 'close'
+                authorizedSigner: Hex
+                channelId: Hex
+                cumulativeAmount: string
+              }
+            | undefined
+        },
+      ]
+      returns: { authorization: string }
+    }>()
+  })
+
   test('wallet_transfer', () => {
     expectTypeOf<Rpc.wallet_transfer.Encoded>().toMatchTypeOf<{
       method: 'wallet_transfer'
@@ -260,7 +292,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[21]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[22]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -275,6 +307,7 @@ describe('Request', () => {
       | 'eth_sendTransaction'
       | 'eth_signTransaction'
       | 'eth_signTypedData_v4'
+      | 'mpp_authorize'
       | 'personal_sign'
       | 'wallet_connect'
       | 'wallet_disconnect'

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -84,6 +84,7 @@ export const schema = from([
   Rpc.eth_sendTransactionSync.schema,
   Rpc.eth_signTransaction.schema,
   Rpc.eth_signTypedData_v4.schema,
+  Rpc.mpp_authorize.schema,
   Rpc.personal_sign.schema,
   Rpc.wallet_authorizeAccessKey.schema,
   Rpc.wallet_connect.schema,

--- a/src/core/adapters/privy.ts
+++ b/src/core/adapters/privy.ts
@@ -3,7 +3,7 @@ import { SignatureEnvelope } from 'ox/tempo'
 import { hashMessage, hashTypedData, isAddressEqual, keccak256 } from 'viem'
 import type { Address, LocalAccount } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Actions, Transaction as TempoTransaction } from 'viem/tempo'
+import { Account as TempoAccount, Actions, Transaction as TempoTransaction } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
@@ -87,7 +87,7 @@ export function privy<const client extends privy.Client>(
       }
     }
 
-    function toTempoAccount(account: privy.EmbeddedWallet) {
+    function toTempoAccount(account: privy.EmbeddedWallet): TempoAccount.Account {
       const address = core_Address.from(account.address)
 
       async function sign(parameters: { hash: Hex.Hex }) {
@@ -104,13 +104,7 @@ export function privy<const client extends privy.Client>(
           await privySignTransaction({ sign, transaction }),
         source: 'privy',
         type: 'local',
-      } satisfies {
-        address: Address
-        sign: (parameters: { hash: Hex.Hex }) => Promise<Hex.Hex>
-        signTransaction: (transaction: unknown) => Promise<Hex.Hex>
-        source: 'privy'
-        type: 'local'
-      }
+      } as unknown as TempoAccount.Account
     }
 
     function clear() {
@@ -341,7 +335,7 @@ export function privy<const client extends privy.Client>(
         ...(feePayer ? { feePayer: true } : {}),
         type: 'tempo',
       } as never)
-      return await account.signTransaction(prepared)
+      return await account.signTransaction(prepared as never)
     }
 
     async function privySignTransaction(parameters: {
@@ -382,7 +376,7 @@ export function privy<const client extends privy.Client>(
       const wallets = await loadEthereumWallets(privyClient)
       const selected = selectWalletAccounts(wallets, addresses)
 
-      const account = selected[0] ? toTempoAccount(selected[0]) : undefined
+      const account = selected[0] ? await toTempoAccount(selected[0]) : undefined
       if (!account && parameters.noAccountsMessage)
         throw new ox_Provider.DisconnectedError({
           message: parameters.noAccountsMessage,
@@ -579,7 +573,7 @@ export function privy<const client extends privy.Client>(
           const account = await getTempoAccount(parameters.address)
           try {
             await Actions.accessKey.revoke(getClient(), {
-              account: account as LocalAccount<'privy'>,
+              account: account as unknown as LocalAccount<'privy'>,
               accessKey: parameters.accessKeyAddress,
             })
           } catch (error) {

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -132,6 +132,40 @@ describe('transactionRequest.keyAuthorization', () => {
   })
 })
 
+describe('mpp_authorize', () => {
+  test('accepts voucher session params', () => {
+    expect(
+      z.parse(Rpc.mpp_authorize.schema.params!, [
+        {
+          challenges: [
+            'Payment id="test", realm="example.com", method="tempo", intent="session", request="eyJhbW91bnQiOiIxIn0"',
+          ],
+          session: {
+            action: 'voucher',
+            authorizedSigner: accessKey,
+            channelId: `0x${'00'.repeat(32)}`,
+            cumulativeAmount: '2500000',
+          },
+        },
+      ]),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "challenges": [
+            "Payment id="test", realm="example.com", method="tempo", intent="session", request="eyJhbW91bnQiOiIxIn0"",
+          ],
+          "session": {
+            "action": "voucher",
+            "authorizedSigner": "0x0000000000000000000000000000000000000002",
+            "channelId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "cumulativeAmount": "2500000",
+          },
+        },
+      ]
+    `)
+  })
+})
+
 describe('wallet_connect.capabilities.request: auth', () => {
   test('accepts string shorthand', () => {
     expect(

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -440,8 +440,55 @@ export namespace wallet_getCapabilities {
             status: z.union([z.literal('supported'), z.literal('unsupported')]),
           }),
         ),
+        mpp: z.optional(
+          z.object({
+            status: z.union([z.literal('supported'), z.literal('unsupported')]),
+          }),
+        ),
       }),
     ),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
+export namespace mpp_authorize {
+  const sessionBase = {
+    authorizedSigner: u.address(),
+    channelId: u.hex(),
+  }
+
+  export const session = z.discriminatedUnion('action', [
+    z.object({
+      ...sessionBase,
+      action: z.literal('voucher'),
+      cumulativeAmount: z.string(),
+    }),
+    z.object({
+      ...sessionBase,
+      action: z.literal('topUp'),
+      additionalDeposit: z.string(),
+    }),
+    z.object({
+      ...sessionBase,
+      action: z.literal('close'),
+      cumulativeAmount: z.string(),
+    }),
+  ])
+
+  export const schema = Schema.defineItem({
+    method: z.literal('mpp_authorize'),
+    params: z.readonly(
+      z.tuple([
+        z.object({
+          challenges: z.readonly(z.array(z.string()).check(z.minLength(1))),
+          session: z.optional(session),
+        }),
+      ]),
+    ),
+    returns: z.object({
+      authorization: z.string(),
+    }),
   })
   export type Encoded = Schema.Encoded<typeof schema>
   export type Decoded = Schema.Decoded<typeof schema>


### PR DESCRIPTION
## Summary
Adds `mpp_authorize` support for Tempo MPP credentials.

## Motivation
Apps need a wallet RPC path for authorizing MPP charge and session credentials without relying on mppx browser interception only.

## Changes
- Add `mpp_authorize` RPC schema/capability and provider handling in `src/core/Provider.ts`
- Add shared signer resolution in `src/core/Account.ts` with exact access-key lookup via `AccessKey.get`
- Add adapter root-account hooks for local, dialog, Privy, and Turnkey adapters
- Pull MPP playground RPC/session changes into `playgrounds/web`

## Testing
- `./node_modules/.bin/tsc -b --noEmit`
- `./node_modules/.bin/vp test src/core/Account.test.ts src/core/AccessKey.test.ts src/core/zod/rpc.test.ts`
- `./node_modules/.bin/vp lint --fix --ignore-pattern package.json src/core/adapters/privy.ts`