### PR TITLE
feat(turnkey): expose account materialization

### DIFF
--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -1,6 +1,7 @@
 import type { KeyAuthorization } from 'ox/tempo'
 import type { Client, Hex, Transport } from 'viem'
 import type { Address } from 'viem/accounts'
+import type { Account as TempoAccount } from 'viem/tempo'
 import type { tempo } from 'viem/tempo/chains'
 import type * as z from 'zod/mini'
 
@@ -132,6 +133,10 @@ export type Instance = {
   }
   /** Cleanup function called when the provider is destroyed. */
   cleanup?: (() => void) | undefined
+  /** Materialize an adapter-owned signer account. */
+  getAccount?:
+    | ((options?: getAccount.Options | undefined) => Promise<getAccount.ReturnType>)
+    | undefined
   /**
    * When `true`, the provider skips Server Authentication orchestration on
    * `wallet_connect` and forwards `capabilities.auth` to the adapter
@@ -181,6 +186,20 @@ export declare namespace getClient {
     chainId?: number | undefined
     /** Fee payer service URL, or `false` to opt out of fee payers for this transaction if set globally. */
     feePayer?: string | false | undefined
+  }
+}
+
+export declare namespace getAccount {
+  /** Options for materializing an adapter-owned signer account. */
+  type Options = {
+    /** Account address to materialize. Defaults to the active account. */
+    address?: Address | undefined
+  }
+
+  /** Materialized account returned by an adapter. */
+  type ReturnType = {
+    /** Tempo-compatible local signer account. */
+    account: TempoAccount.Account
   }
 }
 

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -39,6 +39,27 @@ describe('local', () => {
     await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(`[]`)
   })
 
+  test('behavior: getAccount materializes a local signer', async () => {
+    const { adapter, store } = setup()
+    store.setState({
+      accounts: [
+        {
+          address: core_accounts[0]!.address,
+          keyType: 'secp256k1',
+          privateKey: privateKeys[0]!,
+        },
+      ],
+      activeAccount: 0,
+    })
+
+    const { account } = await adapter.getAccount!({ address: core_accounts[0]!.address })
+    const signature = await account.sign({ hash: hashMessage({ raw: '0x68656c6c6f' }) })
+
+    expect(signature).toMatchInlineSnapshot(
+      `"0xf16ea9a3478698f695fd1401bfe27e9e4a7e8e3da94aa72b021125e31fa899cc573c48ea3fe1d4ab61a9db10c19032026e3ed2dbccba5a178235ac27f94504311c"`,
+    )
+  })
+
   describe('loadAccounts', () => {
     test('default: loads accounts', async () => {
       const { adapter } = setup()

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -154,6 +154,9 @@ export function local(options: local.Options): Adapter.Adapter {
       }
 
       return {
+        async getAccount(options = {}) {
+          return { account: getAccount({ ...options, signable: true }) }
+        },
         actions: {
           async createAccount(parameters) {
             if (!createAccount)

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -1,5 +1,5 @@
 import { Hex, PublicKey } from 'ox'
-import { decodeFunctionData } from 'viem'
+import { decodeFunctionData, hashMessage } from 'viem'
 import type { Address } from 'viem/accounts'
 import { Abis } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
@@ -352,6 +352,25 @@ describe('turnkey', () => {
 
     expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
     expect(client.loadCalls).toMatchInlineSnapshot(`0`)
+  })
+
+  test('behavior: getAccount materializes a local signer from an existing session', async () => {
+    const { adapter, client, store } = setup()
+    store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const { account } = await adapter.getAccount!({ address })
+    const result = await account.sign({ hash: hashMessage({ raw: '0x68656c6c6f' }) })
+
+    expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
+    expect(client.loadCalls).toMatchInlineSnapshot(`0`)
+    expect(client.signWith).toMatchInlineSnapshot(`
+      [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ]
+    `)
+    expect(result).toMatchInlineSnapshot(
+      `"0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
+    )
   })
 
   test('behavior: silent restore does not connect accounts when the provider store is empty', async () => {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -323,6 +323,9 @@ export function turnkey<const client extends turnkey.Client>(
       cleanup() {
         if (expiry_timeout) clearTimeout(expiry_timeout)
       },
+      async getAccount(options = {}) {
+        return { account: await getTurnkeyAccount(options.address) }
+      },
       actions: {
         async createAccount(parameters) {
           const { authorizeAccessKey, personalSign } = parameters


### PR DESCRIPTION
## Summary
Expose local and Turnkey signer accounts through an adapter account materialization hook.

## Motivation
Provider-owned RPC actions need adapters to materialize signer accounts without duplicating adapter-specific account lookup logic.

## Changes
- Add optional `Adapter.Instance.getAccount`.
- Implement local `getAccount` through the provider-supplied account finder.
- Implement Turnkey `getAccount` using the existing `getTurnkeyAccount` path.
- Add focused local and Turnkey tests for signing through materialized Tempo accounts.

## Testing
- `./node_modules/.bin/vp test src/core/adapters/local.test.ts -t getAccount`
- `./node_modules/.bin/vp test src/core/adapters/turnkey.test.ts -t getAccount`
- `./node_modules/.bin/tsc -b --noEmit`
