### PR TITLE
fix(playground): dedupe Privy React provider imports

### DIFF
--- a/playgrounds/web/vite.config.ts
+++ b/playgrounds/web/vite.config.ts
@@ -1,10 +1,21 @@
 import { cloudflare } from '@cloudflare/vite-plugin'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath } from 'node:url'
 import regen from 'regen-ui/vite'
 import icons from 'unplugin-icons/vite'
 import { defineConfig } from 'vp'
 
+const privyReactAuth = fileURLToPath(
+  new URL('./node_modules/@privy-io/react-auth/dist/esm/index.mjs', import.meta.url),
+)
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@privy-io/react-auth': privyReactAuth,
+    },
+    dedupe: ['@privy-io/react-auth', 'react', 'react-dom'],
+  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
Production playground builds now canonicalize `@privy-io/react-auth` to the playground dependency before placing Privy React code in the manual chunk.

The first chunking fix kept Privy code together, but prod still bundled two transformed copies of Privy's provider contexts. `PrivyProvider` installed one copy while `PrivyAccountsBridge` read another, so `useWallets()` and `useLogin()` behaved as though they were outside the provider.

The alias and dedupe config force the playground and workspace `accounts/react/privy` import to share the same Privy React module instance.