### PR TITLE
fix: validate persisted adapter accounts

### DIFF
--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -2,6 +2,7 @@ import type { KeyAuthorization } from 'ox/tempo'
 import type { Client, Hex, Transport } from 'viem'
 import type { Address } from 'viem/accounts'
 import type { tempo } from 'viem/tempo/chains'
+import type * as z from 'zod/mini'
 
 import type * as Account from './Account.js'
 import type * as Schema from './Schema.js'
@@ -27,6 +28,8 @@ export type Meta = {
   icon?: `data:image/${string}` | undefined
   /** Display name of the provider (e.g. `"My Wallet"`). @default "Injected Wallet" */
   name?: string | undefined
+  /** Schema for the minimum persisted account shape the adapter can restore. */
+  persistedAccount?: z.ZodMiniType | undefined
   /** Reverse DNS identifier (e.g. `"com.example.mywallet"`). @default `com.{lowercase name}` */
   rdns?: string | undefined
 }

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -28,7 +28,11 @@ export type Meta = {
   icon?: `data:image/${string}` | undefined
   /** Display name of the provider (e.g. `"My Wallet"`). @default "Injected Wallet" */
   name?: string | undefined
-  /** Schema for the minimum persisted account shape the adapter can restore. */
+  /**
+   * Minimum persisted account schema the adapter can hydrate.
+   *
+   * This only guards the storage boundary; it is not the full runtime account schema.
+   */
   persistedAccount?: z.ZodMiniType | undefined
   /** Reverse DNS identifier (e.g. `"com.example.mywallet"`). @default `com.{lowercase name}` */
   rdns?: string | undefined

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -33,7 +33,7 @@ export type Meta = {
    *
    * This only guards the storage boundary; it is not the full runtime account schema.
    */
-  persistedAccount?: z.ZodMiniType | undefined
+  schema?: z.ZodMiniType | undefined
   /** Reverse DNS identifier (e.g. `"com.example.mywallet"`). @default `com.{lowercase name}` */
   rdns?: string | undefined
 }

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1584,6 +1584,25 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(accts2[0]).toBe(accts1[0])
     })
 
+    test('behavior: ignores persisted accounts the adapter cannot restore', async () => {
+      const storage = Storage.memory({ key: 'persist-invalid' })
+      storage.setItem('store', {
+        state: {
+          accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+          activeAccount: 0,
+          chainId: chain.id,
+        },
+        version: 0,
+      })
+
+      const provider = Provider.create({ adapter: adapter(), chains: [chain], storage })
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+        `[]`,
+      )
+    })
+
     test('behavior: concurrent providers with different storage keys are isolated', async () => {
       const providerA = Provider.create({
         adapter: adapter(),

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -91,6 +91,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     : chains[0]!
 
   const store = Store.create({
+    account: adapter.persistedAccount,
     chainId: defaultChain.id,
     maxAccounts,
     persistCredentials,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -92,7 +92,6 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   const store = Store.create({
     chainId: defaultChain.id,
-    chainIds: chains.map((chain) => chain.id),
     maxAccounts,
     persistCredentials,
     schema: adapter.schema,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -91,10 +91,10 @@ export function create(options: create.Options = {}): create.ReturnType {
     : chains[0]!
 
   const store = Store.create({
-    account: adapter.persistedAccount,
     chainId: defaultChain.id,
     maxAccounts,
     persistCredentials,
+    schema: adapter.persistedAccount,
     storage,
   })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -92,6 +92,7 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   const store = Store.create({
     chainId: defaultChain.id,
+    chainIds: chains.map((chain) => chain.id),
     maxAccounts,
     persistCredentials,
     schema: adapter.schema,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -94,7 +94,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     chainId: defaultChain.id,
     maxAccounts,
     persistCredentials,
-    schema: adapter.persistedAccount,
+    schema: adapter.schema,
     storage,
   })
 

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -305,7 +305,7 @@ describe('hydrate', () => {
       },
       current,
       {
-        account: secp256k1Account,
+        schema: secp256k1Account,
       },
     )
 
@@ -342,7 +342,7 @@ describe('hydrate', () => {
         chainId: 456,
       },
       current,
-      { account: secp256k1Account },
+      { schema: secp256k1Account },
     )
 
     expect(result).toMatchInlineSnapshot(`
@@ -379,7 +379,7 @@ describe('hydrate', () => {
         chainId: 456,
       },
       current,
-      { account: secp256k1Account },
+      { schema: secp256k1Account },
     )
 
     expect(result.accounts).toMatchInlineSnapshot(`
@@ -498,7 +498,7 @@ describe('persistence', () => {
 
     const store = Store.create({
       chainId: 123,
-      account: secp256k1Account,
+      schema: secp256k1Account,
       storage,
     })
     await Store.waitForHydration(store)

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -281,6 +281,39 @@ describe('hydrate', () => {
     `)
   })
 
+  test('behavior: ignores persisted chain IDs outside the supported set', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        chainId: 999,
+      },
+      current,
+      { chainIds: [123, 456] },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 123,
+        "requestQueue": [],
+      }
+    `)
+  })
+
   test('behavior: filters accounts that the adapter cannot restore', () => {
     const current: Store.State = {
       accessKeys: [],
@@ -515,6 +548,39 @@ describe('persistence', () => {
         ],
         "activeAccount": 0,
         "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: ignores stored chain IDs outside the supported set', async () => {
+    const storage = Storage.memory()
+    storage.setItem('store', {
+      state: {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: 999,
+      },
+      version: 0,
+    })
+
+    const store = Store.create({
+      chainId: 123,
+      chainIds: [123, 456],
+      storage,
+    })
+    await Store.waitForHydration(store)
+
+    expect(store.getState()).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 123,
         "requestQueue": [],
       }
     `)

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -281,39 +281,6 @@ describe('hydrate', () => {
     `)
   })
 
-  test('behavior: ignores persisted chain IDs outside the supported set', () => {
-    const current: Store.State = {
-      accessKeys: [],
-      accounts: [],
-      activeAccount: 0,
-      chainId: 123,
-      requestQueue: [],
-    }
-
-    const result = Store.hydrate(
-      {
-        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
-        chainId: 999,
-      },
-      current,
-      { chainIds: [123, 456] },
-    )
-
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "accessKeys": [],
-        "accounts": [
-          {
-            "address": "0x0000000000000000000000000000000000000001",
-          },
-        ],
-        "activeAccount": 0,
-        "chainId": 123,
-        "requestQueue": [],
-      }
-    `)
-  })
-
   test('behavior: filters accounts that the adapter cannot restore', () => {
     const current: Store.State = {
       accessKeys: [],
@@ -548,39 +515,6 @@ describe('persistence', () => {
         ],
         "activeAccount": 0,
         "chainId": 456,
-        "requestQueue": [],
-      }
-    `)
-  })
-
-  test('behavior: ignores stored chain IDs outside the supported set', async () => {
-    const storage = Storage.memory()
-    storage.setItem('store', {
-      state: {
-        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
-        activeAccount: 0,
-        chainId: 999,
-      },
-      version: 0,
-    })
-
-    const store = Store.create({
-      chainId: 123,
-      chainIds: [123, 456],
-      storage,
-    })
-    await Store.waitForHydration(store)
-
-    expect(store.getState()).toMatchInlineSnapshot(`
-      {
-        "accessKeys": [],
-        "accounts": [
-          {
-            "address": "0x0000000000000000000000000000000000000001",
-          },
-        ],
-        "activeAccount": 0,
-        "chainId": 123,
         "requestQueue": [],
       }
     `)

--- a/src/core/Store.test.ts
+++ b/src/core/Store.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'vp/test'
+import * as z from 'zod/mini'
 
 import * as Storage from './Storage.js'
 import * as Store from './Store.js'
+import * as u from './zod/utils.js'
+
+const secp256k1Account = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  privateKey: u.hex(),
+})
 
 describe('create', () => {
   test('default', () => {
@@ -273,6 +281,119 @@ describe('hydrate', () => {
     `)
   })
 
+  test('behavior: filters accounts that the adapter cannot restore', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [
+          { address: '0x0000000000000000000000000000000000000001' },
+          {
+            address: '0x0000000000000000000000000000000000000002',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 1,
+        chainId: 456,
+      },
+      current,
+      {
+        account: secp256k1Account,
+      },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+            "keyType": "secp256k1",
+            "privateKey": "0x1234",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: clears active account when every persisted account is invalid', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: 456,
+      },
+      current,
+      { account: secp256k1Account },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: keeps unknown account fields after schema validation', () => {
+    const current: Store.State = {
+      accessKeys: [],
+      accounts: [],
+      activeAccount: 0,
+      chainId: 123,
+      requestQueue: [],
+    }
+
+    const result = Store.hydrate(
+      {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            extra: 'kept',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 0,
+        chainId: 456,
+      },
+      current,
+      { account: secp256k1Account },
+    )
+
+    expect(result.accounts).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x0000000000000000000000000000000000000001",
+          "extra": "kept",
+          "keyType": "secp256k1",
+          "privateKey": "0x1234",
+        },
+      ]
+    `)
+  })
+
   test('behavior: drops legacy access key without chain context', () => {
     const current: Store.State = {
       accessKeys: [],
@@ -348,6 +469,48 @@ describe('persistence', () => {
         "accounts": [
           {
             "address": "0x0000000000000000000000000000000000000001",
+          },
+        ],
+        "activeAccount": 0,
+        "chainId": 456,
+        "requestQueue": [],
+      }
+    `)
+  })
+
+  test('behavior: filters stored accounts with the adapter restore guard', async () => {
+    const storage = Storage.memory()
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          { address: '0x0000000000000000000000000000000000000001' },
+          {
+            address: '0x0000000000000000000000000000000000000002',
+            keyType: 'secp256k1',
+            privateKey: '0x1234',
+          },
+        ],
+        activeAccount: 1,
+        chainId: 456,
+      },
+      version: 0,
+    })
+
+    const store = Store.create({
+      chainId: 123,
+      account: secp256k1Account,
+      storage,
+    })
+    await Store.waitForHydration(store)
+
+    expect(store.getState()).toMatchInlineSnapshot(`
+      {
+        "accessKeys": [],
+        "accounts": [
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+            "keyType": "secp256k1",
+            "privateKey": "0x1234",
           },
         ],
         "activeAccount": 0,

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -65,8 +65,12 @@ export type Store = Mutate<
 
 /** Options for {@link create}. */
 export type Options = {
-  /** Schema for the minimum persisted account shape the current adapter can restore. */
-  account?: z.ZodMiniType | undefined
+  /**
+   * Minimum account schema required for hydration.
+   *
+   * This is a perimeter check for persisted state, not the full account schema.
+   */
+  schema?: z.ZodMiniType | undefined
   /** Initial chain ID. */
   chainId: number
   /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
@@ -100,10 +104,10 @@ export type QueuedRequest<result = unknown> = OneOf<
  */
 export function create(options: Options): Store {
   const {
-    account,
     chainId,
     maxAccounts,
     persistCredentials = true,
+    schema,
     storage = typeof window !== 'undefined'
       ? Storage.idb({ key: 'tempo' })
       : Storage.memory({ key: 'tempo' }),
@@ -120,7 +124,7 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge: (persisted, current) => hydrate(persisted, current, { account }),
+          merge: (persisted, current) => hydrate(persisted, current, { schema }),
           name: 'store',
           partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
@@ -170,8 +174,8 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
       )
       return account ?? persisted
     }) ?? current.accounts
-  const accounts_valid = options.account
-    ? accounts.filter((account) => z.safeParse(options.account!, account).success)
+  const accounts_valid = options.schema
+    ? accounts.filter((account) => z.safeParse(options.schema!, account).success)
     : accounts
   return {
     ...state,
@@ -189,8 +193,12 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
 export declare namespace hydrate {
   /** Options for {@link hydrate}. */
   type Options = {
-    /** Schema for the minimum persisted account shape the current adapter can restore. */
-    account?: z.ZodMiniType | undefined
+    /**
+     * Minimum account schema required for hydration.
+     *
+     * This is a perimeter check for persisted state, not the full account schema.
+     */
+    schema?: z.ZodMiniType | undefined
   }
 }
 

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -65,18 +65,20 @@ export type Store = Mutate<
 
 /** Options for {@link create}. */
 export type Options = {
+  /** Initial chain ID. */
+  chainId: number
+  /** Chain IDs the provider supports. Persisted chain IDs outside this list are ignored. */
+  chainIds?: readonly number[] | undefined
+  /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
+  maxAccounts?: number | undefined
+  /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */
+  persistCredentials?: boolean | undefined
   /**
    * Minimum account schema required for hydration.
    *
    * This is a perimeter check for persisted state, not the full account schema.
    */
   schema?: z.ZodMiniType | undefined
-  /** Initial chain ID. */
-  chainId: number
-  /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
-  maxAccounts?: number | undefined
-  /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */
-  persistCredentials?: boolean | undefined
   /** Storage adapter for persistence. */
   storage?: Storage.Storage | undefined
 }
@@ -105,6 +107,7 @@ export type QueuedRequest<result = unknown> = OneOf<
 export function create(options: Options): Store {
   const {
     chainId,
+    chainIds,
     maxAccounts,
     persistCredentials = true,
     schema,
@@ -124,7 +127,7 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge: (persisted, current) => hydrate(persisted, current, { schema }),
+          merge: (persisted, current) => hydrate(persisted, current, { chainIds, schema }),
           name: 'store',
           partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
@@ -177,6 +180,10 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
   const accounts_valid = options.schema
     ? accounts.filter((account) => z.safeParse(options.schema!, account).success)
     : accounts
+  const chainId =
+    state.chainId !== undefined && (options.chainIds?.includes(state.chainId) ?? true)
+      ? state.chainId
+      : current.chainId
   return {
     ...state,
     ...current,
@@ -186,13 +193,15 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
         ? 0
         : Math.min(state.activeAccount ?? current.activeAccount, accounts_valid.length - 1),
     accessKeys: normalizeAccessKeys(state.accessKeys) ?? current.accessKeys,
-    chainId: state.chainId ?? current.chainId,
+    chainId,
   }
 }
 
 export declare namespace hydrate {
   /** Options for {@link hydrate}. */
   type Options = {
+    /** Chain IDs the provider supports. Persisted chain IDs outside this list are ignored. */
+    chainIds?: readonly number[] | undefined
     /**
      * Minimum account schema required for hydration.
      *

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -3,6 +3,7 @@ import type { Mutate, StoreApi } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { createStore } from 'zustand/vanilla'
+import * as z from 'zod/mini'
 
 import type { OneOf } from '../internal/types.js'
 import type { AccessKey } from './AccessKey.js'
@@ -64,6 +65,8 @@ export type Store = Mutate<
 
 /** Options for {@link create}. */
 export type Options = {
+  /** Schema for the minimum persisted account shape the current adapter can restore. */
+  account?: z.ZodMiniType | undefined
   /** Initial chain ID. */
   chainId: number
   /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
@@ -97,6 +100,7 @@ export type QueuedRequest<result = unknown> = OneOf<
  */
 export function create(options: Options): Store {
   const {
+    account,
     chainId,
     maxAccounts,
     persistCredentials = true,
@@ -116,7 +120,7 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge: hydrate,
+          merge: (persisted, current) => hydrate(persisted, current, { account }),
           name: 'store',
           partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
@@ -154,21 +158,39 @@ export declare namespace serialize {
 }
 
 /** Restores runtime provider state from a persisted refresh snapshot. */
-export function hydrate(persisted: unknown, current: State): State {
+export function hydrate(persisted: unknown, current: State, options: hydrate.Options = {}): State {
   const state = persisted && typeof persisted === 'object' ? (persisted as Partial<Persisted>) : {}
+  const accounts_persisted = Array.isArray(state.accounts)
+    ? state.accounts.filter(isStoredAccount)
+    : undefined
+  const accounts =
+    accounts_persisted?.map((persisted) => {
+      const account = current.accounts.find(
+        (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
+      )
+      return account ?? persisted
+    }) ?? current.accounts
+  const accounts_valid = options.account
+    ? accounts.filter((account) => z.safeParse(options.account!, account).success)
+    : accounts
   return {
     ...state,
     ...current,
-    // Preserve in-memory credentials when persisted accounts only have addresses.
-    accounts:
-      state.accounts?.map((persisted) => {
-        const account = current.accounts.find(
-          (a) => a.address.toLowerCase() === persisted.address.toLowerCase(),
-        )
-        return account ?? persisted
-      }) ?? current.accounts,
+    accounts: accounts_valid,
+    activeAccount:
+      accounts_valid.length === 0
+        ? 0
+        : Math.min(state.activeAccount ?? current.activeAccount, accounts_valid.length - 1),
     accessKeys: normalizeAccessKeys(state.accessKeys) ?? current.accessKeys,
     chainId: state.chainId ?? current.chainId,
+  }
+}
+
+export declare namespace hydrate {
+  /** Options for {@link hydrate}. */
+  type Options = {
+    /** Schema for the minimum persisted account shape the current adapter can restore. */
+    account?: z.ZodMiniType | undefined
   }
 }
 
@@ -192,6 +214,11 @@ function normalizeAccessKeys(accessKeys: Persisted['accessKeys']) {
         value.keyType === 'webCrypto')
     )
   })
+}
+
+function isStoredAccount(account: unknown): account is Account {
+  if (!account || typeof account !== 'object') return false
+  return typeof (account as { address?: unknown }).address === 'string'
 }
 
 /**

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -65,20 +65,18 @@ export type Store = Mutate<
 
 /** Options for {@link create}. */
 export type Options = {
-  /** Initial chain ID. */
-  chainId: number
-  /** Chain IDs the provider supports. Persisted chain IDs outside this list are ignored. */
-  chainIds?: readonly number[] | undefined
-  /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
-  maxAccounts?: number | undefined
-  /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */
-  persistCredentials?: boolean | undefined
   /**
    * Minimum account schema required for hydration.
    *
    * This is a perimeter check for persisted state, not the full account schema.
    */
   schema?: z.ZodMiniType | undefined
+  /** Initial chain ID. */
+  chainId: number
+  /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
+  maxAccounts?: number | undefined
+  /** Whether to persist credentials and access keys to storage. When `false`, only account addresses are persisted. @default true */
+  persistCredentials?: boolean | undefined
   /** Storage adapter for persistence. */
   storage?: Storage.Storage | undefined
 }
@@ -107,7 +105,6 @@ export type QueuedRequest<result = unknown> = OneOf<
 export function create(options: Options): Store {
   const {
     chainId,
-    chainIds,
     maxAccounts,
     persistCredentials = true,
     schema,
@@ -127,7 +124,7 @@ export function create(options: Options): Store {
           requestQueue: [],
         }),
         {
-          merge: (persisted, current) => hydrate(persisted, current, { chainIds, schema }),
+          merge: (persisted, current) => hydrate(persisted, current, { schema }),
           name: 'store',
           partialize: (state) => serialize(state, { maxAccounts, persistCredentials }),
           storage,
@@ -180,10 +177,6 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
   const accounts_valid = options.schema
     ? accounts.filter((account) => z.safeParse(options.schema!, account).success)
     : accounts
-  const chainId =
-    state.chainId !== undefined && (options.chainIds?.includes(state.chainId) ?? true)
-      ? state.chainId
-      : current.chainId
   return {
     ...state,
     ...current,
@@ -193,15 +186,13 @@ export function hydrate(persisted: unknown, current: State, options: hydrate.Opt
         ? 0
         : Math.min(state.activeAccount ?? current.activeAccount, accounts_valid.length - 1),
     accessKeys: normalizeAccessKeys(state.accessKeys) ?? current.accessKeys,
-    chainId,
+    chainId: state.chainId ?? current.chainId,
   }
 }
 
 export declare namespace hydrate {
   /** Options for {@link hydrate}. */
   type Options = {
-    /** Chain IDs the provider supports. Persisted chain IDs outside this list are ignored. */
-    chainIds?: readonly number[] | undefined
     /**
      * Minimum account schema required for hydration.
      *

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -5,17 +5,42 @@ import { describe, expect, test } from 'vp/test'
 
 import {
   accounts as core_accounts,
+  chain,
   getClient,
   privateKeys,
   webAuthnAccounts,
 } from '../../../test/config.js'
 import * as Account from '../Account.js'
 import type * as Adapter from '../Adapter.js'
+import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
 import { local } from './local.js'
 
 describe('local', () => {
+  test('behavior: does not hydrate account without local signing fields', async () => {
+    const storage = Storage.memory({ key: 'local-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({
+      adapter: local({ loadAccounts: async () => ({ accounts: [] }) }),
+      chains: [chain],
+      storage,
+    })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+
   describe('loadAccounts', () => {
     test('default: loads accounts', async () => {
       const { adapter } = setup()

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,13 +1,72 @@
-import { Provider as ox_Provider } from 'ox'
+import { Provider as ox_Provider, type WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { hashMessage } from 'viem'
 import { prepareTransactionRequest } from 'viem/actions'
-import { Actions } from 'viem/tempo'
+import { Account as TempoAccount, Actions } from 'viem/tempo'
+import * as z from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Account from '../Account.js'
 import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
+import * as u from '../zod/utils.js'
+
+const secp256k1Stored = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
+
+const p256Stored = z.object({
+  address: u.address(),
+  keyType: z.literal('p256'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
+
+const webAuthnStored = z.object({
+  address: u.address(),
+  credential: z.object({
+    id: z.string(),
+    publicKey: u.hex(),
+    rpId: z.string(),
+  }),
+  keyType: z.literal('webAuthn'),
+  label: z.optional(z.string()),
+})
+
+const webAuthnHeadlessStored = z.object({
+  address: u.address(),
+  keyType: z.literal('webAuthn_headless'),
+  label: z.optional(z.string()),
+  origin: z.string(),
+  privateKey: u.hex(),
+  rpId: z.string(),
+})
+
+const webCryptoStored = z.object({
+  address: u.address(),
+  keyPair: z.custom<Awaited<ReturnType<typeof WebCryptoP256.createKeyPair>>>(),
+  keyType: z.literal('webCrypto'),
+  label: z.optional(z.string()),
+})
+
+const functionSignerStored = z.object({
+  address: u.address(),
+  keyType: z.union([z.literal('secp256k1'), z.literal('p256'), z.literal('webAuthn')]),
+  label: z.optional(z.string()),
+  sign: z.custom<TempoAccount.Account['sign']>(),
+})
+
+const signableStored = z.union([
+  secp256k1Stored,
+  p256Stored,
+  webAuthnStored,
+  webAuthnHeadlessStored,
+  webCryptoStored,
+  functionSignerStored,
+])
 
 /**
  * Creates a local adapter where the app manages keys and signing in-process.
@@ -28,7 +87,7 @@ import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, persistedAccount: signableStored, rdns }, ({ getAccount, getClient, store }) => {
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const { feePayer, ...rest } = parameters
       const client = getClient({

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -11,21 +11,21 @@ import * as Adapter from '../Adapter.js'
 import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 import * as u from '../zod/utils.js'
 
-const secp256k1Stored = z.object({
+const secp256k1Schema = z.object({
   address: u.address(),
   keyType: z.literal('secp256k1'),
   label: z.optional(z.string()),
   privateKey: u.hex(),
 })
 
-const p256Stored = z.object({
+const p256Schema = z.object({
   address: u.address(),
   keyType: z.literal('p256'),
   label: z.optional(z.string()),
   privateKey: u.hex(),
 })
 
-const webAuthnStored = z.object({
+const webAuthnSchema = z.object({
   address: u.address(),
   credential: z.object({
     id: z.string(),
@@ -36,7 +36,7 @@ const webAuthnStored = z.object({
   label: z.optional(z.string()),
 })
 
-const webAuthnHeadlessStored = z.object({
+const webAuthnHeadlessSchema = z.object({
   address: u.address(),
   keyType: z.literal('webAuthn_headless'),
   label: z.optional(z.string()),
@@ -45,27 +45,27 @@ const webAuthnHeadlessStored = z.object({
   rpId: z.string(),
 })
 
-const webCryptoStored = z.object({
+const webCryptoSchema = z.object({
   address: u.address(),
   keyPair: z.custom<Awaited<ReturnType<typeof WebCryptoP256.createKeyPair>>>(),
   keyType: z.literal('webCrypto'),
   label: z.optional(z.string()),
 })
 
-const functionSignerStored = z.object({
+const functionSignerSchema = z.object({
   address: u.address(),
   keyType: z.union([z.literal('secp256k1'), z.literal('p256'), z.literal('webAuthn')]),
   label: z.optional(z.string()),
   sign: z.custom<TempoAccount.Account['sign']>(),
 })
 
-const signableStored = z.union([
-  secp256k1Stored,
-  p256Stored,
-  webAuthnStored,
-  webAuthnHeadlessStored,
-  webCryptoStored,
-  functionSignerStored,
+const signableSchema = z.union([
+  secp256k1Schema,
+  p256Schema,
+  webAuthnSchema,
+  webAuthnHeadlessSchema,
+  webCryptoSchema,
+  functionSignerSchema,
 ])
 
 /**
@@ -87,7 +87,7 @@ const signableStored = z.union([
 export function local(options: local.Options): Adapter.Adapter {
   const { createAccount, icon, loadAccounts, name, rdns } = options
 
-  return Adapter.define({ icon, name, persistedAccount: signableStored, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, rdns, schema: signableSchema }, ({ getAccount, getClient, store }) => {
     async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
       const { feePayer, ...rest } = parameters
       const client = getClient({

--- a/src/core/adapters/secp256k1.test.ts
+++ b/src/core/adapters/secp256k1.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, test } from 'vp/test'
 
-import { accounts, privateKeys } from '../../../test/config.js'
+import { accounts, chain, privateKeys } from '../../../test/config.js'
 import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
 import { secp256k1 } from './secp256k1.js'
 
 describe('secp256k1', () => {
+  test('behavior: does not hydrate account without private key', async () => {
+    const storage = Storage.memory({ key: 'secp256k1-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            keyType: 'secp256k1',
+          },
+        ],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({ adapter: secp256k1(), chains: [chain], storage })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+
   test('behavior: privateKey option pins the connected account', async () => {
     const account = accounts[1]!
     const provider = Provider.create({

--- a/src/core/adapters/secp256k1.ts
+++ b/src/core/adapters/secp256k1.ts
@@ -1,8 +1,17 @@
 import type { Hex } from 'viem'
 import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
+import * as z from 'zod/mini'
 
 import * as Adapter from '../Adapter.js'
+import * as u from '../zod/utils.js'
 import { local } from './local.js'
+
+const persistedAccount = z.object({
+  address: u.address(),
+  keyType: z.literal('secp256k1'),
+  label: z.optional(z.string()),
+  privateKey: u.hex(),
+})
 
 /**
  * Creates a secp256k1 adapter that signs in-process with a `secp256k1` private key.
@@ -43,7 +52,7 @@ export function secp256k1(options: secp256k1.Options = {}): Adapter.Adapter {
       }
     : undefined
 
-  return Adapter.define({ icon, name, rdns }, (config) => {
+  return Adapter.define({ icon, name, persistedAccount, rdns }, (config) => {
     const { store } = config
 
     return local({

--- a/src/core/adapters/secp256k1.ts
+++ b/src/core/adapters/secp256k1.ts
@@ -6,7 +6,7 @@ import * as Adapter from '../Adapter.js'
 import * as u from '../zod/utils.js'
 import { local } from './local.js'
 
-const persistedAccount = z.object({
+const schema = z.object({
   address: u.address(),
   keyType: z.literal('secp256k1'),
   label: z.optional(z.string()),
@@ -52,7 +52,7 @@ export function secp256k1(options: secp256k1.Options = {}): Adapter.Adapter {
       }
     : undefined
 
-  return Adapter.define({ icon, name, persistedAccount, rdns }, (config) => {
+  return Adapter.define({ icon, name, rdns, schema }, (config) => {
     const { store } = config
 
     return local({

--- a/src/core/adapters/webAuthn.test.ts
+++ b/src/core/adapters/webAuthn.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vp/test'
+
+import { chain } from '../../../test/config.js'
+import * as Provider from '../Provider.js'
+import * as Storage from '../Storage.js'
+import * as Store from '../Store.js'
+import { webAuthn } from './webAuthn.js'
+
+describe('webAuthn', () => {
+  test('behavior: does not hydrate account without credential', async () => {
+    const storage = Storage.memory({ key: 'webauthn-invalid-account' })
+    storage.setItem('store', {
+      state: {
+        accounts: [
+          {
+            address: '0x0000000000000000000000000000000000000001',
+            keyType: 'webAuthn',
+          },
+        ],
+        activeAccount: 0,
+        chainId: chain.id,
+      },
+      version: 0,
+    })
+    const provider = Provider.create({ adapter: webAuthn(), chains: [chain], storage })
+
+    await Store.waitForHydration(provider.store)
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(
+      `[]`,
+    )
+  })
+})

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -12,7 +12,7 @@ import * as Rpc from '../zod/rpc.js'
 import * as u from '../zod/utils.js'
 import { local } from './local.js'
 
-const persistedAccount = z.object({
+const schema = z.object({
   address: u.address(),
   credential: z.object({
     id: z.string(),
@@ -46,7 +46,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
     return authUrl
   })()
 
-  return Adapter.define({ icon, name, persistedAccount, rdns }, (parameters) => {
+  return Adapter.define({ icon, name, rdns, schema }, (parameters) => {
     const { storage } = parameters
 
     const ceremony =

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -2,13 +2,26 @@ import { PublicKey, Signature } from 'ox'
 import { SignatureEnvelope } from 'ox/tempo'
 import { Account } from 'viem/tempo'
 import { Authentication, Registration } from 'webauthx/client'
-import type { z } from 'zod'
+import type * as core_z from 'zod'
+import * as z from 'zod/mini'
 
 import type { OneOf } from '../../internal/types.js'
 import * as Adapter from '../Adapter.js'
 import * as WebAuthnCeremony from '../WebAuthnCeremony.js'
 import * as Rpc from '../zod/rpc.js'
+import * as u from '../zod/utils.js'
 import { local } from './local.js'
+
+const persistedAccount = z.object({
+  address: u.address(),
+  credential: z.object({
+    id: z.string(),
+    publicKey: u.hex(),
+    rpId: z.string(),
+  }),
+  keyType: z.literal('webAuthn'),
+  label: z.optional(z.string()),
+})
 
 /**
  * Creates a WebAuthn adapter backed by real passkey ceremonies.
@@ -33,7 +46,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
     return authUrl
   })()
 
-  return Adapter.define({ icon, name, rdns }, (parameters) => {
+  return Adapter.define({ icon, name, persistedAccount, rdns }, (parameters) => {
     const { storage } = parameters
 
     const ceremony =
@@ -151,7 +164,7 @@ export declare namespace webAuthn {
          * other fields (`challenge`, `verify`, `logout`, `returnToken`) are
          * SIWE-only and ignored by the WebAuthn ceremony.
          */
-        auth?: z.input<typeof Rpc.wallet_connect.auth> | undefined
+        auth?: core_z.input<typeof Rpc.wallet_connect.auth> | undefined
         /** @deprecated Use `auth` instead. */
         authUrl?: string | undefined
       }


### PR DESCRIPTION
## Summary
Persisted accounts are validated against adapter requirements before hydration.

## Motivation
Recover in the face of storage corruption (e.g. multiple account SDK providers can share storage on the same page). 

## Changes
- Add adapter account validation before persisted state is accepted.
- Define minimum persisted account requirements for local, secp256k1, and WebAuthn adapters.
- Add store and adapter regression coverage for invalid persisted account state.

## Testing
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`
- `./node_modules/.bin/vp test src/core/Store.test.ts`
- `./node_modules/.bin/vp test src/core/Store.test.ts src/core/Provider.localnet.test.ts src/core/adapters/local.test.ts src/core/adapters/secp256k1.test.ts src/core/adapters/webAuthn.test.ts`