### PR TITLE
refactor(react-native): use provider storage for access keys

### DIFF
--- a/src/react-native/Provider.localnet.test.ts
+++ b/src/react-native/Provider.localnet.test.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, PublicKey } from 'ox'
+import { Address, Hex, Json, PublicKey } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { parseUnits, type Address as viem_Address } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
@@ -6,6 +6,7 @@ import { describe, expect, test } from 'vp/test'
 
 import { accounts, chain, getClient } from '../../test/config.js'
 import * as Storage from '../core/Storage.js'
+import * as Store from '../core/Store.js'
 import * as Provider from './Provider.js'
 
 const root = accounts[0]!
@@ -25,7 +26,27 @@ async function fund(address: viem_Address) {
   })
 }
 
-function createOpen(options: { mismatchFirstCall?: boolean | undefined } = {}) {
+function asyncJsonStorage(options: Storage.from.Options = {}) {
+  const store = new Map<string, string>()
+  return Storage.from(
+    {
+      async getItem(name) {
+        const raw = store.get(name)
+        if (!raw) return null
+        return Json.parse(raw)
+      },
+      async setItem(name, value) {
+        store.set(name, Json.stringify(value))
+      },
+      async removeItem(name) {
+        store.delete(name)
+      },
+    },
+    options,
+  )
+}
+
+function createOpen() {
   let calls = 0
   const urls: string[] = []
 
@@ -52,10 +73,7 @@ function createOpen(options: { mismatchFirstCall?: boolean | undefined } = {}) {
 
       const keyAuthorization = await root.signKeyAuthorization(
         {
-          accessKeyAddress:
-            options.mismatchFirstCall && calls === 1
-              ? accounts[1]!.address
-              : Address.fromPublicKey(PublicKey.fromHex(pubKey as Hex.Hex)),
+          accessKeyAddress: Address.fromPublicKey(PublicKey.fromHex(pubKey as Hex.Hex)),
           keyType,
         },
         {
@@ -85,6 +103,8 @@ function createOpen(options: { mismatchFirstCall?: boolean | undefined } = {}) {
         callbackUrl.searchParams.set('personalSignMessage', message)
         callbackUrl.searchParams.set('signature', await root.signMessage({ message }))
       }
+      const digest = authUrl.searchParams.get('digest') as Hex.Hex | null
+      if (digest) callbackUrl.searchParams.set('signature', await root.sign({ hash: digest }))
       callbackUrl.searchParams.set('state', state)
       return callbackUrl.toString()
     },
@@ -92,10 +112,10 @@ function createOpen(options: { mismatchFirstCall?: boolean | undefined } = {}) {
 }
 
 describe('create', () => {
-  test('behavior: reauthorizes the managed key when the saved authorization targets the wrong key', async () => {
-    const secureStorage = Storage.memory()
-    const browser = createOpen({ mismatchFirstCall: true })
-    const provider = Provider.create({
+  test('behavior: persists managed access keys through provider storage', async () => {
+    const storage = asyncJsonStorage({ key: 'react-native-managed-key' })
+    const browser = createOpen()
+    const provider1 = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
@@ -103,10 +123,10 @@ describe('create', () => {
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage,
+      storage,
     })
 
-    const result = await provider.request({
+    const result = await provider1.request({
       method: 'wallet_connect',
       params: [{ capabilities: { method: 'register', name: 'Accounts RN Test' } }],
     })
@@ -114,12 +134,21 @@ describe('create', () => {
 
     await fund(root.address)
 
-    const receipt = await provider.request({
+    const provider2 = Provider.create({
+      chains: [chain],
+      host: 'https://wallet.tempo.xyz',
+      open: browser.open,
+      redirectUri: 'accounts-playground://auth',
+      storage,
+    })
+    await Store.waitForHydration(provider2.store)
+
+    const receipt = await provider2.request({
       method: 'eth_sendTransactionSync',
       params: [{ calls: [transferCall], feeToken: Addresses.pathUsd }],
     })
     expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
-    expect(browser.calls()).toMatchInlineSnapshot(`2`)
+    expect(browser.calls()).toMatchInlineSnapshot(`1`)
   })
 
   test('behavior: forwards showDeposit boolean to the mobile auth URL for registration', async () => {
@@ -132,7 +161,7 @@ describe('create', () => {
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage: Storage.memory(),
+      storage: Storage.memory(),
     })
 
     await provider.request({
@@ -156,7 +185,7 @@ describe('create', () => {
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage: Storage.memory(),
+      storage: Storage.memory(),
     })
 
     await provider.request({
@@ -179,7 +208,7 @@ describe('create', () => {
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage: Storage.memory(),
+      storage: Storage.memory(),
     })
 
     await provider.request({
@@ -213,11 +242,19 @@ describe('create', () => {
   test('behavior: forwards showDeposit params to the mobile auth URL for wallet_authorizeAccessKey', async () => {
     const browser = createOpen()
     const provider = Provider.create({
+      authorizeAccessKey: () => ({
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+      }),
       chains: [chain],
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage: Storage.memory(),
+      storage: Storage.memory(),
+    })
+
+    await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login' } }],
     })
 
     await provider.request({
@@ -233,7 +270,7 @@ describe('create', () => {
       ],
     })
 
-    expect(JSON.parse(new URL(browser.urls()[0]!).searchParams.get('showDeposit')!))
+    expect(JSON.parse(new URL(browser.urls()[1]!).searchParams.get('showDeposit')!))
       .toMatchInlineSnapshot(`
       {
         "amount": "25",
@@ -252,7 +289,7 @@ describe('create', () => {
       host: 'https://wallet.tempo.xyz',
       open: browser.open,
       redirectUri: 'accounts-playground://auth',
-      secureStorage: Storage.memory(),
+      storage: Storage.memory(),
     })
 
     const result = await provider.request({
@@ -264,6 +301,31 @@ describe('create', () => {
       `"{"message":"hello"}"`,
     )
     expect(result.accounts[0]!.capabilities.personalSign).toEqual({ message: 'hello' })
+    expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
+  })
+
+  test('behavior: forwards digest to the mobile auth URL and returns signature', async () => {
+    const browser = createOpen()
+    const provider = Provider.create({
+      authorizeAccessKey: () => ({
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+      }),
+      chains: [chain],
+      host: 'https://wallet.tempo.xyz',
+      open: browser.open,
+      redirectUri: 'accounts-playground://auth',
+      storage: Storage.memory(),
+    })
+
+    const digest = Hex.random(32)
+    const result = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { digest, method: 'login' } }],
+    })
+
+    expect(new URL(browser.urls()[0]!).searchParams.get('digest')).toMatchInlineSnapshot(
+      `"${digest}"`,
+    )
     expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
   })
 })

--- a/src/react-native/Provider.ts
+++ b/src/react-native/Provider.ts
@@ -1,11 +1,11 @@
 import * as CoreProvider from '../core/Provider.js'
 import * as Storage from '../core/Storage.js'
 import { reactNative } from './adapter.js'
-import { asyncStorage } from './storage.js'
+import { secureStorage } from './storage.js'
 
 /** Creates a provider for React Native apps using system browser authentication. */
 export function create(options: create.Options): create.ReturnType {
-  const { host = 'https://wallet.tempo.xyz', redirectUri, open, secureStorage, ...rest } = options
+  const { host = 'https://wallet.tempo.xyz', redirectUri, open, ...rest } = options
 
   return CoreProvider.create({
     storage: defaultStorage(),
@@ -14,13 +14,13 @@ export function create(options: create.Options): create.ReturnType {
       host,
       redirectUri,
       ...(open ? { open } : {}),
-      ...(secureStorage ? { secureStorage } : {}),
     }),
   })
 }
 
 function defaultStorage(): Storage.Storage {
-  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') return asyncStorage()
+  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative')
+    return secureStorage()
   return Storage.memory()
 }
 

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -4,15 +4,15 @@ import {
   Hex,
   P256,
   Provider as core_Provider,
-  PublicKey,
   RpcResponse,
 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { Actions, Account as TempoAccount, Secp256k1 } from 'viem/tempo'
+import { custom } from 'viem'
+import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
+import * as z from 'zod/mini'
 
 import * as Adapter from '../core/Adapter.js'
-import * as AccessKeyTransaction from '../core/internal/AccessKeyTransaction.js'
-import type * as Storage from '../core/Storage.js'
+import * as Rpc from '../core/zod/rpc.js'
 
 /**
  * Creates a React Native adapter that authorizes access keys via the system browser.
@@ -23,221 +23,38 @@ import type * as Storage from '../core/Storage.js'
 export function reactNative(options: reactNative.Options): Adapter.Adapter {
   const { name = 'Tempo Mobile', rdns = 'xyz.tempo.mobile' } = options
 
-  return Adapter.define({ name, rdns }, ({ getAccount, getClient, store }) => {
-    async function loadManagedKey(
-      address: Adapter.authorizeAccessKey.ReturnType['rootAddress'],
-      parameters: loadManagedKey.Options = {},
-    ): Promise<loadManagedKey.ReturnType | undefined> {
+  return Adapter.define({ name, rdns }, ({ getAccount, store }) => {
+    function generateAccessKey(
+      parameters: Adapter.generateAccessKey.Options = {},
+    ): Adapter.generateAccessKey.ReturnType {
       const { keyType } = parameters
-      const { secureStorage } = options
-      if (!secureStorage) return undefined
-
-      const { chainId } = store.getState()
-      const storageKeys = keyType
-        ? [managedKeyStorageKey(address, chainId, keyType)]
-        : [
-            managedKeyStorageKey(address, chainId, 'secp256k1'),
-            managedKeyStorageKey(address, chainId, 'p256'),
-            managedKeyStorageKey(address, chainId),
-          ]
-      let entry: ManagedKeyEntry | null = null
-      for (const storageKey of storageKeys) {
-        entry = await secureStorage.getItem<ManagedKeyEntry>(storageKey)
-        if (entry) break
-      }
-      if (!entry) return undefined
-
-      const account =
-        entry.keyType === 'p256'
-          ? TempoAccount.fromP256(entry.key, { access: address })
-          : TempoAccount.fromSecp256k1(entry.key, { access: address })
-      const keyAddress = core_Address.fromPublicKey(PublicKey.from(account.publicKey))
-      const deserialized = KeyAuthorization.deserialize(entry.keyAuthorization)
-      if (!deserialized.signature) throw new Error('Managed access key is missing a signature.')
-      const keyAuthorization = deserialized as KeyAuthorization.Signed
-
-      if (keyAuthorization.address.toLowerCase() === keyAddress.toLowerCase())
-        store.accessKeys.add({
-          account: address,
-          authorization: keyAuthorization,
-          privateKey: entry.key,
+      if (keyType && keyType !== 'p256' && keyType !== 'secp256k1')
+        throw new RpcResponse.InvalidParamsError({
+          message: `\`keyType: "${keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
         })
-      else
-        store.accessKeys.remove({
-          account: address,
-          accessKey: keyAuthorization.address,
-          chainId: Number(keyAuthorization.chainId),
-        })
-
-      return {
-        account,
-        expiry: entry.expiry,
-        key: entry.key,
-        keyAddress,
-        keyType: entry.keyType,
-        publicKey: account.publicKey,
-        storedAuthorization: keyAuthorization,
-      }
-    }
-
-    async function resolveManagedKey(
-      resolveOptions: {
-        address?: Adapter.authorizeAccessKey.ReturnType['rootAddress'] | undefined
-        keyType?: Adapter.authorizeAccessKey.Parameters['keyType'] | undefined
-      } = {},
-    ): Promise<resolveManagedKey.ReturnType> {
-      const { address, keyType } = resolveOptions
-
-      const requestedKeyType = keyType === 'p256' || keyType === 'secp256k1' ? keyType : undefined
-      const entry = address
-        ? await loadManagedKey(address, requestedKeyType ? { keyType: requestedKeyType } : {})
-        : undefined
-      if (entry)
-        return {
-          account: entry.account,
-          key: entry.key,
-          keyAddress: entry.keyAddress,
-          keyType: entry.keyType,
-          publicKey: entry.publicKey,
-        }
-
-      const nextKeyType = requestedKeyType === 'p256' ? 'p256' : 'secp256k1'
-      const key = nextKeyType === 'p256' ? P256.randomPrivateKey() : Secp256k1.randomPrivateKey()
+      const type = keyType ?? 'secp256k1'
+      const privateKey = type === 'p256' ? P256.randomPrivateKey() : Secp256k1.randomPrivateKey()
       const account =
-        nextKeyType === 'p256'
-          ? TempoAccount.fromP256(key, address ? { access: address } : undefined)
-          : TempoAccount.fromSecp256k1(key, address ? { access: address } : undefined)
-
+        type === 'p256' ? TempoAccount.fromP256(privateKey) : TempoAccount.fromSecp256k1(privateKey)
       return {
-        account,
-        key,
-        keyAddress: core_Address.fromPublicKey(PublicKey.from(account.publicKey)),
-        keyType: nextKeyType,
+        keyType: type,
+        privateKey,
         publicKey: account.publicKey,
       }
     }
 
-    async function saveManagedKey(
-      address: Adapter.authorizeAccessKey.ReturnType['rootAddress'],
-      managedKey: Awaited<ReturnType<typeof resolveManagedKey>>,
-      keyAuthorization: KeyAuthorization.Signed,
-    ) {
-      if (!managedKey) return
-
-      store.accessKeys.add({
-        account: address,
-        authorization: keyAuthorization,
-        privateKey: managedKey.key,
-      })
-
-      const { secureStorage } = options
-      if (!secureStorage) return
-
-      const { chainId } = store.getState()
-      const storageKey = managedKeyStorageKey(address, chainId, managedKey.keyType)
-      const entry: ManagedKeyEntry = {
-        chainId,
-        expiry: keyAuthorization.expiry ?? 0,
-        key: managedKey.key,
-        keyAddress: managedKey.keyAddress,
-        keyAuthorization: KeyAuthorization.serialize(keyAuthorization),
-        keyType: managedKey.keyType,
-        walletAddress: address,
-      }
-      await secureStorage.setItem(storageKey, entry)
-    }
-
-    async function isManagedKeyAuthorized(
-      address: Adapter.authorizeAccessKey.ReturnType['rootAddress'],
-      managedKey: loadManagedKey.ReturnType,
-    ) {
-      try {
-        const metadata = await Actions.accessKey.getMetadata(getClient(), {
-          account: address,
-          accessKey: managedKey.keyAddress,
-        })
-        return (
-          metadata.address.toLowerCase() === managedKey.keyAddress.toLowerCase() &&
-          !metadata.isRevoked
-        )
-      } catch {
-        return false
-      }
-    }
-
-    async function reauthorizeManagedKey(
-      address: Adapter.authorizeAccessKey.ReturnType['rootAddress'],
-      managedKey: loadManagedKey.ReturnType,
-    ) {
-      const result = await authorize({
-        account: address,
-        authorizeAccessKey: {
-          expiry: managedKey.expiry,
-          keyType: managedKey.keyType,
-          ...(managedKey.storedAuthorization.limits
-            ? { limits: managedKey.storedAuthorization.limits.map((limit) => ({ ...limit })) }
-            : {}),
-          publicKey: managedKey.publicKey,
-        },
-        method: 'wallet_authorizeAccessKey',
-      })
-      await saveManagedKey(address, managedKey, result.keyAuthorization)
-      return result.keyAuthorization
-    }
-
-    async function prepareManagedTransaction(
-      client: ReturnType<typeof getClient>,
-      parameters: AccessKeyTransaction.create.PrepareParameters,
-      options: {
-        calls?: AccessKeyTransaction.create.Options['calls'] | undefined
-        chainId?: number | undefined
-      } = {},
-    ) {
-      const state = store.getState()
-      const address = parameters.from ?? state.accounts[state.activeAccount]?.address
-      if (!address) throw new core_Provider.DisconnectedError({ message: 'No active account.' })
-      const managedKey = await loadManagedKey(address)
-      if (managedKey && !(await isManagedKeyAuthorized(address, managedKey)))
-        await reauthorizeManagedKey(address, managedKey)
-      const transaction = await AccessKeyTransaction.create({
-        address,
-        calls: options.calls,
-        chainId: options.chainId ?? state.chainId,
-        client,
-        store,
-      })
-      if (!transaction)
-        throw new core_Provider.UnauthorizedError({
-          message: `Account "${address}" cannot sign with an access key.`,
-        })
-      return await transaction.prepare(parameters)
-    }
-
-    async function loadManagedAccount(address: Adapter.signPersonalMessage.Parameters['address']) {
-      await loadManagedKey(address)
-      return getAccount({ address, signable: true })
-    }
-
-    async function authorize(request: {
-      account?: Adapter.authorizeAccessKey.ReturnType['rootAddress'] | undefined
+    async function authorizeMobile(request: {
       authorizeAccessKey: Adapter.authorizeAccessKey.Parameters | undefined
+      digest?: Adapter.loadAccounts.Parameters['digest'] | undefined
       method: 'wallet_authorizeAccessKey' | 'wallet_connect'
       personalSign?: Adapter.loadAccounts.Parameters['personalSign'] | undefined
       showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
     }) {
       const { host, redirectUri, open = defaultOpen } = options
-      const { account, authorizeAccessKey, method, personalSign, showDeposit } = request
+      const { authorizeAccessKey, digest, method, personalSign, showDeposit } = request
 
-      const managedKey =
-        authorizeAccessKey && !authorizeAccessKey.publicKey && !authorizeAccessKey.address
-          ? await resolveManagedKey({
-              ...(account ? { address: account } : {}),
-              ...(authorizeAccessKey.keyType ? { keyType: authorizeAccessKey.keyType } : {}),
-            })
-          : undefined
-
-      const publicKey = authorizeAccessKey?.publicKey ?? managedKey?.publicKey
-      const keyType = authorizeAccessKey?.keyType ?? managedKey?.keyType
+      const publicKey = authorizeAccessKey?.publicKey
+      const keyType = authorizeAccessKey?.keyType
 
       if (!publicKey)
         throw new RpcResponse.InvalidParamsError({
@@ -250,7 +67,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       const state = Base64.fromBytes(Hex.toBytes(Hex.random(16)), { pad: false, url: true })
       const authUrl = buildAuthUrl(host, {
         callback: redirectUri,
-        chainId: store.getState().chainId,
+        chainId: Number(authorizeAccessKey?.chainId ?? store.getState().chainId),
         ...(typeof authorizeAccessKey?.expiry !== 'undefined'
           ? { expiry: authorizeAccessKey.expiry }
           : {}),
@@ -258,6 +75,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
         ...(authorizeAccessKey?.limits
           ? { limits: authorizeAccessKey.limits.map((l) => ({ ...l, limit: String(l.limit) })) }
           : {}),
+        ...(digest ? { digest } : {}),
         ...(personalSign ? { personalSign } : {}),
         pubKey: publicKey,
         ...(showDeposit !== undefined ? { showDeposit } : {}),
@@ -284,9 +102,6 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       const signature = params.get('signature') as Hex.Hex | null
       const personalSignMessage = params.get('personalSignMessage')
 
-      if (managedKey)
-        await saveManagedKey(accountAddress as core_Address.Address, managedKey, signed)
-
       return {
         accountAddress: accountAddress as core_Address.Address,
         keyAuthorization: signed,
@@ -295,147 +110,104 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       }
     }
 
+    async function authorizeAccessKeyMobile(
+      request: Pick<Rpc.wallet_authorizeAccessKey.Encoded, 'method' | 'params'>,
+    ): Promise<Rpc.wallet_authorizeAccessKey.Encoded['returns']> {
+      const [parameters] = z.decode(Rpc.wallet_authorizeAccessKey.schema.params!, request.params)
+      const result = await authorizeMobile({
+        authorizeAccessKey: parameters,
+        method: 'wallet_authorizeAccessKey',
+        ...(parameters.showDeposit !== undefined ? { showDeposit: parameters.showDeposit } : {}),
+      })
+
+      return {
+        keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
+        rootAddress: result.accountAddress,
+      }
+    }
+
+    async function connectMobile(
+      request: Pick<Rpc.wallet_connect.Encoded, 'method' | 'params'>,
+    ): Promise<Rpc.wallet_connect.Encoded['returns']> {
+      const [parameters] = z.decode(Rpc.wallet_connect.schema.params!, request.params) ?? []
+      const capabilities = parameters?.capabilities
+
+      const result = await authorizeMobile({
+        authorizeAccessKey: capabilities?.authorizeAccessKey,
+        ...(capabilities?.digest ? { digest: capabilities.digest } : {}),
+        method: 'wallet_connect',
+        ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
+        ...(capabilities?.showDeposit !== undefined
+          ? { showDeposit: capabilities.showDeposit }
+          : {}),
+      })
+
+      return {
+        accounts: [
+          {
+            address: result.accountAddress,
+            capabilities: {
+              keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
+              ...(result.personalSign ? { personalSign: result.personalSign } : {}),
+              ...(result.signature ? { signature: result.signature } : {}),
+            },
+          },
+        ],
+      }
+    }
+
+    const provider = core_Provider.from({
+      async request(request) {
+        switch (request.method) {
+          case 'eth_chainId':
+            return Hex.fromNumber(store.getState().chainId)
+          case 'wallet_authorizeAccessKey':
+            return await authorizeAccessKeyMobile(request as never)
+          case 'wallet_connect':
+            return await connectMobile(request as never)
+          default:
+            throw unsupported(`\`${request.method}\` not supported by React Native adapter.`)
+        }
+      },
+    })
+
+    function toConnectReturn(result: Rpc.wallet_connect.Encoded['returns']) {
+      const capabilities = result.accounts[0]?.capabilities
+      return {
+        accounts: result.accounts.map((account) => ({ address: account.address })),
+        ...(capabilities?.keyAuthorization
+          ? { keyAuthorization: capabilities.keyAuthorization }
+          : {}),
+        ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
+        ...(capabilities?.signature ? { signature: capabilities.signature } : {}),
+      }
+    }
+
     return {
       actions: {
-        async authorizeAccessKey(parameters) {
-          const { accounts, activeAccount } = store.getState()
-          const account = accounts[activeAccount]?.address
-          const result = await authorize({
-            ...(account ? { account } : {}),
-            authorizeAccessKey: parameters,
-            method: 'wallet_authorizeAccessKey',
-            ...(parameters.showDeposit !== undefined
-              ? { showDeposit: parameters.showDeposit }
-              : {}),
-          })
-
-          if (!account)
-            store.setState({
-              accounts: [{ address: result.accountAddress }],
-              activeAccount: 0,
-            })
-
-          return {
-            keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-            rootAddress: result.accountAddress,
-          }
+        async createAccount(_parameters, request) {
+          return toConnectReturn(
+            (await provider.request(request)) as Rpc.wallet_connect.Encoded['returns'],
+          )
         },
-        async createAccount(parameters) {
-          if (parameters?.digest)
-            throw unsupported(
-              '`wallet_connect` digest signing not supported by React Native adapter.',
-            )
-
-          const result = await authorize({
-            authorizeAccessKey: parameters?.authorizeAccessKey,
-            method: 'wallet_connect',
-            ...(parameters?.personalSign ? { personalSign: parameters.personalSign } : {}),
-            ...(parameters?.showDeposit !== undefined
-              ? { showDeposit: parameters.showDeposit }
-              : {}),
-          })
-
-          return {
-            accounts: [
-              {
-                address: result.accountAddress,
-                capabilities: {},
-              },
-            ],
-            keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-            ...(result.personalSign ? { personalSign: result.personalSign } : {}),
-            ...(result.signature ? { signature: result.signature } : {}),
-          }
-        },
-        async loadAccounts(parameters) {
-          if (parameters?.digest)
-            throw unsupported(
-              '`wallet_connect` digest signing not supported by React Native adapter.',
-            )
-
-          const result = await authorize({
-            authorizeAccessKey: parameters?.authorizeAccessKey,
-            method: 'wallet_connect',
-            ...(parameters?.personalSign ? { personalSign: parameters.personalSign } : {}),
-            ...(parameters?.showDeposit !== undefined
-              ? { showDeposit: parameters.showDeposit }
-              : {}),
-          })
-
-          return {
-            accounts: [
-              {
-                address: result.accountAddress,
-                capabilities: {},
-              },
-            ],
-            keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-            ...(result.personalSign ? { personalSign: result.personalSign } : {}),
-            ...(result.signature ? { signature: result.signature } : {}),
-          }
+        async loadAccounts(_parameters, request) {
+          return toConnectReturn(
+            (await provider.request(request)) as Rpc.wallet_connect.Encoded['returns'],
+          )
         },
         async revokeAccessKey() {
           throw unsupported('`wallet_revokeAccessKey` not supported by React Native adapter.')
         },
-        async sendTransaction(parameters) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient(typeof feePayer === 'string' ? { feePayer } : {})
-          const prepared = await prepareManagedTransaction(
-            client,
-            {
-              ...rest,
-              ...(feePayer ? { feePayer: true } : {}),
-            },
-            {
-              calls: parameters.calls as AccessKeyTransaction.create.Options['calls'],
-              chainId: parameters.chainId,
-            },
-          )
-          return await prepared.send()
-        },
-        async sendTransactionSync(parameters) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient(typeof feePayer === 'string' ? { feePayer } : {})
-          const prepared = await prepareManagedTransaction(
-            client,
-            {
-              ...rest,
-              ...(feePayer ? { feePayer: true } : {}),
-            },
-            {
-              calls: parameters.calls as AccessKeyTransaction.create.Options['calls'],
-              chainId: parameters.chainId,
-            },
-          )
-          return await prepared.sendSync()
-        },
-        async signPersonalMessage({ address, data }) {
-          const account = await loadManagedAccount(address)
-          return await account.signMessage({ message: { raw: data } })
-        },
-        async signTransaction(parameters) {
-          const { feePayer, ...rest } = parameters
-          const client = getClient(typeof feePayer === 'string' ? { feePayer } : {})
-          const prepared = await prepareManagedTransaction(
-            client,
-            {
-              ...rest,
-              ...(feePayer ? { feePayer: true } : {}),
-            },
-            {
-              calls: parameters.calls as AccessKeyTransaction.create.Options['calls'],
-              chainId: parameters.chainId,
-            },
-          )
-          return await prepared.sign()
-        },
-        async signTypedData({ address, data }) {
-          const account = await loadManagedAccount(address)
-          return await account.signTypedData(JSON.parse(data) as never)
-        },
       },
-      generateAccessKey() {
-        return undefined
+      generateAccessKey,
+      getAccount(parameters = {}) {
+        return {
+          account: {
+            address: parameters.address ?? getAccount({ signable: false }).address,
+            type: 'json-rpc' as const,
+          },
+          transport: custom(provider),
+        }
       },
     }
   })
@@ -456,41 +228,7 @@ export declare namespace reactNative {
     redirectUri: string
     /** Reverse-DNS provider identifier. @default "xyz.tempo.mobile" */
     rdns?: string | undefined
-    /** Secure storage adapter for persisting managed access keys. */
-    secureStorage?: Storage.Storage | undefined
   }
-}
-
-declare namespace resolveManagedKey {
-  type ReturnType = {
-    account: TempoAccount.Account
-    key: Hex.Hex
-    keyAddress: core_Address.Address
-    keyType: 'secp256k1' | 'p256'
-    publicKey: Hex.Hex
-  }
-}
-
-declare namespace loadManagedKey {
-  type Options = {
-    keyType?: 'secp256k1' | 'p256' | undefined
-  }
-
-  type ReturnType = resolveManagedKey.ReturnType & {
-    expiry: number
-    storedAuthorization: KeyAuthorization.Signed
-  }
-}
-
-/** Entry shape persisted to secure storage for managed access keys. */
-type ManagedKeyEntry = {
-  chainId: number
-  expiry: number
-  key: Hex.Hex
-  keyAddress: core_Address.Address
-  keyAuthorization: Hex.Hex
-  keyType: 'secp256k1' | 'p256'
-  walletAddress: core_Address.Address
 }
 
 class AuthCancelledError extends Error {
@@ -519,6 +257,7 @@ function buildAuthUrl(
   params: {
     callback: string
     chainId: number
+    digest?: Hex.Hex | undefined
     expiry?: number | undefined
     keyType?: string | undefined
     limits?: readonly { token: string; limit: string }[] | undefined
@@ -532,6 +271,7 @@ function buildAuthUrl(
   url.searchParams.set('pubKey', params.pubKey)
   if (params.keyType) url.searchParams.set('keyType', params.keyType)
   url.searchParams.set('chainId', `0x${params.chainId.toString(16)}`)
+  if (params.digest) url.searchParams.set('digest', params.digest)
   if (typeof params.expiry !== 'undefined')
     url.searchParams.set('expiry', `0x${params.expiry.toString(16)}`)
   if (params.limits) url.searchParams.set('limits', JSON.stringify(params.limits))
@@ -542,14 +282,6 @@ function buildAuthUrl(
   url.searchParams.set('callback', params.callback)
   url.searchParams.set('state', params.state)
   return url.toString()
-}
-
-function managedKeyStorageKey(
-  address: core_Address.Address,
-  chainId: number,
-  keyType?: string | undefined,
-): string {
-  return `managedKey.${address.toLowerCase()}.${chainId}${keyType ? `.${keyType}` : ''}`
 }
 
 function unsupported(message: string) {

--- a/src/react-native/storage.ts
+++ b/src/react-native/storage.ts
@@ -2,7 +2,7 @@ import { Json } from 'ox'
 
 import * as Storage from '../core/Storage.js'
 
-/** Creates a storage adapter backed by `expo-secure-store`. For private key material. */
+/** Creates a storage adapter backed by `expo-secure-store`. */
 export function secureStorage(options: secureStorage.Options = {}): Storage.Storage {
   return Storage.from(
     {


### PR DESCRIPTION
## Summary
React Native now uses provider storage and the standard Provider access-key flow instead of adapter-specific key persistence.

## Motivation
The React Native adapter was still carrying managed-key persistence and custom unsupported branches after access-key persistence moved into the core store. That made RN behave differently from dialog-style adapters and kept `secureStorage` as a special adapter option.

## Changes
- Removed React Native managed-key persistence and `secureStorage` adapter options from `src/react-native/adapter.ts`.
- Routed mobile `wallet_connect` and `wallet_authorizeAccessKey` through a small internal JSON-RPC provider used by `getAccount`.
- Forwarded `wallet_connect` digest requests through the mobile auth URL and returned callback signatures through the normal capabilities path.
- Defaulted `src/react-native/Provider.ts` to secure provider storage on React Native and memory storage elsewhere.

## Testing
- `pnpm check:types`
- `git diff --check`
- `pnpm test src/react-native/Provider.localnet.test.ts` — 1 file passed, 7 tests passed