### PR TITLE
fix(playground): use KV for challenge nonce store

### DIFF
--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -93,34 +93,45 @@ payment.onPaymentSuccess(recordInspection)
 const walletOrigin = process.env.VITE_WALLET_HOST
   ? new URL(process.env.VITE_WALLET_HOST).origin
   : undefined
-const auth = Handler.auth({
-  origin: process.env.ORIGIN,
-  path: '/auth',
-  // Opt into OIDC identity verification. `issuer` defaults to the Tempo wallet's
-  // production OIDC mount; override it for local dev (or a self-hosted wallet).
-  identity: walletOrigin ? { issuer: `${walletOrigin}/api/oidc` } : {},
-})
 
-const handler = Handler.compose([
-  Handler.webAuthn({
-    kv: Kv.memory(),
+// `Handler.auth`/`Handler.webAuthn` need the KV binding from `env`, so build them
+// lazily on first request and memoize. The default in-memory store is
+// isolate-local and loses challenges across isolates, causing `409` on verify;
+// a shared KV store fixes that.
+let handlers: ReturnType<typeof createHandlers> | undefined
+function createHandlers(env: Cloudflare.Env) {
+  const store = Kv.cloudflare(env.NONCE_KV)
+  const auth = Handler.auth({
     origin: process.env.ORIGIN,
-    path: '/webauthn',
-    rpId: process.env.RP_ID,
-  }),
-  Handler.relay({
-    feePayer: {
-      account,
-      name: 'Playground',
-      url: 'https://playground.tempo.xyz',
-    },
-    path: '/relay',
-  }),
-  auth,
-])
+    path: '/auth',
+    // Opt into OIDC identity verification. `issuer` defaults to the Tempo wallet's
+    // production OIDC mount; override it for local dev (or a self-hosted wallet).
+    identity: walletOrigin ? { issuer: `${walletOrigin}/api/oidc` } : {},
+    store,
+  })
+  const handler = Handler.compose([
+    Handler.webAuthn({
+      kv: store,
+      origin: process.env.ORIGIN,
+      path: '/webauthn',
+      rpId: process.env.RP_ID,
+    }),
+    Handler.relay({
+      feePayer: {
+        account,
+        name: 'Playground',
+        url: 'https://playground.tempo.xyz',
+      },
+      path: '/relay',
+    }),
+    auth,
+  ])
+  return { auth, handler }
+}
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
+    const { auth, handler } = (handlers ??= createHandlers(env))
     const url = new URL(request.url)
 
     if (url.pathname === '/mpp/inspect') {

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
-  "kv_namespaces": [{ "binding": "NONCE_KV", "id": "5da9137e853d4009954fab6f689ca61b" }],
+  "kv_namespaces": [{ "binding": "NONCE_KV", "id": "5c4651ee1bf344cf9ccafa91981423b8" }],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": [

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -4,10 +4,6 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
-  // KV backs the single-use SIWE/WebAuthn challenge store. The default in-memory
-  // store is isolate-local, so a challenge written on `/auth/challenge` is missing
-  // when `/auth` verify lands on a different isolate → `409 invalid or replayed
-  // nonce`. A shared store fixes that.
   "kv_namespaces": [{ "binding": "NONCE_KV", "id": "5da9137e853d4009954fab6f689ca61b" }],
   "assets": {
     "not_found_handling": "single-page-application",

--- a/playgrounds/web/wrangler.jsonc
+++ b/playgrounds/web/wrangler.jsonc
@@ -4,6 +4,11 @@
   "compatibility_date": "2026-03-09",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./worker/index.ts",
+  // KV backs the single-use SIWE/WebAuthn challenge store. The default in-memory
+  // store is isolate-local, so a challenge written on `/auth/challenge` is missing
+  // when `/auth` verify lands on a different isolate → `409 invalid or replayed
+  // nonce`. A shared store fixes that.
+  "kv_namespaces": [{ "binding": "NONCE_KV", "id": "5da9137e853d4009954fab6f689ca61b" }],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": [


### PR DESCRIPTION
## Problem

Enabling **Authenticate with Server** in the hosted playground (`accounts-pg.tempo.xyz`) returns:

```
RpcResponse.InternalError: Server Authentication verify endpoint `.../auth` returned 409.
```

The playground built `Handler.auth` / `Handler.webAuthn` with the default `Kv.memory()` store. On Cloudflare, `/auth/challenge` writes the nonce into **isolate-local** memory, then `/auth` verify frequently lands on a **different isolate** where the nonce is gone → `409 invalid or replayed nonce`. It's a playground deployment/config bug, not a wallet_connect/OIDC regression.

## Fix

Back the single-use SIWE/WebAuthn challenge store with a shared KV namespace (`NONCE_KV`) so the nonce survives across isolates.

- `wrangler.jsonc` — add `NONCE_KV` binding.
- `worker/index.ts` — build `auth`/`handler` lazily from `env` (the KV binding only exists on `env`, not `process.env`), memoized per isolate; `Handler.auth` and `Handler.webAuthn` share `Kv.cloudflare(env.NONCE_KV)`.

## Notes

- The KV namespace was provisioned via `wrangler kv namespace create NONCE_KV` (id `5da9137e853d4009954fab6f689ca61b`). **Hosted playground must be redeployed** for the fix to take effect.
- `Kv.cloudflare` is eventually consistent; the SDK docs recommend a Durable Object (`Kv.durableObject` + `Kv.NonceStorage`) for strict single-use nonce semantics. KV removes the 100%-reproducible cross-isolate miss, which is sufficient for the playground. If rare 409s reappear, switch this binding to a DO.

## Test plan

- [x] `pnpm check:types` (playground)
- [ ] Redeploy hosted playground and verify **Authenticate with Server** succeeds