### PR TITLE
fix: allow explicit trustProxy in place of pinned auth origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "src": "./src/index.ts",
       "react-native": "./dist/index.js",
+      "src": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./server": {
@@ -165,20 +165,20 @@
     },
     "./react-native": {
       "types": "./dist/react-native/index.d.ts",
-      "src": "./src/react-native/index.ts",
       "react-native": "./dist/react-native/index.js",
+      "src": "./src/react-native/index.ts",
       "default": "./dist/react-native/index.js"
     },
     "./react-native/async-storage": {
       "types": "./dist/react-native/asyncStorage.d.ts",
-      "src": "./src/react-native/asyncStorage.ts",
       "react-native": "./dist/react-native/asyncStorage.js",
+      "src": "./src/react-native/asyncStorage.ts",
       "default": "./dist/react-native/asyncStorage.js"
     },
     "./react-native/secure-storage": {
       "types": "./dist/react-native/secureStorage.d.ts",
-      "src": "./src/react-native/secureStorage.ts",
       "react-native": "./dist/react-native/secureStorage.js",
+      "src": "./src/react-native/secureStorage.ts",
       "default": "./dist/react-native/secureStorage.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "react-native": "./dist/index.js",
       "src": "./src/index.ts",
+      "react-native": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./server": {
@@ -165,20 +165,20 @@
     },
     "./react-native": {
       "types": "./dist/react-native/index.d.ts",
-      "react-native": "./dist/react-native/index.js",
       "src": "./src/react-native/index.ts",
+      "react-native": "./dist/react-native/index.js",
       "default": "./dist/react-native/index.js"
     },
     "./react-native/async-storage": {
       "types": "./dist/react-native/asyncStorage.d.ts",
-      "react-native": "./dist/react-native/asyncStorage.js",
       "src": "./src/react-native/asyncStorage.ts",
+      "react-native": "./dist/react-native/asyncStorage.js",
       "default": "./dist/react-native/asyncStorage.js"
     },
     "./react-native/secure-storage": {
       "types": "./dist/react-native/secureStorage.d.ts",
-      "react-native": "./dist/react-native/secureStorage.js",
       "src": "./src/react-native/secureStorage.ts",
+      "react-native": "./dist/react-native/secureStorage.js",
       "default": "./dist/react-native/secureStorage.js"
     }
   }

--- a/playgrounds/web/.env.example
+++ b/playgrounds/web/.env.example
@@ -1,4 +1,6 @@
-ORIGIN=https://localhost:5173
+# Leave ORIGIN unset in local dev — the auth handler trusts proxy headers
+# (`trustProxy`). Pin it for deployments, e.g. ORIGIN=https://app.example.com
+ORIGIN=
 RP_ID=localhost
 MPP_SECRET_KEY=secret-key
 # note: "test test ..." mnemonic private key

--- a/playgrounds/web/.env.example
+++ b/playgrounds/web/.env.example
@@ -1,6 +1,7 @@
-# Leave ORIGIN unset in local dev — the auth handler trusts proxy headers
-# (`trustProxy`). Pin it for deployments, e.g. ORIGIN=https://app.example.com
+# Pin for deployments, e.g. ORIGIN=https://app.example.com
 ORIGIN=
+# Trust x-forwarded-* from the local dev proxies (OrbStack domains, vite)
+TRUST_PROXY=true
 RP_ID=localhost
 MPP_SECRET_KEY=secret-key
 # note: "test test ..." mnemonic private key

--- a/playgrounds/web/env.d.ts
+++ b/playgrounds/web/env.d.ts
@@ -4,5 +4,6 @@ declare namespace NodeJS {
     RP_ID: string
     MPP_SECRET_KEY: string
     PRIVATE_KEY: `0x${string}`
+    TRUST_PROXY: string
   }
 }

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -101,15 +101,10 @@ const walletOrigin = process.env.VITE_WALLET_HOST
 let handlers: ReturnType<typeof createHandlers> | undefined
 function createHandlers(env: Cloudflare.Env) {
   const store = Kv.cloudflare(env.NONCE_KV)
-  const origin = process.env.ORIGIN || undefined
   const auth = Handler.auth({
-    origin,
+    origin: process.env.ORIGIN || undefined,
     path: '/auth',
-    // Local dev only: with no `ORIGIN` pinned, derive the SIWE binding from
-    // forwarded headers — the playground sits behind trusted proxies
-    // (OrbStack domains, vite) on per-checkout hostnames. Deployments pin
-    // `ORIGIN` instead.
-    trustProxy: !origin,
+    trustProxy: process.env.TRUST_PROXY === 'true',
     // Opt into OIDC identity verification. `issuer` defaults to the Tempo wallet's
     // production OIDC mount; override it for local dev (or a self-hosted wallet).
     identity: walletOrigin ? { issuer: `${walletOrigin}/api/oidc` } : {},

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -102,8 +102,12 @@ let handlers: ReturnType<typeof createHandlers> | undefined
 function createHandlers(env: Cloudflare.Env) {
   const store = Kv.cloudflare(env.NONCE_KV)
   const auth = Handler.auth({
-    origin: process.env.ORIGIN,
+    // Local dev serves the playground behind trusted proxies (OrbStack
+    // domains, vite) on per-checkout hostnames, so derive the SIWE binding
+    // from forwarded headers; deployments pin the canonical origin via `ORIGIN`.
+    origin: process.env.ORIGIN || undefined,
     path: '/auth',
+    trustProxy: true,
     // Opt into OIDC identity verification. `issuer` defaults to the Tempo wallet's
     // production OIDC mount; override it for local dev (or a self-hosted wallet).
     identity: walletOrigin ? { issuer: `${walletOrigin}/api/oidc` } : {},

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -101,13 +101,15 @@ const walletOrigin = process.env.VITE_WALLET_HOST
 let handlers: ReturnType<typeof createHandlers> | undefined
 function createHandlers(env: Cloudflare.Env) {
   const store = Kv.cloudflare(env.NONCE_KV)
+  const origin = process.env.ORIGIN || undefined
   const auth = Handler.auth({
-    // Local dev serves the playground behind trusted proxies (OrbStack
-    // domains, vite) on per-checkout hostnames, so derive the SIWE binding
-    // from forwarded headers; deployments pin the canonical origin via `ORIGIN`.
-    origin: process.env.ORIGIN || undefined,
+    origin,
     path: '/auth',
-    trustProxy: true,
+    // Local dev only: with no `ORIGIN` pinned, derive the SIWE binding from
+    // forwarded headers — the playground sits behind trusted proxies
+    // (OrbStack domains, vite) on per-checkout hostnames. Deployments pin
+    // `ORIGIN` instead.
+    trustProxy: !origin,
     // Opt into OIDC identity verification. `issuer` defaults to the Tempo wallet's
     // production OIDC mount; override it for local dev (or a self-hosted wallet).
     identity: walletOrigin ? { issuer: `${walletOrigin}/api/oidc` } : {},

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -49,6 +49,25 @@ describe('challenge', () => {
     )
   })
 
+  test('explicit trustProxy substitutes for a pinned origin', async () => {
+    const app = new Hono().route('/', auth({ trustProxy: true }))
+
+    const res = await app.request('/challenge', {
+      body: JSON.stringify({ chainId: 1 }),
+      headers: {
+        'content-type': 'application/json',
+        host: 'internal.upstream',
+        'x-forwarded-host': 'app.example.com',
+        'x-forwarded-proto': 'https',
+      },
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    const { message } = (await res.json()) as { message: string }
+    expect(parseSiweMessage(message).domain).toBe('app.example.com')
+  })
+
   test('returns challenge message with chainId, nonce, zero-address placeholder', async () => {
     const { app } = setup()
 

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -45,7 +45,7 @@ function signWitnessKeyAuth(options: {
 describe('challenge', () => {
   test('error: requires pinned origin or domain', () => {
     expect(() => auth()).toThrowErrorMatchingInlineSnapshot(
-      `[Error: \`auth()\` requires \`origin\` or \`domain\` to pin SIWE domain binding.]`,
+      `[Error: \`auth()\` requires \`origin\` or \`domain\` to pin SIWE domain binding (or explicit \`trustProxy: true\`).]`,
     )
   })
 

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -167,11 +167,10 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     ...rest
   } = options
 
-  // Explicit `trustProxy: true` is an acceptable alternative to pinning:
-  // the operator vouches that a proxy in front sets `x-forwarded-*`
-  // honestly (e.g. local dev behind OrbStack/vite on per-checkout hosts).
   if (!origin_option && !domain && !options.trustProxy)
-    throw new Error('`auth()` requires `origin` or `domain` to pin SIWE domain binding.')
+    throw new Error(
+      '`auth()` requires `origin` or `domain` to pin SIWE domain binding (or explicit `trustProxy: true`).',
+    )
 
   async function take(key: string): Promise<ChallengePayload | undefined> {
     if (store.take) return store.take<ChallengePayload>(key)
@@ -520,6 +519,10 @@ export declare namespace auth {
      * `false`, forwarded headers are ignored to prevent spoofing on
      * deployments that expose the origin server directly. Ignored when
      * `origin` is set.
+     *
+     * Explicitly passing `true` also satisfies the `origin`/`domain`
+     * requirement. Only do so behind a proxy that overwrites (not appends)
+     * `x-forwarded-host` and is the only way to reach the server.
      * @default `true` on Cloudflare Workers (always edge-fronted), `false` elsewhere.
      */
     trustProxy?: boolean | undefined

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -167,7 +167,10 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     ...rest
   } = options
 
-  if (!origin_option && !domain)
+  // Explicit `trustProxy: true` is an acceptable alternative to pinning:
+  // the operator vouches that a proxy in front sets `x-forwarded-*`
+  // honestly (e.g. local dev behind OrbStack/vite on per-checkout hosts).
+  if (!origin_option && !domain && !options.trustProxy)
     throw new Error('`auth()` requires `origin` or `domain` to pin SIWE domain binding.')
 
   async function take(key: string): Promise<ChallengePayload | undefined> {


### PR DESCRIPTION
## Summary
Let an explicit `trustProxy: true` satisfy `Handler.auth`'s SIWE domain-binding requirement in place of a pinned `origin`/`domain`, and use it in the web playground so local dev works on any proxied hostname.

## Motivation
The playground dev script copies `.env.example` → `.env`, which pinned `ORIGIN=https://localhost:5173` into the worker. Auth challenges therefore bound `localhost:5173`, and the client-side origin validation correctly rejected `wallet_connect` auth on any real dev host (e.g. OrbStack per-worktree domains like `playground-<slug>.tempo.local`):

> Server Authentication challenge endpoint … returned a message bound to `localhost:5173` (expected `playground-81e1.tempo.local`)

The validation error already suggests `trustProxy: true` as the remedy, but `auth()` hard-required a pinned `origin`/`domain`, so the suggestion wasn't actually usable.

## Changes
- `Handler.auth`: explicit `trustProxy: true` now satisfies the pin requirement — the operator vouches that a fronting proxy sets `x-forwarded-*` honestly. The Cloudflare Workers `trustProxy` *default* does not relax the requirement; only explicit opt-in does, so the #458 pinned-domain hardening is preserved for deployments.
- Web playground: proxy trust is an explicit operator opt-in — `trustProxy: process.env.TRUST_PROXY === 'true'`; deployments pin via `ORIGIN` instead.
- `.env.example`: leave `ORIGIN` unset and set `TRUST_PROXY=true` for local dev.

## Testing
- `vp test src/server/internal/handlers/auth.test.ts` — 49 passed, including a new test that a `trustProxy`-only handler binds the challenge to `x-forwarded-host`.
- Verified live against a wallet-next dev stack: `POST https://playground-81e1.tempo.local/auth/challenge` now binds `playground-81e1.tempo.local` / `URI: https://playground-81e1.tempo.local`, and `wallet_connect` auth proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
