### PR TITLE
fix(react-native): allow connect without access key

### DIFF
--- a/.changeset/react-native-connect-without-access-key.md
+++ b/.changeset/react-native-connect-without-access-key.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Let the React Native adapter connect without requesting an access key.

--- a/.changeset/react-native-connect-without-access-key.md
+++ b/.changeset/react-native-connect-without-access-key.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Let the React Native adapter connect without requesting an access key.
+Allowed the React Native adapter to connect without requesting an access key.

--- a/src/react-native/Provider.localnet.test.ts
+++ b/src/react-native/Provider.localnet.test.ts
@@ -63,40 +63,44 @@ function createOpen() {
       const pubKey = authUrl.searchParams.get('pubKey')
       const state = authUrl.searchParams.get('state')
 
-      if (!callback || !chainId || !pubKey || !state)
-        throw new Error('Expected callback, chainId, pubKey, and state in auth URL.')
-
-      const limits = authUrl.searchParams.get('limits')
-      const keyType = authUrl.searchParams.get('keyType')
-      if (keyType !== 'p256' && keyType !== 'secp256k1')
-        throw new Error('Expected a managed key type in auth URL.')
-
-      const keyAuthorization = await root.signKeyAuthorization(
-        {
-          accessKeyAddress: Address.fromPublicKey(PublicKey.fromHex(pubKey as Hex.Hex)),
-          keyType,
-        },
-        {
-          chainId: BigInt(chainId),
-          ...(authUrl.searchParams.get('expiry')
-            ? { expiry: Number(authUrl.searchParams.get('expiry')) }
-            : {}),
-          ...(limits
-            ? {
-                limits: (JSON.parse(limits) as { token: `0x${string}`; limit: string }[]).map(
-                  (x) => ({
-                    limit: BigInt(x.limit),
-                    token: x.token,
-                  }),
-                ),
-              }
-            : {}),
-        },
-      )
+      if (!callback || !chainId || !state)
+        throw new Error('Expected callback, chainId, and state in auth URL.')
 
       const callbackUrl = new URL(callback)
       callbackUrl.searchParams.set('accountAddress', root.address)
-      callbackUrl.searchParams.set('keyAuthorization', KeyAuthorization.serialize(keyAuthorization))
+      if (pubKey) {
+        const limits = authUrl.searchParams.get('limits')
+        const keyType = authUrl.searchParams.get('keyType')
+        if (keyType !== 'p256' && keyType !== 'secp256k1')
+          throw new Error('Expected a managed key type in auth URL.')
+
+        const keyAuthorization = await root.signKeyAuthorization(
+          {
+            accessKeyAddress: Address.fromPublicKey(PublicKey.fromHex(pubKey as Hex.Hex)),
+            keyType,
+          },
+          {
+            chainId: BigInt(chainId),
+            ...(authUrl.searchParams.get('expiry')
+              ? { expiry: Number(authUrl.searchParams.get('expiry')) }
+              : {}),
+            ...(limits
+              ? {
+                  limits: (JSON.parse(limits) as { token: `0x${string}`; limit: string }[]).map(
+                    (x) => ({
+                      limit: BigInt(x.limit),
+                      token: x.token,
+                    }),
+                  ),
+                }
+              : {}),
+          },
+        )
+        callbackUrl.searchParams.set(
+          'keyAuthorization',
+          KeyAuthorization.serialize(keyAuthorization),
+        )
+      }
       const personalSign = authUrl.searchParams.get('personalSign')
       if (personalSign) {
         const { message } = JSON.parse(personalSign) as { message: string }
@@ -149,6 +153,27 @@ describe('create', () => {
     })
     expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
     expect(browser.calls()).toMatchInlineSnapshot(`1`)
+  })
+
+  test('behavior: wallet_connect does not require authorizeAccessKey capability', async () => {
+    const browser = createOpen()
+    const provider = Provider.create({
+      chains: [chain],
+      host: 'https://wallet.tempo.xyz',
+      open: browser.open,
+      redirectUri: 'accounts-playground://auth',
+      storage: Storage.memory(),
+    })
+
+    const result = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login', showDeposit: true } }],
+    })
+    const url = new URL(browser.urls()[0]!)
+
+    expect(url.searchParams.get('pubKey')).toMatchInlineSnapshot(`null`)
+    expect(url.searchParams.get('showDeposit')).toMatchInlineSnapshot(`"true"`)
+    expect(result.accounts[0]!.capabilities).toMatchInlineSnapshot(`{}`)
   })
 
   test('behavior: forwards showDeposit boolean to the mobile auth URL for registration', async () => {

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -43,42 +43,12 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       }
     }
 
-    async function authorizeMobile(request: {
-      authorizeAccessKey: Adapter.authorizeAccessKey.Parameters | undefined
-      digest?: Adapter.loadAccounts.Parameters['digest'] | undefined
-      method: 'wallet_authorizeAccessKey' | 'wallet_connect'
-      personalSign?: Adapter.loadAccounts.Parameters['personalSign'] | undefined
-      showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
-    }) {
+    async function openMobileAuth(parameters: Omit<buildAuthUrl.Parameters, 'callback' | 'state'>) {
       const { host, redirectUri, open = defaultOpen } = options
-      const { authorizeAccessKey, digest, method, personalSign, showDeposit } = request
-
-      const publicKey = authorizeAccessKey?.publicKey
-      const keyType = authorizeAccessKey?.keyType
-
-      if (!publicKey && (method === 'wallet_authorizeAccessKey' || authorizeAccessKey))
-        throw new RpcResponse.InvalidParamsError({
-          message:
-            method === 'wallet_connect'
-              ? '`wallet_connect` on the React Native adapter requires key parameters when `capabilities.authorizeAccessKey` is set.'
-              : '`wallet_authorizeAccessKey` on the React Native adapter requires key parameters.',
-        })
-
       const state = Base64.fromBytes(Hex.toBytes(Hex.random(16)), { pad: false, url: true })
       const authUrl = buildAuthUrl(host, {
         callback: redirectUri,
-        chainId: Number(authorizeAccessKey?.chainId ?? store.getState().chainId),
-        ...(typeof authorizeAccessKey?.expiry !== 'undefined'
-          ? { expiry: authorizeAccessKey.expiry }
-          : {}),
-        ...(keyType ? { keyType } : {}),
-        ...(authorizeAccessKey?.limits
-          ? { limits: authorizeAccessKey.limits.map((l) => ({ ...l, limit: String(l.limit) })) }
-          : {}),
-        ...(digest ? { digest } : {}),
-        ...(personalSign ? { personalSign } : {}),
-        ...(publicKey ? { pubKey: publicKey } : {}),
-        ...(showDeposit !== undefined ? { showDeposit } : {}),
+        ...parameters,
         state,
       })
 
@@ -89,77 +59,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       const returnedState = params.get('state')
       if (returnedState !== state) throw new StateMismatchError()
 
-      const accountAddress = params.get('accountAddress')
-      if (!accountAddress) throw new Error('Missing accountAddress in callback.')
-
-      const keyAuthorization = (() => {
-        const value = params.get('keyAuthorization')
-        if (!value) return undefined
-        const keyAuthorization = KeyAuthorization.deserialize(value as Hex.Hex)
-        if (!keyAuthorization.signature)
-          throw new Error('Key authorization in callback is missing a signature.')
-        return keyAuthorization as KeyAuthorization.Signed
-      })()
-      if (publicKey && !keyAuthorization) throw new Error('Missing keyAuthorization in callback.')
-
-      const signature = params.get('signature') as Hex.Hex | null
-      const personalSignMessage = params.get('personalSignMessage')
-
-      return {
-        accountAddress: accountAddress as core_Address.Address,
-        ...(keyAuthorization ? { keyAuthorization } : {}),
-        ...(personalSignMessage ? { personalSign: { message: personalSignMessage } } : {}),
-        ...(signature ? { signature } : {}),
-      }
-    }
-
-    async function authorizeAccessKeyMobile(
-      request: Pick<Rpc.wallet_authorizeAccessKey.Encoded, 'method' | 'params'>,
-    ): Promise<Rpc.wallet_authorizeAccessKey.Encoded['returns']> {
-      const [parameters] = z.decode(Rpc.wallet_authorizeAccessKey.schema.params!, request.params)
-      const result = await authorizeMobile({
-        authorizeAccessKey: parameters,
-        method: 'wallet_authorizeAccessKey',
-        ...(parameters.showDeposit !== undefined ? { showDeposit: parameters.showDeposit } : {}),
-      })
-      if (!result.keyAuthorization) throw new Error('Missing keyAuthorization in callback.')
-
-      return {
-        keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-        rootAddress: result.accountAddress,
-      }
-    }
-
-    async function connectMobile(
-      request: Pick<Rpc.wallet_connect.Encoded, 'method' | 'params'>,
-    ): Promise<Rpc.wallet_connect.Encoded['returns']> {
-      const [parameters] = z.decode(Rpc.wallet_connect.schema.params!, request.params) ?? []
-      const capabilities = parameters?.capabilities
-
-      const result = await authorizeMobile({
-        authorizeAccessKey: capabilities?.authorizeAccessKey,
-        ...(capabilities?.digest ? { digest: capabilities.digest } : {}),
-        method: 'wallet_connect',
-        ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
-        ...(capabilities?.showDeposit !== undefined
-          ? { showDeposit: capabilities.showDeposit }
-          : {}),
-      })
-
-      return {
-        accounts: [
-          {
-            address: result.accountAddress,
-            capabilities: {
-              ...(result.keyAuthorization
-                ? { keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization) }
-                : {}),
-              ...(result.personalSign ? { personalSign: result.personalSign } : {}),
-              ...(result.signature ? { signature: result.signature } : {}),
-            },
-          },
-        ],
-      }
+      return params
     }
 
     const provider = core_Provider.from({
@@ -167,10 +67,112 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
         switch (request.method) {
           case 'eth_chainId':
             return Hex.fromNumber(store.getState().chainId)
-          case 'wallet_authorizeAccessKey':
-            return await authorizeAccessKeyMobile(request as never)
-          case 'wallet_connect':
-            return await connectMobile(request as never)
+          case 'wallet_authorizeAccessKey': {
+            const [parameters] = z.decode(
+              Rpc.wallet_authorizeAccessKey.schema.params!,
+              request.params as never,
+            )
+            const publicKey = parameters.publicKey
+            if (!publicKey)
+              throw new RpcResponse.InvalidParamsError({
+                message:
+                  '`wallet_authorizeAccessKey` on the React Native adapter requires key parameters.',
+              })
+
+            const params = await openMobileAuth({
+              chainId: Number(parameters.chainId ?? store.getState().chainId),
+              ...(typeof parameters.expiry !== 'undefined' ? { expiry: parameters.expiry } : {}),
+              ...(parameters.keyType ? { keyType: parameters.keyType } : {}),
+              ...(parameters.limits
+                ? { limits: parameters.limits.map((l) => ({ ...l, limit: String(l.limit) })) }
+                : {}),
+              pubKey: publicKey,
+              ...(parameters.showDeposit !== undefined
+                ? { showDeposit: parameters.showDeposit }
+                : {}),
+            })
+            const accountAddress = params.get('accountAddress')
+            if (!accountAddress) throw new Error('Missing accountAddress in callback.')
+
+            const value = params.get('keyAuthorization')
+            if (!value) throw new Error('Missing keyAuthorization in callback.')
+            const keyAuthorization = KeyAuthorization.deserialize(value as Hex.Hex)
+            if (!keyAuthorization.signature)
+              throw new Error('Key authorization in callback is missing a signature.')
+
+            return {
+              keyAuthorization: KeyAuthorization.toRpc(keyAuthorization as KeyAuthorization.Signed),
+              rootAddress: accountAddress as core_Address.Address,
+            } satisfies Rpc.wallet_authorizeAccessKey.Encoded['returns']
+          }
+          case 'wallet_connect': {
+            const [parameters] =
+              z.decode(Rpc.wallet_connect.schema.params!, request.params as never) ?? []
+            const capabilities = parameters?.capabilities
+            const authorizeAccessKey = capabilities?.authorizeAccessKey
+            const publicKey = authorizeAccessKey?.publicKey
+            if (authorizeAccessKey && !publicKey)
+              throw new RpcResponse.InvalidParamsError({
+                message:
+                  '`wallet_connect` on the React Native adapter requires key parameters when `capabilities.authorizeAccessKey` is set.',
+              })
+
+            const params = await openMobileAuth({
+              chainId: Number(authorizeAccessKey?.chainId ?? store.getState().chainId),
+              ...(typeof authorizeAccessKey?.expiry !== 'undefined'
+                ? { expiry: authorizeAccessKey.expiry }
+                : {}),
+              ...(authorizeAccessKey?.keyType ? { keyType: authorizeAccessKey.keyType } : {}),
+              ...(authorizeAccessKey?.limits
+                ? {
+                    limits: authorizeAccessKey.limits.map((l) => ({
+                      ...l,
+                      limit: String(l.limit),
+                    })),
+                  }
+                : {}),
+              ...(capabilities?.digest ? { digest: capabilities.digest } : {}),
+              ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
+              ...(publicKey ? { pubKey: publicKey } : {}),
+              ...(capabilities?.showDeposit !== undefined
+                ? { showDeposit: capabilities.showDeposit }
+                : {}),
+            })
+
+            const accountAddress = params.get('accountAddress')
+            if (!accountAddress) throw new Error('Missing accountAddress in callback.')
+
+            const keyAuthorization = (() => {
+              const value = params.get('keyAuthorization')
+              if (!value) return undefined
+              const keyAuthorization = KeyAuthorization.deserialize(value as Hex.Hex)
+              if (!keyAuthorization.signature)
+                throw new Error('Key authorization in callback is missing a signature.')
+              return keyAuthorization as KeyAuthorization.Signed
+            })()
+            if (publicKey && !keyAuthorization)
+              throw new Error('Missing keyAuthorization in callback.')
+
+            const signature = params.get('signature') as Hex.Hex | null
+            const personalSignMessage = params.get('personalSignMessage')
+
+            return {
+              accounts: [
+                {
+                  address: accountAddress as core_Address.Address,
+                  capabilities: {
+                    ...(keyAuthorization
+                      ? { keyAuthorization: KeyAuthorization.toRpc(keyAuthorization) }
+                      : {}),
+                    ...(personalSignMessage
+                      ? { personalSign: { message: personalSignMessage } }
+                      : {}),
+                    ...(signature ? { signature } : {}),
+                  },
+                },
+              ],
+            } satisfies Rpc.wallet_connect.Encoded['returns']
+          }
           default:
             throw unsupported(`\`${request.method}\` not supported by React Native adapter.`)
         }
@@ -258,21 +260,7 @@ async function defaultOpen(url: string, redirectUri: string): Promise<string | n
   return result.url
 }
 
-function buildAuthUrl(
-  host: string,
-  params: {
-    callback: string
-    chainId: number
-    digest?: Hex.Hex | undefined
-    expiry?: number | undefined
-    keyType?: string | undefined
-    limits?: readonly { token: string; limit: string }[] | undefined
-    personalSign?: { message: string } | undefined
-    pubKey?: Hex.Hex | undefined
-    showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
-    state: string
-  },
-): string {
+function buildAuthUrl(host: string, params: buildAuthUrl.Parameters): string {
   const url = new URL('/remote/auth/mobile', host)
   if (params.pubKey) url.searchParams.set('pubKey', params.pubKey)
   if (params.keyType) url.searchParams.set('keyType', params.keyType)
@@ -288,6 +276,21 @@ function buildAuthUrl(
   url.searchParams.set('callback', params.callback)
   url.searchParams.set('state', params.state)
   return url.toString()
+}
+
+declare namespace buildAuthUrl {
+  type Parameters = {
+    callback: string
+    chainId: number
+    digest?: Hex.Hex | undefined
+    expiry?: number | undefined
+    keyType?: string | undefined
+    limits?: readonly { token: string; limit: string }[] | undefined
+    personalSign?: { message: string } | undefined
+    pubKey?: Hex.Hex | undefined
+    showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
+    state: string
+  }
 }
 
 function unsupported(message: string) {

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -56,11 +56,11 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       const publicKey = authorizeAccessKey?.publicKey
       const keyType = authorizeAccessKey?.keyType
 
-      if (!publicKey)
+      if (!publicKey && (method === 'wallet_authorizeAccessKey' || authorizeAccessKey))
         throw new RpcResponse.InvalidParamsError({
           message:
             method === 'wallet_connect'
-              ? '`wallet_connect` on the React Native adapter requires `capabilities.authorizeAccessKey`.'
+              ? '`wallet_connect` on the React Native adapter requires key parameters when `capabilities.authorizeAccessKey` is set.'
               : '`wallet_authorizeAccessKey` on the React Native adapter requires key parameters.',
         })
 
@@ -77,7 +77,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           : {}),
         ...(digest ? { digest } : {}),
         ...(personalSign ? { personalSign } : {}),
-        pubKey: publicKey,
+        ...(publicKey ? { pubKey: publicKey } : {}),
         ...(showDeposit !== undefined ? { showDeposit } : {}),
         state,
       })
@@ -92,19 +92,22 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       const accountAddress = params.get('accountAddress')
       if (!accountAddress) throw new Error('Missing accountAddress in callback.')
 
-      const keyAuthorizationHex = params.get('keyAuthorization')
-      if (!keyAuthorizationHex) throw new Error('Missing keyAuthorization in callback.')
+      const keyAuthorization = (() => {
+        const value = params.get('keyAuthorization')
+        if (!value) return undefined
+        const keyAuthorization = KeyAuthorization.deserialize(value as Hex.Hex)
+        if (!keyAuthorization.signature)
+          throw new Error('Key authorization in callback is missing a signature.')
+        return keyAuthorization as KeyAuthorization.Signed
+      })()
+      if (publicKey && !keyAuthorization) throw new Error('Missing keyAuthorization in callback.')
 
-      const keyAuthorization = KeyAuthorization.deserialize(keyAuthorizationHex as Hex.Hex)
-      if (!keyAuthorization.signature)
-        throw new Error('Key authorization in callback is missing a signature.')
-      const signed = keyAuthorization as KeyAuthorization.Signed
       const signature = params.get('signature') as Hex.Hex | null
       const personalSignMessage = params.get('personalSignMessage')
 
       return {
         accountAddress: accountAddress as core_Address.Address,
-        keyAuthorization: signed,
+        ...(keyAuthorization ? { keyAuthorization } : {}),
         ...(personalSignMessage ? { personalSign: { message: personalSignMessage } } : {}),
         ...(signature ? { signature } : {}),
       }
@@ -119,6 +122,7 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
         method: 'wallet_authorizeAccessKey',
         ...(parameters.showDeposit !== undefined ? { showDeposit: parameters.showDeposit } : {}),
       })
+      if (!result.keyAuthorization) throw new Error('Missing keyAuthorization in callback.')
 
       return {
         keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
@@ -147,7 +151,9 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           {
             address: result.accountAddress,
             capabilities: {
-              keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
+              ...(result.keyAuthorization
+                ? { keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization) }
+                : {}),
               ...(result.personalSign ? { personalSign: result.personalSign } : {}),
               ...(result.signature ? { signature: result.signature } : {}),
             },
@@ -262,18 +268,18 @@ function buildAuthUrl(
     keyType?: string | undefined
     limits?: readonly { token: string; limit: string }[] | undefined
     personalSign?: { message: string } | undefined
-    pubKey: Hex.Hex
+    pubKey?: Hex.Hex | undefined
     showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
     state: string
   },
 ): string {
   const url = new URL('/remote/auth/mobile', host)
-  url.searchParams.set('pubKey', params.pubKey)
+  if (params.pubKey) url.searchParams.set('pubKey', params.pubKey)
   if (params.keyType) url.searchParams.set('keyType', params.keyType)
-  url.searchParams.set('chainId', `0x${params.chainId.toString(16)}`)
+  url.searchParams.set('chainId', Hex.fromNumber(params.chainId))
   if (params.digest) url.searchParams.set('digest', params.digest)
   if (typeof params.expiry !== 'undefined')
-    url.searchParams.set('expiry', `0x${params.expiry.toString(16)}`)
+    url.searchParams.set('expiry', Hex.fromNumber(params.expiry))
   if (params.limits) url.searchParams.set('limits', JSON.stringify(params.limits))
   if (params.personalSign) url.searchParams.set('personalSign', JSON.stringify(params.personalSign))
   if (params.showDeposit === true) url.searchParams.set('showDeposit', 'true')


### PR DESCRIPTION
## Summary
Let the React Native adapter handle `wallet_connect` without `capabilities.authorizeAccessKey`.

## Motivation
React Native callers can request account connection without asking for an access key, but the adapter still required access-key parameters and failed before opening mobile auth.

## Changes
- Updated `src/react-native/adapter.ts` to omit `pubKey` when no access key is requested.
- Return `keyAuthorization` from `wallet_connect` only when the mobile callback includes one.
- Keep `wallet_authorizeAccessKey` strict about missing key authorization.
- Added localnet coverage in `src/react-native/Provider.localnet.test.ts`.

## Testing
- `pnpm test src/react-native/Provider.localnet.test.ts` — 8 passed
- `pnpm vp fmt src/react-native/adapter.ts src/react-native/Provider.localnet.test.ts`
- `pnpm check:types`
- Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test` — 0 errors, 2 warnings in unrelated files