### PR TITLE
feat(dialog): accept access key private material

### DIFF
--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -330,6 +330,8 @@ export declare namespace authorizeAccessKey {
     keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
     /** TIP-20 spending limits for this key. */
     limits?: readonly { token: Address; limit: bigint; period?: number | undefined }[] | undefined
+    /** Exported private key backing the access key. The local SDK stores it and forwards only public material. */
+    privateKey?: Hex | undefined
     /** External public key to authorize. When provided, no key pair is generated — the caller holds the signing material. */
     publicKey?: Hex | undefined
     /** Call scopes restricting which contracts/selectors this key can call. */

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -1,5 +1,7 @@
 import { Address, Hex, Provider as ox_Provider, PublicKey } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { generatePrivateKey } from 'viem/accounts'
+import { Account as TempoAccount } from 'viem/tempo'
 import { tempoLocalnet } from 'viem/tempo/chains'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vp/test'
 
@@ -220,6 +222,63 @@ describe('dialog', () => {
         "auth": {
           "token": "test-token",
         },
+      }
+    `)
+  })
+
+  test('behavior: authorizeAccessKey forwards public material for a provided private key', async () => {
+    const { adapter, dialog, store } = setup()
+    const expiry = 123
+    const privateKey = generatePrivateKey()
+    const accessKey = TempoAccount.fromSecp256k1(privateKey)
+    const promise = adapter.actions.authorizeAccessKey!(
+      { expiry, keyType: 'secp256k1', privateKey },
+      {
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry, keyType: 'secp256k1' }],
+      },
+    )
+
+    const queued = await dialog.takeRequest()
+    const request = queued.request as {
+      params: readonly [
+        {
+          expiry: number
+          keyType: 'secp256k1'
+          privateKey?: Hex.Hex | undefined
+          publicKey: Hex.Hex
+        },
+      ]
+    }
+    const params = request.params[0] as {
+      expiry: number
+      keyType: 'secp256k1'
+      privateKey?: Hex.Hex | undefined
+      publicKey: Hex.Hex
+    }
+    dialog.success(queued, {
+      keyAuthorization: createKeyAuthorization(params),
+      rootAddress: address,
+    })
+
+    await expect(promise).resolves.toMatchObject({ rootAddress: address })
+    expect(params.privateKey).toMatchInlineSnapshot(`undefined`)
+    expect(params.publicKey).toMatchInlineSnapshot(`"${accessKey.publicKey}"`)
+    const {
+      address: storedAddress,
+      privateKey: storedPrivateKey,
+      ...stored
+    } = store.getState().accessKeys.map(({ keyAuthorization: _, ...key }) => key)[0]!
+    expect(storedAddress).toBe(accessKey.address.toLowerCase())
+    expect(storedPrivateKey).toBe(privateKey)
+    expect(stored).toMatchInlineSnapshot(`
+      {
+        "access": "0x0000000000000000000000000000000000000001",
+        "chainId": 1337,
+        "expiry": 123,
+        "keyType": "secp256k1",
+        "limits": undefined,
+        "scopes": undefined,
       }
     `)
   })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -1,5 +1,6 @@
-import { Address, Provider as ox_Provider, RpcResponse } from 'ox'
+import { Address, Hex, Provider as ox_Provider, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
+import { Account as TempoAccount } from 'viem/tempo'
 import { z } from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
@@ -75,8 +76,32 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
      * an external publicKey/address, and returns the params to inject into the
      * RPC request so the dialog signs the authorization.
      */
-    async function generateAccessKey(options: Adapter.authorizeAccessKey.Parameters | undefined) {
+    async function prepareAccessKey(options: Adapter.authorizeAccessKey.Parameters | undefined) {
       if (!options) return undefined
+      if (options.privateKey) {
+        const keyType = options.keyType ?? 'secp256k1'
+        const accessKey = (() => {
+          switch (keyType) {
+            case 'secp256k1':
+              return TempoAccount.fromSecp256k1(options.privateKey)
+            case 'p256':
+              return TempoAccount.fromP256(options.privateKey)
+            case 'webAuthn':
+              throw new RpcResponse.InvalidParamsError({
+                message: '`privateKey` cannot be used with `keyType: "webAuthn"`.',
+              })
+          }
+        })()
+        const { privateKey: _privateKey, ...request } = options
+        return {
+          generated: { privateKey: options.privateKey },
+          request: {
+            ...request,
+            publicKey: accessKey.publicKey,
+            keyType,
+          },
+        }
+      }
       if (options.publicKey || options.address) return undefined
       if (options.keyType && options.keyType !== 'p256')
         throw new RpcResponse.InvalidParamsError({
@@ -103,13 +128,14 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     function saveAccessKey(
       address: Address.Address,
       keyAuth: KeyAuthorization.Rpc,
-      generated: Awaited<ReturnType<typeof AccessKey.generate>>,
+      generated: Awaited<ReturnType<typeof AccessKey.generate>> | { privateKey: Hex.Hex },
     ) {
       const keyAuthorization = KeyAuthorization.fromRpc(keyAuth)
       AccessKey.add({
         account: address,
         authorization: keyAuthorization,
-        keyPair: generated.keyPair,
+        ...('keyPair' in generated ? { keyPair: generated.keyPair } : {}),
+        ...('privateKey' in generated ? { privateKey: generated.privateKey } : {}),
         store,
       })
     }
@@ -121,7 +147,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       forwardsAuth: true,
       actions: {
         async createAccount(parameters, request) {
-          const accessKey = await generateAccessKey(parameters.authorizeAccessKey)
+          const accessKey = await prepareAccessKey(parameters.authorizeAccessKey)
 
           const { accounts } = await provider.request({
             ...request,
@@ -160,7 +186,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         },
 
         async loadAccounts(parameters, request) {
-          const accessKey = await generateAccessKey(parameters?.authorizeAccessKey)
+          const accessKey = await prepareAccessKey(parameters?.authorizeAccessKey)
 
           const { accounts } = await provider.request({
             ...request,
@@ -318,7 +344,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         },
 
         async authorizeAccessKey(parameters, request) {
-          const accessKey = await generateAccessKey(parameters)
+          const accessKey = await prepareAccessKey(parameters)
 
           const result = await provider.request({
             ...request,


### PR DESCRIPTION
## Summary
Allow dialog authorization to accept caller-provided access key private material.

## Motivation
The playground can generate non-P256 access keys outside the SDK, but dialog still needs to forward only public material to the wallet and retain the private key locally.

## Changes
- Add `privateKey` to `Adapter.authorizeAccessKey.Parameters`.
- Derive public material in `src/core/adapters/dialog.ts` and strip `privateKey` before forwarding.
- Store provided private key material after the wallet returns a signed key authorization.

## Testing
- `pnpm test src/core/adapters/dialog.test.ts -t "provided private key|generates a p256 key|loadAccounts forwards auth"`
- `./node_modules/.bin/tsc -b --noEmit`
