### PR TITLE
fix(provider): honor signable getAccount option

### DIFF
--- a/.changeset/signable-account.md
+++ b/.changeset/signable-account.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+getAccount signs again

--- a/.changeset/signable-account.md
+++ b/.changeset/signable-account.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-getAccount signs again
+Fixed getAccounts to respect signable.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -187,14 +187,6 @@ export function create(options: create.Options = {}): create.ReturnType {
     return url
   }
 
-  const getProviderAccount: Provider['getAccount'] = (
-    (options?: Omit<Account.find.Options, 'store'>) => {
-      const account = getAccount(options)
-      if (options?.signable) return account
-      return { address: account.address, type: 'json-rpc' as const }
-    }
-  ) as Provider['getAccount']
-
   const provider = Object.assign(
     ox_Provider.from(
       {
@@ -996,7 +988,11 @@ export function create(options: create.Options = {}): create.ReturnType {
     ),
     {
       chains,
-      getAccount: getProviderAccount,
+      getAccount: ((options?: Omit<Account.find.Options, 'store'>) => {
+        const account = getAccount(options)
+        if (options?.signable) return account
+        return { address: account.address, type: 'json-rpc' as const }
+      }) as Provider['getAccount'],
       async getAccessKeyStatus(options: getAccessKeyStatus.Options = {}) {
         const state = store.getState()
         const address = options.address ?? state.accounts[state.activeAccount]?.address

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -4,7 +4,7 @@ import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from '
 import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
-import { Actions } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/tempo/chains'
 import * as z from 'zod/mini'
 
@@ -26,8 +26,9 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
   ox_Provider.Emitter & {
     /** Configured chains. */
     chains: readonly [Chain, ...Chain[]]
-    /** Returns the active root account as a viem JSON-RPC account. */
-    getAccount(): JsonRpcAccount
+    /** Returns the active root account as a viem account. */
+    getAccount(options: Omit<Account.find.Options, 'store'> & { signable: true }): TempoAccount.Account
+    getAccount(options?: Omit<Account.find.Options, 'store'>): JsonRpcAccount
     /** Returns local or on-chain publication status for an access key. */
     getAccessKeyStatus(
       options?: getAccessKeyStatus.Options | undefined,
@@ -185,6 +186,14 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (typeof window !== 'undefined') return new URL(url, window.location.origin).href
     return url
   }
+
+  const getProviderAccount: Provider['getAccount'] = (
+    (options?: Omit<Account.find.Options, 'store'>) => {
+      const account = getAccount(options)
+      if (options?.signable) return account
+      return { address: account.address, type: 'json-rpc' as const }
+    }
+  ) as Provider['getAccount']
 
   const provider = Object.assign(
     ox_Provider.from(
@@ -987,10 +996,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     ),
     {
       chains,
-      getAccount() {
-        const account = getAccount()
-        return { address: account.address, type: 'json-rpc' as const }
-      },
+      getAccount: getProviderAccount,
       async getAccessKeyStatus(options: getAccessKeyStatus.Options = {}) {
         const state = store.getState()
         const address = options.address ?? state.accounts[state.activeAccount]?.address

--- a/src/core/adapters/secp256k1.test.ts
+++ b/src/core/adapters/secp256k1.test.ts
@@ -21,4 +21,22 @@ describe('secp256k1', () => {
     expect(connected).toHaveLength(1)
     expect(connected[0]).toBe(account.address)
   })
+
+  test('behavior: provider getAccount honors signable option', async () => {
+    const account = accounts[1]!
+    const provider = Provider.create({
+      adapter: secp256k1({ privateKey: privateKeys[1]! }),
+      storage: Storage.memory({ key: 'secp256k1-provider-get-account' }),
+    })
+
+    await provider.request({ method: 'wallet_connect' })
+
+    const jsonRpc = provider.getAccount()
+    expect(jsonRpc).toEqual({ address: account.address, type: 'json-rpc' })
+
+    const signable = provider.getAccount({ signable: true })
+    expect(signable.address).toBe(account.address)
+    expect(signable.type).toBe('local')
+    expect(typeof signable.sign).toBe('function')
+  })
 })


### PR DESCRIPTION
## Summary
Provider.getAccount({ signable: true }) now returns the adapter-backed Tempo account instead of the JSON-RPC account wrapper.

## Motivation
Zone authorization asks the wagmi connector/provider for a signable account so viem/tempo can call account.sign({ hash }). Returning a JSON-RPC account dropped sign() and prevented the passkey signing dialog from opening.

## Changes
- Update src/core/Provider.ts overloads so signable: true returns a Tempo account.
- Keep plain getAccount() returning { address, type: 'json-rpc' } for transport callers.
- Add secp256k1 regression coverage for signable provider account access.

## Testing
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false
- ./node_modules/.bin/vp test src/core/adapters/secp256k1.test.ts