### PR TITLE
docs: simplify mobile web auth required labels

### DIFF
--- a/site/src/pages/docs/api/mobileWebAuth.mdx
+++ b/site/src/pages/docs/api/mobileWebAuth.mdx
@@ -91,14 +91,14 @@ Override the fetch implementation used for discovery and auth-session requests.
 ### host
 
 - **Type:** `string | object`
-- **Required by:** `mobileWebAuth`
+- **Required**
 
 Wallet discovery origin, or a preloaded host document.
 
 ### name
 
 - **Type:** `string`
-- **Required by:** `mobileWebAuth`
+- **Required**
 
 Provider display name.
 
@@ -116,7 +116,7 @@ import { openAuthSession } from 'accounts/react-native/expo-web-browser'
 ### rdns
 
 - **Type:** `string`
-- **Required by:** `mobileWebAuth`
+- **Required**
 
 Reverse-DNS provider identifier.
 


### PR DESCRIPTION
Drops `Required by: mobileWebAuth` in favor of `Required` on the mobileWebAuth reference page — the parameters section only documents `mobileWebAuth()` now.