### PR TITLE
feat: use WATA mobile web auth in React Native

### DIFF
--- a/.changeset/react-native-wata-mobile-web-auth.md
+++ b/.changeset/react-native-wata-mobile-web-auth.md
@@ -1,0 +1,7 @@
+---
+"accounts": minor
+---
+
+Added Wata mobile web auth adapters for React Native.
+
+Added `tempoWallet()` defaults and `mobileWebAuth()` for custom Wata host and provider identity.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mipd": "^0.0.7",
     "mppx": "catalog:",
     "ox": "~0.14.20",
-    "wata": "git+https://github.com/wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239",
+    "wata": "https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239",
     "webauthx": "~0.1.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mipd": "^0.0.7",
     "mppx": "catalog:",
     "ox": "~0.14.20",
-    "wata": "https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239",
+    "wata": "https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2",
     "webauthx": "~0.1.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "mipd": "^0.0.7",
     "mppx": "catalog:",
     "ox": "~0.14.20",
+    "wata": "git+https://github.com/wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239",
     "webauthx": "~0.1.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -28,9 +28,10 @@ const tokens = {
 }
 
 const redirectUri = Linking.createURL('auth')
+const walletOrigin = process.env.EXPO_PUBLIC_WALLET_ORIGIN
 
 const provider = Provider.create({
-  baseUrl: 'https://accounts-react-native.example',
+  baseUrl: walletOrigin ?? 'https://accounts-react-native.example',
   redirectUri,
   authorizeAccessKey: () => ({
     expiry: Math.floor(Date.now() / 1000) + 60 * 5,

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -30,6 +30,7 @@ const tokens = {
 const redirectUri = Linking.createURL('auth')
 
 const provider = Provider.create({
+  baseUrl: 'https://accounts-react-native.example',
   redirectUri,
   authorizeAccessKey: () => ({
     expiry: Math.floor(Date.now() / 1000) + 60 * 5,

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -28,10 +28,11 @@ const tokens = {
 }
 
 const redirectUri = Linking.createURL('auth')
-const walletOrigin = process.env.EXPO_PUBLIC_WALLET_ORIGIN
+const walletOrigin = process.env.EXPO_PUBLIC_WALLET_ORIGIN ?? 'https://wallet.tempo.xyz'
 
 const provider = Provider.create({
-  baseUrl: walletOrigin ?? 'https://accounts-react-native.example',
+  baseUrl: walletOrigin,
+  host: walletOrigin,
   redirectUri,
   authorizeAccessKey: () => ({
     expiry: Math.floor(Date.now() / 1000) + 60 * 5,

--- a/playgrounds/react-native/README.md
+++ b/playgrounds/react-native/README.md
@@ -1,7 +1,30 @@
 # React Native Playground
 
+The playground uses Wata mobile web auth through the React Native
+`tempoWallet()` adapter. By default, both the wallet host discovery origin and
+the consumer discovery origin are `https://wallet.tempo.xyz`.
+
+The default wallet origin must serve a consumer document that allows the
+playground callback scheme.
+
+```json
+{
+  "callback_urls": [
+    "xyz.tempo.accounts.playground:/auth",
+    "xyz.tempo.accounts.playground://auth"
+  ],
+  "id": "wallet.tempo.xyz",
+  "name": "Tempo Wallet",
+  "origin": "https://wallet.tempo.xyz",
+  "version": "1.0"
+}
+```
+
+To run against a different origin, set `EXPO_PUBLIC_WALLET_ORIGIN`. The custom
+origin must serve both Wata discovery documents for the app and wallet roles.
+
 ```
 pnpm install
 cd playgrounds/react-native
-npx expo start
+EXPO_PUBLIC_WALLET_ORIGIN=https://wallet-81e1.tempo.local npx expo start
 ```

--- a/playgrounds/react-native/app.json
+++ b/playgrounds/react-native/app.json
@@ -4,7 +4,7 @@
     "slug": "accounts-rn-playground",
     "version": "0.0.0",
     "orientation": "portrait",
-    "scheme": "accounts-playground",
+    "scheme": "xyz.tempo.accounts.playground",
     "platforms": ["ios", "android"],
     "ios": {
       "bundleIdentifier": "xyz.tempo.accounts.playground"

--- a/playgrounds/react-native/index.js
+++ b/playgrounds/react-native/index.js
@@ -1,4 +1,4 @@
-import 'react-native-get-random-values'
+import './polyfills'
 import { registerRootComponent } from 'expo'
 
 import App from './App'

--- a/playgrounds/react-native/metro.config.js
+++ b/playgrounds/react-native/metro.config.js
@@ -4,12 +4,15 @@ const path = require('node:path')
 const { getDefaultConfig } = require('expo/metro-config')
 
 const config = getDefaultConfig(__dirname)
+const nodeServerShim = path.resolve(__dirname, './node-server-shim.js')
 const resolveRequest =
   config.resolver.resolveRequest ??
   ((context, moduleName, platform) => context.resolveRequest(context, moduleName, platform))
 const src = path.resolve(__dirname, '../../src')
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === '@hono/node-server') return { filePath: nodeServerShim, type: 'sourceFile' }
+
   if (
     moduleName.startsWith('.') &&
     moduleName.endsWith('.js') &&

--- a/playgrounds/react-native/node-server-shim.js
+++ b/playgrounds/react-native/node-server-shim.js
@@ -1,0 +1,3 @@
+exports.getRequestListener = function getRequestListener() {
+  throw new Error('@hono/node-server is not available in React Native')
+}

--- a/playgrounds/react-native/polyfills.js
+++ b/playgrounds/react-native/polyfills.js
@@ -1,0 +1,16 @@
+import 'react-native-get-random-values'
+
+if (typeof globalThis.MessageEvent === 'undefined') {
+  class MessageEventPolyfill extends Event {
+    constructor(type, options = {}) {
+      super(type, options)
+      this.data = options.data ?? null
+      this.lastEventId = options.lastEventId ?? ''
+      this.origin = options.origin ?? ''
+      this.ports = options.ports ?? []
+      this.source = options.source ?? null
+    }
+  }
+
+  globalThis.MessageEvent = MessageEventPolyfill
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,13 @@ overrides:
   uuid@<11.1.1: 11.1.1
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
+  wata>@hono/node-server: ^1.13.7
+  wata>@noble/ciphers: ^2.2.0
+  wata>@noble/hashes: ^2.2.0
+  wata>hono: ^4.6.14
+  wata>ox: ~0.14.20
+  wata>rettime: ^0.11.11
+  wata>zod: ^4.4.3
   ws@>=8.0.0 <8.20.1: 8.20.1
   wrangler: ^4.90.1
 
@@ -106,6 +113,9 @@ importers:
       ox:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.3.6)
+      wata:
+        specifier: git+https://github.com/wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239
+        version: git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3)
       webauthx:
         specifier: ~0.1.1
         version: 0.1.1(typescript@5.9.3)(zod@4.3.6)
@@ -907,7 +917,7 @@ importers:
         version: 0.61.3(viem@2.52.2(typescript@5.9.3)(zod@4.4.3))
       '@turnkey/core':
         specifier: 1.13.0
-        version: 1.13.0(typescript@5.9.3)(zod@4.4.3)
+        version: 1.13.0(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
       accounts:
         specifier: workspace:*
         version: link:../..
@@ -2778,6 +2788,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -2808,6 +2822,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -8746,6 +8764,9 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -9885,6 +9906,10 @@ packages:
 
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
+
+  wata@git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239:
+    resolution: {commit: a79d660252690a848a73a98003ea3c4ed7656239, repo: git@github.com:wevm/wata.git, type: git}
+    version: 0.0.0
 
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
@@ -12673,6 +12698,8 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.2.0': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -12698,6 +12725,8 @@ snapshots:
   '@noble/hashes@1.7.0': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14147,7 +14176,7 @@ snapshots:
       '@turnkey/encoding': 0.6.0
       sha256-uint8array: 0.10.7
 
-  '@turnkey/core@1.13.0(typescript@5.9.3)(zod@4.4.3)':
+  '@turnkey/core@1.13.0(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)':
     dependencies:
       '@turnkey/api-key-stamper': 0.6.3
       '@turnkey/crypto': 2.8.12
@@ -14157,13 +14186,15 @@ snapshots:
       '@turnkey/webauthn-stamper': 0.6.0
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/sign-client': 2.23.9(typescript@5.9.3)(zod@4.4.3)
-      '@walletconnect/types': 2.23.9
+      '@walletconnect/sign-client': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/types': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       cross-fetch: 3.2.0
       ethers: 6.16.0
       jwt-decode: 4.0.0
       uuid: 11.1.1
       viem: 2.52.2(typescript@5.9.3)(zod@4.4.3)
+    optionalDependencies:
+      '@react-native-async-storage/async-storage': 3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15220,21 +15251,21 @@ snapshots:
 
   '@wallet-standard/base@1.1.0': {}
 
-  '@walletconnect/core@2.23.9(typescript@5.9.3)(zod@4.4.3)':
+  '@walletconnect/core@2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/jsonrpc-ws-connection': 1.0.16
-      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       '@walletconnect/logger': 3.0.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/types': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
+      '@walletconnect/utils': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -15306,11 +15337,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@walletconnect/keyvaluestorage@1.1.1':
+  '@walletconnect/keyvaluestorage@1.1.1(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@walletconnect/safe-json': 1.0.2
       idb-keyval: 6.2.2
       unstorage: 1.17.5(idb-keyval@6.2.2)
+    optionalDependencies:
+      '@react-native-async-storage/async-storage': 3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15352,16 +15385,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.9(typescript@5.9.3)(zod@4.4.3)':
+  '@walletconnect/sign-client@2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.23.9(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/core': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/types': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
+      '@walletconnect/utils': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15392,12 +15425,12 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/types@2.23.9':
+  '@walletconnect/types@2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       '@walletconnect/logger': 3.0.2
       events: 3.3.0
     transitivePeerDependencies:
@@ -15421,7 +15454,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/utils@2.23.9(typescript@5.9.3)(zod@4.4.3)':
+  '@walletconnect/utils@2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
       '@noble/ciphers': 1.3.0
@@ -15429,13 +15462,13 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       '@walletconnect/logger': 3.0.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.9
+      '@walletconnect/types': 2.23.9(@react-native-async-storage/async-storage@3.0.2(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1
@@ -19965,6 +19998,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  rettime@0.11.11: {}
+
   reusify@1.1.0: {}
 
   rimraf@3.0.2:
@@ -21453,6 +21488,18 @@ snapshots:
       makeerror: 1.0.12
 
   warn-once@0.1.1: {}
+
+  wata@git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3):
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      hono: 4.12.23
+      ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
+      rettime: 0.11.11
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - typescript
 
   watchpack@2.5.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.3.6)
       wata:
-        specifier: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239
-        version: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3)
+        specifier: https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2
+        version: https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2(typescript@5.9.3)
       webauthx:
         specifier: ~0.1.1
         version: 0.1.1(typescript@5.9.3)(zod@4.3.6)
@@ -9900,8 +9900,8 @@ packages:
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
-  wata@https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239:
-    resolution: {integrity: sha512-W4AyexeOInib1RYbRFtAFqgnDfYq0Y1jTv4dk3qA7mlMNYDHHhQuzSKy+UxoNQBDzfZ/+2Z/DobsK0OzbQNzuQ==, tarball: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239}
+  wata@https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2:
+    resolution: {integrity: sha512-7fcgNB01pkq1C4cAhVn7vlhhp1Ex0eLoQJgDyLb0itTvd6oFy6QnhTY/L9Vc70CT8bHILAV2Y5glZRSvI/FnGA==, tarball: https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2}
     version: 0.0.0
 
   watchpack@2.5.1:
@@ -21482,7 +21482,7 @@ snapshots:
 
   warn-once@0.1.1: {}
 
-  wata@https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3):
+  wata@https://pkg.pr.new/wevm/wata/wata@41c81f9c14a99f8c3a4e82609d29de21665a78a2(typescript@5.9.3):
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
       '@noble/ciphers': 2.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,13 +78,6 @@ overrides:
   uuid@<11.1.1: 11.1.1
   vite-plus: ~0.1.18
   vp: npm:vite-plus@~0.1.18
-  wata>@hono/node-server: ^1.13.7
-  wata>@noble/ciphers: ^2.2.0
-  wata>@noble/hashes: ^2.2.0
-  wata>hono: ^4.6.14
-  wata>ox: ~0.14.20
-  wata>rettime: ^0.11.11
-  wata>zod: ^4.4.3
   ws@>=8.0.0 <8.20.1: 8.20.1
   wrangler: ^4.90.1
 
@@ -114,8 +107,8 @@ importers:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.3.6)
       wata:
-        specifier: git+https://github.com/wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239
-        version: git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3)
+        specifier: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239
+        version: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3)
       webauthx:
         specifier: ~0.1.1
         version: 0.1.1(typescript@5.9.3)(zod@4.3.6)
@@ -9907,8 +9900,8 @@ packages:
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
-  wata@git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239:
-    resolution: {commit: a79d660252690a848a73a98003ea3c4ed7656239, repo: git@github.com:wevm/wata.git, type: git}
+  wata@https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239:
+    resolution: {integrity: sha512-W4AyexeOInib1RYbRFtAFqgnDfYq0Y1jTv4dk3qA7mlMNYDHHhQuzSKy+UxoNQBDzfZ/+2Z/DobsK0OzbQNzuQ==, tarball: https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239}
     version: 0.0.0
 
   watchpack@2.5.1:
@@ -21489,7 +21482,7 @@ snapshots:
 
   warn-once@0.1.1: {}
 
-  wata@git+https://git@github.com:wevm/wata.git#a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3):
+  wata@https://pkg.pr.new/wevm/wata/wata@a79d660252690a848a73a98003ea3c4ed7656239(typescript@5.9.3):
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
       '@noble/ciphers': 2.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,6 @@ minimumReleaseAgeExclude:
   - viem
   - vite-plus
   - wagmi
-  - wata
 
 nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'
 
@@ -93,13 +92,6 @@ overrides:
   'uuid@<11.1.1': '11.1.1'
   vite-plus: 'catalog:'
   vp: 'catalog:'
-  'wata>@hono/node-server': ^1.13.7
-  'wata>@noble/ciphers': ^2.2.0
-  'wata>@noble/hashes': ^2.2.0
-  'wata>hono': ^4.6.14
-  'wata>ox': ~0.14.20
-  'wata>rettime': ^0.11.11
-  'wata>zod': ^4.4.3
   'ws@>=8.0.0 <8.20.1': '8.20.1'
   wrangler: 'catalog:'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ minimumReleaseAgeExclude:
   - viem
   - vite-plus
   - wagmi
+  - wata
 
 nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'
 
@@ -92,6 +93,13 @@ overrides:
   'uuid@<11.1.1': '11.1.1'
   vite-plus: 'catalog:'
   vp: 'catalog:'
+  'wata>@hono/node-server': ^1.13.7
+  'wata>@noble/ciphers': ^2.2.0
+  'wata>@noble/hashes': ^2.2.0
+  'wata>hono': ^4.6.14
+  'wata>ox': ~0.14.20
+  'wata>rettime': ^0.11.11
+  'wata>zod': ^4.4.3
   'ws@>=8.0.0 <8.20.1': '8.20.1'
   wrangler: 'catalog:'
 

--- a/site/src/pages.gen.ts
+++ b/site/src/pages.gen.ts
@@ -54,6 +54,7 @@ type Page =
 | { path: '/docs/guides/connect-accounts'; render: 'static' }
 | { path: '/docs/guides/deposits'; render: 'static' }
 | { path: '/docs/guides/fee-sponsorship'; render: 'static' }
+| { path: '/docs/guides/react-native'; render: 'static' }
 | { path: '/docs/guides/spend-permissions'; render: 'static' }
 | { path: '/docs/guides/subscriptions'; render: 'static' }
 | { path: '/docs/guides/swaps'; render: 'static' }

--- a/site/src/pages/docs/guides/react-native.mdx
+++ b/site/src/pages/docs/guides/react-native.mdx
@@ -1,0 +1,118 @@
+---
+title: React Native
+description: Connect React Native apps with Tempo Wallet.
+---
+
+# React Native
+
+React Native apps use `accounts/react-native`. The provider opens Tempo Wallet in a system browser session, then receives an app-link callback with the encrypted response.
+
+```ts twoslash
+import * as Linking from 'expo-linking'
+import { Provider } from 'accounts'
+import { tempoWallet } from 'accounts/react-native'
+
+const redirectUri = Linking.createURL('auth')
+
+const provider = Provider.create({
+  adapter: tempoWallet({ redirectUri }),
+})
+```
+
+## Consumer Discovery
+
+The React Native `tempoWallet()` adapter uses `https://wallet.tempo.xyz` for both Wata roles by default:
+
+- `baseUrl`: consumer discovery origin serving `/.well-known/urpc/consumer.json`
+- `host`: wallet discovery origin serving `/.well-known/urpc/host.json`
+
+Using the same origin is valid when the mobile app and wallet are owned by the same domain. The consumer document must include the exact `redirectUri` passed to `tempoWallet()`.
+
+```json
+{
+  "callback_urls": [
+    "xyz.tempo.accounts.playground:/auth",
+    "xyz.tempo.accounts.playground://auth"
+  ],
+  "id": "wallet.tempo.xyz",
+  "name": "Tempo Wallet",
+  "origin": "https://wallet.tempo.xyz",
+  "version": "1.0"
+}
+```
+
+For Expo apps, log `Linking.createURL('auth')` from the same build you are testing and publish that value in the consumer document.
+
+## Custom Wata Hosts
+
+Use `mobileWebAuth()` directly when the app origin, wallet host, or provider identity differs from Tempo Wallet.
+
+```ts twoslash
+import * as Linking from 'expo-linking'
+import { Provider } from 'accounts'
+import { mobileWebAuth } from 'accounts/react-native'
+
+const redirectUri = Linking.createURL('auth')
+
+const provider = Provider.create({
+  adapter: mobileWebAuth({
+    baseUrl: 'https://app.example',
+    host: 'https://wallet.example',
+    name: 'Example Wallet',
+    rdns: 'com.example.wallet',
+    redirectUri,
+  }),
+})
+```
+
+## Options
+
+### tempoWallet
+
+`tempoWallet()` accepts `redirectUri`, `fetch`, `open`, and `openAuthSession`, plus optional overrides for `baseUrl`, `host`, `name`, and `rdns`.
+
+### baseUrl
+
+- **Type:** `string`
+- **Default:** `'https://wallet.tempo.xyz'`
+
+Public origin serving the Wata consumer discovery document.
+
+### redirectUri
+
+- **Type:** `string`
+- **Required**
+
+Deep-link URI watched by the system browser auth session.
+
+### name
+
+- **Type:** `string`
+- **Default:** `'Tempo Wallet'`
+
+Display name sent to Tempo Wallet during mobile web auth.
+
+### rdns
+
+- **Type:** `string`
+- **Default:** `'xyz.tempo'`
+
+Reverse-DNS app identifier sent to Tempo Wallet during mobile web auth.
+
+### host
+
+- **Type:** `string | HostDocument`
+- **Default:** `'https://wallet.tempo.xyz'`
+
+Tempo Wallet discovery origin, or a preloaded Wata host document.
+
+### openAuthSession
+
+- **Type:** `({ authorizationUrl, callback }) => string | undefined | Promise<string | undefined>`
+- **Optional**
+
+Override for the browser auth-session primitive. By default the adapter uses `expo-web-browser`.
+
+### mobileWebAuth
+
+`mobileWebAuth()` is the lower-level Wata adapter. It requires `baseUrl`, `host`, `name`, `rdns`, and `redirectUri` so custom integrations do not inherit Tempo Wallet metadata accidentally.

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -47,6 +47,7 @@ const config: Config = defineConfig({
           { text: 'Authentication', link: '/docs/guides/authentication' },
           { text: 'Transfers', link: '/docs/guides/transfers' },
           { text: 'Spend Permissions', link: '/docs/guides/spend-permissions' },
+          { text: 'React Native', link: '/docs/guides/react-native' },
           { text: 'Subscriptions', link: '/docs/guides/subscriptions' },
           { text: 'Fee Sponsorship', link: '/docs/guides/fee-sponsorship' },
           { text: 'Deposits', link: '/docs/guides/deposits' },

--- a/src/react-native/Provider.localnet.test.ts
+++ b/src/react-native/Provider.localnet.test.ts
@@ -1,14 +1,21 @@
-import { Address, Hex, Json, PublicKey } from 'ox'
+import { Address, Base64, Bytes, Hex, Json, PublicKey } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { parseUnits, type Address as viem_Address } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
+import { Wata as HostWata, mobileWebAuth as hostMobileWebAuth } from 'wata/host'
+import * as z from 'zod/mini'
 
 import { accounts, chain, getClient } from '../../test/config.js'
 import * as Storage from '../core/Storage.js'
 import * as Store from '../core/Store.js'
+import * as Rpc from '../core/zod/rpc.js'
 import * as Provider from './Provider.js'
 
+const callback = 'xyz.tempo.accounts.playground:/auth'
+const consumerOrigin = 'https://accounts-playground.example'
+const hostIdentity = Base64.fromBytes(Bytes.random(32), { pad: false, url: true })
+const hostOrigin = 'https://wallet.tempo.xyz'
 const root = accounts[0]!
 const transferCall = Actions.token.transfer.call({
   to: '0x0000000000000000000000000000000000000001',
@@ -46,83 +53,172 @@ function asyncJsonStorage(options: Storage.from.Options = {}) {
   )
 }
 
-function createOpen() {
+function createWallet() {
   let calls = 0
+  const requests: { method: string; params: unknown }[] = []
   const urls: string[] = []
 
   return {
     calls: () => calls,
+    fetch: async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (request.url === `${hostOrigin}/.well-known/urpc/host.json`)
+        return Response.json({
+          id: 'wallet.tempo.xyz',
+          identity_pubkey: hostIdentity,
+          name: 'Tempo Wallet',
+          origin: hostOrigin,
+          transports: {
+            'mobile-web-auth': { auth_url: `${hostOrigin}/auth/mobile` },
+          },
+          version: '1.0',
+        })
+      throw new Error(`unexpected fetch to ${request.url}`)
+    },
+    requests: () => requests,
     urls: () => urls,
     open: async (url: string) => {
       calls += 1
       urls.push(url)
-
-      const authUrl = new URL(url)
-      const callback = authUrl.searchParams.get('callback')
-      const chainId = authUrl.searchParams.get('chainId')
-      const pubKey = authUrl.searchParams.get('pubKey')
-      const state = authUrl.searchParams.get('state')
-
-      if (!callback || !chainId || !pubKey || !state)
-        throw new Error('Expected callback, chainId, pubKey, and state in auth URL.')
-
-      const limits = authUrl.searchParams.get('limits')
-      const keyType = authUrl.searchParams.get('keyType')
-      if (keyType !== 'p256' && keyType !== 'secp256k1')
-        throw new Error('Expected a managed key type in auth URL.')
-
-      const keyAuthorization = await root.signKeyAuthorization(
-        {
-          accessKeyAddress: Address.fromPublicKey(PublicKey.fromHex(pubKey as Hex.Hex)),
-          keyType,
-        },
-        {
-          chainId: BigInt(chainId),
-          ...(authUrl.searchParams.get('expiry')
-            ? { expiry: Number(authUrl.searchParams.get('expiry')) }
-            : {}),
-          ...(limits
-            ? {
-                limits: (JSON.parse(limits) as { token: `0x${string}`; limit: string }[]).map(
-                  (x) => ({
-                    limit: BigInt(x.limit),
-                    token: x.token,
-                  }),
-                ),
-              }
-            : {}),
-        },
-      )
-
-      const callbackUrl = new URL(callback)
-      callbackUrl.searchParams.set('accountAddress', root.address)
-      callbackUrl.searchParams.set('keyAuthorization', KeyAuthorization.serialize(keyAuthorization))
-      const personalSign = authUrl.searchParams.get('personalSign')
-      if (personalSign) {
-        const { message } = JSON.parse(personalSign) as { message: string }
-        callbackUrl.searchParams.set('personalSignMessage', message)
-        callbackUrl.searchParams.set('signature', await root.signMessage({ message }))
-      }
-      const digest = authUrl.searchParams.get('digest') as Hex.Hex | null
-      if (digest) callbackUrl.searchParams.set('signature', await root.sign({ hash: digest }))
-      callbackUrl.searchParams.set('state', state)
-      return callbackUrl.toString()
+      const host = createHost(requests)
+      const response = await host.fetch(new Request(url))
+      return response.headers.get('location')
     },
   }
 }
 
+function createHost(requests: { method: string; params: unknown }[]) {
+  const host = HostWata.create({
+    baseUrl: hostOrigin,
+    meta: { name: 'Tempo Wallet' },
+    privateKey: '0x2222222222222222222222222222222222222222222222222222222222222222',
+    transports: [
+      hostMobileWebAuth({
+        fetch: async (input): Promise<Response> => {
+          const url = input instanceof Request ? input.url : String(input)
+          if (url === `${consumerOrigin}/.well-known/urpc/consumer.json`)
+            return Response.json({
+              callback_urls: [callback],
+              id: 'accounts-playground.example',
+              name: 'Accounts RN Test',
+              origin: consumerOrigin,
+              version: '1.0',
+            })
+          throw new Error(`unexpected fetch to ${url}`)
+        },
+        html: {
+          authenticate: ({ actions }) => actions.approve(),
+        },
+        path: '/auth/mobile',
+      }),
+    ],
+  })
+
+  host.on('request', async (event) => {
+    requests.push({ method: event.method, params: event.params })
+    if (event.method === 'wallet_connect') {
+      const [parameters] = z.decode(Rpc.wallet_connect.schema.params!, event.params as never) ?? []
+      const capabilities = parameters?.capabilities
+      const authorization = capabilities?.authorizeAccessKey
+      await event.respond({
+        accounts: [
+          {
+            address: root.address,
+            capabilities: {
+              ...(authorization
+                ? {
+                    keyAuthorization: KeyAuthorization.toRpc(
+                      await signKeyAuthorization(authorization),
+                    ),
+                  }
+                : {}),
+              ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
+              ...(await signature(capabilities)),
+            },
+          },
+        ],
+      })
+      return
+    }
+    if (event.method === 'wallet_authorizeAccessKey') {
+      const [parameters] = z.decode(
+        Rpc.wallet_authorizeAccessKey.schema.params!,
+        event.params as never,
+      )
+      await event.respond({
+        keyAuthorization: KeyAuthorization.toRpc(await signKeyAuthorization(parameters)),
+        rootAddress: root.address,
+      })
+    }
+  })
+
+  return host
+}
+
+async function signKeyAuthorization(parameters: AdapterAuthorizeParameters) {
+  return await root.signKeyAuthorization(
+    {
+      accessKeyAddress: accessKeyAddress(parameters),
+      keyType: parameters.keyType ?? 'secp256k1',
+    },
+    {
+      chainId: parameters.chainId ?? BigInt(chain.id),
+      expiry: parameters.expiry,
+      ...(parameters.limits ? { limits: parameters.limits } : {}),
+    },
+  )
+}
+
+function accessKeyAddress(parameters: AdapterAuthorizeParameters) {
+  if (parameters.address) return parameters.address
+  if (!parameters.publicKey)
+    throw new Error('Expected access key address or public key in wallet request.')
+  return Address.fromPublicKey(PublicKey.fromHex(parameters.publicKey))
+}
+
+async function signature(
+  capabilities:
+    | NonNullable<NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']>
+    | undefined,
+) {
+  if (capabilities?.digest) return { signature: await root.sign({ hash: capabilities.digest }) }
+  if (capabilities?.personalSign)
+    return { signature: await root.signMessage({ message: capabilities.personalSign.message }) }
+  return {}
+}
+
+function connectParameters(wallet: ReturnType<typeof createWallet>, index: number) {
+  const [parameters] =
+    z.decode(Rpc.wallet_connect.schema.params!, wallet.requests()[index]!.params as never) ?? []
+  return parameters
+}
+
+function authorizeParameters(wallet: ReturnType<typeof createWallet>, index: number) {
+  const [parameters] = z.decode(
+    Rpc.wallet_authorizeAccessKey.schema.params!,
+    wallet.requests()[index]!.params as never,
+  )
+  return parameters
+}
+
+type AdapterAuthorizeParameters = NonNullable<
+  Rpc.wallet_authorizeAccessKey.Decoded['params']
+>[number]
+
 describe('create', () => {
   test('behavior: persists managed access keys through provider storage', async () => {
     const storage = asyncJsonStorage({ key: 'react-native-managed-key' })
-    const browser = createOpen()
+    const wallet = createWallet()
     const provider1 = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage,
     })
 
@@ -135,10 +231,12 @@ describe('create', () => {
     await fund(root.address)
 
     const provider2 = Provider.create({
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage,
     })
     await Store.waitForHydration(provider2.store)
@@ -148,19 +246,21 @@ describe('create', () => {
       params: [{ calls: [transferCall], feeToken: Addresses.pathUsd }],
     })
     expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
-    expect(browser.calls()).toMatchInlineSnapshot(`1`)
+    expect(wallet.calls()).toMatchInlineSnapshot(`1`)
   })
 
-  test('behavior: forwards showDeposit boolean to the mobile auth URL for registration', async () => {
-    const browser = createOpen()
+  test('behavior: forwards showDeposit boolean through wallet_connect for registration', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -169,22 +269,22 @@ describe('create', () => {
       params: [{ capabilities: { method: 'register', showDeposit: true } }],
     })
 
-    expect(new URL(browser.urls()[0]!).pathname).toMatchInlineSnapshot(`"/remote/auth/mobile"`)
-    expect(new URL(browser.urls()[0]!).searchParams.get('showDeposit')).toMatchInlineSnapshot(
-      `"true"`,
-    )
+    expect(new URL(wallet.urls()[0]!).pathname).toMatchInlineSnapshot(`"/auth/mobile"`)
+    expect(connectParameters(wallet, 0)?.capabilities?.showDeposit).toMatchInlineSnapshot(`true`)
   })
 
-  test('behavior: forwards showDeposit boolean to the mobile auth URL for login', async () => {
-    const browser = createOpen()
+  test('behavior: forwards showDeposit boolean through wallet_connect for login', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -193,21 +293,21 @@ describe('create', () => {
       params: [{ capabilities: { method: 'login', showDeposit: true } }],
     })
 
-    expect(new URL(browser.urls()[0]!).searchParams.get('showDeposit')).toMatchInlineSnapshot(
-      `"true"`,
-    )
+    expect(connectParameters(wallet, 0)?.capabilities?.showDeposit).toMatchInlineSnapshot(`true`)
   })
 
-  test('behavior: forwards showDeposit params to the mobile auth URL for registration', async () => {
-    const browser = createOpen()
+  test('behavior: forwards showDeposit params through wallet_connect for registration', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -228,8 +328,7 @@ describe('create', () => {
       ],
     })
 
-    expect(JSON.parse(new URL(browser.urls()[0]!).searchParams.get('showDeposit')!))
-      .toMatchInlineSnapshot(`
+    expect(connectParameters(wallet, 0)?.capabilities?.showDeposit).toMatchInlineSnapshot(`
       {
         "amount": "50",
         "displayName": "DoorDash",
@@ -239,16 +338,18 @@ describe('create', () => {
     `)
   })
 
-  test('behavior: forwards showDeposit params to the mobile auth URL for wallet_authorizeAccessKey', async () => {
-    const browser = createOpen()
+  test('behavior: forwards showDeposit params through wallet_authorizeAccessKey', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -270,8 +371,7 @@ describe('create', () => {
       ],
     })
 
-    expect(JSON.parse(new URL(browser.urls()[1]!).searchParams.get('showDeposit')!))
-      .toMatchInlineSnapshot(`
+    expect(authorizeParameters(wallet, 1).showDeposit).toMatchInlineSnapshot(`
       {
         "amount": "25",
         "token": "USDC",
@@ -279,16 +379,18 @@ describe('create', () => {
     `)
   })
 
-  test('behavior: forwards personalSign to the mobile auth URL and returns signature', async () => {
-    const browser = createOpen()
+  test('behavior: forwards personalSign through wallet_connect and returns signature', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -297,23 +399,31 @@ describe('create', () => {
       params: [{ capabilities: { method: 'login', personalSign: { message: 'hello' } } }],
     })
 
-    expect(new URL(browser.urls()[0]!).searchParams.get('personalSign')).toMatchInlineSnapshot(
-      `"{"message":"hello"}"`,
-    )
-    expect(result.accounts[0]!.capabilities.personalSign).toEqual({ message: 'hello' })
+    expect(connectParameters(wallet, 0)?.capabilities?.personalSign).toMatchInlineSnapshot(`
+      {
+        "message": "hello",
+      }
+    `)
+    expect(result.accounts[0]!.capabilities.personalSign).toMatchInlineSnapshot(`
+      {
+        "message": "hello",
+      }
+    `)
     expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
   })
 
-  test('behavior: forwards digest to the mobile auth URL and returns signature', async () => {
-    const browser = createOpen()
+  test('behavior: forwards digest through wallet_connect and returns signature', async () => {
+    const wallet = createWallet()
     const provider = Provider.create({
       authorizeAccessKey: () => ({
         expiry: Math.floor(Date.now() / 1000) + 3600,
       }),
+      baseUrl: consumerOrigin,
       chains: [chain],
-      host: 'https://wallet.tempo.xyz',
-      open: browser.open,
-      redirectUri: 'accounts-playground://auth',
+      fetch: wallet.fetch,
+      host: hostOrigin,
+      open: wallet.open,
+      redirectUri: callback,
       storage: Storage.memory(),
     })
 
@@ -323,9 +433,7 @@ describe('create', () => {
       params: [{ capabilities: { digest, method: 'login' } }],
     })
 
-    expect(new URL(browser.urls()[0]!).searchParams.get('digest')).toMatchInlineSnapshot(
-      `"${digest}"`,
-    )
+    expect(connectParameters(wallet, 0)?.capabilities?.digest).toBe(digest)
     expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)
   })
 })

--- a/src/react-native/Provider.ts
+++ b/src/react-native/Provider.ts
@@ -3,17 +3,28 @@ import * as Storage from '../core/Storage.js'
 import { reactNative } from './adapter.js'
 import { secureStorage } from './storage.js'
 
-/** Creates a provider for React Native apps using system browser authentication. */
+/** Creates a provider for React Native apps using Wata mobile web auth. */
 export function create(options: create.Options): create.ReturnType {
-  const { host = 'https://wallet.tempo.xyz', redirectUri, open, ...rest } = options
+  const {
+    baseUrl,
+    fetch,
+    host = 'https://wallet.tempo.xyz',
+    open,
+    openAuthSession,
+    redirectUri,
+    ...rest
+  } = options
 
   return CoreProvider.create({
     storage: defaultStorage(),
     ...rest,
     adapter: reactNative({
+      baseUrl,
+      ...(fetch ? { fetch } : {}),
       host,
-      redirectUri,
       ...(open ? { open } : {}),
+      ...(openAuthSession ? { openAuthSession } : {}),
+      redirectUri,
     }),
   })
 }
@@ -29,8 +40,8 @@ export declare namespace create {
     CoreProvider.create.Options & reactNative.Options,
     'adapter' | 'host'
   > & {
-    /** Host URL for the mobile auth page. @default "https://wallet.tempo.xyz" */
-    host?: string | undefined
+    /** Host discovery origin or preloaded Wata host document. @default "https://wallet.tempo.xyz" */
+    host?: reactNative.Options['host'] | undefined
   }
   export type ReturnType = CoreProvider.create.ReturnType
 }

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -1,27 +1,32 @@
-import {
-  Address as core_Address,
-  Base64,
-  Hex,
-  P256,
-  Provider as core_Provider,
-  RpcResponse,
-} from 'ox'
-import { KeyAuthorization } from 'ox/tempo'
+import { Hex, P256, Provider as core_Provider, RpcResponse } from 'ox'
 import { custom } from 'viem'
 import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
-import * as z from 'zod/mini'
+import {
+  mobileWebAuth,
+  type Options as MobileWebAuthOptions,
+} from 'wata/consumer/transports/mobileWebAuth'
+import * as Wata from 'wata/Wata'
 
 import * as Adapter from '../core/Adapter.js'
 import * as Rpc from '../core/zod/rpc.js'
 
 /**
- * Creates a React Native adapter that authorizes access keys via the system browser.
+ * Creates a React Native adapter that forwards mobile wallet RPC through Wata.
  *
- * Authentication opens a browser session and completes via a redirect callback
- * that returns the signed key authorization.
+ * Authentication opens a browser session and completes via an encrypted app-link
+ * callback carrying the wallet RPC response.
  */
 export function reactNative(options: reactNative.Options): Adapter.Adapter {
-  const { name = 'Tempo Mobile', rdns = 'xyz.tempo.mobile' } = options
+  const {
+    baseUrl,
+    fetch,
+    host = 'https://wallet.tempo.xyz',
+    name = 'Tempo Mobile',
+    open,
+    openAuthSession,
+    rdns = 'xyz.tempo.mobile',
+    redirectUri,
+  } = options
 
   return Adapter.define({ name, rdns }, ({ getAccount, store }) => {
     function generateAccessKey(
@@ -43,117 +48,34 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
       }
     }
 
-    async function authorizeMobile(request: {
-      authorizeAccessKey: Adapter.authorizeAccessKey.Parameters | undefined
-      digest?: Adapter.loadAccounts.Parameters['digest'] | undefined
-      method: 'wallet_authorizeAccessKey' | 'wallet_connect'
-      personalSign?: Adapter.loadAccounts.Parameters['personalSign'] | undefined
-      showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
-    }) {
-      const { host, redirectUri, open = defaultOpen } = options
-      const { authorizeAccessKey, digest, method, personalSign, showDeposit } = request
-
-      const publicKey = authorizeAccessKey?.publicKey
-      const keyType = authorizeAccessKey?.keyType
-
-      if (!publicKey)
-        throw new RpcResponse.InvalidParamsError({
-          message:
-            method === 'wallet_connect'
-              ? '`wallet_connect` on the React Native adapter requires `capabilities.authorizeAccessKey`.'
-              : '`wallet_authorizeAccessKey` on the React Native adapter requires key parameters.',
-        })
-
-      const state = Base64.fromBytes(Hex.toBytes(Hex.random(16)), { pad: false, url: true })
-      const authUrl = buildAuthUrl(host, {
-        callback: redirectUri,
-        chainId: Number(authorizeAccessKey?.chainId ?? store.getState().chainId),
-        ...(typeof authorizeAccessKey?.expiry !== 'undefined'
-          ? { expiry: authorizeAccessKey.expiry }
-          : {}),
-        ...(keyType ? { keyType } : {}),
-        ...(authorizeAccessKey?.limits
-          ? { limits: authorizeAccessKey.limits.map((l) => ({ ...l, limit: String(l.limit) })) }
-          : {}),
-        ...(digest ? { digest } : {}),
-        ...(personalSign ? { personalSign } : {}),
-        pubKey: publicKey,
-        ...(showDeposit !== undefined ? { showDeposit } : {}),
-        state,
-      })
-
-      const callbackUrl = await open(authUrl, redirectUri)
-      if (!callbackUrl) throw new AuthCancelledError()
-
-      const params = new URL(callbackUrl).searchParams
-      const returnedState = params.get('state')
-      if (returnedState !== state) throw new StateMismatchError()
-
-      const accountAddress = params.get('accountAddress')
-      if (!accountAddress) throw new Error('Missing accountAddress in callback.')
-
-      const keyAuthorizationHex = params.get('keyAuthorization')
-      if (!keyAuthorizationHex) throw new Error('Missing keyAuthorization in callback.')
-
-      const keyAuthorization = KeyAuthorization.deserialize(keyAuthorizationHex as Hex.Hex)
-      if (!keyAuthorization.signature)
-        throw new Error('Key authorization in callback is missing a signature.')
-      const signed = keyAuthorization as KeyAuthorization.Signed
-      const signature = params.get('signature') as Hex.Hex | null
-      const personalSignMessage = params.get('personalSignMessage')
-
-      return {
-        accountAddress: accountAddress as core_Address.Address,
-        keyAuthorization: signed,
-        ...(personalSignMessage ? { personalSign: { message: personalSignMessage } } : {}),
-        ...(signature ? { signature } : {}),
-      }
-    }
-
-    async function authorizeAccessKeyMobile(
+    async function requestMobile(
       request: Pick<Rpc.wallet_authorizeAccessKey.Encoded, 'method' | 'params'>,
-    ): Promise<Rpc.wallet_authorizeAccessKey.Encoded['returns']> {
-      const [parameters] = z.decode(Rpc.wallet_authorizeAccessKey.schema.params!, request.params)
-      const result = await authorizeMobile({
-        authorizeAccessKey: parameters,
-        method: 'wallet_authorizeAccessKey',
-        ...(parameters.showDeposit !== undefined ? { showDeposit: parameters.showDeposit } : {}),
-      })
-
-      return {
-        keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-        rootAddress: result.accountAddress,
-      }
-    }
-
-    async function connectMobile(
+    ): Promise<Rpc.wallet_authorizeAccessKey.Encoded['returns']>
+    async function requestMobile(
       request: Pick<Rpc.wallet_connect.Encoded, 'method' | 'params'>,
-    ): Promise<Rpc.wallet_connect.Encoded['returns']> {
-      const [parameters] = z.decode(Rpc.wallet_connect.schema.params!, request.params) ?? []
-      const capabilities = parameters?.capabilities
-
-      const result = await authorizeMobile({
-        authorizeAccessKey: capabilities?.authorizeAccessKey,
-        ...(capabilities?.digest ? { digest: capabilities.digest } : {}),
-        method: 'wallet_connect',
-        ...(capabilities?.personalSign ? { personalSign: capabilities.personalSign } : {}),
-        ...(capabilities?.showDeposit !== undefined
-          ? { showDeposit: capabilities.showDeposit }
-          : {}),
-      })
-
-      return {
-        accounts: [
-          {
-            address: result.accountAddress,
-            capabilities: {
-              keyAuthorization: KeyAuthorization.toRpc(result.keyAuthorization),
-              ...(result.personalSign ? { personalSign: result.personalSign } : {}),
-              ...(result.signature ? { signature: result.signature } : {}),
-            },
-          },
+    ): Promise<Rpc.wallet_connect.Encoded['returns']>
+    async function requestMobile(request: {
+      method: 'wallet_authorizeAccessKey' | 'wallet_connect'
+      params: readonly unknown[] | undefined
+    }): Promise<unknown> {
+      const session = Wata.create({
+        baseUrl,
+        meta: { name },
+        transports: [
+          mobileWebAuth({
+            callback: redirectUri,
+            host,
+            openAuthSession:
+              openAuthSession ??
+              (async ({ authorizationUrl, callback }) => {
+                const result = await (open ?? defaultOpen)(authorizationUrl, callback)
+                return result ?? undefined
+              }),
+            ...(fetch ? { fetch } : {}),
+          }),
         ],
-      }
+      })
+      return (await session.send({ method: request.method, params: request.params ?? [] })).result
     }
 
     const provider = core_Provider.from({
@@ -162,9 +84,9 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
           case 'eth_chainId':
             return Hex.fromNumber(store.getState().chainId)
           case 'wallet_authorizeAccessKey':
-            return await authorizeAccessKeyMobile(request as never)
+            return await requestMobile(request as never)
           case 'wallet_connect':
-            return await connectMobile(request as never)
+            return await requestMobile(request as never)
           default:
             throw unsupported(`\`${request.method}\` not supported by React Native adapter.`)
         }
@@ -215,8 +137,12 @@ export function reactNative(options: reactNative.Options): Adapter.Adapter {
 
 export declare namespace reactNative {
   export type Options = {
-    /** Host URL for the mobile auth page. @default "https://wallet.tempo.xyz" */
-    host: string
+    /** Public HTTPS origin that hosts this app's Wata consumer discovery document. */
+    baseUrl: string
+    /** Override the Wata discovery `fetch` implementation. */
+    fetch?: MobileWebAuthOptions['fetch'] | undefined
+    /** Host discovery origin or preloaded Wata host document. @default "https://wallet.tempo.xyz" */
+    host?: MobileWebAuthOptions['host'] | undefined
     /** Provider display name. @default "Tempo Mobile" */
     name?: string | undefined
     /**
@@ -224,24 +150,12 @@ export declare namespace reactNative {
      * @default Uses `expo-web-browser`'s `openAuthSessionAsync`.
      */
     open?: ((url: string, redirectUri: string) => Promise<string | null>) | undefined
+    /** Wata browser auth-session override. */
+    openAuthSession?: MobileWebAuthOptions['openAuthSession'] | undefined
     /** Redirect URI for the auth callback (e.g. your app's deep link scheme). */
     redirectUri: string
     /** Reverse-DNS provider identifier. @default "xyz.tempo.mobile" */
     rdns?: string | undefined
-  }
-}
-
-class AuthCancelledError extends Error {
-  constructor() {
-    super('Authentication was cancelled by the user.')
-    this.name = 'AuthCancelledError'
-  }
-}
-
-class StateMismatchError extends Error {
-  constructor() {
-    super('State parameter mismatch — possible CSRF attack.')
-    this.name = 'StateMismatchError'
   }
 }
 
@@ -250,38 +164,6 @@ async function defaultOpen(url: string, redirectUri: string): Promise<string | n
   const result = await openAuthSessionAsync(url, redirectUri)
   if (result.type !== 'success') return null
   return result.url
-}
-
-function buildAuthUrl(
-  host: string,
-  params: {
-    callback: string
-    chainId: number
-    digest?: Hex.Hex | undefined
-    expiry?: number | undefined
-    keyType?: string | undefined
-    limits?: readonly { token: string; limit: string }[] | undefined
-    personalSign?: { message: string } | undefined
-    pubKey: Hex.Hex
-    showDeposit?: Adapter.createAccount.Parameters['showDeposit'] | undefined
-    state: string
-  },
-): string {
-  const url = new URL('/remote/auth/mobile', host)
-  url.searchParams.set('pubKey', params.pubKey)
-  if (params.keyType) url.searchParams.set('keyType', params.keyType)
-  url.searchParams.set('chainId', `0x${params.chainId.toString(16)}`)
-  if (params.digest) url.searchParams.set('digest', params.digest)
-  if (typeof params.expiry !== 'undefined')
-    url.searchParams.set('expiry', `0x${params.expiry.toString(16)}`)
-  if (params.limits) url.searchParams.set('limits', JSON.stringify(params.limits))
-  if (params.personalSign) url.searchParams.set('personalSign', JSON.stringify(params.personalSign))
-  if (params.showDeposit === true) url.searchParams.set('showDeposit', 'true')
-  else if (params.showDeposit)
-    url.searchParams.set('showDeposit', JSON.stringify(params.showDeposit))
-  url.searchParams.set('callback', params.callback)
-  url.searchParams.set('state', params.state)
-  return url.toString()
 }
 
 function unsupported(message: string) {

--- a/src/react-native/adapter.ts
+++ b/src/react-native/adapter.ts
@@ -1,11 +1,7 @@
 import { Hex, P256, Provider as core_Provider, RpcResponse } from 'ox'
 import { custom } from 'viem'
 import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
-import {
-  mobileWebAuth,
-  type Options as MobileWebAuthOptions,
-} from 'wata/consumer/transports/mobileWebAuth'
-import * as Wata from 'wata/Wata'
+import { Wata, mobileWebAuth, type MobileWebAuth } from 'wata'
 
 import * as Adapter from '../core/Adapter.js'
 import * as Rpc from '../core/zod/rpc.js'
@@ -140,9 +136,9 @@ export declare namespace reactNative {
     /** Public HTTPS origin that hosts this app's Wata consumer discovery document. */
     baseUrl: string
     /** Override the Wata discovery `fetch` implementation. */
-    fetch?: MobileWebAuthOptions['fetch'] | undefined
+    fetch?: MobileWebAuth.Options['fetch'] | undefined
     /** Host discovery origin or preloaded Wata host document. @default "https://wallet.tempo.xyz" */
-    host?: MobileWebAuthOptions['host'] | undefined
+    host?: MobileWebAuth.Options['host'] | undefined
     /** Provider display name. @default "Tempo Mobile" */
     name?: string | undefined
     /**
@@ -151,7 +147,7 @@ export declare namespace reactNative {
      */
     open?: ((url: string, redirectUri: string) => Promise<string | null>) | undefined
     /** Wata browser auth-session override. */
-    openAuthSession?: MobileWebAuthOptions['openAuthSession'] | undefined
+    openAuthSession?: MobileWebAuth.Options['openAuthSession'] | undefined
     /** Redirect URI for the auth callback (e.g. your app's deep link scheme). */
     redirectUri: string
     /** Reverse-DNS provider identifier. @default "xyz.tempo.mobile" */


### PR DESCRIPTION
## Summary
Uses WATA mobile web auth for the React Native remote connector.

## Motivation
React Native should send wallet RPCs through the mobile web auth transport so the mobile app can open wallet-next, wait for user approval, and receive the result through the WATA callback.

## Changes
- Replace the React Native adapter's custom URL/callback handling with WATA `mobileWebAuth`.
- Cover mobile web auth behavior in the React Native localnet provider tests.
- Point the React Native playground at the e2e wallet host.
- Pin WATA to `wevm/wata#a79d660252690a848a73a98003ea3c4ed7656239` with consumer overrides for WATA's catalog dependencies.

## Testing
- `pnpm check:types` — passed.
- `pnpm exec vp test src/react-native/Provider.localnet.test.ts` — fails locally before running tests with `error: Cannot find binary path for command 'node'`.
