### PR TITLE
fix: filter access key selection by key type

### DIFF
--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -4,7 +4,7 @@ import { BaseError, encodeErrorResult, encodeFunctionResult } from 'viem'
 import { Abis, Account as TempoAccount } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
-import { accounts } from '../../test/config.js'
+import { accounts, privateKeys } from '../../test/config.js'
 import * as AccessKey from './AccessKey.js'
 import * as AccessKeyTransaction from './internal/AccessKeyTransaction.js'
 import * as Store from './Store.js'
@@ -20,6 +20,7 @@ function createKeyAuthorization(
   options: {
     chainId?: bigint | undefined
     expiry?: number | undefined
+    keyType?: 'secp256k1' | 'p256' | 'webAuthn' | undefined
     limits?: { token: `0x${string}`; limit: bigint }[] | undefined
     scopes?: KeyAuthorization.Scope[] | undefined
   } = {},
@@ -31,7 +32,7 @@ function createKeyAuthorization(
       expiry: options.expiry,
       limits: options.limits,
       scopes: options.scopes,
-      type: 'p256',
+      type: options.keyType ?? 'p256',
     },
     { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
   )
@@ -552,6 +553,38 @@ describe('select', () => {
         "miss": false,
       }
     `)
+  })
+
+  test('behavior: filters access keys by key type', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accounts[1]!.address, {
+        keyType: 'secp256k1',
+      }),
+      privateKey: privateKeys[1],
+      store,
+    })
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress),
+      keyPair,
+      store,
+    })
+
+    const result = await AccessKey.select({
+      account: rootAddress,
+      calls: [],
+      chainId: 1,
+      keyType: 'secp256k1',
+      store,
+    })
+
+    expect(result?.accessKeyAddress).toMatchInlineSnapshot(
+      `"0x8c8d35429f74ec245f8ef2f4fd1e551cff97d650"`,
+    )
   })
 })
 

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -96,6 +96,8 @@ type SelectQuery = {
   calls?: readonly Call[] | undefined
   /** Chain ID the access key must be authorized on. */
   chainId: number
+  /** Key type the access key must use. */
+  keyType?: AccessKey['keyType'] | undefined
   /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
   now?: number | undefined
   /** Reactive state store. */
@@ -294,11 +296,12 @@ export async function getStatus(options: StatusQuery): Promise<Status> {
 export async function select(
   options: SelectQuery,
 ): Promise<TempoAccount.AccessKeyAccount | undefined> {
-  const { account, calls, chainId, store } = options
+  const { account, calls, chainId, keyType, store } = options
   const now = options.now ?? Date.now() / 1000
   const records = list({ account, chainId, store })
 
   for (const record of records) {
+    if (keyType && record.keyType !== keyType) continue
     if (!scopesMatch(record, { calls })) continue
     if (isExpired(record.expiry, now)) {
       remove({ accessKey: record.address, account: record.access, chainId: record.chainId, store })


### PR DESCRIPTION
## Summary
Filter local access-key selection by key type.

## Motivation
Some callers need a specific signing scheme, such as SECP256K1 for session voucher signing. Exact key lookup should stay address-only, while capability-based selection can filter by key type.

## Changes
- Add an optional `keyType` filter to `AccessKey.select`.
- Skip locally stored access keys whose stored type does not match the requested type.
- Add a unit test covering selection between P256 and SECP256K1 keys.

## Testing
- `./node_modules/.bin/vp test src/core/AccessKey.test.ts -t "filters access keys by key type|matches access key scopes"`
- `./node_modules/.bin/tsc -b --noEmit`
