### PR TITLE
refactor(provider): centralize adapter rpc actions

### DIFF
--- a/.changeset/provider-owned-rpc-actions.md
+++ b/.changeset/provider-owned-rpc-actions.md
@@ -1,0 +1,7 @@
+---
+"accounts": minor
+---
+
+Add provider-owned RPC action handling for adapters that expose a viem account with `getAccount`.
+
+Adapters can now implement `getAccount` and optional `generateAccessKey` instead of duplicating transaction, signing, and access-key RPC actions.

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -378,6 +378,9 @@ export function cli(options: cli.Options): Adapter.Adapter {
           return await account.signTypedData(JSON.parse(data) as never)
         },
       },
+      generateAccessKey() {
+        return undefined
+      },
     }
   })
 }

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -244,22 +244,6 @@ describe('isUnavailableError', () => {
   })
 })
 
-describe('generate', () => {
-  test('default: returns p256 access key and key pair', async () => {
-    const result = await AccessKey.generate()
-
-    expect(result.accessKey.address).toMatch(/^0x[0-9a-f]{40}$/i)
-    expect(result.keyPair).toBeDefined()
-  })
-
-  test('behavior: with account attaches access to root', async () => {
-    const result = await AccessKey.generate({ account: accounts[0]! })
-
-    expect(result.accessKey.source).toMatchInlineSnapshot(`"accessKey"`)
-    expect(result.accessKey.accessKeyAddress).toMatch(/^0x[0-9a-f]{40}$/i)
-  })
-})
-
 describe('prepareAuthorization', () => {
   test('default: prepares generated p256 key authorization', async () => {
     const result = await AccessKey.prepareAuthorization({ chainId: 1, expiry: 123 })

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -128,31 +128,6 @@ type ManagedAccount = TempoAccount.AccessKeyAccount
 
 type KeyAuthorizationManager = TempoKeyAuthorizationManager.KeyAuthorizationManager
 
-/** Generates a P256 key pair and access key account. */
-export async function generate(options: generate.Options = {}): Promise<generate.ReturnType> {
-  const { account } = options
-  const keyPair = await WebCryptoP256.createKeyPair()
-  const accessKey = TempoAccount.fromWebCryptoP256(
-    keyPair,
-    account ? { access: account } : undefined,
-  )
-  return { accessKey, keyPair }
-}
-
-export declare namespace generate {
-  type Options = {
-    /** Root account to attach to the access key. */
-    account?: TempoAccount.Account | undefined
-  }
-
-  type ReturnType = {
-    /** The generated access key account. */
-    accessKey: TempoAccount.AccessKeyAccount
-    /** Generated key pair to pass to `authorizeAccessKey`. */
-    keyPair: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>>
-  }
-}
-
 /** Prepares an unsigned key authorization and local key material when needed. */
 export async function prepareAuthorization(
   options: prepareAuthorization.Options,
@@ -175,6 +150,11 @@ export async function prepareAuthorization(
       message: `\`keyType: "${keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
     })
 
+  if (!globalThis.crypto?.subtle)
+    throw new RpcResponse.InvalidParamsError({
+      message:
+        'Generated P256 access keys require WebCrypto support; provide `publicKey` or `address` instead.',
+    })
   const keyPair = await WebCryptoP256.createKeyPair()
   const keyAuthorization = KeyAuthorization.from({
     address: Address.fromPublicKey(PublicKey.from(keyPair.publicKey)),

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -1,9 +1,12 @@
+import type { WebCryptoP256 } from 'ox'
 import type { KeyAuthorization } from 'ox/tempo'
 import type { Client, Hex, Transport } from 'viem'
-import type { Address } from 'viem/accounts'
+import type { Address, JsonRpcAccount } from 'viem/accounts'
+import type { Account as TempoAccount } from 'viem/tempo'
 import type { tempo } from 'viem/tempo/chains'
 import type * as z from 'zod/mini'
 
+import type { MaybePromise } from '../internal/types.js'
 import type * as Account from './Account.js'
 import type * as Schema from './Schema.js'
 import type * as Storage from './Storage.js'
@@ -96,30 +99,40 @@ export type Instance = {
         ) => Promise<swap.ReturnType>)
       | undefined
     /** Send a transaction. */
-    sendTransaction: (
-      params: sendTransaction.Parameters,
-      request: EncodedRequest<Rpc.eth_sendTransaction.Encoded>,
-    ) => Promise<sendTransaction.ReturnType>
+    sendTransaction?:
+      | ((
+          params: sendTransaction.Parameters,
+          request: EncodedRequest<Rpc.eth_sendTransaction.Encoded>,
+        ) => Promise<sendTransaction.ReturnType>)
+      | undefined
     /** Send a transaction and wait for the receipt. */
-    sendTransactionSync: (
-      params: sendTransactionSync.Parameters,
-      request: EncodedRequest<Rpc.eth_sendTransactionSync.Encoded>,
-    ) => Promise<sendTransactionSync.ReturnType>
+    sendTransactionSync?:
+      | ((
+          params: sendTransactionSync.Parameters,
+          request: EncodedRequest<Rpc.eth_sendTransactionSync.Encoded>,
+        ) => Promise<sendTransactionSync.ReturnType>)
+      | undefined
     /** Sign a personal message (EIP-191). */
-    signPersonalMessage: (
-      params: signPersonalMessage.Parameters,
-      request: EncodedRequest<Rpc.personal_sign.Encoded>,
-    ) => Promise<Hex>
+    signPersonalMessage?:
+      | ((
+          params: signPersonalMessage.Parameters,
+          request: EncodedRequest<Rpc.personal_sign.Encoded>,
+        ) => Promise<Hex>)
+      | undefined
     /** Sign a transaction without broadcasting it. */
-    signTransaction: (
-      params: signTransaction.Parameters,
-      request: EncodedRequest<Rpc.eth_signTransaction.Encoded>,
-    ) => Promise<signTransaction.ReturnType>
+    signTransaction?:
+      | ((
+          params: signTransaction.Parameters,
+          request: EncodedRequest<Rpc.eth_signTransaction.Encoded>,
+        ) => Promise<signTransaction.ReturnType>)
+      | undefined
     /** Sign EIP-712 typed data. */
-    signTypedData: (
-      params: signTypedData.Parameters,
-      request: EncodedRequest<Rpc.eth_signTypedData_v4.Encoded>,
-    ) => Promise<Hex>
+    signTypedData?:
+      | ((
+          params: signTypedData.Parameters,
+          request: EncodedRequest<Rpc.eth_signTypedData_v4.Encoded>,
+        ) => Promise<Hex>)
+      | undefined
     /** Switch chain hook for adapter-specific handling. */
     switchChain?: ((params: switchChain.Parameters) => Promise<void>) | undefined
     /** Open the zone-withdraw flow. */
@@ -132,6 +145,18 @@ export type Instance = {
   }
   /** Cleanup function called when the provider is destroyed. */
   cleanup?: (() => void) | undefined
+  /**
+   * Generates access-key material when `authorizeAccessKey` omits `address`
+   * and `publicKey`. Return `undefined` to let adapter actions handle key
+   * generation themselves.
+   */
+  generateAccessKey?:
+    | ((
+        options?: generateAccessKey.Options | undefined,
+      ) => MaybePromise<generateAccessKey.ReturnType>)
+    | undefined
+  /** Materializes the adapter-managed account used for provider-owned RPC actions. */
+  getAccount?: ((options?: getAccount.Options | undefined) => getAccount.ReturnType) | undefined
   /**
    * When `true`, the provider skips Server Authentication orchestration on
    * `wallet_connect` and forwards `capabilities.auth` to the adapter
@@ -182,6 +207,61 @@ export declare namespace getClient {
     /** Fee payer service URL, or `false` to opt out of fee payers for this transaction if set globally. */
     feePayer?: string | false | undefined
   }
+}
+
+export declare namespace generateAccessKey {
+  /** Options for {@link Instance.generateAccessKey}. */
+  type Options = {
+    /** Requested key type from `authorizeAccessKey`. Defaults to adapter policy. */
+    keyType?: authorizeAccessKey.Parameters['keyType'] | undefined
+  }
+
+  /** Generated access-key material. */
+  type ReturnType =
+    | {
+        /** Generated key type. */
+        keyType: 'secp256k1' | 'p256'
+        /** Generated public key. */
+        publicKey: Hex
+        /** Exported private key backing the generated access key. */
+        privateKey?: Hex | undefined
+        /** WebCrypto key pair backing the generated access key. */
+        keyPair?: Awaited<globalThis.ReturnType<typeof WebCryptoP256.createKeyPair>> | undefined
+      }
+    | undefined
+}
+
+export declare namespace getAccount {
+  type Options = {
+    /** Address to materialize. Defaults to the active account. */
+    address?: Address | undefined
+  }
+
+  type ReturnType =
+    | {
+        /** Viem-compatible account used by provider-owned RPC actions. */
+        account: JsonRpcAccount
+        /** Transport used to route JSON-RPC wallet account requests. */
+        transport: Transport
+      }
+    | Promise<{
+        /** Viem-compatible account used by provider-owned RPC actions. */
+        account: JsonRpcAccount
+        /** Transport used to route JSON-RPC wallet account requests. */
+        transport: Transport
+      }>
+    | {
+        /** Viem-compatible account used by provider-owned RPC actions. */
+        account: TempoAccount.Account
+        /** Local signer accounts do not use a wallet transport. */
+        transport?: undefined
+      }
+    | Promise<{
+        /** Viem-compatible account used by provider-owned RPC actions. */
+        account: TempoAccount.Account
+        /** Local signer accounts do not use a wallet transport. */
+        transport?: undefined
+      }>
 }
 
 export declare namespace createAccount {

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as Adapter from './Adapter.js'
+import * as Provider from './Provider.js'
+import * as Storage from './Storage.js'
+
+const address = '0x0000000000000000000000000000000000000001'
+
+describe('wallet_connect', () => {
+  test('behavior: validates auth before preparing access key material', async () => {
+    const generateAccessKey = vi.fn(() => {
+      throw new Error('generateAccessKey called')
+    })
+    const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+      actions: {
+        async createAccount() {
+          return { accounts: [{ address }] }
+        },
+        async loadAccounts() {
+          return { accounts: [{ address }] }
+        },
+      },
+      generateAccessKey,
+    }))
+    const provider = Provider.create({ adapter, storage: Storage.memory() })
+
+    await expect(
+      provider.request({
+        method: 'wallet_connect',
+        params: [
+          {
+            capabilities: {
+              auth: { returnToken: true },
+              authorizeAccessKey: { expiry: 123 },
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`auth\` capability must include either \`url\` or an explicit \`challenge\` endpoint.]`,
+    )
+    expect(generateAccessKey.mock.calls).toMatchInlineSnapshot(`[]`)
+  })
+})
+
+describe('adapter actions', () => {
+  test('behavior: explicit adapter action overrides provider default', async () => {
+    const getAccount = vi.fn(() => {
+      throw new Error('getAccount called')
+    })
+    const signPersonalMessage = vi.fn(
+      async (_parameters: Adapter.signPersonalMessage.Parameters) => {
+        return '0x1234' as const
+      },
+    )
+    const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+      actions: {
+        async createAccount() {
+          return { accounts: [{ address }] }
+        },
+        async loadAccounts() {
+          return { accounts: [{ address }] }
+        },
+        signPersonalMessage,
+      },
+      getAccount: getAccount as never,
+    }))
+    const provider = Provider.create({ adapter, storage: Storage.memory() })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({
+        method: 'personal_sign',
+        params: ['0x68656c6c6f', address],
+      }),
+    ).resolves.toMatchInlineSnapshot(`"0x1234"`)
+    expect(getAccount.mock.calls).toMatchInlineSnapshot(`[]`)
+    expect(signPersonalMessage.mock.calls.map(([parameters]) => parameters)).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x0000000000000000000000000000000000000001",
+          "data": "0x68656c6c6f",
+        },
+      ]
+    `)
+  })
+})

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,8 +1,34 @@
 import { announceProvider } from 'mipd'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
-import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
-import { http, parseUnits, type Chain, type Client as ViemClient, type Transport } from 'viem'
+import {
+  Address,
+  Hash,
+  Hex,
+  Json,
+  Provider as ox_Provider,
+  PublicKey,
+  RpcResponse,
+  WebCryptoP256,
+} from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
+import {
+  createWalletClient,
+  custom,
+  hashMessage,
+  hashTypedData,
+  http,
+  parseUnits,
+  type Chain,
+  type Client as ViemClient,
+  type Transport,
+} from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
+import {
+  prepareTransactionRequest,
+  sendTransaction,
+  sendTransactionSync as viem_sendTransactionSync,
+  signTransaction as viem_signTransaction,
+} from 'viem/actions'
 import { parseSiweMessage } from 'viem/siwe'
 import { Account as TempoAccount, Actions } from 'viem/tempo'
 import { tempo, tempoDevnet, tempoModerato } from 'viem/tempo/chains'
@@ -45,6 +71,12 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
   }
 
 const announced = new Set<string>()
+
+type TransactionParameters = Adapter.ActionRequest<typeof Rpc.eth_sendTransaction.schema>
+
+function isBrowserWebCrypto() {
+  return typeof document !== 'undefined' && !!globalThis.crypto?.subtle
+}
 
 /**
  * Creates an EIP-1193 provider with a pluggable adapter.
@@ -168,6 +200,433 @@ export function create(options: create.Options = {}): create.ReturnType {
     return sorted.map((a) => a.address)
   }
 
+  function unsupported(action: string): never {
+    throw new ox_Provider.UnsupportedMethodError({
+      message: `\`${action}\` not supported by adapter.`,
+    })
+  }
+
+  async function getAdapterAccount(
+    options: Adapter.getAccount.Options = {},
+  ): Promise<Awaited<Adapter.getAccount.ReturnType>> {
+    if (!instance.getAccount) unsupported('getAccount')
+    return await instance.getAccount(options)
+  }
+
+  function getWalletClient(options: {
+    account: Awaited<Adapter.getAccount.ReturnType>['account']
+    chainId?: number | undefined
+    feePayer?: string | false | undefined
+    transport?: Transport | undefined
+  }) {
+    const client = getClient({ chainId: options.chainId, feePayer: options.feePayer })
+    return createWalletClient({
+      account: options.account,
+      chain: client.chain,
+      transport: options.transport ?? custom({ request: client.request }),
+    })
+  }
+
+  async function prepareRootTransaction(parameters: TransactionParameters) {
+    const { feePayer, ...rest } = parameters
+    const selected = await getAdapterAccount({ address: parameters.from })
+    const client = getWalletClient({
+      account: selected.account,
+      chainId: parameters.chainId,
+      feePayer: feePayer === true ? undefined : feePayer,
+      transport: selected.transport,
+    })
+    const request = {
+      ...rest,
+      ...(feePayer ? { feePayer: true as const } : {}),
+    }
+    if (selected.account.type === 'json-rpc') return { client, request, selected }
+    const prepared = await prepareTransactionRequest(client, {
+      account: selected.account,
+      ...request,
+      type: 'tempo',
+    } as never)
+    return { client, request: prepared, selected }
+  }
+
+  async function signTransaction_(parameters: TransactionParameters) {
+    {
+      const state = store.getState()
+      const chainId = parameters.chainId ?? state.chainId
+      const client = getClient({
+        chainId,
+        feePayer: (() => {
+          if (parameters.feePayer === false) return false
+          if (typeof parameters.feePayer === 'string') return parameters.feePayer
+          return undefined
+        })(),
+      })
+      const transaction = parameters.from
+        ? await AccessKeyTransaction.create({
+            address: parameters.from,
+            calls: parameters.calls,
+            chainId,
+            client,
+            store,
+          })
+        : undefined
+      if (transaction)
+        try {
+          const { feePayer, ...rest } = parameters
+          const prepared = await transaction.prepare({
+            ...rest,
+            ...(feePayer ? { feePayer: true as never } : {}),
+          })
+          return await prepared.sign()
+        } catch {}
+    }
+
+    const { client, request, selected } = await prepareRootTransaction(parameters)
+    if (selected.account.type === 'json-rpc')
+      return await viem_signTransaction(client, request as never)
+    return await selected.account.signTransaction!(request as never)
+  }
+
+  async function sendTransaction_(parameters: TransactionParameters) {
+    {
+      const state = store.getState()
+      const chainId = parameters.chainId ?? state.chainId
+      const client = getClient({
+        chainId,
+        feePayer: (() => {
+          if (parameters.feePayer === false) return false
+          if (typeof parameters.feePayer === 'string') return parameters.feePayer
+          return undefined
+        })(),
+      })
+      const transaction = parameters.from
+        ? await AccessKeyTransaction.create({
+            address: parameters.from,
+            calls: parameters.calls,
+            chainId,
+            client,
+            store,
+          })
+        : undefined
+      if (transaction)
+        try {
+          const { feePayer, ...rest } = parameters
+          const prepared = await transaction.prepare({
+            ...rest,
+            ...(feePayer ? { feePayer: true as never } : {}),
+          })
+          return await prepared.send()
+        } catch {}
+    }
+
+    const { feePayer, ...rest } = parameters
+    const selected = await getAdapterAccount({ address: parameters.from })
+    const client = getWalletClient({
+      account: selected.account,
+      chainId: parameters.chainId,
+      feePayer: feePayer === true ? undefined : feePayer,
+      transport: selected.transport,
+    })
+    return await sendTransaction(client, {
+      ...rest,
+      ...(feePayer ? { feePayer: true as never } : {}),
+    } as never)
+  }
+
+  async function sendTransactionSync_(parameters: TransactionParameters) {
+    {
+      const state = store.getState()
+      const chainId = parameters.chainId ?? state.chainId
+      const client = getClient({
+        chainId,
+        feePayer: (() => {
+          if (parameters.feePayer === false) return false
+          if (typeof parameters.feePayer === 'string') return parameters.feePayer
+          return undefined
+        })(),
+      })
+      const transaction = parameters.from
+        ? await AccessKeyTransaction.create({
+            address: parameters.from,
+            calls: parameters.calls,
+            chainId,
+            client,
+            store,
+          })
+        : undefined
+      if (transaction)
+        try {
+          const { feePayer, ...rest } = parameters
+          const prepared = await transaction.prepare({
+            ...rest,
+            ...(feePayer ? { feePayer: true as never } : {}),
+          })
+          return await prepared.sendSync()
+        } catch {}
+    }
+
+    const { feePayer, ...rest } = parameters
+    const selected = await getAdapterAccount({ address: parameters.from })
+    const client = getWalletClient({
+      account: selected.account,
+      chainId: parameters.chainId,
+      feePayer: feePayer === true ? undefined : feePayer,
+      transport: selected.transport,
+    })
+    const request = {
+      ...rest,
+      ...(feePayer ? { feePayer: true as const } : {}),
+    }
+    if (selected.account.type === 'json-rpc')
+      return (await client.request({
+        method: 'eth_sendTransactionSync' as never,
+        params: [z.encode(Rpc.transactionRequest, request)] as never,
+      })) as Rpc.eth_sendTransactionSync.Encoded['returns']
+    const receipt = await viem_sendTransactionSync(client, {
+      account: selected.account,
+      ...request,
+    } as never)
+    return z.encode(Rpc.receipt, receipt as never) as Rpc.eth_sendTransactionSync.Encoded['returns']
+  }
+
+  async function signPersonalMessage(parameters: { address: Address.Address; data: Hex.Hex }) {
+    const selected = await getAdapterAccount({ address: parameters.address })
+    const client = getWalletClient({ account: selected.account, transport: selected.transport })
+    if (selected.account.type === 'json-rpc')
+      return await client.signMessage({
+        account: selected.account,
+        message: { raw: parameters.data },
+      })
+    return await selected.account.sign!({ hash: hashMessage({ raw: parameters.data }) })
+  }
+
+  async function signTypedData(parameters: { address: Address.Address; data: string }) {
+    const typedData = JSON.parse(parameters.data) as {
+      domain: Record<string, unknown>
+      message: Record<string, unknown>
+      primaryType: string
+      types: Record<string, unknown>
+    }
+    const selected = await getAdapterAccount({ address: parameters.address })
+    const client = getWalletClient({ account: selected.account, transport: selected.transport })
+    if (selected.account.type === 'json-rpc')
+      return await client.signTypedData({
+        account: selected.account,
+        ...typedData,
+      } as never)
+    return await selected.account.sign!({ hash: hashTypedData(typedData as never) })
+  }
+
+  async function authorizeAccessKey(parameters: Adapter.authorizeAccessKey.Parameters) {
+    const selected = await getAdapterAccount()
+    const chainId = parameters.chainId ?? getClient().chain.id
+    if (selected.account.type !== 'json-rpc') {
+      const keyAuthorization = await AccessKey.authorize({
+        account: selected.account as Pick<TempoAccount.Account, 'address' | 'sign'>,
+        chainId,
+        parameters,
+        store,
+      })
+      return { keyAuthorization, rootAddress: selected.account.address }
+    }
+
+    const prepared = await prepareAuthorizeAccessKey(parameters, Number(chainId))
+    const client = getWalletClient({
+      account: selected.account,
+      chainId: Number(chainId),
+      transport: selected.transport,
+    })
+    const result = (await client.request({
+      method: 'wallet_authorizeAccessKey' as never,
+      params: [z.encode(Rpc.wallet_authorizeAccessKey.parameters, prepared.parameters)] as never,
+    })) as Adapter.authorizeAccessKey.ReturnType
+    savePreparedAccessKey({
+      account: result.rootAddress,
+      accessKey: prepared,
+      keyAuthorization: result.keyAuthorization,
+    })
+    return result
+  }
+
+  async function prepareAuthorizeAccessKey(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+    chainId: number | undefined,
+  ) {
+    const chainId_ = parameters.chainId ?? chainId ?? getClient().chain.id
+    if (parameters.address || parameters.publicKey) {
+      const prepared = await AccessKey.prepareAuthorization({
+        ...parameters,
+        chainId: chainId_,
+      })
+      return {
+        parameters: toAuthorizeAccessKeyParameters(parameters, prepared.keyAuthorization),
+      }
+    }
+
+    const generated = instance.generateAccessKey
+      ? await instance.generateAccessKey({ keyType: parameters.keyType })
+      : await generateBrowserP256AccessKey(parameters)
+    if (!generated) return { parameters }
+
+    const prepared = await AccessKey.prepareAuthorization({
+      ...parameters,
+      chainId: chainId_,
+      keyType: generated.keyType,
+      publicKey: generated.publicKey,
+    })
+    return {
+      keyPair: generated.keyPair,
+      parameters: {
+        ...toAuthorizeAccessKeyParameters(parameters, prepared.keyAuthorization),
+        publicKey: generated.publicKey,
+      },
+      privateKey: generated.privateKey,
+    }
+  }
+
+  function toAuthorizeAccessKeyParameters(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+    keyAuthorization: Awaited<
+      ReturnType<typeof AccessKey.prepareAuthorization>
+    >['keyAuthorization'],
+  ) {
+    return {
+      ...parameters,
+      address: keyAuthorization.address,
+      chainId: keyAuthorization.chainId,
+      keyType: keyAuthorization.type,
+    }
+  }
+
+  async function generateBrowserP256AccessKey(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+  ): Promise<Adapter.generateAccessKey.ReturnType> {
+    if (!isBrowserWebCrypto()) return undefined
+    if (parameters.keyType && parameters.keyType !== 'p256')
+      throw new RpcResponse.InvalidParamsError({
+        message: `\`keyType: "${parameters.keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
+      })
+    const keyPair = await WebCryptoP256.createKeyPair()
+    return {
+      keyPair,
+      keyType: 'p256',
+      publicKey: PublicKey.toHex(keyPair.publicKey),
+    }
+  }
+
+  function savePreparedAccessKey(options: {
+    accessKey: Awaited<ReturnType<typeof prepareAuthorizeAccessKey>> | undefined
+    account: Address.Address | undefined
+    keyAuthorization: KeyAuthorization.Rpc | undefined
+  }) {
+    const { accessKey, account, keyAuthorization } = options
+    if (!account || !keyAuthorization || !accessKey) return
+    const { keyPair, privateKey } = accessKey
+    const material = keyPair ? { keyPair } : privateKey ? { privateKey } : undefined
+    if (!material) return
+    AccessKey.add({
+      account,
+      authorization: KeyAuthorization.fromRpc(keyAuthorization),
+      ...material,
+      store,
+    })
+  }
+
+  async function revokeAccessKey(parameters: {
+    address: Address.Address
+    accessKeyAddress: Address.Address
+  }) {
+    const selected = await getAdapterAccount({ address: parameters.address })
+    const client = getWalletClient({
+      account: selected.account,
+      transport: selected.transport,
+    })
+    if (selected.account.type === 'json-rpc') {
+      await client.request({
+        method: 'wallet_revokeAccessKey' as never,
+        params: [parameters] as never,
+      })
+    } else {
+      try {
+        await Actions.accessKey.revoke(getClient(), {
+          account: selected.account as TempoAccount.Account,
+          accessKey: parameters.accessKeyAddress,
+        })
+      } catch (error) {
+        if (!AccessKey.isUnavailableError(error)) throw error
+      }
+    }
+    AccessKey.remove({
+      accessKey: parameters.accessKeyAddress,
+      account: parameters.address,
+      chainId: store.getState().chainId,
+      store,
+    })
+  }
+
+  async function signTransactionAction(
+    parameters: TransactionParameters,
+    request: Pick<Rpc.eth_signTransaction.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.signTransaction) return await actions.signTransaction(parameters, request)
+    if (instance.getAccount) return await signTransaction_(parameters)
+    unsupported('signTransaction')
+  }
+
+  async function sendTransactionAction(
+    parameters: TransactionParameters,
+    request: Pick<Rpc.eth_sendTransaction.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.sendTransaction) return await actions.sendTransaction(parameters, request)
+    if (instance.getAccount) return await sendTransaction_(parameters)
+    unsupported('sendTransaction')
+  }
+
+  async function sendTransactionSyncAction(
+    parameters: TransactionParameters,
+    request: Pick<Rpc.eth_sendTransactionSync.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.sendTransactionSync) return await actions.sendTransactionSync(parameters, request)
+    if (instance.getAccount) return await sendTransactionSync_(parameters)
+    unsupported('sendTransactionSync')
+  }
+
+  async function signPersonalMessageAction(
+    parameters: { address: Address.Address; data: Hex.Hex },
+    request: Pick<Rpc.personal_sign.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.signPersonalMessage) return await actions.signPersonalMessage(parameters, request)
+    if (instance.getAccount) return await signPersonalMessage(parameters)
+    unsupported('signPersonalMessage')
+  }
+
+  async function signTypedDataAction(
+    parameters: { address: Address.Address; data: string },
+    request: Pick<Rpc.eth_signTypedData_v4.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.signTypedData) return await actions.signTypedData(parameters, request)
+    if (instance.getAccount) return await signTypedData(parameters)
+    unsupported('signTypedData')
+  }
+
+  async function authorizeAccessKeyAction(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+    request: Pick<Rpc.wallet_authorizeAccessKey.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.authorizeAccessKey) return await actions.authorizeAccessKey(parameters, request)
+    if (instance.getAccount) return await authorizeAccessKey(parameters)
+    unsupported('authorizeAccessKey')
+  }
+
+  async function revokeAccessKeyAction(
+    parameters: Adapter.revokeAccessKey.Parameters,
+    request: Pick<Rpc.wallet_revokeAccessKey.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.revokeAccessKey) return await actions.revokeAccessKey(parameters, request)
+    if (instance.getAccount) return await revokeAccessKey(parameters)
+    unsupported('revokeAccessKey')
+  }
+
   /** Returns accounts to persist. When `persistAccounts` is set, merges new accounts with existing ones. */
   function resolveAccounts(accounts: readonly Account.Store[]) {
     if (!instance.persistAccounts) return accounts
@@ -255,7 +714,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
                     const state = store.getState()
-                    return (await actions.sendTransaction(
+                    return (await sendTransactionAction(
                       {
                         ...rest,
                         chainId: decoded.chainId ?? state.chainId,
@@ -341,7 +800,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
                     const state = store.getState()
-                    return (await actions.signTransaction(
+                    return (await signTransactionAction(
                       {
                         ...rest,
                         chainId: decoded.chainId ?? state.chainId,
@@ -360,7 +819,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
                     const state = store.getState()
-                    return (await actions.sendTransactionSync(
+                    return (await sendTransactionSyncAction(
                       {
                         ...rest,
                         chainId: decoded.chainId ?? state.chainId,
@@ -375,7 +834,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                   case 'eth_signTypedData_v4': {
                     assertConnected()
                     const [address, data] = request._decoded.params
-                    return (await actions.signTypedData(
+                    return (await signTypedDataAction(
                       {
                         address,
                         data,
@@ -387,7 +846,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                   case 'personal_sign': {
                     assertConnected()
                     const [data, address] = request._decoded.params
-                    return (await actions.signPersonalMessage(
+                    return (await signPersonalMessageAction(
                       {
                         address,
                         data,
@@ -413,7 +872,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         ...(feePayer ? { feePayer } : {}),
                       }
                       if (!sync) {
-                        const hash = await actions.sendTransaction(txRequest, {
+                        const hash = await sendTransactionAction(txRequest, {
                           method: 'eth_sendTransaction',
                           params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
                         })
@@ -421,7 +880,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         const id = Hex.concat(hash, Hex.padLeft(chainId, 32), sendCallsMagic)
                         return { capabilities: { sync }, id }
                       }
-                      const receipt = await actions.sendTransactionSync(txRequest as never, {
+                      const receipt = await sendTransactionSyncAction(txRequest as never, {
                         method: 'eth_sendTransactionSync',
                         params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
                       })
@@ -582,9 +1041,14 @@ export function create(options: create.Options = {}): create.ReturnType {
                           '`auth` and `personalSign` cannot both be set on `wallet_connect`.',
                       })
 
+                    const accessKey = authorizeAccessKey
+                      ? await prepareAuthorizeAccessKey(authorizeAccessKey, chainId)
+                      : undefined
+
                     // Patch the raw request so forwarding adapters carry the
-                    // absolutized auth URLs downstream.
-                    if (auth_request)
+                    // absolutized auth URLs and prepared access-key material
+                    // downstream.
+                    if (auth_request || accessKey)
                       request = {
                         ...request,
                         params: [
@@ -592,7 +1056,15 @@ export function create(options: create.Options = {}): create.ReturnType {
                             ...request.params?.[0],
                             capabilities: {
                               ...request.params?.[0]?.capabilities,
-                              auth: auth_request,
+                              ...(auth_request ? { auth: auth_request } : {}),
+                              ...(accessKey
+                                ? {
+                                    authorizeAccessKey: z.encode(
+                                      Rpc.wallet_connect.authorizeAccessKey,
+                                      accessKey.parameters,
+                                    ),
+                                  }
+                                : {}),
                             },
                           },
                         ] as never,
@@ -636,7 +1108,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             {
                               credentialId: existing.credential?.id,
                               digest: capabilities.digest,
-                              authorizeAccessKey,
+                              authorizeAccessKey: accessKey?.parameters,
                               ...(personalSign_request
                                 ? { personalSign: personalSign_request }
                                 : {}),
@@ -649,7 +1121,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         return await actions.createAccount(
                           {
                             digest: capabilities.digest,
-                            authorizeAccessKey,
+                            authorizeAccessKey: accessKey?.parameters,
                             name: capabilities.name ?? 'default',
                             ...(capabilities.showDeposit !== undefined
                               ? { showDeposit: capabilities.showDeposit }
@@ -664,7 +1136,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         {
                           credentialId: capabilities?.credentialId,
                           digest: capabilities?.digest,
-                          authorizeAccessKey,
+                          authorizeAccessKey: accessKey?.parameters,
                           selectAccount: capabilities?.selectAccount,
                           ...(personalSign_request ? { personalSign: personalSign_request } : {}),
                           ...(capabilities?.showDeposit !== undefined
@@ -690,6 +1162,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                     })
 
                     const accountAddress = accounts[0]?.address
+                    savePreparedAccessKey({
+                      accessKey,
+                      account: accountAddress,
+                      keyAuthorization,
+                    })
 
                     // Server Authentication verify: POST the signed SIWE message
                     // to the verify endpoint. Skipped when the auth capability
@@ -783,12 +1260,8 @@ export function create(options: create.Options = {}): create.ReturnType {
                   }
 
                   case 'wallet_authorizeAccessKey': {
-                    if (!actions.authorizeAccessKey)
-                      throw new ox_Provider.UnsupportedMethodError({
-                        message: '`authorizeAccessKey` not supported by adapter.',
-                      })
                     const decoded = request._decoded.params[0]
-                    const result = await actions.authorizeAccessKey(decoded, request)
+                    const result = await authorizeAccessKeyAction(decoded, request)
                     return {
                       keyAuthorization: {
                         ...result.keyAuthorization,
@@ -800,17 +1273,8 @@ export function create(options: create.Options = {}): create.ReturnType {
 
                   case 'wallet_revokeAccessKey': {
                     assertConnected()
-                    if (!actions.revokeAccessKey)
-                      throw new ox_Provider.UnsupportedMethodError({
-                        message: '`revokeAccessKey` not supported by adapter.',
-                      })
                     const [decoded] = request._decoded.params
-                    await actions.revokeAccessKey(
-                      {
-                        ...decoded,
-                      },
-                      request,
-                    )
+                    await revokeAccessKeyAction({ ...decoded }, request)
                     return
                   }
 
@@ -912,7 +1376,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                       from: signerAddress,
                       ...(resolvedFeePayer !== undefined ? { feePayer: resolvedFeePayer } : {}),
                     }
-                    const receipt = await actions.sendTransactionSync(txRequest, {
+                    const receipt = await sendTransactionSyncAction(txRequest, {
                       method: 'eth_sendTransactionSync',
                       params: [z.encode(Rpc.transactionRequest, txRequest)] as const,
                     })

--- a/src/core/adapters/dialog.test.ts
+++ b/src/core/adapters/dialog.test.ts
@@ -1,37 +1,33 @@
-import { Address, Hex, Provider as ox_Provider, PublicKey } from 'ox'
-import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { Provider as ox_Provider } from 'ox'
 import { tempoLocalnet } from 'viem/tempo/chains'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Dialog from '../Dialog.js'
-import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 import * as RemoteRequests from '../internal/RemoteRequests.js'
+import * as Provider from '../Provider.js'
 import type * as Remote from '../Remote.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
 import { dialog } from './dialog.js'
 
 const address = '0x0000000000000000000000000000000000000001'
+const accessKey = '0x0000000000000000000000000000000000000002'
 const host = 'https://wallet.test/embed'
-const recipient = '0x0000000000000000000000000000000000000002'
-
-function createKeyAuthorization(options: {
-  expiry: number
-  keyType: 'secp256k1' | 'p256'
-  publicKey: Hex.Hex
-}) {
-  const { expiry, keyType, publicKey } = options
-  return KeyAuthorization.toRpc(
-    KeyAuthorization.from(
-      {
-        address: Address.fromPublicKey(PublicKey.from(publicKey)),
-        chainId: BigInt(tempoLocalnet.id),
-        expiry,
-        type: keyType,
-      },
-      { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
-    ),
-  )
+const receipt = {
+  blockHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  blockNumber: '0x1',
+  contractAddress: null,
+  cumulativeGasUsed: '0x1',
+  effectiveGasPrice: '0x1',
+  from: address,
+  gasUsed: '0x1',
+  logs: [],
+  logsBloom: `0x${'00'.repeat(256)}`,
+  status: '0x1',
+  to: address,
+  transactionHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  transactionIndex: '0x0',
+  type: '0x76',
 }
 
 function setup() {
@@ -83,6 +79,15 @@ function createDialog() {
   }
 }
 
+async function getDialogClient(adapter: ReturnType<typeof setup>['adapter']) {
+  const result = await adapter.getAccount!()
+  if (result.account.type !== 'json-rpc') throw new Error('Expected JSON-RPC account.')
+  if (!result.transport) throw new Error('Expected dialog transport.')
+  return result.transport({}) as never as {
+    request: (request: unknown) => Promise<unknown>
+  }
+}
+
 describe('dialog', () => {
   beforeEach(() => {
     RemoteRequests.reset(host)
@@ -93,94 +98,8 @@ describe('dialog', () => {
     RemoteRequests.reset(host)
   })
 
-  test('behavior: sendTransaction signs locally when an access key is selected', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: tempoLocalnet.id, storage })
-    const clientRequests: unknown[] = []
-    const signRequests: unknown[] = []
-    vi.spyOn(AccessKeyTransaction, 'create').mockResolvedValue({
-      fill: async () => ({ capabilities: { sponsored: false }, tx: {} }),
-      prepare: async (request) => ({
-        request: request as never,
-        send: async () => {
-          signRequests.push(request)
-          clientRequests.push({ method: 'eth_sendRawTransaction', params: ['0xsigned'] })
-          return '0xtransaction'
-        },
-        sendSync: async () => {
-          throw new Error('unexpected sendSync')
-        },
-        sign: async () => {
-          signRequests.push(request)
-          return '0xsigned'
-        },
-      }),
-    })
-    const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () =>
-        ({
-          chain: { id: tempoLocalnet.id },
-          request: async (request: unknown) => {
-            clientRequests.push(request)
-            return '0xtransaction'
-          },
-        }) as never,
-      storage,
-      store,
-    })
-    const result = await adapter.actions.sendTransaction(
-      {
-        calls: [{ data: '0x12345678', to: recipient }],
-        chainId: 1,
-        from: address,
-        gas: 1n,
-        maxFeePerGas: 1n,
-        maxPriorityFeePerGas: 1n,
-        nonce: 0,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            calls: [{ data: '0x12345678' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
-          },
-        ] as const,
-      },
-    )
-
-    expect(result).toMatchInlineSnapshot(`"0xtransaction"`)
-    expect(signRequests.length).toMatchInlineSnapshot(`1`)
-    expect(clientRequests).toMatchInlineSnapshot(`
-      [
-        {
-          "method": "eth_sendRawTransaction",
-          "params": [
-            "0xsigned",
-          ],
-        },
-      ]
-    `)
-    expect(dialog_.syncs).toMatchInlineSnapshot(`[]`)
-  })
-
   test('behavior: loadAccounts forwards auth capabilities returned by the dialog', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: tempoLocalnet.id, storage })
-    const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () => ({}) as never,
-      storage,
-      store,
-    })
+    const { adapter, dialog } = setup()
     const request = {
       method: 'wallet_connect' as const,
       params: [
@@ -198,8 +117,8 @@ describe('dialog', () => {
 
     const promise = adapter.actions.loadAccounts(undefined, request)
 
-    const queued = await dialog_.takeRequest()
-    dialog_.success(queued, {
+    const queued = await dialog.takeRequest()
+    dialog.success(queued, {
       accounts: [
         {
           address,
@@ -232,39 +151,23 @@ describe('dialog', () => {
     const dialog_a = createDialog()
     const dialog_b = createDialog()
     const adapter_a = dialog({ dialog: dialog_a.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
+      getAccount: () => ({ address, type: 'json-rpc' }) as never,
       getClient: () => ({}) as never,
       storage,
       store: store_a,
     })
     const adapter_b = dialog({ dialog: dialog_b.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
+      getAccount: () => ({ address, type: 'json-rpc' }) as never,
       getClient: () => ({}) as never,
       storage,
       store: store_b,
     })
 
-    const promise = adapter_a.actions.sendTransaction(
-      {
-        calls: [{ data: '0x12345678', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            calls: [{ data: '0x12345678' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
-          },
-        ] as const,
-      },
-    )
+    const client = await getDialogClient(adapter_a)
+    const promise = client.request({
+      method: 'eth_sendTransaction',
+      params: [{ from: address }],
+    })
 
     const queued = await dialog_b.takeRequest()
 
@@ -292,14 +195,6 @@ describe('dialog', () => {
     dialog_b.success(queued, '0x1234')
 
     await expect(promise).resolves.toMatchInlineSnapshot(`"0x1234"`)
-    expect(dialog_b.synced.map((requests) => requests.map((x) => x.request.method)))
-      .toMatchInlineSnapshot(`
-        [
-          [
-            "eth_sendTransaction",
-          ],
-        ]
-      `)
     adapter_a.cleanup?.()
     adapter_b.cleanup?.()
   })
@@ -310,31 +205,17 @@ describe('dialog', () => {
     store_a.setState({ accounts: [{ address }], activeAccount: 0 })
     const dialog_a = createDialog()
     const adapter_a = dialog({ dialog: dialog_a.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
+      getAccount: () => ({ address, type: 'json-rpc' }) as never,
       getClient: () => ({}) as never,
       storage,
       store: store_a,
     })
 
-    const promise = adapter_a.actions.sendTransaction(
-      {
-        calls: [{ data: '0x12345678', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            calls: [{ data: '0x12345678' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
-          },
-        ] as const,
-      },
-    )
+    const client = await getDialogClient(adapter_a)
+    const promise = client.request({
+      method: 'eth_sendTransaction',
+      params: [{ from: address }],
+    })
 
     const queued = await dialog_a.takeRequest()
     adapter_a.cleanup?.()
@@ -342,9 +223,7 @@ describe('dialog', () => {
     const store_b = Store.create({ chainId: 456, storage })
     const dialog_b = createDialog()
     const adapter_b = dialog({ dialog: dialog_b.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
+      getAccount: () => ({ address, type: 'json-rpc' }) as never,
       getClient: () => ({}) as never,
       storage,
       store: store_b,
@@ -377,58 +256,23 @@ describe('dialog', () => {
   })
 
   test('behavior: resolving one pending request advances the remote queue', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: 123, storage })
-    const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () => ({}) as never,
-      storage,
-      store,
+    const { adapter, dialog } = setup()
+    const client = await getDialogClient(adapter)
+
+    const first = client.request({
+      method: 'eth_sendTransaction',
+      params: [{ from: address }],
+    })
+    const second = client.request({
+      method: 'eth_signTransaction',
+      params: [{ from: address }],
     })
 
-    const first = adapter.actions.sendTransaction(
-      {
-        calls: [{ data: '0x11111111', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            calls: [{ data: '0x11111111' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
-          },
-        ] as const,
-      },
-    )
-    const second = adapter.actions.sendTransaction(
-      {
-        calls: [{ data: '0x22222222', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            calls: [{ data: '0x22222222' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
-          },
-        ] as const,
-      },
-    )
-
-    const request_1 = await dialog_.takeRequest()
-    dialog_.success(request_1, '0x1')
+    const request_1 = await dialog.takeRequest()
+    dialog.success(request_1, '0x1')
 
     await expect(first).resolves.toMatchInlineSnapshot(`"0x1"`)
-    expect(dialog_.synced.map((requests) => requests.map((x) => x.request.id)))
+    expect(dialog.synced.map((requests) => requests.map((x) => x.request.id)))
       .toMatchInlineSnapshot(`
         [
           [
@@ -440,303 +284,153 @@ describe('dialog', () => {
         ]
       `)
 
-    const request_2 = dialog_.synced.at(-1)![0]!
-    dialog_.success(request_2, '0x2')
+    const request_2 = dialog.synced.at(-1)![0]!
+    dialog.success(request_2, '0x2')
 
     await expect(second).resolves.toMatchInlineSnapshot(`"0x2"`)
-    adapter.cleanup?.()
   })
 
-  test('behavior: sendTransaction falls through when no access key is selected', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: tempoLocalnet.id, storage })
-    const lookups: unknown[] = []
-    const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: (options) => {
-        lookups.push(options)
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () => ({}) as never,
-      storage,
-      store,
-    })
-    const request = {
-      method: 'eth_sendTransaction' as const,
-      params: [
-        {
-          calls: [{ data: '0x12345678' as const, to: recipient }],
-          chainId: '0x1' as const,
-          from: address,
-        },
-      ] as const,
-    }
+  test('behavior: dialog transport resolves chain ID locally', async () => {
+    const { adapter, dialog } = setup()
+    const client = await getDialogClient(adapter)
 
-    const promise = adapter.actions.sendTransaction(
-      {
-        calls: [{ data: '0x12345678', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      request,
+    await expect(client.request({ method: 'eth_chainId' })).resolves.toMatchInlineSnapshot(
+      `"0x539"`,
     )
+    expect(dialog.synced).toMatchInlineSnapshot(`[]`)
+  })
 
-    const queued = await dialog_.takeRequest()
-    dialog_.success(queued, '0x1234')
+  test('behavior: provider forwards eth_sendTransaction without chain preflight', async () => {
+    const dialog_ = createDialog()
+    const provider = Provider.create({
+      adapter: dialog({ dialog: dialog_.dialog, host }),
+      chains: [tempoLocalnet],
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const promise = provider.request({
+      method: 'eth_sendTransaction',
+      params: [{ calls: [{ to: address, value: '0x1' }] }],
+    })
+    const request = await dialog_.takeRequest()
+
+    expect(request.request).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "method": "eth_sendTransaction",
+        "params": [
+          {
+            "calls": [
+              {
+                "data": "0x",
+                "to": "0x0000000000000000000000000000000000000001",
+                "value": "0x1",
+              },
+            ],
+            "chainId": "0x539",
+            "data": undefined,
+            "from": "0x0000000000000000000000000000000000000001",
+            "to": undefined,
+            "type": "0x76",
+            "value": undefined,
+          },
+        ],
+      }
+    `)
+
+    dialog_.success(request, '0x1234')
 
     await expect(promise).resolves.toMatchInlineSnapshot(`"0x1234"`)
-    expect(lookups).toMatchInlineSnapshot(`[]`)
   })
 
-  test('behavior: revokeAccessKey clears the forwarded key from local state', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: tempoLocalnet.id, storage })
-    store.setState({
-      accessKeys: [
-        {
-          access: address,
-          address: recipient,
-          chainId: tempoLocalnet.id,
-          keyType: 'p256',
-        } as never,
-      ],
-    })
+  test('behavior: provider forwards eth_sendTransactionSync with encoded params', async () => {
     const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () => ({}) as never,
-      storage,
-      store,
+    const provider = Provider.create({
+      adapter: dialog({ dialog: dialog_.dialog, host }),
+      chains: [tempoLocalnet],
+      storage: Storage.memory(),
     })
-    const request = {
-      method: 'wallet_revokeAccessKey' as const,
-      params: [{ accessKeyAddress: recipient, address }] as const,
-    }
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    const promise = adapter.actions.revokeAccessKey!(
-      { accessKeyAddress: recipient, address },
-      request,
-    )
-
-    const queued = await dialog_.takeRequest()
-    dialog_.success(queued, undefined)
-
-    await expect(promise).resolves.toMatchInlineSnapshot(`undefined`)
-    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('behavior: authorizeAccessKey forwards an external secp256k1 key', async () => {
-    const { adapter, dialog, store } = setup()
-    const expiry = 123
-    const promise = adapter.actions.authorizeAccessKey!(
-      { address: recipient, expiry, keyType: 'secp256k1' },
-      {
-        method: 'wallet_authorizeAccessKey',
-        params: [{ address: recipient, expiry, keyType: 'secp256k1' }],
-      },
-    )
-
-    const queued = await dialog.takeRequest()
-    const request = queued.request as {
-      params: [{ address: typeof recipient; expiry: number; keyType: 'secp256k1' }]
-    }
-    const params = request.params[0]
-    const keyAuthorization = KeyAuthorization.toRpc(
-      KeyAuthorization.from(
-        {
-          address: recipient,
-          chainId: BigInt(tempoLocalnet.id),
-          expiry,
-          type: 'secp256k1',
-        },
-        { signature: SignatureEnvelope.from(`0x${'00'.repeat(65)}`) },
-      ),
-    )
-    dialog.success(queued, { keyAuthorization, rootAddress: address })
-
-    await expect(promise).resolves.toMatchObject({ rootAddress: address })
-    expect(params.keyType).toMatchInlineSnapshot(`"secp256k1"`)
-    expect(params.address).toMatchInlineSnapshot(`"0x0000000000000000000000000000000000000002"`)
-    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('behavior: authorizeAccessKey generates a p256 key by default', async () => {
-    const { adapter, dialog, store } = setup()
-    const expiry = 123
-    const promise = adapter.actions.authorizeAccessKey!(
-      { expiry },
-      { method: 'wallet_authorizeAccessKey', params: [{ expiry }] },
-    )
-
-    const queued = await dialog.takeRequest()
-    const request = queued.request as {
-      params: [{ expiry: number; keyType: 'p256'; publicKey: Hex.Hex }]
-    }
-    const params = request.params[0]
-    dialog.success(queued, {
-      keyAuthorization: createKeyAuthorization(params),
-      rootAddress: address,
+    const promise = provider.request({
+      method: 'eth_sendTransactionSync',
+      params: [{ calls: [{ to: address, value: '0x1' }] }],
     })
+    const request = await dialog_.takeRequest()
 
-    await expect(promise).resolves.toMatchObject({ rootAddress: address })
-    expect(params.keyType).toMatchInlineSnapshot(`"p256"`)
-    expect(store.getState().accessKeys).toMatchObject([
+    expect(request.request).toMatchInlineSnapshot(`
       {
-        access: address,
-        keyType: 'p256',
-      },
-    ])
-    expect('keyPair' in store.getState().accessKeys[0]!).toMatchInlineSnapshot(`true`)
-  })
-
-  test('behavior: authorizeAccessKey forwards showDeposit', async () => {
-    const { adapter, dialog } = setup()
-    const expiry = 123
-    const showDeposit = { amount: '50', token: 'USDC' }
-    const promise = adapter.actions.authorizeAccessKey!(
-      { expiry, showDeposit },
-      { method: 'wallet_authorizeAccessKey', params: [{ expiry, showDeposit }] },
-    )
-
-    const queued = await dialog.takeRequest()
-    const request = queued.request as {
-      params: [
-        {
-          expiry: number
-          keyType: 'p256'
-          publicKey: Hex.Hex
-          showDeposit: typeof showDeposit
-        },
-      ]
-    }
-    const params = request.params[0]
-    dialog.success(queued, {
-      keyAuthorization: createKeyAuthorization(params),
-      rootAddress: address,
-    })
-
-    await expect(promise).resolves.toMatchObject({ rootAddress: address })
-    expect(params.showDeposit).toMatchInlineSnapshot(`
-      {
-        "amount": "50",
-        "token": "USDC",
-      }
-    `)
-  })
-
-  test('behavior: authorizeAccessKey generates a p256 key when requested', async () => {
-    const { adapter, dialog, store } = setup()
-    const expiry = 123
-    const promise = adapter.actions.authorizeAccessKey!(
-      { expiry, keyType: 'p256' },
-      { method: 'wallet_authorizeAccessKey', params: [{ expiry, keyType: 'p256' }] },
-    )
-
-    const queued = await dialog.takeRequest()
-    const request = queued.request as {
-      params: [{ expiry: number; keyType: 'p256'; publicKey: Hex.Hex }]
-    }
-    const params = request.params[0]
-    dialog.success(queued, {
-      keyAuthorization: createKeyAuthorization(params),
-      rootAddress: address,
-    })
-
-    await expect(promise).resolves.toMatchObject({ rootAddress: address })
-    expect(params.keyType).toMatchInlineSnapshot(`"p256"`)
-    expect(store.getState().accessKeys).toMatchObject([
-      {
-        access: address,
-        keyType: 'p256',
-      },
-    ])
-    expect('keyPair' in store.getState().accessKeys[0]!).toMatchInlineSnapshot(`true`)
-  })
-
-  test('error: secp256k1 access key requires external key material', async () => {
-    const { adapter, dialog } = setup()
-
-    await expect(
-      adapter.actions.authorizeAccessKey!(
-        { expiry: 123, keyType: 'secp256k1' },
-        {
-          method: 'wallet_authorizeAccessKey',
-          params: [{ expiry: 123, keyType: 'secp256k1' }],
-        },
-      ),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[RpcResponse.InvalidParamsError: \`keyType: "secp256k1"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
-    )
-    expect(dialog.syncs).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('error: webAuthn access key requires external key material', async () => {
-    const { adapter, dialog } = setup()
-
-    await expect(
-      adapter.actions.authorizeAccessKey!(
-        { expiry: 123, keyType: 'webAuthn' },
-        {
-          method: 'wallet_authorizeAccessKey',
-          params: [{ expiry: 123, keyType: 'webAuthn' }],
-        },
-      ),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[RpcResponse.InvalidParamsError: \`keyType: "webAuthn"\` requires externally generated key material; provide \`publicKey\` or \`address\`.]`,
-    )
-    expect(dialog.syncs).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('error: wallet validation errors keep their RPC code', async () => {
-    const storage = Storage.memory()
-    const store = Store.create({ chainId: tempoLocalnet.id, storage })
-    const dialog_ = createDialog()
-    const adapter = dialog({ dialog: dialog_.dialog, host })({
-      getAccount: () => {
-        throw new ox_Provider.UnauthorizedError({ message: 'No local signer.' })
-      },
-      getClient: () => ({}) as never,
-      storage,
-      store,
-    })
-    const promise = adapter.actions.sendTransaction(
-      {
-        calls: [{ data: '0x12345678', to: recipient }],
-        chainId: 1,
-        from: address,
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
+        "id": 0,
+        "jsonrpc": "2.0",
+        "method": "eth_sendTransactionSync",
+        "params": [
           {
-            calls: [{ data: '0x12345678' as const, to: recipient }],
-            chainId: '0x1' as const,
-            from: address,
+            "calls": [
+              {
+                "to": "0x0000000000000000000000000000000000000001",
+                "value": "0x1",
+              },
+            ],
+            "chainId": "0x539",
+            "from": "0x0000000000000000000000000000000000000001",
           },
-        ] as const,
-      },
-    )
-
-    const queued = await dialog_.takeRequest()
-    dialog_.failure(queued, {
-      code: -32602,
-      message: '`authorizeAccessKey` must include at least one `limits` entry.',
-    })
-
-    await expect(
-      promise.catch((error) => ({
-        code: error.code,
-        message: error.message,
-        name: error.name,
-      })),
-    ).resolves.toMatchInlineSnapshot(`
-      {
-        "code": -32602,
-        "message": "\`authorizeAccessKey\` must include at least one \`limits\` entry.",
-        "name": "RpcResponse.InvalidParamsError",
+        ],
       }
     `)
+
+    dialog_.success(request, receipt)
+
+    await expect(promise.then((x) => x.status)).resolves.toMatchInlineSnapshot(`"0x1"`)
+  })
+
+  test('behavior: provider forwards JSON-RPC access-key authorization with encoded params', async () => {
+    const dialog_ = createDialog()
+    const provider = Provider.create({
+      adapter: dialog({ dialog: dialog_.dialog, host }),
+      chains: [tempoLocalnet],
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const promise = provider.request({
+      method: 'wallet_authorizeAccessKey',
+      params: [{ address: accessKey, expiry: 123 }],
+    })
+    const request = await dialog_.takeRequest()
+
+    expect(request.request).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "method": "wallet_authorizeAccessKey",
+        "params": [
+          {
+            "address": "0x0000000000000000000000000000000000000002",
+            "chainId": "0x539",
+            "expiry": 123,
+            "keyType": "secp256k1",
+          },
+        ],
+      }
+    `)
+
+    dialog_.failure(request, { code: 4001, message: 'Rejected' })
+    await promise.catch(() => undefined)
+  })
+
+  test('behavior: getAccount materializes a json-rpc account with dialog transport', async () => {
+    const { adapter } = setup()
+
+    const result = await adapter.getAccount!()
+
+    expect(result.account).toMatchInlineSnapshot(`
+      {
+        "address": "0x0000000000000000000000000000000000000001",
+        "type": "json-rpc",
+      }
+    `)
+    expect(typeof result.transport).toMatchInlineSnapshot(`"function"`)
   })
 })

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -1,11 +1,9 @@
-import { Address, Provider as ox_Provider, RpcResponse } from 'ox'
-import { KeyAuthorization } from 'ox/tempo'
+import { Hex, Provider as ox_Provider } from 'ox'
+import { custom } from 'viem'
 import { z } from 'zod/mini'
 
-import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
 import * as Dialog from '../Dialog.js'
-import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 import * as RemoteRequests from '../internal/RemoteRequests.js'
 import * as Schema from '../Schema.js'
 import * as Rpc from '../zod/rpc.js'
@@ -42,7 +40,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       'due to lack of WebAuthn passkey support in non-secure contexts.',
     )
 
-  return Adapter.define({ icon, name, rdns }, ({ getAccount, getClient, store }) => {
+  return Adapter.define({ icon, name, rdns }, ({ getAccount, store }) => {
     const detach = RemoteRequests.attach(host, { dialog, host, store, theme })
 
     /** Returns the active account from the adapter source store. */
@@ -60,6 +58,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
     const provider = ox_Provider.from(
       {
         async request(r) {
+          if (r.method === 'eth_chainId') return Hex.fromNumber(store.getState().chainId)
           return RemoteRequests.request(host, {
             account: getActiveAccount(),
             chainId: store.getState().chainId,
@@ -70,85 +69,19 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
       { schema: Schema.ox },
     )
 
-    /**
-     * Prepares a local key pair when `authorizeAccessKey` is requested without
-     * an external publicKey/address, and returns the params to inject into the
-     * RPC request so the dialog signs the authorization.
-     */
-    async function generateAccessKey(options: Adapter.authorizeAccessKey.Parameters | undefined) {
-      if (!options) return undefined
-      if (options.publicKey || options.address) return undefined
-      if (options.keyType && options.keyType !== 'p256')
-        throw new RpcResponse.InvalidParamsError({
-          message: `\`keyType: "${options.keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
-        })
-
-      const generated = await AccessKey.generate()
-      const { accessKey } = generated
-      return {
-        accessKey,
-        generated,
-        request: {
-          ...options,
-          publicKey: accessKey.publicKey,
-          keyType: 'p256' as const,
-        },
-      }
-    }
-
-    /**
-     * After the dialog returns a signed key authorization, saves the local
-     * key pair + key authorization into the store.
-     */
-    function saveAccessKey(
-      address: Address.Address,
-      keyAuth: KeyAuthorization.Rpc,
-      generated: Awaited<ReturnType<typeof AccessKey.generate>>,
-    ) {
-      const keyAuthorization = KeyAuthorization.fromRpc(keyAuth)
-      AccessKey.add({
-        account: address,
-        authorization: keyAuthorization,
-        keyPair: generated.keyPair,
-        store,
-      })
-    }
-
     return {
       cleanup() {
         detach()
       },
       forwardsAuth: true,
       actions: {
-        async createAccount(parameters, request) {
-          const accessKey = await generateAccessKey(parameters.authorizeAccessKey)
-
+        async createAccount(_parameters, request) {
           const { accounts } = await provider.request({
             ...request,
-            params: [
-              {
-                ...request.params?.[0],
-                capabilities: {
-                  ...request.params?.[0]?.capabilities,
-                  ...(accessKey
-                    ? {
-                        authorizeAccessKey: z.encode(
-                          Rpc.wallet_connect.authorizeAccessKey,
-                          accessKey.request,
-                        ),
-                      }
-                    : {}),
-                },
-              },
-            ] as const,
           })
 
-          const address = accounts[0]?.address
           const capabilities = accounts[0]?.capabilities
           const keyAuthorization = capabilities?.keyAuthorization
-
-          if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.generated)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -159,35 +92,13 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
           }
         },
 
-        async loadAccounts(parameters, request) {
-          const accessKey = await generateAccessKey(parameters?.authorizeAccessKey)
-
+        async loadAccounts(_parameters, request) {
           const { accounts } = await provider.request({
             ...request,
-            params: [
-              {
-                ...request.params?.[0],
-                capabilities: {
-                  ...request.params?.[0]?.capabilities,
-                  ...(accessKey
-                    ? {
-                        authorizeAccessKey: z.encode(
-                          Rpc.wallet_connect.authorizeAccessKey,
-                          accessKey.request,
-                        ),
-                      }
-                    : {}),
-                },
-              },
-            ] as const,
           })
 
-          const address = accounts[0]?.address
           const capabilities = accounts[0]?.capabilities
           const keyAuthorization = capabilities?.keyAuthorization
-
-          if (accessKey && address && keyAuthorization)
-            saveAccessKey(address, keyAuthorization, accessKey.generated)
 
           return {
             accounts: accounts.map((a) => ({ address: a.address })),
@@ -196,156 +107,6 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
             ...(capabilities?.signature ? { signature: capabilities.signature } : {}),
             ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
           }
-        },
-
-        async signPersonalMessage(_params, request) {
-          return await provider.request(request)
-        },
-
-        async signTransaction(parameters, request) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient({
-            chainId: parameters.chainId,
-            feePayer: (() => {
-              if (feePayer === false) return false
-              if (typeof feePayer === 'string') return feePayer
-              return undefined
-            })(),
-          })
-          const transaction =
-            parameters.from && typeof parameters.chainId !== 'undefined'
-              ? await AccessKeyTransaction.create({
-                  address: parameters.from,
-                  calls: parameters.calls,
-                  chainId: parameters.chainId,
-                  client,
-                  store,
-                })
-              : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(typeof feePayer !== 'undefined' ? { feePayer: !!feePayer as never } : {}),
-              })
-              return await prepared.sign()
-            } catch (error) {
-              console.warn('[accounts] access key sign failed, falling through to dialog:', error)
-            }
-          }
-          return await provider.request({
-            ...request,
-            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
-          })
-        },
-
-        async signTypedData(_params, request) {
-          return await provider.request(request)
-        },
-
-        async sendTransaction(parameters, request) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient({
-            chainId: parameters.chainId,
-            feePayer: (() => {
-              if (feePayer === false) return false
-              if (typeof feePayer === 'string') return feePayer
-              return undefined
-            })(),
-          })
-          const transaction =
-            parameters.from && typeof parameters.chainId !== 'undefined'
-              ? await AccessKeyTransaction.create({
-                  address: parameters.from,
-                  calls: parameters.calls,
-                  chainId: parameters.chainId,
-                  client,
-                  store,
-                })
-              : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(typeof feePayer !== 'undefined' ? { feePayer: !!feePayer as never } : {}),
-              })
-              return await prepared.send()
-            } catch (error) {
-              console.warn('[accounts] access key sign failed, falling through to dialog:', error)
-            }
-          }
-          return await provider.request({
-            ...request,
-            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
-          })
-        },
-
-        async sendTransactionSync(parameters, request) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient({
-            chainId: parameters.chainId,
-            feePayer: (() => {
-              if (feePayer === false) return false
-              if (typeof feePayer === 'string') return feePayer
-              return undefined
-            })(),
-          })
-          const transaction =
-            parameters.from && typeof parameters.chainId !== 'undefined'
-              ? await AccessKeyTransaction.create({
-                  address: parameters.from,
-                  calls: parameters.calls,
-                  chainId: parameters.chainId,
-                  client,
-                  store,
-                })
-              : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(typeof feePayer !== 'undefined' ? { feePayer: !!feePayer as never } : {}),
-              })
-              return await prepared.sendSync()
-            } catch (error) {
-              console.warn('[accounts] access key sign failed, falling through to dialog:', error)
-            }
-          }
-          return await provider.request({
-            ...request,
-            params: [z.encode(Rpc.transactionRequest, parameters)] as const,
-          })
-        },
-
-        async authorizeAccessKey(parameters, request) {
-          const accessKey = await generateAccessKey(parameters)
-
-          const result = await provider.request({
-            ...request,
-            params: [
-              z.encode(
-                Rpc.wallet_authorizeAccessKey.parameters,
-                accessKey ? accessKey.request : parameters,
-              )!,
-            ],
-          })
-
-          if (accessKey) {
-            const account = getAccount({ signable: false })
-            saveAccessKey(account.address, result.keyAuthorization, accessKey.generated)
-          }
-
-          return result
-        },
-
-        async revokeAccessKey(params, request) {
-          await provider.request(request)
-          AccessKey.remove({
-            accessKey: params.accessKeyAddress,
-            account: params.address,
-            chainId: store.getState().chainId,
-            store,
-          })
         },
 
         async deposit(_params, request) {
@@ -380,6 +141,13 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
         async disconnect() {
           store.setState({ accessKeys: [], accounts: [], activeAccount: 0 })
         },
+      },
+      getAccount(options = {}) {
+        const account = getAccount({ address: options.address, signable: false })
+        return {
+          account: { address: account.address, type: 'json-rpc' as const },
+          transport: custom(provider),
+        }
       },
     }
   })

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,14 +1,12 @@
 import { Provider as ox_Provider, type WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { hashMessage } from 'viem'
-import { prepareTransactionRequest } from 'viem/actions'
-import { Account as TempoAccount, Actions } from 'viem/tempo'
+import { Account as TempoAccount } from 'viem/tempo'
 import * as z from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Account from '../Account.js'
 import * as Adapter from '../Adapter.js'
-import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 import * as u from '../zod/utils.js'
 
 const secp256k1Schema = z.object({
@@ -90,69 +88,6 @@ export function local(options: local.Options): Adapter.Adapter {
   return Adapter.define(
     { icon, name, rdns, schema: signableSchema },
     ({ getAccount, getClient, store }) => {
-      async function prepareTransaction(parameters: Adapter.signTransaction.Parameters) {
-        const { feePayer, ...rest } = parameters
-        const client = getClient({
-          chainId: parameters.chainId,
-          feePayer: (() => {
-            if (feePayer === false) return false
-            if (typeof feePayer === 'string') return feePayer
-            return undefined
-          })(),
-        })
-        const request = {
-          ...rest,
-          ...(feePayer ? { feePayer: true as const } : {}),
-        }
-        const state = store.getState()
-        const address = parameters.from ?? state.accounts[state.activeAccount]?.address
-        const transaction = address
-          ? await AccessKeyTransaction.create({
-              address,
-              calls: parameters.calls,
-              chainId: parameters.chainId ?? state.chainId,
-              client,
-              store,
-            })
-          : undefined
-        if (transaction) {
-          try {
-            return await transaction.prepare(request)
-          } catch {}
-        }
-
-        const account = getAccount({
-          address: parameters.from,
-          signable: true,
-        })
-        const prepared = await prepareTransactionRequest(client, {
-          account,
-          ...request,
-          type: 'tempo',
-        })
-        async function sign() {
-          return await account.signTransaction(prepared as never)
-        }
-        return {
-          request: prepared,
-          sign,
-          async send() {
-            const signed = await sign()
-            return (await client.request({
-              method: 'eth_sendRawTransaction' as never,
-              params: [signed],
-            })) as Adapter.sendTransaction.ReturnType
-          },
-          async sendSync() {
-            const signed = await sign()
-            return (await client.request({
-              method: 'eth_sendRawTransactionSync' as never,
-              params: [signed],
-            })) as Adapter.sendTransactionSync.ReturnType
-          },
-        }
-      }
-
       return {
         actions: {
           async createAccount(parameters) {
@@ -207,16 +142,6 @@ export function local(options: local.Options): Adapter.Adapter {
               username,
               ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
             }
-          },
-          async authorizeAccessKey(parameters) {
-            const account = getAccount({ signable: true })
-            const keyAuthorization = await AccessKey.authorize({
-              account,
-              chainId: getClient().chain.id,
-              parameters,
-              store,
-            })
-            return { keyAuthorization, rootAddress: account.address }
           },
           async loadAccounts(parameters) {
             const { authorizeAccessKey, personalSign, ...rest } =
@@ -304,50 +229,9 @@ export function local(options: local.Options): Adapter.Adapter {
               ...(personalSign ? { personalSign: { message: personalSign.message } } : {}),
             }
           },
-          async revokeAccessKey(parameters) {
-            const account = getAccount({ signable: true })
-            const client = getClient()
-            try {
-              await Actions.accessKey.revoke(client, {
-                account,
-                accessKey: parameters.accessKeyAddress,
-              })
-            } catch (error) {
-              if (!AccessKey.isUnavailableError(error)) throw error
-            }
-            AccessKey.remove({
-              accessKey: parameters.accessKeyAddress,
-              account: account.address,
-              chainId: client.chain.id,
-              store,
-            })
-          },
-          async signPersonalMessage({ data, address }) {
-            const account = getAccount({ address, signable: true })
-            return await account.signMessage({ message: { raw: data } })
-          },
-          async signTransaction(parameters) {
-            const prepared = await prepareTransaction(parameters)
-            return await prepared.sign()
-          },
-          async signTypedData({ data, address }) {
-            const account = getAccount({ address, signable: true })
-            const parsed = JSON.parse(data) as {
-              domain: Record<string, unknown>
-              message: Record<string, unknown>
-              primaryType: string
-              types: Record<string, unknown>
-            }
-            return await account.signTypedData(parsed)
-          },
-          async sendTransaction(parameters) {
-            const prepared = await prepareTransaction(parameters)
-            return await prepared.send()
-          },
-          async sendTransactionSync(parameters) {
-            const prepared = await prepareTransaction(parameters)
-            return await prepared.sendSync()
-          },
+        },
+        getAccount(options = {}) {
+          return { account: getAccount({ address: options.address, signable: true }) }
         },
       }
     },

--- a/src/core/adapters/privy.test.ts
+++ b/src/core/adapters/privy.test.ts
@@ -108,7 +108,7 @@ describe('privy', () => {
     const { adapter, client, store } = setup()
 
     await connect({ adapter, store })
-    const result = await adapter.actions.signPersonalMessage(
+    const result = await adapter.actions.signPersonalMessage!(
       { address, data: '0x68656c6c6f' },
       { method: 'personal_sign', params: ['0x68656c6c6f', address] },
     )
@@ -198,7 +198,7 @@ describe('privy', () => {
     const { adapter, client, store } = setup()
     await connect({ adapter, store })
 
-    const result = await adapter.actions.signTransaction(
+    const result = await adapter.actions.signTransaction!(
       {
         chainId: 1,
         from: address,
@@ -327,7 +327,7 @@ describe('privy', () => {
     const { adapter, client, store } = setup()
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    await adapter.actions.signPersonalMessage(
+    await adapter.actions.signPersonalMessage!(
       { address, data: '0x68656c6c6f' },
       { method: 'personal_sign', params: ['0x68656c6c6f', address] },
     )
@@ -340,7 +340,7 @@ describe('privy', () => {
     const { adapter, client } = setup()
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -356,7 +356,7 @@ describe('privy', () => {
     client.addWallet(other)
     store.setState({ accounts: [{ address: other }], activeAccount: 0 })
 
-    await adapter.actions.signPersonalMessage(
+    await adapter.actions.signPersonalMessage!(
       { address: other, data: '0x68656c6c6f' },
       { method: 'personal_sign', params: ['0x68656c6c6f', other] },
     )
@@ -380,7 +380,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -395,7 +395,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -409,7 +409,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -425,7 +425,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -441,7 +441,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -456,7 +456,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address: other }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address: other, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', other] },
       ),
@@ -480,7 +480,7 @@ describe('privy', () => {
     )
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address: other, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', other] },
       ),
@@ -504,7 +504,7 @@ describe('privy', () => {
     )
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address: other, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', other] },
       ),
@@ -519,7 +519,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -542,7 +542,7 @@ describe('privy', () => {
     await connect({ adapter, store })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -556,7 +556,7 @@ describe('privy', () => {
     await connect({ adapter, store })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address: other, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', other] },
       ),
@@ -570,7 +570,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -596,7 +596,7 @@ describe('privy', () => {
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),
@@ -610,7 +610,7 @@ describe('privy', () => {
     await connect({ adapter, store })
 
     await expect(
-      adapter.actions.signPersonalMessage(
+      adapter.actions.signPersonalMessage!(
         { address, data: '0x68656c6c6f' },
         { method: 'personal_sign', params: ['0x68656c6c6f', address] },
       ),

--- a/src/core/adapters/turnkey.test.ts
+++ b/src/core/adapters/turnkey.test.ts
@@ -1,7 +1,6 @@
 import { Hex, PublicKey } from 'ox'
-import { decodeFunctionData } from 'viem'
+import { hashMessage } from 'viem'
 import type { Address } from 'viem/accounts'
-import { Abis } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { accounts } from '../../../test/config.js'
@@ -52,68 +51,14 @@ describe('turnkey', () => {
 
     expect(client.createCalls).toMatchInlineSnapshot(`0`)
     expect(client.loadCalls).toMatchInlineSnapshot(`1`)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "accounts": [
-          {
-            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            "label": "Ada",
-          },
-        ],
-        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
-      }
-    `)
-  })
-
-  test('default: createAccount can select the active fetched wallet account', async () => {
-    const { adapter, client } = setup({ createAddresses: [other] })
-    client.wallets = [
-      {
-        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
-      },
-    ]
-
-    const result = await adapter.actions.createAccount(
-      { digest: '0x1234', name: 'Ada' },
-      { method: 'wallet_connect', params: undefined },
-    )
-
-    expect(client.signWith).toMatchInlineSnapshot(`
+    expect(result.accounts).toMatchInlineSnapshot(`
       [
-        "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "label": "Ada",
+        },
       ]
     `)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "accounts": [
-          {
-            "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-            "label": "Ada",
-          },
-        ],
-        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
-      }
-    `)
-  })
-
-  test('default: loadAccounts returns accounts for store-backed signing', async () => {
-    const { adapter, client, store } = setup()
-
-    await connect({ adapter, store })
-    const result = await adapter.actions.signPersonalMessage(
-      { address, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-    )
-
-    expect(client.loadCalls).toMatchInlineSnapshot(`1`)
-    expect(client.signWith).toMatchInlineSnapshot(`
-      [
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      ]
-    `)
-    expect(result).toMatchInlineSnapshot(
-      `"0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
-    )
   })
 
   test('default: loadAccounts can select and order fetched wallet accounts', async () => {
@@ -134,86 +79,16 @@ describe('turnkey', () => {
         "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
       ]
     `)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "accounts": [
-          {
-            "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-          },
-          {
-            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-          },
-        ],
-        "signature": "0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b",
-      }
-    `)
-  })
-
-  test('default: signs transactions with a hydrated Tempo account', async () => {
-    const { adapter, client, store } = setup()
-
-    await connect({ adapter, store })
-    const result = await adapter.actions.signTransaction(
-      {
-        chainId: 1,
-        from: address,
-        gas: 21_000n,
-        maxFeePerGas: 1n,
-        maxPriorityFeePerGas: 1n,
-        nonce: 0,
-        to: other,
-        value: 1n,
-      },
-      { method: 'eth_signTransaction', params: [{ from: address }] },
-    )
-
-    expect(client.signWith).toMatchInlineSnapshot(`
+    expect(result.accounts).toMatchInlineSnapshot(`
       [
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        {
+          "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+        },
+        {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        },
       ]
     `)
-    expect(client.signPayloads).toMatchInlineSnapshot(`
-      [
-        "0x1d573a406538a466857ad6ac07f34eac6ede297aba6e85116a1e9a7cda46d9f2",
-      ]
-    `)
-    expect(result).toMatchInlineSnapshot(
-      `"0x76f86a010101825208d8d7948c8d35429f74ec245f8ef2f4fd1e551cff97d6500180c0808080808080c0b841000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
-    )
-  })
-
-  test('default: accepts prefixed Turnkey public keys', async () => {
-    const { adapter, client, store } = setup()
-    const walletAccount = toWalletAccount(account)
-    client.wallets = [
-      {
-        accounts: [
-          {
-            ...walletAccount,
-            publicKey: `0x${walletAccount.publicKey}`,
-          },
-        ],
-      },
-    ]
-
-    await connect({ adapter, store })
-    const result = await adapter.actions.signTransaction(
-      {
-        chainId: 1,
-        from: address,
-        gas: 21_000n,
-        maxFeePerGas: 1n,
-        maxPriorityFeePerGas: 1n,
-        nonce: 0,
-        to: other,
-        value: 1n,
-      },
-      { method: 'eth_signTransaction', params: [{ from: address }] },
-    )
-
-    expect(result).toMatchInlineSnapshot(
-      `"0x76f86a010101825208d8d7948c8d35429f74ec245f8ef2f4fd1e551cff97d6500180c0808080808080c0b841000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
-    )
   })
 
   test('default: loadAccounts can provision an external access key', async () => {
@@ -235,165 +110,29 @@ describe('turnkey', () => {
         "0xea47721547363fc82a5dca62b4544e4718d861b3df10bfac65d30102594b5c26",
       ]
     `)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "accounts": [
-          {
-            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-          },
-        ],
-        "keyAuthorization": {
-          "chainId": "0x1",
-          "expiry": "0x7b",
-          "keyId": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-          "keyType": "secp256k1",
-          "limits": undefined,
-          "signature": {
-            "r": "0x0000000000000000000000000000000000000000000000000000000000000011",
-            "s": "0x0000000000000000000000000000000000000000000000000000000000000022",
-            "type": "secp256k1",
-            "yParity": "0x0",
-          },
-        },
-        "signature": undefined,
-      }
-    `)
+    expect(result.keyAuthorization?.keyId).toMatchInlineSnapshot(
+      `"0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650"`,
+    )
   })
 
-  test('default: authorizeAccessKey signs with the connected Turnkey account', async () => {
+  test('behavior: getAccount silently restores and materializes a local signer', async () => {
     const { adapter, client, store } = setup()
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    const result = await adapter.actions.authorizeAccessKey!(
-      {
-        address: other,
-        expiry: 123,
-        keyType: 'secp256k1',
-      },
-      { method: 'wallet_authorizeAccessKey', params: [{ expiry: 123 }] },
-    )
-
-    expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "keyAuthorization": {
-          "chainId": "0x1",
-          "expiry": "0x7b",
-          "keyId": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-          "keyType": "secp256k1",
-          "limits": undefined,
-          "signature": {
-            "r": "0x0000000000000000000000000000000000000000000000000000000000000011",
-            "s": "0x0000000000000000000000000000000000000000000000000000000000000022",
-            "type": "secp256k1",
-            "yParity": "0x0",
-          },
-        },
-        "rootAddress": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      }
-    `)
-  })
-
-  test('default: revokeAccessKey revokes with the connected Turnkey account', async () => {
-    const { adapter, client, store } = setup()
-    store.setState({
-      accounts: [{ address }],
-      activeAccount: 0,
-      accessKeys: [
-        {
-          access: address,
-          address: other,
-          chainId: 1,
-          keyType: 'secp256k1',
-        } as never,
-      ],
-    })
-
-    await adapter.actions.revokeAccessKey!(
-      { accessKeyAddress: other, address },
-      { method: 'wallet_revokeAccessKey', params: [{ accessKeyAddress: other, address }] },
-    )
-
-    const transaction = client.transactions[0] as
-      | { account: { address: Address }; data: Hex.Hex; to: Address }
-      | undefined
-    const decoded = transaction
-      ? decodeFunctionData({ abi: Abis.accountKeychain, data: transaction.data })
-      : undefined
-    expect(
-      transaction &&
-        decoded && {
-          account: transaction.account.address,
-          args: decoded.args,
-          functionName: decoded.functionName,
-          to: transaction.to,
-        },
-    ).toMatchInlineSnapshot(`
-        {
-          "account": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-          "args": [
-            "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-          ],
-          "functionName": "revokeKey",
-          "to": "0xaAAAaaAA00000000000000000000000000000000",
-        }
-      `)
-    expect(store.getState().accessKeys).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('behavior: signing silently restores wallet accounts from an existing session', async () => {
-    const { adapter, client, store } = setup()
-    store.setState({ accounts: [{ address }], activeAccount: 0 })
-
-    await adapter.actions.signPersonalMessage(
-      { address, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-    )
+    const { account } = await adapter.getAccount!({ address })
+    if (account.type === 'json-rpc') throw new Error('Expected local signer account.')
+    const result = await account.sign!({ hash: hashMessage({ raw: '0x68656c6c6f' }) })
 
     expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
     expect(client.loadCalls).toMatchInlineSnapshot(`0`)
-  })
-
-  test('behavior: silent restore does not connect accounts when the provider store is empty', async () => {
-    const { adapter, client } = setup()
-
-    await expect(
-      adapter.actions.signPersonalMessage(
-        { address, data: '0x68656c6c6f' },
-        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-      ),
-    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: No Turnkey account connected.]')
-
-    expect(client.fetchCalls).toMatchInlineSnapshot(`0`)
-    expect(client.signPayloads).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('behavior: silent restore uses persisted provider accounts', async () => {
-    const { adapter, client, store } = setup()
-    client.wallets = [
-      {
-        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
-      },
-    ]
-    store.setState({ accounts: [{ address: other }], activeAccount: 0 })
-
-    await adapter.actions.signPersonalMessage(
-      { address: other, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', other] },
-    )
-
     expect(client.signWith).toMatchInlineSnapshot(`
       [
-        "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       ]
     `)
-    expect(store.getState().accounts).toMatchInlineSnapshot(`
-      [
-        {
-          "address": "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650",
-        },
-      ]
-    `)
+    expect(result).toMatchInlineSnapshot(
+      `"0x000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000221b"`,
+    )
   })
 
   test('behavior: silent restore rejects connected accounts missing from Turnkey metadata', async () => {
@@ -411,93 +150,24 @@ describe('turnkey', () => {
     ]
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    await expect(
-      adapter.actions.signPersonalMessage(
-        { address, data: '0x68656c6c6f' },
-        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-      ),
-    ).rejects.toMatchInlineSnapshot(
+    await expect(adapter.getAccount!({ address })).rejects.toMatchInlineSnapshot(
       '[RpcResponse.InternalError: Connected Turnkey account "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" was not found in fetched Turnkey wallet accounts. Reconnect with Turnkey.]',
     )
 
     expect(client.fetchCalls).toMatchInlineSnapshot(`1`)
     expect(client.signPayloads).toMatchInlineSnapshot(`[]`)
-    expect(store.getState().accounts).toMatchInlineSnapshot(`
-      [
-        {
-          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-        },
-      ]
-    `)
-  })
-
-  test('behavior: reconnecting refreshes wallet account metadata', async () => {
-    const { adapter, client, store } = setup()
-
-    await connect({ adapter, store })
-    client.wallets = [
-      {
-        accounts: [toWalletAccount(account), toWalletAccount(account_2)],
-      },
-    ]
-    await connect({ adapter, store })
-
-    await adapter.actions.signPersonalMessage(
-      { address, data: '0x68656c6c6f' },
-      { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-    )
-
-    expect(client.fetchCalls).toMatchInlineSnapshot(`2`)
-    expect(client.signPayloads).toMatchInlineSnapshot(`
-      [
-        "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750",
-      ]
-    `)
   })
 
   test('behavior: expired sessions clear provider accounts', async () => {
     const { adapter, client, store } = setup({ session: { expiry: 1 } })
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    await expect(
-      adapter.actions.signPersonalMessage(
-        { address, data: '0x68656c6c6f' },
-        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-      ),
-    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: Turnkey session expired.]')
+    await expect(adapter.getAccount!({ address })).rejects.toMatchInlineSnapshot(
+      '[Provider.DisconnectedError: Turnkey session expired.]',
+    )
 
     expect(client.signPayloads).toMatchInlineSnapshot(`[]`)
     expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('behavior: server session errors clear provider accounts', async () => {
-    const { adapter, store } = setup({
-      signError: { details: [{ turnkeyErrorCode: 'API_KEY_EXPIRED' }] },
-    })
-    store.setState({ accounts: [{ address }], activeAccount: 0 })
-
-    await expect(
-      adapter.actions.signPersonalMessage(
-        { address, data: '0x68656c6c6f' },
-        { method: 'personal_sign', params: ['0x68656c6c6f', address] },
-      ),
-    ).rejects.toMatchInlineSnapshot('[Provider.DisconnectedError: Turnkey session expired.]')
-
-    expect(store.getState().accounts).toMatchInlineSnapshot(`[]`)
-  })
-
-  test('error: signing an unconnected account fails', async () => {
-    const { adapter, store } = setup()
-    await connect({ adapter, store })
-
-    await expect(
-      adapter.actions.signPersonalMessage(
-        { address: other, data: '0x68656c6c6f' },
-        { method: 'personal_sign', params: ['0x68656c6c6f', other] },
-      ),
-    ).rejects.toMatchInlineSnapshot(
-      `[Provider.UnauthorizedError: Account "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650" not found.]`,
-    )
   })
 
   test('error: rejects a Turnkey wallet account with mismatched address and public key', async () => {
@@ -514,23 +184,8 @@ describe('turnkey', () => {
     ]
     store.setState({ accounts: [{ address }], activeAccount: 0 })
 
-    await expect(
-      adapter.actions.signTransaction(
-        { from: address },
-        { method: 'eth_signTransaction', params: [{ from: address }] },
-      ),
-    ).rejects.toMatchInlineSnapshot(
+    await expect(adapter.getAccount!({ address })).rejects.toMatchInlineSnapshot(
       `[RpcResponse.InternalError: Turnkey account publicKey does not match address "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".]`,
-    )
-  })
-
-  test('error: rejects a selected address missing from fetched wallet accounts', async () => {
-    const { adapter } = setup({ loadAddresses: [other] })
-
-    await expect(
-      adapter.actions.loadAccounts(undefined, { method: 'wallet_connect', params: undefined }),
-    ).rejects.toMatchInlineSnapshot(
-      `[RpcResponse.InternalError: Turnkey callback returned address "0x8C8d35429F74ec245F8Ef2f4Fd1e551cFF97d650" that was not found in fetched wallet accounts.]`,
     )
   })
 })
@@ -557,27 +212,11 @@ function setup(options: setup.Options = {}) {
     getAccount: (() => {
       throw new Error('not implemented')
     }) as never,
-    getClient: (() => ({
-      chain: { id: 1 },
-      sendTransaction: async (parameters: unknown) => {
-        client.transactions.push(parameters)
-        return Hex.padLeft('0x1', 32)
-      },
-    })) as never,
+    getClient: (() => ({ chain: { id: 1 } })) as never,
     storage,
     store,
   })
   return { adapter, client, store }
-}
-
-async function connect(options: Pick<ReturnType<typeof setup>, 'adapter' | 'store'>) {
-  const { adapter, store } = options
-  const loaded = await adapter.actions.loadAccounts(undefined, {
-    method: 'wallet_connect',
-    params: undefined,
-  })
-  store.setState({ accounts: loaded.accounts, activeAccount: 0 })
-  return loaded
 }
 
 declare namespace setup {
@@ -586,7 +225,6 @@ declare namespace setup {
     createAddresses?: readonly Address[] | undefined
     loadAddresses?: readonly Address[] | undefined
     session?: turnkey.Session | null | undefined
-    signError?: unknown
   }
 }
 
@@ -601,10 +239,9 @@ function createClient(options: setup.Options = {}) {
     loadCalls: 0,
     signPayloads: [] as Hex.Hex[],
     signWith: [] as string[],
-    transactions: [] as unknown[],
     wallets: [{ accounts: [toWalletAccount(account)] }] as WalletShape[],
   }
-  const client = {
+  return {
     get fetchCalls() {
       return state.fetchCalls
     },
@@ -629,9 +266,6 @@ function createClient(options: setup.Options = {}) {
     get signWith() {
       return state.signWith
     },
-    get transactions() {
-      return state.transactions
-    },
     get wallets() {
       return state.wallets
     },
@@ -648,7 +282,6 @@ function createClient(options: setup.Options = {}) {
         : options.session,
     httpClient: {
       signRawPayload: async (parameters: turnkey.SignRawPayloadParameters) => {
-        if (options.signError) throw options.signError
         state.signPayloads.push(parameters.payload)
         state.signWith.push(parameters.signWith)
         return {
@@ -669,11 +302,8 @@ function createClient(options: setup.Options = {}) {
     loadCalls: number
     signPayloads: Hex.Hex[]
     signWith: string[]
-    transactions: unknown[]
     wallets: WalletShape[]
   }
-
-  return client
 }
 
 function toWalletAccount(account: (typeof accounts)[number]): turnkey.WalletAccount {

--- a/src/core/adapters/turnkey.ts
+++ b/src/core/adapters/turnkey.ts
@@ -7,14 +7,12 @@ import {
   RpcResponse,
   Secp256k1,
 } from 'ox'
-import { hashMessage, hashTypedData, isAddressEqual } from 'viem'
+import { hashMessage, isAddressEqual } from 'viem'
 import type { Address } from 'viem/accounts'
-import { prepareTransactionRequest } from 'viem/actions'
-import { Account as TempoAccount, Actions } from 'viem/tempo'
+import { Account as TempoAccount } from 'viem/tempo'
 
 import * as AccessKey from '../AccessKey.js'
 import * as Adapter from '../Adapter.js'
-import * as AccessKeyTransaction from '../internal/AccessKeyTransaction.js'
 import * as Store from '../Store.js'
 
 const turnkeySessionErrorCodes = new Set([
@@ -277,22 +275,6 @@ export function turnkey<const client extends turnkey.Client>(
       return signatureToHex(result)
     }
 
-    async function signTransaction(parameters: Adapter.signTransaction.Parameters) {
-      const account = await getTurnkeyAccount(parameters.from)
-      const { feePayer, ...rest } = parameters
-      const viemClient = getClient({
-        chainId: parameters.chainId,
-        feePayer: feePayer === true ? undefined : feePayer,
-      })
-      const prepared = await prepareTransactionRequest(viemClient, {
-        account,
-        ...rest,
-        ...(feePayer ? { feePayer: true } : {}),
-        type: 'tempo',
-      } as never)
-      return await account.signTransaction(prepared as never)
-    }
-
     function isSessionError(error: unknown) {
       const code = getTurnkeyErrorCode(error)
       return !!code && turnkeySessionErrorCodes.has(code)
@@ -417,149 +399,13 @@ export function turnkey<const client extends turnkey.Client>(
                 : undefined,
           }
         },
-        async authorizeAccessKey(parameters) {
-          const account = await getTurnkeyAccount(undefined)
-          const keyAuthorization = await AccessKey.authorize({
-            account,
-            chainId: getClient().chain.id,
-            parameters,
-            store,
-          })
-          return { keyAuthorization, rootAddress: account.address }
-        },
-        async revokeAccessKey(parameters) {
-          const account = await getTurnkeyAccount(parameters.address)
-          try {
-            await Actions.accessKey.revoke(getClient(), {
-              account,
-              accessKey: parameters.accessKeyAddress,
-            })
-          } catch (error) {
-            if (!AccessKey.isUnavailableError(error)) throw error
-          }
-          AccessKey.remove({
-            accessKey: parameters.accessKeyAddress,
-            account: account.address,
-            chainId: store.getState().chainId,
-            store,
-          })
-        },
-        async signPersonalMessage(parameters) {
-          return await (
-            await getTurnkeyAccount(parameters.address)
-          ).sign({
-            hash: hashMessage({ raw: parameters.data }),
-          })
-        },
-        async signTransaction(parameters) {
-          const { feePayer, ...rest } = parameters
-          const viemClient = getClient({
-            chainId: parameters.chainId,
-            feePayer: feePayer === true ? undefined : feePayer,
-          })
-          const state = store.getState()
-          const address = parameters.from ?? state.accounts[state.activeAccount]?.address
-          const transaction = address
-            ? await AccessKeyTransaction.create({
-                address,
-                calls: parameters.calls,
-                chainId: parameters.chainId ?? state.chainId,
-                client: viemClient,
-                store,
-              })
-            : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(feePayer ? { feePayer: true } : {}),
-              })
-              return await prepared.sign()
-            } catch {}
-          }
-          return await signTransaction(parameters)
-        },
-        async signTypedData(parameters) {
-          const typedData = JSON.parse(parameters.data) as {
-            domain: Record<string, unknown>
-            message: Record<string, unknown>
-            primaryType: string
-            types: Record<string, unknown>
-          }
-          return await (
-            await getTurnkeyAccount(parameters.address)
-          ).sign({
-            hash: hashTypedData(typedData as never),
-          })
-        },
-        async sendTransaction(parameters) {
-          const { feePayer, ...rest } = parameters
-          const viemClient = getClient({
-            chainId: parameters.chainId,
-            feePayer: feePayer === true ? undefined : feePayer,
-          })
-          const state = store.getState()
-          const address = parameters.from ?? state.accounts[state.activeAccount]?.address
-          const transaction = address
-            ? await AccessKeyTransaction.create({
-                address,
-                calls: parameters.calls,
-                chainId: parameters.chainId ?? state.chainId,
-                client: viemClient,
-                store,
-              })
-            : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(feePayer ? { feePayer: true } : {}),
-              })
-              return await prepared.send()
-            } catch {}
-          }
-          const signed = await signTransaction(parameters)
-          return await viemClient.request({
-            method: 'eth_sendRawTransaction' as never,
-            params: [signed],
-          })
-        },
-        async sendTransactionSync(parameters) {
-          const { feePayer, ...rest } = parameters
-          const viemClient = getClient({
-            chainId: parameters.chainId,
-            feePayer: feePayer === true ? undefined : feePayer,
-          })
-          const state = store.getState()
-          const address = parameters.from ?? state.accounts[state.activeAccount]?.address
-          const transaction = address
-            ? await AccessKeyTransaction.create({
-                address,
-                calls: parameters.calls,
-                chainId: parameters.chainId ?? state.chainId,
-                client: viemClient,
-                store,
-              })
-            : undefined
-          if (transaction) {
-            try {
-              const prepared = await transaction.prepare({
-                ...rest,
-                ...(feePayer ? { feePayer: true } : {}),
-              })
-              return await prepared.sendSync()
-            } catch {}
-          }
-          const signed = await signTransaction(parameters)
-          return await viemClient.request({
-            method: 'eth_sendRawTransactionSync' as never,
-            params: [signed],
-          })
-        },
         async disconnect() {
           await (await getTurnkeyClient()).logout()
           clear()
         },
+      },
+      async getAccount(options = {}) {
+        return { account: await getTurnkeyAccount(options.address) }
       },
     }
   })

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -438,6 +438,9 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           return await account.signTypedData(JSON.parse(data) as never)
         },
       },
+      generateAccessKey() {
+        return undefined
+      },
     }
   })
 }


### PR DESCRIPTION
## Summary
Move shared RPC signing and transaction behavior into provider defaults.

Ideally we'd do this for all of our adapters but we have a few non-conforming one:
- react-native / cli don't conform on storage
- privy doesn't confirm in that it can't construct a proper viem account

We have pending work to address both of these so that these adapters can move into the shared action pattern.

## Motivation
Dialog, local, and Turnkey had duplicated RPC action implementations. The provider can own the common paths once adapters expose a viem-compatible account, while adapters keep account lifecycle and materialization concerns. Explicit adapter actions still win when an adapter needs custom behavior.

## Changes
- Add optional `Adapter.Instance.getAccount` and provider-owned default RPC action routing in `src/core/Provider.ts`.
- Simplify dialog, local, and Turnkey adapters to materialize JSON-RPC or local signer accounts.
- Move fallback access-key preparation/generation into provider code and keep CLI/React Native opting out of browser key generation.
- Encode JSON-RPC boundary params for `eth_sendTransactionSync` and `wallet_authorizeAccessKey`.

## Testing
- `CI=true pnpm test src/core/Provider.test.ts src/core/adapters/dialog.test.ts src/core/adapters/turnkey.test.ts src/core/adapters/privy.test.ts src/core/AccessKey.test.ts`
- `./node_modules/.bin/tsc -b --noEmit`
- `git diff --check`

Note: commit hook ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it reported existing warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`, but no errors.