### PR TITLE
feat: allow conditional access key authorization

### DIFF
--- a/.changeset/conditional-authorize-access-key.md
+++ b/.changeset/conditional-authorize-access-key.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Allow `Provider.create({ authorizeAccessKey })` to return `undefined` to skip access-key authorization for the current `wallet_connect`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@
 - **Inline snapshots over direct assertions** — prefer `toMatchInlineSnapshot()` over `.toBe()`, `.toEqual()`, etc. for return values. Use `toThrowErrorMatchingInlineSnapshot()` for error assertions. Never use try/catch + `expect.unreachable()` for error tests.
 - **Snapshot whole objects, omit nondeterministic properties** — destructure out nondeterministic fields (e.g. `blockHash`, `gasUsed`, timestamps) and snapshot the rest, rather than cherry-picking individual fields to assert.
 - **Unit and type tests as you go** — write unit tests and `.test-d.ts` type tests alongside implementation for each module. Save high-level integration tests (with and without browser) for the end.
+- **Validate `.test-d.ts` with TypeScript** — `pnpm test <file>.test-d.ts` does not match the Vitest project includes; use `pnpm exec tsc -b --noEmit` for type-test coverage.
 - **Mark localnet tests explicitly** — tests that touch RPC/localnet should use the `*.localnet.test.ts` suffix so only those files inherit `test/setup.ts`; pure `*.test.ts` files run in the no-setup `lib/pure` project.
 
 ## Git Conventions

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -128,10 +128,10 @@ const provider = Provider.create({
 
 ### authorizeAccessKey
 
-- **Type:** `() => Adapter.authorizeAccessKey.Parameters`
+- **Type:** `() => Adapter.authorizeAccessKey.Parameters | undefined`
 - **Optional**
 
-Default access key parameters for `wallet_connect`. When set, `wallet_connect` will automatically authorize an access key.
+Default access key parameters for `wallet_connect`. When set, `wallet_connect` will automatically authorize an access key. Return `undefined` to skip authorization for the current request.
 
 Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Local adapters accept unbounded keys, but production apps should pass both so local and wallet-hosted flows use the same policy.
 
@@ -158,7 +158,7 @@ declare function authorizeAccessKey(): {
   scopes?:
     | { address: Address; recipients?: readonly Address[]; selector?: Hex | string }[]
     | undefined
-}
+} | undefined
 ```
 
 ```ts twoslash

--- a/site/src/pages/docs/wagmi/tempoWallet.mdx
+++ b/site/src/pages/docs/wagmi/tempoWallet.mdx
@@ -29,10 +29,10 @@ Accepts all [`dialog`](/docs/api/dialog) adapter options, plus all [`Provider`](
 
 ### authorizeAccessKey
 
-- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] }`
+- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | undefined`
 - **Optional**
 
-Default access key parameters for `wallet_connect`.
+Default access key parameters for `wallet_connect`. Return `undefined` to skip authorization for the current request.
 
 This matches [`Provider.authorizeAccessKey`](/docs/api/provider#authorizeaccesskey).
 

--- a/site/src/pages/docs/wagmi/webAuthn.mdx
+++ b/site/src/pages/docs/wagmi/webAuthn.mdx
@@ -60,10 +60,10 @@ export const config = createConfig({
 
 ### authorizeAccessKey
 
-- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] }`
+- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | undefined`
 - **Optional**
 
-Default access key parameters for `wallet_connect`.
+Default access key parameters for `wallet_connect`. Return `undefined` to skip authorization for the current request.
 
 This matches [`Provider.authorizeAccessKey`](/docs/api/provider#authorizeaccesskey).
 

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -1,6 +1,7 @@
 import type { RpcSchema } from 'ox'
 import { describe, expectTypeOf, test } from 'vp/test'
 
+import type * as Adapter from './Adapter.js'
 import * as Provider from './Provider.js'
 import type * as Schema from './Schema.js'
 
@@ -60,6 +61,16 @@ describe('request', () => {
 })
 
 describe('create options', () => {
+  test('authorizeAccessKey can return undefined to opt out', () => {
+    expectTypeOf<NonNullable<Parameters<typeof Provider.create>[0]>>().toMatchTypeOf<{
+      authorizeAccessKey?: (() => Adapter.authorizeAccessKey.Parameters | undefined) | undefined
+    }>()
+
+    Provider.create({
+      authorizeAccessKey: () => undefined,
+    })
+  })
+
   test('mpp accepts session deposit options', () => {
     expectTypeOf<NonNullable<Parameters<typeof Provider.create>[0]>>().toMatchTypeOf<{
       mpp?:

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1564,8 +1564,9 @@ export declare namespace create {
      * Default access key parameters for `wallet_connect`.
      *
      * When set, `wallet_connect` will automatically authorize an access key.
+     * Return `undefined` to skip authorization for the current request.
      */
-    authorizeAccessKey?: (() => Adapter.authorizeAccessKey.Parameters) | undefined
+    authorizeAccessKey?: (() => Adapter.authorizeAccessKey.Parameters | undefined) | undefined
     /**
      * Supported chains. First chain is the default.
      * @default [tempo, tempoModerato, tempoDevnet]


### PR DESCRIPTION
## Summary
Allows `Provider.create({ authorizeAccessKey })` to return `undefined` so apps can skip access-key authorization per `wallet_connect`.

## Motivation
Apps need to authorize access keys only for some connects without casting `undefined as never`.

## Changes
- Widened `create.Options.authorizeAccessKey` in `src/core/Provider.ts` to return `Adapter.authorizeAccessKey.Parameters | undefined`
- Added a type regression in `src/core/Provider.test-d.ts`
- Updated Provider and Wagmi docs, plus a patch changeset

## Testing
- `pnpm exec tsc -b --noEmit` — passed
- `pnpm test src/core/Provider.test.ts` — 1 file, 2 tests passed
- `pnpm docs:build` — passed; emitted existing dead-link warnings in `/docs/adapters/private-key.mdx` and `/docs/adapters/webauthn.mdx`
- `git diff --check` — passed