### PR TITLE
Reject malformed keyring integer fields

### DIFF
--- a/src/cli/keyring.test.ts
+++ b/src/cli/keyring.test.ts
@@ -116,3 +116,24 @@ describe('Keyring.find', () => {
     `)
   })
 })
+
+
+describe('Keyring.parse', () => {
+  test('rejects malformed integer fields', () => {
+    const content = `# Tempo connect keys — managed by \`tempo connect\`
+# Do not edit manually.
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "${root.address}"
+chain_id = ${chain.id}abc
+key_type = "secp256k1"
+key_address = "${accessKey.address}"
+key = "0x11"
+key_authorization = "0x22"
+expiry = 2
+`
+
+    expect(() => Keyring.parse(content)).toThrow('Invalid chain_id')
+  })
+})

--- a/src/cli/keyring.test.ts
+++ b/src/cli/keyring.test.ts
@@ -134,6 +134,8 @@ key_authorization = "0x22"
 expiry = 2
 `
 
-    expect(() => Keyring.parse(content)).toThrow('Invalid chain_id')
+    expect(() => Keyring.parse(content)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid chain_id: ${chain.id}abc]`,
+    )
   })
 })

--- a/src/cli/keyring.ts
+++ b/src/cli/keyring.ts
@@ -105,7 +105,7 @@ export declare namespace upsert {
   }
 }
 
-function parse(text: string): readonly Entry[] {
+export function parse(text: string): readonly Entry[] {
   const keys: Entry[] = []
   let key: Partial<Entry> | undefined
   let limit: Partial<{ token: Address.Address; limit: bigint }> | undefined
@@ -171,12 +171,12 @@ function parse(text: string): readonly Entry[] {
 
     if (!key) continue
     if (name === 'wallet_address') key.walletAddress = stripQuotes(value) as Address.Address
-    if (name === 'chain_id') key.chainId = Number.parseInt(value, 10)
+    if (name === 'chain_id') key.chainId = parseInteger(value, 'chain_id')
     if (name === 'key_type') key.keyType = stripQuotes(value) as Entry['keyType']
     if (name === 'key_address') key.keyAddress = stripQuotes(value) as Address.Address
     if (name === 'key') key.key = stripQuotes(value) as Hex.Hex
     if (name === 'key_authorization') key.keyAuthorization = stripQuotes(value) as Hex.Hex
-    if (name === 'expiry') key.expiry = Number.parseInt(value, 10)
+    if (name === 'expiry') key.expiry = parseInteger(value, 'expiry')
   }
 
   flushKey()
@@ -207,6 +207,13 @@ function stringify(keys: readonly Entry[]) {
       ]),
     ]),
   ].join('\n')
+}
+
+function parseInteger(value: string, name: string) {
+  if (!/^\d+$/.test(value)) throw new Error(`Invalid ${name}: ${value}`)
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) throw new Error(`Invalid ${name}: ${value}`)
+  return parsed
 }
 
 function stripQuotes(value: string) {

--- a/src/cli/keyring.ts
+++ b/src/cli/keyring.ts
@@ -105,6 +105,7 @@ export declare namespace upsert {
   }
 }
 
+/** Parses managed key entries from TOML text. */
 export function parse(text: string): readonly Entry[] {
   const keys: Entry[] = []
   let key: Partial<Entry> | undefined


### PR DESCRIPTION
The CLI keyring parser was using `Number.parseInt` for `chain_id` and `expiry`, which accepts partial strings like `123abc` as `123`.

This rejects malformed integer fields instead, so edited or corrupted keyring entries do not get accepted with truncated values.
