### PR TITLE
feat: automatic access key authorizations

### DIFF
--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -128,10 +128,12 @@ const provider = Provider.create({
 
 ### authorizeAccessKey
 
-- **Type:** `() => Adapter.authorizeAccessKey.Parameters | undefined`
+- **Type:** `() => Provider.create.AuthorizeAccessKeyParameters`
 - **Optional**
 
-Default access key parameters for `wallet_connect`. When set, `wallet_connect` will automatically authorize an access key. Return `undefined` to skip authorization for the current request.
+Default access key parameters for `wallet_connect` and transaction sends. When set, the provider first checks stored local access keys. If one can satisfy the request, the provider reuses it. If none can, `wallet_connect` includes `capabilities.authorizeAccessKey`, and send requests authorize the key immediately before sending when the requested scopes cover the transaction calls. Return `undefined` to skip authorization for the current request.
+
+The optional `reuse` object is SDK-only. It is never sent to the wallet RPC. Use it to make reuse stricter than the default scope check.
 
 Tempo Wallet-hosted approval pages require at least one `limits` entry and one `scopes` entry. Local adapters accept unbounded keys, but production apps should pass both so local and wallet-hosted flows use the same policy.
 
@@ -158,6 +160,13 @@ declare function authorizeAccessKey(): {
   scopes?:
     | { address: Address; recipients?: readonly Address[]; selector?: Hex | string }[]
     | undefined
+  /** SDK-only reuse policy. Omitted before `wallet_connect` or `wallet_authorizeAccessKey` RPCs. */
+  reuse?: {
+    /** Minimum Unix timestamp (seconds) a stored key must be valid through. */
+    minExpiry?: number | undefined
+    /** Minimum spending limits a stored key must satisfy. */
+    minLimits?: { limit: bigint; period?: number; token: Address }[] | undefined
+  } | undefined
 } | undefined
 ```
 
@@ -177,9 +186,19 @@ const provider = Provider.create({
       address: '0x20c0000000000000000000000000000000000001', // [!code focus]
       selector: 'transfer(address,uint256)', // [!code focus]
     }], // [!code focus]
+    reuse: { // [!code focus]
+      minExpiry: Expiry.hours(1), // [!code focus]
+      minLimits: [{ // [!code focus]
+        token: '0x20c0000000000000000000000000000000000001', // [!code focus]
+        limit: parseUnits('50', 6), // [!code focus]
+        period: 60 * 60 * 24, // [!code focus]
+      }], // [!code focus]
+    }, // [!code focus]
   }), // [!code focus]
 })
 ```
+
+If `reuse` is omitted, the provider reuses any unexpired locally signable key whose scopes cover the requested scopes and transaction calls. Add `reuse.minExpiry` or `reuse.minLimits` when a stored key must also be valid long enough or have enough remaining policy capacity for your app's workflow.
 
 You can also pre-derive the access key locally by passing `publicKey` or `address` with `keyType`. The wallet still authorizes that key during `wallet_connect`; the app keeps the signing material.
 

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -128,10 +128,10 @@ const provider = Provider.create({
 
 ### authorizeAccessKey
 
-- **Type:** `() => Provider.create.AuthorizeAccessKeyParameters`
+- **Type:** `Provider.create.AuthorizeAccessKeyParameters | (() => Provider.create.AuthorizeAccessKeyParameters | undefined)`
 - **Optional**
 
-Default access key parameters for `wallet_connect` and transaction sends. When set, the provider first checks stored local access keys. If one can satisfy the request, the provider reuses it. If none can, `wallet_connect` includes `capabilities.authorizeAccessKey`, and send requests authorize the key immediately before sending when the requested scopes cover the transaction calls. Return `undefined` to skip authorization for the current request.
+Default access key parameters for `wallet_connect` and transaction sends. Pass an object to use the same policy for every applicable request, or a function to compute it dynamically. When set, the provider first checks stored local access keys. If one can satisfy the request, the provider reuses it. If none can, `wallet_connect` includes `capabilities.authorizeAccessKey`, and send requests authorize the key immediately before sending when the requested scopes cover the transaction calls. Return `undefined` from the function to skip authorization for the current request.
 
 The optional `reuse` object is SDK-only. It is never sent to the wallet RPC. Use it to make reuse stricter than the default scope check.
 
@@ -175,7 +175,7 @@ import { parseUnits } from 'viem'
 import { Expiry, Provider } from 'accounts'
 
 const provider = Provider.create({
-  authorizeAccessKey: () => ({ // [!code focus]
+  authorizeAccessKey: { // [!code focus]
     expiry: Expiry.days(7), // [!code focus]
     limits: [{ // [!code focus]
       token: '0x20c0000000000000000000000000000000000001', // [!code focus]
@@ -194,7 +194,7 @@ const provider = Provider.create({
         period: 60 * 60 * 24, // [!code focus]
       }], // [!code focus]
     }, // [!code focus]
-  }), // [!code focus]
+  }, // [!code focus]
 })
 ```
 
@@ -211,11 +211,11 @@ Alternatively, pass `privateKey` to let the SDK derive the access-key address an
 import { Expiry, Provider } from 'accounts'
 
 const provider = Provider.create({
-  authorizeAccessKey: () => ({ // [!code focus]
+  authorizeAccessKey: { // [!code focus]
     expiry: Expiry.days(7), // [!code focus]
     keyType: 'p256', // [!code focus]
     publicKey: '0x1234', // [!code focus]
-  }), // [!code focus]
+  }, // [!code focus]
 })
 ```
 

--- a/site/src/pages/docs/guides/spend-permissions.mdx
+++ b/site/src/pages/docs/guides/spend-permissions.mdx
@@ -43,7 +43,7 @@ Follow the [Connect Accounts](/docs/guides/connect-accounts) guide to set up Wag
 
 ### Define the Spend Policy
 
-Add `authorizeAccessKey` to the connector. The callback returns the permission the user will approve when a matching local key is not already available.
+Add `authorizeAccessKey` to the connector. The object describes the permission the user will approve when a matching local key is not already available. Pass a function instead when the policy needs to be computed dynamically.
 
 ```tsx twoslash [src/config.ts]
 // @noErrors
@@ -60,7 +60,7 @@ export const config = createConfig({
   connectors: [
     tempoWallet({
       testnet: true,
-      authorizeAccessKey: () => ({ // [!code focus]
+      authorizeAccessKey: { // [!code focus]
         expiry: Expiry.days(1), // [!code focus]
         limits: [ // [!code focus]
           { token: pathUsd, limit: parseUnits('100', 6) }, // [!code focus]
@@ -74,7 +74,7 @@ export const config = createConfig({
             { token: pathUsd, limit: parseUnits('10', 6) }, // [!code focus]
           ], // [!code focus]
         }, // [!code focus]
-      }), // [!code focus]
+      }, // [!code focus]
     }),
   ],
   multiInjectedProviderDiscovery: false,

--- a/site/src/pages/docs/guides/spend-permissions.mdx
+++ b/site/src/pages/docs/guides/spend-permissions.mdx
@@ -43,7 +43,7 @@ Follow the [Connect Accounts](/docs/guides/connect-accounts) guide to set up Wag
 
 ### Define the Spend Policy
 
-Add `authorizeAccessKey` to the connector. The callback returns the permission the user will approve during `wallet_connect`.
+Add `authorizeAccessKey` to the connector. The callback returns the permission the user will approve when a matching local key is not already available.
 
 ```tsx twoslash [src/config.ts]
 // @noErrors
@@ -68,6 +68,12 @@ export const config = createConfig({
         scopes: [ // [!code focus]
           { address: pathUsd, selector: 'transfer(address,uint256)' }, // [!code focus]
         ], // [!code focus]
+        reuse: { // [!code focus]
+          minExpiry: Expiry.hours(1), // [!code focus]
+          minLimits: [ // [!code focus]
+            { token: pathUsd, limit: parseUnits('10', 6) }, // [!code focus]
+          ], // [!code focus]
+        }, // [!code focus]
       }), // [!code focus]
     }),
   ],
@@ -89,7 +95,7 @@ Local adapters may accept broader keys, but production apps should keep the same
 
 ### Sign In with the Policy
 
-Use the same sign-in button from the Connect Accounts guide. When the user approves the connection, Tempo Wallet also signs the access key authorization returned by `authorizeAccessKey`.
+Use the same sign-in button from the Connect Accounts guide. If the SDK already has a stored access key that matches the scopes and optional `reuse` policy, sign-in continues without a new access key prompt. Otherwise Tempo Wallet signs the access key authorization returned by `authorizeAccessKey`.
 
 ```tsx twoslash [src/Connect.tsx]
 // @noErrors
@@ -113,6 +119,8 @@ export function Connect() {
 ### Send Within the Permission
 
 Submit calls that match the approved scopes. The SDK selects the access key when the transfer fits the spend policy; otherwise it falls back to the connected account's normal signing path.
+
+If no matching key exists at send time, the SDK checks whether the configured `authorizeAccessKey` scopes would cover the transaction. When they do, it requests the access key first, stores it, then sends the transaction with that key. When they do not, it skips the access key request and uses the normal signing path.
 
 ```tsx twoslash [src/Transfer.tsx]
 // @noErrors
@@ -159,8 +167,14 @@ const spendPermission = {
   scopes: [
     { address: pathUsd, selector: 'transfer(address,uint256)' },
   ],
+  reuse: {
+    minExpiry: Expiry.hours(1),
+    minLimits: [{ token: pathUsd, limit: parseUnits('10', 6) }],
+  },
 }
 ```
+
+The top-level `expiry`, `limits`, and `scopes` define the new key to create when needed. `reuse.minExpiry` and `reuse.minLimits` only decide whether an existing stored key is acceptable to reuse.
 
 ### Keep Expiry Short
 

--- a/site/src/pages/docs/wagmi/tempoWallet.mdx
+++ b/site/src/pages/docs/wagmi/tempoWallet.mdx
@@ -29,10 +29,10 @@ Accepts all [`dialog`](/docs/api/dialog) adapter options, plus all [`Provider`](
 
 ### authorizeAccessKey
 
-- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | undefined`
+- **Type:** `{ address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | (() => { ... } | undefined)`
 - **Optional**
 
-Default access key parameters for `wallet_connect`. Return `undefined` to skip authorization for the current request.
+Default access key parameters for `wallet_connect`. Pass an object to use the same policy for every applicable request, or a function to compute it dynamically. Return `undefined` from the function to skip authorization for the current request.
 
 This matches [`Provider.authorizeAccessKey`](/docs/api/provider#authorizeaccesskey).
 
@@ -49,7 +49,7 @@ export const config = createConfig({
   chains: [tempo],
   connectors: [
     tempoWallet({
-      authorizeAccessKey: () => ({ // [!code focus]
+      authorizeAccessKey: { // [!code focus]
         expiry: Expiry.days(7), // [!code focus]
         limits: [{ // [!code focus]
           token: '0x20c0000000000000000000000000000000000001', // [!code focus]
@@ -59,7 +59,7 @@ export const config = createConfig({
           address: '0x20c0000000000000000000000000000000000001', // [!code focus]
           selector: 'transfer(address,uint256)', // [!code focus]
         }], // [!code focus]
-      }), // [!code focus]
+      }, // [!code focus]
     }),
   ],
   transports: { [tempo.id]: http() },

--- a/site/src/pages/docs/wagmi/webAuthn.mdx
+++ b/site/src/pages/docs/wagmi/webAuthn.mdx
@@ -60,10 +60,10 @@ export const config = createConfig({
 
 ### authorizeAccessKey
 
-- **Type:** `() => { address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | undefined`
+- **Type:** `{ address?: Address; chainId?: bigint; expiry: number; keyType?: 'secp256k1' | 'p256' | 'webAuthn'; limits?: { token: Address; limit: bigint; period?: number }[]; privateKey?: Hex; publicKey?: Hex; scopes?: { address: Address; recipients?: Address[]; selector?: Hex | string }[] } | (() => { ... } | undefined)`
 - **Optional**
 
-Default access key parameters for `wallet_connect`. Return `undefined` to skip authorization for the current request.
+Default access key parameters for `wallet_connect`. Pass an object to use the same policy for every applicable request, or a function to compute it dynamically. Return `undefined` from the function to skip authorization for the current request.
 
 This matches [`Provider.authorizeAccessKey`](/docs/api/provider#authorizeaccesskey).
 
@@ -81,7 +81,7 @@ export const config = createConfig({
   connectors: [
     webAuthn({
       authUrl: '/auth',
-      authorizeAccessKey: () => ({ // [!code focus]
+      authorizeAccessKey: { // [!code focus]
         expiry: Expiry.days(7), // [!code focus]
         limits: [{ // [!code focus]
           token: '0x20c0000000000000000000000000000000000001', // [!code focus]
@@ -91,7 +91,7 @@ export const config = createConfig({
           address: '0x20c0000000000000000000000000000000000001', // [!code focus]
           selector: 'transfer(address,uint256)', // [!code focus]
         }], // [!code focus]
-      }), // [!code focus]
+      }, // [!code focus]
     }),
   ],
   transports: { [tempo.id]: http() },

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -22,7 +22,7 @@ function createKeyAuthorization(
     chainId?: bigint | undefined
     expiry?: number | undefined
     keyType?: KeyAuthorization.KeyAuthorization['type'] | undefined
-    limits?: { token: `0x${string}`; limit: bigint }[] | undefined
+    limits?: { token: `0x${string}`; limit: bigint; period?: number | undefined }[] | undefined
     scopes?: KeyAuthorization.Scope[] | undefined
   } = {},
 ) {
@@ -612,6 +612,120 @@ describe('select', () => {
     })
 
     expect({ match: !!match, miss: !!miss }).toMatchInlineSnapshot(`
+      {
+        "match": true,
+        "miss": false,
+      }
+    `)
+  })
+})
+
+describe('hasReusableAuthorization', () => {
+  test('behavior: matches scopes and optional reuse policy', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const merchant = '0x0000000000000000000000000000000000000def' as const
+    addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress, {
+        expiry: 200,
+        limits: [{ token, limit: 100n, period: 86_400 }],
+        scopes: [
+          {
+            address: token,
+            recipients: [merchant],
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+      }),
+      keyPair,
+      store,
+    })
+
+    const match = await AccessKey.hasReusableAuthorization({
+      account: rootAddress,
+      chainId: 1,
+      now: 100,
+      parameters: {
+        expiry: 300,
+        reuse: {
+          minExpiry: 150,
+          minLimits: [{ token, limit: 10n, period: 86_400 }],
+        },
+        scopes: [
+          {
+            address: token,
+            recipients: [merchant],
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+      },
+      store: { state: store },
+    })
+    const miss = await AccessKey.hasReusableAuthorization({
+      account: rootAddress,
+      chainId: 1,
+      now: 100,
+      parameters: {
+        expiry: 300,
+        reuse: {
+          minExpiry: 250,
+        },
+        scopes: [
+          {
+            address: token,
+            recipients: [merchant],
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+      },
+      store: { state: store },
+    })
+
+    expect({ match, miss }).toMatchInlineSnapshot(`
+      {
+        "match": true,
+        "miss": false,
+      }
+    `)
+  })
+})
+
+describe('canAuthorizeCalls', () => {
+  test('behavior: checks whether requested scopes cover calls', () => {
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    const merchant = '0x0000000000000000000000000000000000000def' as const
+    const data =
+      `0xa9059cbb000000000000000000000000${merchant.slice(2)}0000000000000000000000000000000000000000000000000000000000000001` as const
+
+    const match = AccessKey.canAuthorizeCalls({
+      calls: [{ data, to: token }],
+      parameters: {
+        scopes: [
+          {
+            address: token,
+            recipients: [merchant],
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+      },
+    })
+    const miss = AccessKey.canAuthorizeCalls({
+      calls: [{ data, to: token }],
+      parameters: {
+        scopes: [
+          {
+            address: token,
+            recipients: ['0x0000000000000000000000000000000000000099'],
+            selector: 'transfer(address,uint256)',
+          },
+        ],
+      },
+    })
+
+    expect({ match, miss }).toMatchInlineSnapshot(`
       {
         "match": true,
         "miss": false,

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -64,7 +64,7 @@ export type AccessKey = {
 >
 
 /** Calls used to match access key scopes. */
-type Call = {
+export type Call = {
   /** Contract address being called. */
   to?: Address.Address | undefined
   /** Calldata being sent. */
@@ -101,6 +101,44 @@ type SelectQuery = {
   now?: number | undefined
   /** Access-key manager options. */
   store: ManagerOptions
+}
+
+/** Access key authorization reuse policy. */
+export type ReusePolicy = {
+  /** Minimum Unix timestamp a reusable key must be valid through. */
+  minExpiry?: number | undefined
+  /** Minimum spending limits a reusable key must satisfy. */
+  minLimits?: readonly KeyAuthorization.TokenLimit[] | undefined
+}
+
+/** Access key authorization parameters plus SDK-only reuse policy. */
+export type ReusableAuthorization = Omit<prepareAuthorization.Options, 'chainId'> & {
+  /** Chain ID the key authorization is scoped to. */
+  chainId?: bigint | number | undefined
+  /** SDK-only reuse policy. Not sent over RPC. */
+  reuse?: ReusePolicy | undefined
+}
+
+type ReusableQuery = {
+  /** Root account address. */
+  account: Address.Address
+  /** Calls the access key must be able to sign. */
+  calls?: readonly Call[] | undefined
+  /** Chain ID the access key must be authorized on. */
+  chainId: number
+  /** Current Unix timestamp in seconds. Defaults to `Date.now() / 1000`. */
+  now?: number | undefined
+  /** Access key authorization parameters with optional reuse policy. */
+  parameters: ReusableAuthorization
+  /** Access-key manager options. */
+  store: ManagerOptions
+}
+
+type CallsQuery = {
+  /** Calls the authorization must be able to sign. */
+  calls?: readonly Call[] | undefined
+  /** Access key authorization parameters. */
+  parameters: Pick<ReusableAuthorization, 'scopes'>
 }
 
 type ListQuery = {
@@ -324,13 +362,34 @@ export declare namespace authorize {
   type ReturnType = KeyAuthorization.Rpc
 }
 
+/** Returns whether a local access key satisfies reusable authorization parameters. */
+export async function hasReusableAuthorization(options: ReusableQuery): Promise<boolean> {
+  const { account, calls, chainId, parameters, store } = options
+  const now = options.now ?? Date.now() / 1000
+  const records = list({ account, chainId, store })
+
+  for (const record of records) {
+    if (isExpired(record.expiry, now)) continue
+    if (!authorizationMatches(record, parameters)) continue
+    if (calls && !recordScopesMatch(record, { calls })) continue
+    if (!(await hydrate(record, store))) continue
+    return true
+  }
+  return false
+}
+
+/** Returns whether an authorization request could sign the provided calls. */
+export function canAuthorizeCalls(options: CallsQuery): boolean {
+  return scopesMatch(options.parameters.scopes, { calls: options.calls })
+}
+
 /** Returns publication status for a stored or on-chain access key. */
 export async function getStatus(options: StatusQuery): Promise<Status> {
   const { accessKey, account, calls, chainId, client } = options
   const { store } = options
   const now = options.now ?? Date.now() / 1000
   const local = list({ account, accessKey, chainId, store }).find((key) =>
-    scopesMatch(key, { calls }),
+    recordScopesMatch(key, { calls }),
   )
 
   if (local) {
@@ -366,7 +425,7 @@ export async function select(
   const records = list({ account, chainId, store })
 
   for (const record of records) {
-    if (!scopesMatch(record, { calls })) continue
+    if (!recordScopesMatch(record, { calls })) continue
     if (isExpired(record.expiry, now)) {
       await remove({
         accessKey: record.address,
@@ -572,13 +631,21 @@ export function isUnavailableError(error: unknown): boolean {
   return unavailableErrorNames.has(ExecutionError.parse(error).errorName)
 }
 
-function scopesMatch(
+function recordScopesMatch(
   key: AccessKey,
   options: {
     calls?: readonly Call[] | undefined
   },
 ): boolean {
-  const scopes = key.scopes
+  return scopesMatch(key.scopes, options)
+}
+
+function scopesMatch(
+  scopes: readonly NonNullable<AccessKey['scopes']>[number][] | undefined,
+  options: {
+    calls?: readonly Call[] | undefined
+  },
+): boolean {
   if (typeof scopes === 'undefined') return true
   if (!Array.isArray(scopes)) return false
   if (!options.calls) return false
@@ -591,17 +658,7 @@ function scopesMatch(
       if (scope.address.toLowerCase() !== callTo) return false
       const selector = scope.selector
       if (!selector) return scope.recipients ? scope.recipients.length === 0 : true
-      const scopeSelector = (() => {
-        try {
-          return (
-            selector.startsWith('0x') && selector.length === 10
-              ? selector
-              : AbiFunction.getSelector(selector)
-          ).toLowerCase()
-        } catch {
-          return undefined
-        }
-      })()
+      const scopeSelector = normalizeSelector(selector)
       if (!scopeSelector || callSelector !== scopeSelector) return false
       if (!scope.recipients || scope.recipients.length === 0) return true
       if (!call.data || call.data.length < 74) return false
@@ -610,6 +667,82 @@ function scopesMatch(
       return scope.recipients.some((address) => address.toLowerCase() === recipient.toLowerCase())
     })
   })
+}
+
+function authorizationMatches(key: AccessKey, parameters: ReusableAuthorization): boolean {
+  if (!scopesCover(key.scopes, parameters.scopes)) return false
+  if (
+    typeof parameters.reuse?.minExpiry === 'number' &&
+    key.expiry &&
+    key.expiry < parameters.reuse.minExpiry
+  )
+    return false
+  if (!limitsCover(key.limits, parameters.reuse?.minLimits)) return false
+  return true
+}
+
+function scopesCover(
+  existing: AccessKey['scopes'],
+  requested: ReusableAuthorization['scopes'],
+): boolean {
+  if (!requested) return true
+  if (!existing) return true
+  return requested.every((scope) => existing.some((candidate) => scopeCovers(candidate, scope)))
+}
+
+function scopeCovers(
+  existing: NonNullable<AccessKey['scopes']>[number],
+  requested: NonNullable<ReusableAuthorization['scopes']>[number],
+): boolean {
+  if (!isScope(existing) || !isScope(requested)) return false
+  if (existing.address.toLowerCase() !== requested.address.toLowerCase()) return false
+  if (!selectorCovers(existing.selector, requested.selector)) return false
+  return recipientsCover(existing.recipients, requested.recipients)
+}
+
+function selectorCovers(existing: string | undefined, requested: string | undefined): boolean {
+  if (!existing) return true
+  if (!requested) return false
+  const selector_existing = normalizeSelector(existing)
+  const selector_requested = normalizeSelector(requested)
+  return !!selector_existing && selector_existing === selector_requested
+}
+
+function normalizeSelector(value: string): string | undefined {
+  try {
+    return (
+      value.startsWith('0x') && value.length === 10 ? value : AbiFunction.getSelector(value)
+    ).toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+function recipientsCover(
+  existing: readonly Address.Address[] | undefined,
+  requested: readonly Address.Address[] | undefined,
+): boolean {
+  if (!existing || existing.length === 0) return true
+  if (!requested || requested.length === 0) return false
+  return requested.every((address) =>
+    existing.some((candidate) => candidate.toLowerCase() === address.toLowerCase()),
+  )
+}
+
+function limitsCover(
+  existing: AccessKey['limits'],
+  requested: readonly KeyAuthorization.TokenLimit[] | undefined,
+): boolean {
+  if (!requested) return true
+  if (!existing) return true
+  return requested.every((limit) =>
+    existing.some(
+      (candidate) =>
+        candidate.token.toLowerCase() === limit.token.toLowerCase() &&
+        Number(candidate.period ?? 0) === Number(limit.period ?? 0) &&
+        BigInt(candidate.limit) >= BigInt(limit.limit),
+    ),
+  )
 }
 
 function isScope(scope: unknown): scope is NonNullable<AccessKey['scopes']>[number] {

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -2228,7 +2228,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.accounts[0]!.capabilities.keyAuthorization!.expiry).toBe(Hex.fromNumber(expiry))
     })
 
-    test('behavior: login auto-authorizes access key', async () => {
+    test('behavior: login reuses matching default access key', async () => {
       const provider = Provider.create({
         adapter: adapter(),
         chains: [chain],
@@ -2237,7 +2237,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       await connect(provider)
       const result = await provider.request({ method: 'wallet_connect' })
-      expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
+      expect(result.accounts[0]!.capabilities.keyAuthorization).toMatchInlineSnapshot(`undefined`)
     })
 
     test('behavior: without option, wallet_connect does not auto-authorize', async () => {

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -2229,6 +2229,128 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
     })
 
+    test('behavior: sendTransactionSync authorizes matching default access key just-in-time', async () => {
+      let authorize = false
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        authorizeAccessKey: () => {
+          if (!authorize) return undefined
+          return {
+            expiry: Expiry.days(1),
+            scopes: [{ address: Addresses.pathUsd, selector: 'transfer(address,uint256)' }],
+          }
+        },
+      })
+      const address = await connect(provider)
+      await fund(address)
+      const initialAccessKeys = provider.store.getState().accessKeys.length
+      authorize = true
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      expect({
+        initialAccessKeys,
+        storedAccessKeys: provider.store.getState().accessKeys.length,
+        status: receipt.status,
+      }).toMatchInlineSnapshot(`
+        {
+          "initialAccessKeys": 0,
+          "status": "0x1",
+          "storedAccessKeys": 1,
+        }
+      `)
+    })
+
+    test('behavior: sendTransactionSync skips default access key when scopes do not cover transaction', async () => {
+      let authorize = false
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        authorizeAccessKey: () => {
+          if (!authorize) return undefined
+          return {
+            expiry: Expiry.days(1),
+            scopes: [
+              {
+                address: '0x0000000000000000000000000000000000000099',
+                selector: 'transfer(address,uint256)',
+              },
+            ],
+          }
+        },
+      })
+      const address = await connect(provider)
+      await fund(address)
+      const initialAccessKeys = provider.store.getState().accessKeys.length
+      authorize = true
+
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      expect({
+        fromRoot: receipt.from.toLowerCase() === address.toLowerCase(),
+        initialAccessKeys,
+        storedAccessKeys: provider.store.getState().accessKeys.length,
+        status: receipt.status,
+      }).toMatchInlineSnapshot(`
+        {
+          "fromRoot": true,
+          "initialAccessKeys": 0,
+          "status": "0x1",
+          "storedAccessKeys": 0,
+        }
+      `)
+    })
+
+    test('behavior: wallet_sendCalls authorizes matching default access key just-in-time', async () => {
+      let authorize = false
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        authorizeAccessKey: () => {
+          if (!authorize) return undefined
+          return {
+            expiry: Expiry.days(1),
+            scopes: [{ address: Addresses.pathUsd, selector: 'transfer(address,uint256)' }],
+          }
+        },
+      })
+      const address = await connect(provider)
+      await fund(address)
+      const initialAccessKeys = provider.store.getState().accessKeys.length
+      authorize = true
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [transferCall],
+            capabilities: { sync: true },
+          },
+        ],
+      })
+
+      expect({
+        initialAccessKeys,
+        status: result.status,
+        storedAccessKeys: provider.store.getState().accessKeys.length,
+        sync: result.capabilities?.sync,
+      }).toMatchInlineSnapshot(`
+        {
+          "initialAccessKeys": 0,
+          "status": 200,
+          "storedAccessKeys": 1,
+          "sync": true,
+        }
+      `)
+    })
+
     test('behavior: explicit authorizeAccessKey overrides default', async () => {
       const expiry = Math.floor(Date.now() / 1000) + 3600
       const provider = Provider.create({

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -2192,6 +2192,22 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       expect(result.accounts[0]!.capabilities.keyAuthorization!.keyId).toMatch(/^0x[0-9a-f]{40}$/i)
     })
 
+    test('default: wallet_connect auto-authorizes access key from literal option', async () => {
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        authorizeAccessKey: { expiry: Expiry.days(1) },
+      })
+
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { method: 'register' } }],
+      })
+      expect(result.accounts.length).toBeGreaterThanOrEqual(1)
+      expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
+      expect(result.accounts[0]!.capabilities.keyAuthorization!.keyId).toMatch(/^0x[0-9a-f]{40}$/i)
+    })
+
     test('behavior: auto-authorized access key can send transactions', async () => {
       const provider = Provider.create({
         adapter: adapter(),

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -1,7 +1,6 @@
 import type { RpcSchema } from 'ox'
 import { describe, expectTypeOf, test } from 'vp/test'
 
-import type * as Adapter from './Adapter.js'
 import * as Provider from './Provider.js'
 import type * as Schema from './Schema.js'
 
@@ -61,10 +60,14 @@ describe('request', () => {
 })
 
 describe('create options', () => {
-  test('authorizeAccessKey can return undefined to opt out', () => {
+  test('authorizeAccessKey accepts a literal value or function', () => {
     expectTypeOf<NonNullable<Parameters<typeof Provider.create>[0]>>().toMatchTypeOf<{
-      authorizeAccessKey?: (() => Adapter.authorizeAccessKey.Parameters | undefined) | undefined
+      authorizeAccessKey?: Provider.create.AuthorizeAccessKey | undefined
     }>()
+
+    Provider.create({
+      authorizeAccessKey: { expiry: 123 },
+    })
 
     Provider.create({
       authorizeAccessKey: () => undefined,

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -74,6 +74,10 @@ const announced = new Set<string>()
 
 type TransactionParameters = Adapter.ActionRequest<typeof Rpc.eth_sendTransaction.schema>
 
+type WalletConnectCapabilities = NonNullable<
+  NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']
+>
+
 function isBrowserWebCrypto() {
   return typeof document !== 'undefined' && !!globalThis.crypto?.subtle
 }
@@ -657,6 +661,76 @@ export function create(options: create.Options = {}): create.ReturnType {
     return url
   }
 
+  function stripAuthorizeAccessKey(
+    parameters: create.AuthorizeAccessKeyParameters,
+  ): Adapter.authorizeAccessKey.Parameters {
+    const { reuse: _reuse, ...rest } = parameters
+    return rest
+  }
+
+  async function defaultAuthorizeAccessKeyForConnect(options_: {
+    capabilities: WalletConnectCapabilities | undefined
+    chainId: number
+  }): Promise<Adapter.authorizeAccessKey.Parameters | undefined> {
+    const parameters = options.authorizeAccessKey?.()
+    if (!parameters) return undefined
+    const address = reusableConnectAccount(options_.capabilities)
+    if (
+      address &&
+      (await AccessKey.hasReusableAuthorization({
+        account: address,
+        chainId: Number(parameters.chainId ?? options_.chainId),
+        parameters,
+        store: { state: store },
+      }))
+    )
+      return undefined
+    return stripAuthorizeAccessKey(parameters)
+  }
+
+  function reusableConnectAccount(
+    capabilities: WalletConnectCapabilities | undefined,
+  ): Address.Address | undefined {
+    const state = store.getState()
+    if (state.accounts.length === 0) return undefined
+    if (capabilities && 'selectAccount' in capabilities && capabilities.selectAccount)
+      return undefined
+    if (capabilities && 'credentialId' in capabilities && capabilities.credentialId) {
+      const account = state.accounts.find(
+        (a) => 'credential' in a && a.credential?.id === capabilities.credentialId,
+      )
+      return account?.address
+    }
+    if (capabilities?.method === 'register' && capabilities.name) {
+      const account = state.accounts.find(
+        (a) => 'credential' in a && a.label?.toLowerCase() === capabilities.name!.toLowerCase(),
+      )
+      return account?.address
+    }
+    return state.accounts[state.activeAccount]?.address ?? state.accounts[0]?.address
+  }
+
+  async function authorizeDefaultAccessKeyForTransaction(options_: {
+    address: Address.Address
+    calls?: readonly AccessKey.Call[] | undefined
+    chainId: number
+  }): Promise<void> {
+    const parameters = options.authorizeAccessKey?.()
+    if (!parameters) return
+    const existing = await store.accessKeys.select({
+      account: options_.address,
+      ...(options_.calls ? { calls: options_.calls } : {}),
+      chainId: Number(parameters.chainId ?? options_.chainId),
+    })
+    if (existing) return
+    if (!AccessKey.canAuthorizeCalls({ parameters, calls: options_.calls })) return
+    const decoded = stripAuthorizeAccessKey(parameters)
+    await authorizeAccessKeyAction(decoded, {
+      method: 'wallet_authorizeAccessKey',
+      params: [z.encode(Rpc.wallet_authorizeAccessKey.parameters, decoded)!],
+    })
+  }
+
   const provider = Object.assign(
     ox_Provider.from(
       {
@@ -722,11 +796,19 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
                     const state = store.getState()
+                    const chainId = decoded.chainId ?? state.chainId
+                    const from = decoded.from ?? state.accounts[state.activeAccount]?.address
+                    if (from)
+                      await authorizeDefaultAccessKeyForTransaction({
+                        address: from,
+                        ...(calls ? { calls } : {}),
+                        chainId,
+                      })
                     return (await sendTransactionAction(
                       {
                         ...rest,
-                        chainId: decoded.chainId ?? state.chainId,
-                        from: decoded.from ?? state.accounts[state.activeAccount]?.address,
+                        chainId,
+                        from,
                         ...(calls ? { calls } : {}),
                         feePayer: resolveFeePayer(decoded.feePayer),
                       },
@@ -827,11 +909,19 @@ export function create(options: create.Options = {}): create.ReturnType {
                     const calls =
                       decoded.calls ?? (to ? [{ to, data, value: decoded.value }] : undefined)
                     const state = store.getState()
+                    const chainId = decoded.chainId ?? state.chainId
+                    const from = decoded.from ?? state.accounts[state.activeAccount]?.address
+                    if (from)
+                      await authorizeDefaultAccessKeyForTransaction({
+                        address: from,
+                        ...(calls ? { calls } : {}),
+                        chainId,
+                      })
                     return (await sendTransactionSyncAction(
                       {
                         ...rest,
-                        chainId: decoded.chainId ?? state.chainId,
-                        from: decoded.from ?? state.accounts[state.activeAccount]?.address,
+                        chainId,
+                        from,
                         ...(calls ? { calls } : {}),
                         feePayer: resolveFeePayer(decoded.feePayer),
                       },
@@ -873,10 +963,17 @@ export function create(options: create.Options = {}): create.ReturnType {
                         capabilities?.feePayer ?? (feePayerConfig ? true : undefined),
                       )
                       const state = store.getState()
+                      const from_ = from ?? state.accounts[state.activeAccount]?.address
+                      if (from_)
+                        await authorizeDefaultAccessKeyForTransaction({
+                          address: from_,
+                          calls,
+                          chainId: chainId ?? state.chainId,
+                        })
                       const txRequest = {
                         calls,
                         chainId,
-                        from: from ?? state.accounts[state.activeAccount]?.address,
+                        from: from_,
                         ...(feePayer ? { feePayer } : {}),
                       }
                       if (!sync) {
@@ -1021,7 +1118,11 @@ export function create(options: create.Options = {}): create.ReturnType {
 
                     const capabilities = request._decoded.params?.[0]?.capabilities
                     const authorizeAccessKey =
-                      capabilities?.authorizeAccessKey ?? options.authorizeAccessKey?.()
+                      capabilities?.authorizeAccessKey ??
+                      (await defaultAuthorizeAccessKeyForConnect({
+                        capabilities,
+                        chainId: chainId ?? store.getState().chainId,
+                      }))
 
                     // Server Authentication: pre-resolve `auth` URLs against
                     // this dapp-side Provider's `window.location.origin`. The
@@ -1573,10 +1674,11 @@ export declare namespace create {
     /**
      * Default access key parameters for `wallet_connect`.
      *
-     * When set, `wallet_connect` will automatically authorize an access key.
-     * Return `undefined` to skip authorization for the current request.
+     * When set, `wallet_connect` and send transaction requests will authorize
+     * an access key only when no reusable local key is available. Return
+     * `undefined` to skip authorization for the current request.
      */
-    authorizeAccessKey?: (() => Adapter.authorizeAccessKey.Parameters | undefined) | undefined
+    authorizeAccessKey?: (() => AuthorizeAccessKeyParameters | undefined) | undefined
     /**
      * Supported chains. First chain is the default.
      * @default [tempo, tempoModerato, tempoDevnet]
@@ -1635,6 +1737,12 @@ export declare namespace create {
      * ```
      */
     transports?: Record<number, Transport> | undefined
+  }
+
+  /** Default access-key authorization parameters with SDK-only reuse policy. */
+  type AuthorizeAccessKeyParameters = Adapter.authorizeAccessKey.Parameters & {
+    /** SDK-only policy for deciding whether a stored local key can be reused. */
+    reuse?: AccessKey.ReusePolicy | undefined
   }
   type ReturnType = Provider
 }

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -668,11 +668,17 @@ export function create(options: create.Options = {}): create.ReturnType {
     return rest
   }
 
+  function resolveDefaultAuthorizeAccessKey(): create.AuthorizeAccessKeyParameters | undefined {
+    const authorizeAccessKey = options.authorizeAccessKey
+    if (typeof authorizeAccessKey === 'function') return authorizeAccessKey()
+    return authorizeAccessKey
+  }
+
   async function defaultAuthorizeAccessKeyForConnect(options_: {
     capabilities: WalletConnectCapabilities | undefined
     chainId: number
   }): Promise<Adapter.authorizeAccessKey.Parameters | undefined> {
-    const parameters = options.authorizeAccessKey?.()
+    const parameters = resolveDefaultAuthorizeAccessKey()
     if (!parameters) return undefined
     const address = reusableConnectAccount(options_.capabilities)
     if (
@@ -715,7 +721,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     calls?: readonly AccessKey.Call[] | undefined
     chainId: number
   }): Promise<void> {
-    const parameters = options.authorizeAccessKey?.()
+    const parameters = resolveDefaultAuthorizeAccessKey()
     if (!parameters) return
     const existing = await store.accessKeys.select({
       account: options_.address,
@@ -1674,11 +1680,13 @@ export declare namespace create {
     /**
      * Default access key parameters for `wallet_connect`.
      *
-     * When set, `wallet_connect` and send transaction requests will authorize
-     * an access key only when no reusable local key is available. Return
-     * `undefined` to skip authorization for the current request.
+     * Pass an object to use the same access-key policy for every applicable
+     * request, or a function to compute it dynamically. When set,
+     * `wallet_connect` and send transaction requests will authorize an access
+     * key only when no reusable local key is available. Return `undefined`
+     * from the function to skip authorization for the current request.
      */
-    authorizeAccessKey?: (() => AuthorizeAccessKeyParameters | undefined) | undefined
+    authorizeAccessKey?: AuthorizeAccessKey | undefined
     /**
      * Supported chains. First chain is the default.
      * @default [tempo, tempoModerato, tempoDevnet]
@@ -1744,6 +1752,10 @@ export declare namespace create {
     /** SDK-only policy for deciding whether a stored local key can be reused. */
     reuse?: AccessKey.ReusePolicy | undefined
   }
+  /** Static or dynamic default access-key authorization policy. */
+  type AuthorizeAccessKey =
+    | AuthorizeAccessKeyParameters
+    | (() => AuthorizeAccessKeyParameters | undefined)
   type ReturnType = Provider
 }
 


### PR DESCRIPTION
## Summary
Automatically provision access keys when possible, and authorize them just-in-time for matching transactions.

```
Provider.create({ authorizeAccessKey: { expiry, limits, scopes }})
```

## Motivation
Apps could configure an `authorizeAccessKey` function on their Provider but behavior was too coarse:
- a new access key would always get authorized even if one existed
- it only triggered on `wallet_connect`

This required apps to have to write checks before connecting or sending transactions that they had an access key around that met their criteria. Now apps can declare their desired access key once and it'll get automatically provisioned anytime it's not available.

## Flow
```mermaid
flowchart TD
  Config["Provider configured with authorizeAccessKey"]

  Config --> Connect["wallet_connect"]
  Connect --> SelectConnect["Accounts SDK checks stored access keys by chain, scope, minLimit, and minExpiry"]
  SelectConnect -->|"matching key found"| PlainConnect["Send wallet_connect without authorizeAccessKey capability"]
  SelectConnect -->|"no matching key"| AuthConnect["Attach authorizeAccessKey to wallet_connect capabilities"]
  PlainConnect --> Connected["Connected"]
  AuthConnect --> Connected

  Config --> Tx["eth_sendTransaction / wallet_sendCalls"]
  Tx --> SelectTx["Accounts SDK checks whether a stored key satisfies the transaction"]
  SelectTx -->|"stored key satisfies transaction"| SendKey["Send with access key"]
  SelectTx -->|"no key, configured authorization would satisfy transaction"| AuthTx["Request wallet_authorizeAccessKey"]
  AuthTx --> SendKey
  SelectTx -->|"configured authorization would not satisfy transaction"| Root["Send with root account"]
```
