### PR TITLE
chore: mark provider changesets as patch

### DIFF
--- a/.changeset/local-access-keys.md
+++ b/.changeset/local-access-keys.md
@@ -1,5 +1,5 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
 Persist access keys through provider storage.

--- a/.changeset/provider-owned-rpc-actions.md
+++ b/.changeset/provider-owned-rpc-actions.md
@@ -1,5 +1,5 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
 Add provider-owned RPC action handling for adapters that expose a viem account with `getAccount`.


### PR DESCRIPTION
Updates the two pending provider changesets to use patch bumps for `accounts`, matching the intended release shape before the version-package PR regenerates output.

This keeps the access-key persistence and provider-owned RPC action notes as patch changes instead of producing a minor release.