### PR TITLE
fix(playground): keep Privy React in one chunk

### DIFF
--- a/playgrounds/web/vite.config.ts
+++ b/playgrounds/web/vite.config.ts
@@ -5,6 +5,15 @@ import icons from 'unplugin-icons/vite'
 import { defineConfig } from 'vp'
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/node_modules/@privy-io/react-auth/')) return 'privy-react'
+        },
+      },
+    },
+  },
   server: {
     host: process.env.VITE_HOST ?? 'localhost',
     port: Number(process.env.PORT ?? 5173),


### PR DESCRIPTION
Production playground builds now keep `@privy-io/react-auth` modules in a single `privy-react` chunk.

The Privy React bridge was mounted under `PrivyProvider`, but prod chunking split Privy's provider sentinel and hook modules. `useWallets()` could then read a different context instance than the provider had initialized, producing the misleading outside-provider warning and the follow-on `current` crash.

Keeping Privy's React internals in one manual chunk preserves lazy loading for the rest of the app while ensuring `PrivyProvider`, `usePrivy()`, and `useWallets()` share the same module instance.