### PR TITLE
fix(provider): honor signable getAccount option

### DIFF
--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -2,6 +2,7 @@ import type { KeyAuthorization } from 'ox/tempo'
 import type { Client, Hex, Transport } from 'viem'
 import type { Address } from 'viem/accounts'
 import type { tempo } from 'viem/tempo/chains'
+import type * as z from 'zod/mini'
 
 import type * as Account from './Account.js'
 import type * as Schema from './Schema.js'
@@ -27,6 +28,8 @@ export type Meta = {
   icon?: `data:image/${string}` | undefined
   /** Display name of the provider (e.g. `"My Wallet"`). @default "Injected Wallet" */
   name?: string | undefined
+  /** Schema for the minimum persisted account shape the adapter can restore. */
+  persistedAccount?: z.ZodMiniType | undefined
   /** Reverse DNS identifier (e.g. `"com.example.mywallet"`). @default `com.{lowercase name}` */
   rdns?: string | undefined
 }

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1584,6 +1584,25 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(accts2[0]).toBe(accts1[0])
     })
 
+    test('behavior: ignores persisted accounts the adapter cannot restore', async () => {
+      const storage = Storage.memory({ key: 'persist-invalid' })
+      storage.setItem('store', {
+        state: {
+          accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+          activeAccount: 0,
+          chainId: chain.id,
+        },
+        version: 0,
+      })
+
+      const provider = Provider.create({ adapter: adapter(), chains: [chain], storage })
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+        `[]`,
+      )
+    })
+
     test('behavior: concurrent providers with different storage keys are isolated', async () => {
       const providerA = Provider.create({
         adapter: adapter(),

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -91,6 +91,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     : chains[0]!
 
   const store = Store.create({
+    account: adapter.persistedAccount,
     chainId: defaultChain.id,
     maxAccounts,
     persistCredentials,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -4,7 +4,7 @@ import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from '
 import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
-import { Actions } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/tempo/chains'
 import * as z from 'zod/mini'
 
@@ -26,8 +26,9 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
   ox_Provider.Emitter & {
     /** Configured chains. */
     chains: readonly [Chain, ...Chain[]]
-    /** Returns the active root account as a viem JSON-RPC account. */
-    getAccount(): JsonRpcAccount
+    /** Returns the active root account as a viem account. */
+    getAccount(options: Omit<Account.find.Options, 'store'> & { signable: true }): TempoAccount.Account
+    getAccount(options?: Omit<Account.find.Options, 'store'>): JsonRpcAccount
     /** Returns local or on-chain publication status for an access key. */
     getAccessKeyStatus(
       options?: getAccessKeyStatus.Options | undefined,
@@ -186,6 +187,14 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
     return url
   }
+
+  const getProviderAccount: Provider['getAccount'] = (
+    (options?: Omit<Account.find.Options, 'store'>) => {
+      const account = getAccount(options)
+      if (options?.signable) return account
+      return { address: account.address, type: 'json-rpc' as const }
+    }
+  ) as Provider['getAccount']
 
   const provider = Object.assign(
     ox_Provider.from(
@@ -988,10 +997,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     ),
     {
       chains,
-      getAccount() {
-        const account = getAccount()
-        return { address: account.address, type: 'json-rpc' as const }
-      },
+      getAccount: getProviderAccount,
       async getAccessKeyStatus(options: getAccessKeyStatus.Options = {}) {
         const state = store.getState()
         const address = options.address ?? state.accounts[state.activeAccount]?.address

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'vp/test'
+import * as z from 'zod/mini'
 
 import * as Storage from './Storage.js'
 import * as Store from './Store.js'
+import * as u from './zod/utils.js'
+
+const secp256k1Account = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  privateKey: u.hex(),
+})
 
 describe('create', () => {
   test('default', () => {
@@ -273,6 +281,119 @@ describe('hydrate', () => {
     `)
   })
 
+  test('behavior: filters accounts that the adapter cannot restore', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [
+          { address: '0x0000000000000000000000000000000000000001' },
+          {
+            address: '0x0000000000000000000000000000000000000002',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 1,
+        chainId: 456,
+      },
+      current,
+      {
+        account: secp256k1Account,
+      },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+            "keyType": "secp256k1",
+            "privateKey": "0x1234",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: clears active account when every persisted account is invalid', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: 456,
+      },
+      current,
+      { account: secp256k1Account },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: keeps unknown account fields after schema validation', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            extra: 'kept',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 0,
+        chainId: 456,
+      },
+      current,
+      { account: secp256k1Account },
+    )
+
+    expect(result.accounts).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x0000000000000000000000000000000000000001",
+          "extra": "kept",
+          "keyType": "secp256k1",
+          "privateKey": "0x1234",
+        },
+      ]
+    `)
+  })
+
   test('behavior: drops legacy access key without chain context', () => {
     const current: Store.State = {
       accessKeys: [],
@@ -348,6 +469,48 @@ describe('persistence', () => {
         "accounts": [
           {
             "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: filters stored accounts with the adapter restore guard', async () => {
+    const storage = Storage.memory()
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          { address: '0x0000000000000000000000000000000000000001' },
+          {
+            address: '0x0000000000000000000000000000000000000002',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 1,
+        chainId: 456,
+      },
+      version: 0,
+    })
+
+    const store = Store.create({
+      chainId: 123,
+      account: secp256k1Account,
+      storage,
+    })
+    await Store.waitForHydration(store)
+
+    expect(store.getState()).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+            "keyType": "secp256k1",
+            "privateKey": "0x1234",
           },
         ],
         "activeAccount": 0,

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -3,6 +3,7 @@ import type { Mutate, StoreApi } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { createStore } from 'zustand/vanilla'
+import * as z from 'zod/mini'
 
 import type { OneOf } from '../internal/types.js'
 import type { AccessKey } from './AccessKey.js'
@@ -64,6 +65,8 @@ export type Store = Mutate<
 
 /** Options for {@link create}. */
 export type Options = {
+  /** Schema for the minimum persisted account shape the current adapter can restore. */
+  account?: z.ZodMiniType | undefined
   /** Initial chain ID. */
   chainId: number
   /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
@@ -97,6 +100,7 @@ export type QueuedRequest<result = unknown> = OneOf<
  */
 export function create(options: Options): Store {
   const {
+    account,
     chainId,
     maxAccounts,
     persistCredentials = true,
@@ -116,7 +120,7 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge: hydrate,
+          merge: (persisted, current) => hydrate(persisted, current, { account }),
           name: 'store',
           partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
@@ -154,21 +158,39 @@ export declare namespace serialize {
 }
 
 /** Restores runtime provider state from a persisted refresh snapshot. */
-export function hydrate(persisted: unknown, current: State): State {
+export function hydrate(persisted: unknown, current: State, options: hydrate.Options = {}): State {
   const state = persisted && typeof persisted === 'object' ? (persisted as Partial<Persisted>) : {}
+  const accounts_persisted = Array.isArray(state.accounts)
+    ? state.accounts.filter(isStoredAccount)
+    : undefined
+  const accounts =
+    accounts_persisted?.map((persisted) => {
+      const account = current.accounts.find(
+        (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
+      )
+      return account ?? persisted
+    }) ?? current.accounts
+  const accounts_valid = options.account
+    ? accounts.filter((account) => z.safeParse(options.account!, account).success)
+    : accounts
   return {
     ...state,
     ...current,
-    // Preserve in-memory credentials when persisted accounts only have addresses.
-    accounts:
-      state.accounts?.map((persisted) => {
-        const account = current.accounts.find(
-          (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
-        )
-        return account ?? persisted
-      }) ?? current.accounts,
+    accounts: accounts_valid,
+    activeAccount:
+      accounts_valid.length === 0
+        ? 0
+        : Math.min(state.activeAccount ?? current.activeAccount, accounts_valid.length - 1),
     accessKeys: normalizeAccessKeys(state.accessKeys) ?? current.accessKeys,
     chainId: state.chainId ?? current.chainId,
+  }
+}
+
+export declare namespace hydrate {
+  /** Options for {@link hydrate}. */
+  type Options = {
+    /** Schema for the minimum persisted account shape the current adapter can restore. */
+    account?: z.ZodMiniType | undefined
   }
 }
 
@@ -192,6 +214,11 @@ function normalizeAccessKeys(accessKeys: Persisted['accessKeys']) {
         value.keyType === 'webCrypto')
     )
   })
+}
+
+function isStoredAccount(account: unknown): account is Account {
+  if (!account || typeof account !== 'object') return false
+  return typeof (account as { address?: unknown }).address === 'string'
 }
 
 /**

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -5,17 +5,42 @@ import { describe, expect, test } from 'vp/test'
 
 import {
   accounts as core_accounts,
+  chain,
   getClient,
   privateKeys,
   webAuthnAccounts,
 } from '../../../test/config.js'
 import * as Account from '../Account.js'
 import type * as Adapter from '../Adapter.js'
+import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
 import { local } from './local.js'
 
 describe('local', () => {
+  test('behavior: does not hydrate account without local signing fields', async () => {
+    const storage = Storage.memory({ key: 'local-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({
+      adapter: local({ loadAccounts: async () => ({ accounts: [] }) }),
+      chains: [chain],
+      storage,
+    })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+
   describe('loadAccounts', () => {
     test('default: loads accounts', async () => {
       const { adapter } = setup()

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,13 +1,72 @@
-import { Provider as ox_Provider } from 'ox'
+import { Provider as ox_Provider, type WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { hashMessage } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Actions } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
+import * as z from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Account from '../Account.js'
 import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as u from '../zod/utils.js'
+
+const secp256k1Stored = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
+
+const p256Stored = z.object({
+  address: u.address(),
+  keyType: z.literal('p256'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
+
+const webAuthnStored = z.object({
+  address: u.address(),
+  credential: z.object({
+    id: z.string(),
+    publicKey: u.hex(),
+    rpId: z.string(),
+  }),
+  keyType: z.literal('webAuthn'),
+  label: z.optional(z.string()),
+})
+
+const webAuthnHeadlessStored = z.object({
+  address: u.address(),
+  keyType: z.literal('webAuthn_headless'),
+  label: z.optional(z.string()),
+  origin: z.string(),
+  privateKey: u.hex(),
+  rpId: z.string(),
+})
+
+const webCryptoStored = z.object({
+  address: u.address(),
+  keyPair: z.custom<Awaited<ReturnType<typeof WebCryptoP256.createKeyPair>>>(),
+  keyType: z.literal('webCrypto'),
+  label: z.optional(z.string()),
+})
+
+const functionSignerStored = z.object({
+  address: u.address(),
+  keyType: z.union([z.literal('secp256k1'), z.literal('p256'), z.literal('webAuthn')]),
+  label: z.optional(z.string()),
+  sign: z.custom<TempoAccount.Account['sign']>(),
+})
+
+const signableStored = z.union([
+  secp256k1Stored,
+  p256Stored,
+  webAuthnStored,
+  webAuthnHeadlessStored,
+  webCryptoStored,
+  functionSignerStored,
+])
 
 /**
  * Creates a local adapter where the app manages keys and signing in-process.
@@ -28,7 +87,7 @@ import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, persistedAccount: signableStored, rdns }, ({ getAccount, getClient, store }) => {
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const { feePayer, ...rest } = parameters
       const client = getClient({

--- a/src/core/adapters/secp256k1.test.ts
+++ b/src/core/adapters/secp256k1.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, test } from 'vp/test'
 
-import { accounts, privateKeys } from '../../../test/config.js'
+import { accounts, chain, privateKeys } from '../../../test/config.js'
 import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
 import { secp256k1 } from './secp256k1.js'
 
 describe('secp256k1', () => {
+  test('behavior: does not hydrate account without private key', async () => {
+    const storage = Storage.memory({ key: 'secp256k1-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            keyType: 'secp256k1',
+          },
+        ],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({ adapter: secp256k1(), chains: [chain], storage })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+
   test('behavior: privateKey option pins the connected account', async () => {
     const account = accounts[1]!
     const provider = Provider.create({

--- a/src/core/adapters/secp256k1.test.ts
+++ b/src/core/adapters/secp256k1.test.ts
@@ -46,4 +46,22 @@ describe('secp256k1', () => {
     expect(connected).toHaveLength(1)
     expect(connected[0]).toBe(account.address)
   })
+
+  test('behavior: provider getAccount honors signable option', async () => {
+    const account = accounts[1]!
+    const provider = Provider.create({
+      adapter: secp256k1({ privateKey: privateKeys[1]! }),
+      storage: Storage.memory({ key: 'secp256k1-provider-get-account' }),
+    })
+
+    await provider.request({ method: 'wallet_connect' })
+
+    const jsonRpc = provider.getAccount()
+    expect(jsonRpc).toEqual({ address: account.address, type: 'json-rpc' })
+
+    const signable = provider.getAccount({ signable: true })
+    expect(signable.address).toBe(account.address)
+    expect(signable.type).toBe('local')
+    expect(typeof signable.sign).toBe('function')
+  })
 })

--- a/src/core/adapters/secp256k1.ts
+++ b/src/core/adapters/secp256k1.ts
@@ -1,8 +1,17 @@
 import type { Hex } from 'viem'
 import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
+import * as z from 'zod/mini'
 
 import * as Adapter from '../Adapter.js'
+import * as u from '../zod/utils.js'
 import { local } from './local.js'
+
+const persistedAccount = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
 
 /**
  * Creates a secp256k1 adapter that signs in-process with a `secp256k1` private key.
@@ -43,7 +52,7 @@ export function secp256k1(options: secp256k1.Options = {}): Adapter.Adapter {
       }
     : undefined
 
-  return Adapter.define({ icon, name, rdns }, (config) => {
+  return Adapter.define({ icon, name, persistedAccount, rdns }, (config) => {
     const { store } = config
 
     return local({

--- a/src/core/adapters/webAuthn.test.ts
+++ b/src/core/adapters/webAuthn.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vp/test'
+
+import { chain } from '../../../test/config.js'
+import * as Provider from '../Provider.js'
+import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
+import { webAuthn } from './webAuthn.js'
+
+describe('webAuthn', () => {
+  test('behavior: does not hydrate account without credential', async () => {
+    const storage = Storage.memory({ key: 'webauthn-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            keyType: 'webAuthn',
+          },
+        ],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({ adapter: webAuthn(), chains: [chain], storage })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+})

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -2,13 +2,26 @@ import { PublicKey, Signature } from 'ox'
 import { SignatureEnvelope } from 'ox/tempo'
 import { Account } from 'viem/tempo'
 import { Authentication, Registration } from 'webauthx/client'
-import type { z } from 'zod'
+import type * as core_z from 'zod'
+import * as z from 'zod/mini'
 
 import type { OneOf } from '../../internal/types.js'
 import * as Adapter from '../Adapter.js'
 import * as WebAuthnCeremony from '../WebAuthnCeremony.js'
 import * as Rpc from '../zod/rpc.js'
+import * as u from '../zod/utils.js'
 import { local } from './local.js'
+
+const persistedAccount = z.object({
+  address: u.address(),
+  credential: z.object({
+    id: z.string(),
+    publicKey: u.hex(),
+    rpId: z.string(),
+  }),
+  keyType: z.literal('webAuthn'),
+  label: z.optional(z.string()),
+})
 
 /**
  * Creates a WebAuthn adapter backed by real passkey ceremonies.
@@ -33,7 +46,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
     return authUrl
   })()
 
-  return Adapter.define({ icon, name, rdns }, (parameters) => {
+  return Adapter.define({ icon, name, persistedAccount, rdns }, (parameters) => {
     const { storage } = parameters
 
     const ceremony =
@@ -151,7 +164,7 @@ export declare namespace webAuthn {
          * other fields (`challenge`, `verify`, `logout`, `returnToken`) are
          * SIWE-only and ignored by the WebAuthn ceremony.
          */
-        auth?: z.input<typeof Rpc.wallet_connect.auth> | undefined
+        auth?: core_z.input<typeof Rpc.wallet_connect.auth> | undefined
         /** @deprecated Use `auth` instead. */
         authUrl?: string | undefined
       }


### PR DESCRIPTION
## Summary
Provider.getAccount({ signable: true }) now returns the adapter-backed Tempo account instead of the JSON-RPC account wrapper.

## Motivation
Zone authorization asks the wagmi connector/provider for a signable account so viem/tempo can call account.sign({ hash }). Returning a JSON-RPC account dropped sign() and prevented the passkey signing dialog from opening.

## Changes
- Update src/core/Provider.ts overloads so signable: true returns a Tempo account.
- Keep plain getAccount() returning { address, type: 'json-rpc' } for transport callers.
- Add secp256k1 regression coverage for signable provider account hydration.

## Testing
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false
- ./node_modules/.bin/vp test src/core/adapters/secp256k1.test.ts