### PR TITLE
feat(playground): native React Native UI and production wallet support

### DIFF
--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -3,8 +3,8 @@ import { mobileWebAuth, tempoWallet } from 'accounts/mobileWebAuth'
 import { secureStorage } from 'accounts/react-native/expo-secure-store'
 import { openAuthSession } from 'accounts/react-native/expo-web-browser'
 import { StatusBar } from 'expo-status-bar'
-import { Hex } from 'ox'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Hex, Json } from 'ox'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
 import {
   Button,
   ColorSchemeName,
@@ -17,9 +17,11 @@ import {
   useColorScheme,
   View,
 } from 'react-native'
-import { formatUnits, parseUnits, type Address, type Hex as viem_Hex } from 'viem'
+import { formatUnits, parseUnits, type Address } from 'viem'
 import { Actions } from 'viem/tempo'
 import { tempoModerato } from 'viem/tempo/chains'
+
+import ConnectForm from './ConnectForm'
 
 const chain = tempoModerato
 
@@ -64,88 +66,153 @@ const provider = Provider.create({
   storage: secureStorage(),
 })
 
-const getBackgroundColor = (colorScheme: ColorSchemeName) => {
-  return colorScheme === 'dark' ? 'black' : 'white'
-}
+const text = (scheme: ColorSchemeName) => (scheme === 'dark' ? 'white' : 'black')
+const muted = (scheme: ColorSchemeName) => (scheme === 'dark' ? '#aaa' : '#666')
+const border = (scheme: ColorSchemeName) => (scheme === 'dark' ? '#444' : '#ccc')
+const background = (scheme: ColorSchemeName) => (scheme === 'dark' ? 'black' : 'white')
 
-const getTextColor = (colorScheme: ColorSchemeName) => {
-  return colorScheme === 'dark' ? 'white' : 'black'
-}
-
-const ThemedText = ({
-  children,
-  style,
-}: {
-  children: React.ReactNode
-  style?: StyleProp<TextStyle>
-}) => {
-  const colorScheme = useColorScheme()
-  return <Text style={[{ color: getTextColor(colorScheme) }, style]}>{children}</Text>
+const ThemedText = ({ children, style }: { children: ReactNode; style?: StyleProp<TextStyle> }) => {
+  const scheme = useColorScheme()
+  return <Text style={[{ color: text(scheme) }, style]}>{children}</Text>
 }
 
 const ThemedTextInput = (props: TextInputProps) => {
-  const colorScheme = useColorScheme()
-  const style = useMemo(
-    () => ({ color: getTextColor(colorScheme), ...props.style }),
-    [colorScheme, props.style],
+  const scheme = useColorScheme()
+  return (
+    <TextInput
+      autoCapitalize="none"
+      autoCorrect={false}
+      placeholderTextColor={muted(scheme)}
+      {...props}
+      style={[
+        {
+          borderColor: border(scheme),
+          borderRadius: 6,
+          borderWidth: 1,
+          color: text(scheme),
+          padding: 8,
+        },
+        props.style,
+      ]}
+    />
   )
-  return <TextInput {...props} style={style} />
+}
+
+/** Runs an async request and tracks its result/error/pending state. */
+function useRequest() {
+  const [result, setResult] = useState<unknown>()
+  const [error, setError] = useState<string>()
+  const [pending, setPending] = useState(false)
+  const run = useCallback(async (fn: () => Promise<unknown>) => {
+    setPending(true)
+    setError(undefined)
+    try {
+      setResult(await fn())
+    } catch (e) {
+      setResult(undefined)
+      setError(e instanceof Error ? `${e.name}: ${e.message}` : String(e))
+    } finally {
+      setPending(false)
+    }
+  }, [])
+  return { error, pending, result, run }
+}
+
+/** Card showing a JSON-RPC method, its controls, and the latest result/error. */
+function Method(props: {
+  children: ReactNode
+  error?: string | undefined
+  result?: unknown
+  title: string
+}) {
+  const scheme = useColorScheme()
+  return (
+    <View
+      style={{
+        borderColor: border(scheme),
+        borderRadius: 8,
+        borderWidth: 1,
+        gap: 8,
+        marginTop: 12,
+        padding: 12,
+      }}
+    >
+      <Text style={{ color: text(scheme), fontFamily: 'Courier', fontWeight: '600' }}>
+        {props.title}
+      </Text>
+      {props.children}
+      {props.error && (
+        <Text style={{ color: '#dc2626', fontFamily: 'Courier', fontSize: 11 }} selectable>
+          {props.error}
+        </Text>
+      )}
+      {props.result !== undefined && (
+        <Text style={{ color: text(scheme), fontFamily: 'Courier', fontSize: 11 }} selectable>
+          {stringify(props.result)}
+        </Text>
+      )}
+    </View>
+  )
+}
+
+function Section(props: { children: ReactNode; title: string }) {
+  const scheme = useColorScheme()
+  return (
+    <View style={{ marginTop: 28 }}>
+      <Text
+        style={{
+          color: muted(scheme),
+          fontSize: 13,
+          fontWeight: '700',
+          textTransform: 'uppercase',
+        }}
+      >
+        {props.title}
+      </Text>
+      {props.children}
+    </View>
+  )
 }
 
 export default function App() {
-  const colorScheme = useColorScheme()
+  const scheme = useColorScheme()
   const [address, setAddress] = useState<Address | null>(null)
   const [status, setStatus] = useState('disconnected')
   const [balance, setBalance] = useState<string | null>(null)
-  const [faucetStatus, setFaucetStatus] = useState<string | null>(null)
-  const [isFunding, setIsFunding] = useState(false)
-  const [txHash, setTxHash] = useState<viem_Hex | null>(null)
-  const [signature, setSignature] = useState<viem_Hex | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [to, setTo] = useState('0x0000000000000000000000000000000000000001')
-  const [amount, setAmount] = useState('1')
-  const [message, setMessage] = useState('hello world')
   const [network, setNetwork] = useState('mainnet')
-  const [showDeposit, setShowDeposit] = useState(false)
+  const connectReq = useRequest()
 
-  const switchNetwork = useCallback(async (network: string) => {
-    provider.request({
-      method: 'wallet_switchEthereumChain',
-      params: [{ chainId: Hex.fromNumber(chain.id) }],
-    })
-    setNetwork(network)
-  }, [])
-  console.log('error', error)
-
-  const connect = useCallback(async () => {
-    try {
+  const connect = useCallback(
+    async (capabilities: Record<string, unknown>) => {
       setStatus('connecting')
-      setError(null)
-      let result = await provider.request({
-        method: 'wallet_connect',
-        ...(showDeposit ? { params: [{ capabilities: { showDeposit: true } }] } : {}),
-      })
+      const result = (await connectReq.run(() =>
+        provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: capabilities as never, chainId: Hex.fromNumber(chain.id) }],
+        }),
+      )) as unknown
+      void result
+    },
+    [connectReq],
+  )
 
-      const addr = result.accounts[0]?.address
-      console.log('here', result.accounts[0])
-      if (addr) {
-        setAddress(addr)
-        setStatus('connected')
-        const chainId = result.accounts[0]?.capabilities.keyAuthorization?.chainId
-        if (chainId) {
-          setNetwork(chainId === Hex.fromNumber(tempoModerato.id) ? 'moderato' : 'mainnet')
-        } else {
-          setNetwork('mainnet')
+  // Reflect the connect result into top-level connection state.
+  useEffect(() => {
+    const result = connectReq.result as
+      | {
+          accounts?: {
+            address: Address
+            capabilities: { keyAuthorization?: { chainId?: string } }
+          }[]
         }
-      } else {
-        setError('No account returned from wallet_connect.')
-        setStatus('disconnected')
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-      setStatus('disconnected')
-    }
-  }, [showDeposit])
+      | undefined
+    const account = result?.accounts?.[0]
+    if (!account) return
+    setAddress(account.address)
+    setStatus('connected')
+    const chainId = account.capabilities.keyAuthorization?.chainId
+    setNetwork(chainId === Hex.fromNumber(tempoModerato.id) || !chainId ? 'moderato' : 'mainnet')
+  }, [connectReq.result])
 
   const disconnect = useCallback(async () => {
     try {
@@ -154,10 +221,6 @@ export default function App() {
     setAddress(null)
     setStatus('disconnected')
     setBalance(null)
-    setFaucetStatus(null)
-    setTxHash(null)
-    setSignature(null)
-    setError(null)
   }, [])
 
   const fetchBalance = useCallback(async () => {
@@ -180,158 +243,457 @@ export default function App() {
     return () => clearInterval(interval)
   }, [address, fetchBalance])
 
-  const fund = useCallback(async () => {
-    if (!address) return
-    try {
-      setError(null)
-      setFaucetStatus(null)
-      setIsFunding(true)
-      const receipts = await Actions.faucet.fundSync(provider.getClient({ chainId: chain.id }), {
-        account: address,
-        timeout: 30_000,
-      })
-      setFaucetStatus(`Funded ${receipts.length} transaction${receipts.length === 1 ? '' : 's'}.`)
-      await fetchBalance()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setIsFunding(false)
-    }
-  }, [address, fetchBalance])
-
-  const send = useCallback(async () => {
-    if (!address) return
-    try {
-      setError(null)
-      const hash = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            chainId: Hex.fromNumber(chain.id),
-            feeToken: tokens.pathUSD,
-            from: address,
-            calls: [
-              Actions.token.transfer.call({
-                to: to as Address,
-                token: tokens.pathUSD,
-                amount: parseUnits(amount || '0', 6),
-              }),
-            ],
-          },
-        ],
-      })
-      setTxHash(hash)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    }
-  }, [address, amount, to])
-
-  const sign = useCallback(async () => {
-    if (!address) return
-    try {
-      setError(null)
-      const sig = await provider.request({
-        method: 'personal_sign',
-        params: [Hex.fromString(message), address],
-      })
-      setSignature(sig)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    }
-  }, [address, message])
-
   return (
     <ScrollView
-      style={{
-        flex: 1,
-        padding: 20,
-        paddingTop: 60,
-        backgroundColor: getBackgroundColor(colorScheme),
-      }}
+      style={{ flex: 1, padding: 20, paddingTop: 60, backgroundColor: background(scheme) }}
     >
       <StatusBar style="auto" />
-      <ThemedText style={{ fontSize: 24, fontWeight: 'bold', color: getTextColor(colorScheme) }}>
-        Accounts RN Playground
-      </ThemedText>
+      <ThemedText style={{ fontSize: 24, fontWeight: 'bold' }}>Accounts RN Playground</ThemedText>
 
       <ThemedText style={{ marginTop: 16, fontWeight: 'bold' }}>Status: {status}</ThemedText>
       {address && (
-        <ThemedText style={{ fontFamily: 'monospace', fontSize: 12 }}>{address}</ThemedText>
+        <ThemedText style={{ fontFamily: 'Courier', fontSize: 12 }}>{address}</ThemedText>
       )}
-      <ThemedText style={{ marginTop: 16, fontWeight: 'bold' }}>Network: {network}</ThemedText>
+      <ThemedText style={{ marginTop: 8, fontWeight: 'bold' }}>Network: {network}</ThemedText>
       <ThemedText>Wallet host: {walletHost ?? walletDefaultUrl}</ThemedText>
       <ThemedText>Consumer: {walletConsumerUrl ?? walletDefaultUrl}</ThemedText>
-      <Button title="Switch Network" onPress={() => switchNetwork('moderato')} />
+      {balance !== null && (
+        <ThemedText style={{ marginTop: 8 }}>Balance: {balance} pathUSD</ThemedText>
+      )}
 
-      <View style={{ marginTop: 16 }}>
-        <Button
-          title={`Show Deposit: ${showDeposit ? 'On' : 'Off'}`}
-          onPress={() => setShowDeposit((value) => !value)}
-        />
-        {address ? (
-          <Button title="Disconnect" onPress={disconnect} />
-        ) : (
-          <Button title="Connect" onPress={connect} />
-        )}
-      </View>
-
-      {error && <ThemedText style={{ color: 'red', marginTop: 8 }}>{error}</ThemedText>}
-
-      {address && (
+      {!address ? (
+        <Section title="Connect">
+          <ConnectForm chainId={chain.id} fallbackTokens={tokens} onConnect={connect} />
+          {(connectReq.error || connectReq.result !== undefined) && (
+            <Method error={connectReq.error} result={connectReq.result} title="wallet_connect">
+              {connectReq.pending && <ThemedText>Connecting…</ThemedText>}
+            </Method>
+          )}
+        </Section>
+      ) : (
         <>
-          <ThemedText style={{ marginTop: 24, fontWeight: 'bold' }}>Balance</ThemedText>
-          <ThemedText>{balance !== null ? `${balance} pathUSD` : 'Loading...'}</ThemedText>
-          <View style={{ marginTop: 8 }}>
-            <Button title={isFunding ? 'Funding...' : 'Fund Account'} onPress={fund} />
-          </View>
-          {faucetStatus && <ThemedText style={{ marginTop: 4 }}>{faucetStatus}</ThemedText>}
+          <Section title="Connection">
+            <EthRequestAccounts />
+            <Disconnect onDisconnect={disconnect} />
+          </Section>
 
-          <ThemedText style={{ marginTop: 24, fontWeight: 'bold' }}>Send Transaction</ThemedText>
-          <ThemedTextInput
-            value={to}
-            onChangeText={setTo}
-            placeholder="To (0x...)"
-            style={{
-              borderWidth: 1,
-              borderColor: '#ccc',
-              padding: 8,
-              marginTop: 4,
-              fontFamily: 'monospace',
-              fontSize: 12,
-            }}
-          />
-          <ThemedTextInput
-            value={amount}
-            onChangeText={setAmount}
-            placeholder="Amount"
-            keyboardType="numeric"
-            placeholderTextColor={getTextColor(colorScheme)}
-            style={{ borderWidth: 1, borderColor: '#ccc', padding: 8, marginTop: 4 }}
-          />
-          <Button title="Send" onPress={send} />
-          {txHash && (
-            <ThemedText style={{ fontFamily: 'monospace', fontSize: 12, marginTop: 4 }}>
-              {txHash}
-            </ThemedText>
-          )}
+          <Section title="Accounts & Chain">
+            <EthAccounts />
+            <EthChainId />
+            <SwitchChain onSwitch={setNetwork} />
+          </Section>
 
-          <ThemedText style={{ marginTop: 24, fontWeight: 'bold' }}>Sign Message</ThemedText>
-          <ThemedTextInput
-            value={message}
-            onChangeText={setMessage}
-            placeholder="Message"
-            style={{ borderWidth: 1, borderColor: '#ccc', padding: 8, marginTop: 4 }}
-          />
-          <Button title="Sign" onPress={sign} />
-          {signature && (
-            <ThemedText style={{ fontFamily: 'monospace', fontSize: 10, marginTop: 4 }}>
-              {signature}
-            </ThemedText>
-          )}
+          <Section title="Balances & Funding">
+            <GetBalances />
+            <Faucet onDone={fetchBalance} />
+            <Deposit />
+          </Section>
+
+          <Section title="Transactions">
+            <SendTransaction address={address} />
+            <Transfer />
+            <Swap />
+          </Section>
+
+          <Section title="Signing">
+            <PersonalSign address={address} />
+            <SignTypedData address={address} />
+          </Section>
+
+          <Section title="Access Keys">
+            <AuthorizeAccessKey />
+            <RevokeAccessKey address={address} />
+          </Section>
         </>
       )}
 
-      <View style={{ height: 60 }} />
+      <View style={{ height: 80 }} />
     </ScrollView>
   )
+}
+
+function Disconnect(props: { onDisconnect: () => Promise<void> }) {
+  return (
+    <Method title="wallet_disconnect">
+      <Button title="Disconnect" onPress={props.onDisconnect} />
+    </Method>
+  )
+}
+
+function EthRequestAccounts() {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="eth_requestAccounts">
+      <Button
+        disabled={pending}
+        title="Request Accounts"
+        onPress={() => run(() => provider.request({ method: 'eth_requestAccounts' }))}
+      />
+    </Method>
+  )
+}
+
+function EthAccounts() {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="eth_accounts">
+      <Button
+        disabled={pending}
+        title="Get Accounts"
+        onPress={() => run(() => provider.request({ method: 'eth_accounts' }))}
+      />
+    </Method>
+  )
+}
+
+function EthChainId() {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="eth_chainId">
+      <Button
+        disabled={pending}
+        title="Get Chain ID"
+        onPress={() => run(() => provider.request({ method: 'eth_chainId' }))}
+      />
+    </Method>
+  )
+}
+
+function SwitchChain(props: { onSwitch: (network: string) => void }) {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="wallet_switchEthereumChain">
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        {provider.chains.map((c) => (
+          <View key={c.id} style={{ flexGrow: 1 }}>
+            <Button
+              disabled={pending}
+              title={c.name ?? String(c.id)}
+              onPress={() =>
+                run(async () => {
+                  await provider.request({
+                    method: 'wallet_switchEthereumChain',
+                    params: [{ chainId: Hex.fromNumber(c.id) }],
+                  })
+                  props.onSwitch(c.id === tempoModerato.id ? 'moderato' : 'mainnet')
+                  return `switched to ${c.name} (${c.id})`
+                })
+              }
+            />
+          </View>
+        ))}
+      </View>
+    </Method>
+  )
+}
+
+function GetBalances() {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="wallet_getBalances">
+      <Button
+        disabled={pending}
+        title="Get Balances"
+        onPress={() =>
+          run(() =>
+            provider.request({
+              method: 'wallet_getBalances',
+              params: [{ tokens: Object.values(tokens) }],
+            }),
+          )
+        }
+      />
+    </Method>
+  )
+}
+
+function Faucet(props: { onDone: () => Promise<void> }) {
+  const { error, pending, result, run } = useRequest()
+  return (
+    <Method error={error} result={result} title="tempo_fundAddress">
+      <Button
+        disabled={pending}
+        title={pending ? 'Funding…' : 'Fund Account'}
+        onPress={() =>
+          run(async () => {
+            const accounts = await provider.request({ method: 'eth_accounts' })
+            if (accounts.length === 0) return 'No accounts connected'
+            const result = await provider.request({
+              method: 'tempo_fundAddress',
+              params: [accounts[0]],
+            } as never)
+            await props.onDone()
+            return result
+          })
+        }
+      />
+    </Method>
+  )
+}
+
+function Deposit() {
+  const { error, pending, result, run } = useRequest()
+  const deposit = (params: Record<string, unknown>) =>
+    run(() => provider.request({ method: 'wallet_deposit', params: [params] as never }))
+  return (
+    <Method error={error} result={result} title="wallet_deposit">
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        <Button disabled={pending} title="Deposit" onPress={() => deposit({})} />
+        <Button disabled={pending} title="$25" onPress={() => deposit({ amount: '25' })} />
+        <Button disabled={pending} title="$200" onPress={() => deposit({ amount: '200' })} />
+      </View>
+    </Method>
+  )
+}
+
+function SendTransaction(props: { address: Address }) {
+  const { error, pending, result, run } = useRequest()
+  const [to, setTo] = useState('0x0000000000000000000000000000000000000001')
+  const [amount, setAmount] = useState('1')
+  return (
+    <Method error={error} result={result} title="eth_sendTransaction">
+      <ThemedTextInput
+        onChangeText={setTo}
+        placeholder="To (0x...)"
+        style={{ fontFamily: 'Courier', fontSize: 12 }}
+        value={to}
+      />
+      <ThemedTextInput
+        keyboardType="numeric"
+        onChangeText={setAmount}
+        placeholder="Amount"
+        value={amount}
+      />
+      <Button
+        disabled={pending}
+        title="Send"
+        onPress={() =>
+          run(() =>
+            provider.request({
+              method: 'eth_sendTransaction',
+              params: [
+                {
+                  chainId: Hex.fromNumber(chain.id),
+                  feeToken: tokens.pathUSD,
+                  from: props.address,
+                  calls: [
+                    Actions.token.transfer.call({
+                      to: to as Address,
+                      token: tokens.pathUSD,
+                      amount: parseUnits(amount || '0', 6),
+                    }),
+                  ],
+                },
+              ],
+            }),
+          )
+        }
+      />
+    </Method>
+  )
+}
+
+function Transfer() {
+  const { error, pending, result, run } = useRequest()
+  const transfer = (params: Record<string, unknown>) =>
+    run(() => provider.request({ method: 'wallet_transfer', params: [params] as never }))
+  return (
+    <Method error={error} result={result} title="wallet_transfer">
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        <Button
+          disabled={pending}
+          title="Send $1 pathUSD"
+          onPress={() =>
+            transfer({
+              amount: '1',
+              to: '0x0000000000000000000000000000000000000001',
+              token: tokens.pathUSD,
+            })
+          }
+        />
+        <Button
+          disabled={pending}
+          title="With memo"
+          onPress={() =>
+            transfer({
+              amount: '1',
+              memo: 'invoice #4821',
+              to: '0x0000000000000000000000000000000000000001',
+              token: 'pathUSD',
+            })
+          }
+        />
+        <Button disabled={pending} title="Editable" onPress={() => transfer({ editable: true })} />
+      </View>
+    </Method>
+  )
+}
+
+function Swap() {
+  const { error, pending, result, run } = useRequest()
+  const pairToken = Object.values(tokens).find((x) => x !== tokens.pathUSD) ?? tokens.pathUSD
+  const swap = (params: Record<string, unknown>) =>
+    run(() => provider.request({ method: 'wallet_swap', params: [params] as never }))
+  return (
+    <Method error={error} result={result} title="wallet_swap">
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        <Button disabled={pending} title="Swap" onPress={() => swap({})} />
+        <Button
+          disabled={pending}
+          title="Pair"
+          onPress={() => swap({ pairToken, token: tokens.pathUSD })}
+        />
+        <Button
+          disabled={pending}
+          title="Sell 1 pathUSD"
+          onPress={() =>
+            swap({ amount: '1', pairToken, slippage: 0.01, token: tokens.pathUSD, type: 'sell' })
+          }
+        />
+      </View>
+    </Method>
+  )
+}
+
+function PersonalSign(props: { address: Address }) {
+  const { error, pending, result, run } = useRequest()
+  const [message, setMessage] = useState('hello world')
+  return (
+    <Method error={error} result={result} title="personal_sign">
+      <ThemedTextInput onChangeText={setMessage} placeholder="Message" value={message} />
+      <Button
+        disabled={pending}
+        title="Sign"
+        onPress={() =>
+          run(() =>
+            provider.request({
+              method: 'personal_sign',
+              params: [Hex.fromString(message), props.address],
+            }),
+          )
+        }
+      />
+    </Method>
+  )
+}
+
+function SignTypedData(props: { address: Address }) {
+  const { error, pending, result, run } = useRequest()
+  const sign = (data: object) =>
+    run(async () => {
+      const signature = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [props.address, Json.stringify(data)],
+      } as never)
+      return { data, signature }
+    })
+  const mail = {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+      ],
+      Person: [
+        { name: 'name', type: 'string' },
+        { name: 'wallet', type: 'address' },
+      ],
+      Mail: [
+        { name: 'from', type: 'Person' },
+        { name: 'to', type: 'Person' },
+        { name: 'contents', type: 'string' },
+      ],
+    },
+    primaryType: 'Mail',
+    domain: { name: 'Example', version: '1', chainId: String(chain.id) },
+    message: {
+      from: { name: 'Alice', wallet: '0x0000000000000000000000000000000000000001' },
+      to: { name: 'Bob', wallet: '0x0000000000000000000000000000000000000002' },
+      contents: 'Hello, Bob!',
+    },
+  }
+  return (
+    <Method error={error} result={result} title="eth_signTypedData_v4">
+      <Button disabled={pending} title="Sign (Mail)" onPress={() => sign(mail)} />
+    </Method>
+  )
+}
+
+function AuthorizeAccessKey() {
+  const { error, pending, result, run } = useRequest()
+  const [expiry, setExpiry] = useState('3600')
+  const [amount, setAmount] = useState('100')
+  return (
+    <Method error={error} result={result} title="wallet_authorizeAccessKey">
+      <ThemedTextInput
+        keyboardType="numeric"
+        onChangeText={setExpiry}
+        placeholder="Expiry (seconds)"
+        value={expiry}
+      />
+      <ThemedTextInput
+        keyboardType="numeric"
+        onChangeText={setAmount}
+        placeholder="Limit (pathUSD)"
+        value={amount}
+      />
+      <Button
+        disabled={pending}
+        title="Authorize"
+        onPress={() =>
+          run(() =>
+            provider.request({
+              method: 'wallet_authorizeAccessKey',
+              params: [
+                {
+                  expiry: Math.floor(Date.now() / 1000) + Number(expiry || '3600'),
+                  limits: [
+                    { token: tokens.pathUSD, limit: Hex.fromNumber(parseUnits(amount || '0', 6)) },
+                  ],
+                  scopes: [{ address: tokens.pathUSD, selector: 'transfer(address,uint256)' }],
+                },
+              ],
+            } as never),
+          )
+        }
+      />
+    </Method>
+  )
+}
+
+function RevokeAccessKey(props: { address: Address }) {
+  const { error, pending, result, run } = useRequest()
+  const [accessKeyAddress, setAccessKeyAddress] = useState('')
+  return (
+    <Method error={error} result={result} title="wallet_revokeAccessKey">
+      <ThemedTextInput
+        onChangeText={setAccessKeyAddress}
+        placeholder="Access key address 0x..."
+        style={{ fontFamily: 'Courier', fontSize: 12 }}
+        value={accessKeyAddress}
+      />
+      <Button
+        disabled={pending || !accessKeyAddress}
+        title="Revoke"
+        onPress={() =>
+          run(async () => {
+            await provider.request({
+              method: 'wallet_revokeAccessKey',
+              params: [{ address: props.address, accessKeyAddress: accessKeyAddress as Address }],
+            })
+            return 'revoked'
+          })
+        }
+      />
+    </Method>
+  )
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined) return 'undefined'
+  try {
+    return Json.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
 }

--- a/playgrounds/react-native/ConnectForm.tsx
+++ b/playgrounds/react-native/ConnectForm.tsx
@@ -1,0 +1,395 @@
+import { Hex } from 'ox'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
+import {
+  Button,
+  ColorSchemeName,
+  Pressable,
+  Switch,
+  Text,
+  TextInput,
+  useColorScheme,
+  View,
+} from 'react-native'
+import { parseUnits } from 'viem'
+
+const periodOptions = [
+  { label: '10 seconds', value: '10' },
+  { label: '1 minute', value: '300' },
+  { label: '1 hour', value: '3600' },
+  { label: '1 day', value: '86400' },
+  { label: '1 month', value: '2592000' },
+  { label: '1 year', value: '31536000' },
+] as const
+
+const scopePresets = [
+  { label: 'None', value: '' },
+  { label: 'transfer(address,uint256)', value: 'transfer(address,uint256)' },
+  { label: 'approve(address,uint256)', value: 'approve(address,uint256)' },
+  {
+    label: 'transferFrom(address,address,uint256)',
+    value: 'transferFrom(address,address,uint256)',
+  },
+] as const
+
+type TokenlistEntry = {
+  address: string
+  chainId: number
+  decimals: number
+  logoURI?: string
+  name: string
+  symbol: string
+}
+
+type LimitInput = {
+  token: string
+  amount: string
+  /** Empty string = no period (lifetime budget). */
+  period: string
+}
+
+const textColor = (scheme: ColorSchemeName) => (scheme === 'dark' ? 'white' : 'black')
+const mutedColor = (scheme: ColorSchemeName) => (scheme === 'dark' ? '#aaa' : '#666')
+const borderColor = (scheme: ColorSchemeName) => (scheme === 'dark' ? '#444' : '#ccc')
+
+export default function ConnectForm(props: {
+  chainId: number
+  fallbackTokens: Record<string, string>
+  onConnect: (capabilities: Record<string, unknown>) => Promise<void>
+}) {
+  const { chainId, fallbackTokens, onConnect } = props
+  const scheme = useColorScheme()
+  const tokenlist = useTokenlist(chainId, fallbackTokens)
+  const [name, setName] = useState('')
+  const [digest, setDigest] = useState('')
+  const [accessKeyEnabled, setAccessKeyEnabled] = useState(false)
+  const [expiry, setExpiry] = useState('86400')
+  const [limits, setLimits] = useState<LimitInput[]>([{ token: '', amount: '100', period: '' }])
+  const [scopeSelector, setScopeSelector] = useState('transfer(address,uint256)')
+  const [authEnabled, setAuthEnabled] = useState(false)
+  const [identityEmailEnabled, setIdentityEmailEnabled] = useState(false)
+  const [showDepositEnabled, setShowDepositEnabled] = useState(false)
+  const [showDepositAmount, setShowDepositAmount] = useState('')
+  const [showDepositToken, setShowDepositToken] = useState('')
+  const [pending, setPending] = useState<'login' | 'register' | null>(null)
+
+  // Once the tokenlist resolves, hydrate any unselected limit row with the first token.
+  useEffect(() => {
+    const first = tokenlist[0]?.address
+    if (!first) return
+    setLimits((prev) => prev.map((l) => (l.token ? l : { ...l, token: first })))
+  }, [tokenlist])
+
+  function updateLimit(index: number, patch: Partial<LimitInput>) {
+    setLimits((prev) => prev.map((l, i) => (i === index ? { ...l, ...patch } : l)))
+  }
+  function addLimit() {
+    setLimits((prev) => [...prev, { token: '', amount: '100', period: '' }])
+  }
+  function removeLimit(index: number) {
+    setLimits((prev) => prev.filter((_, i) => i !== index))
+  }
+  function tokenInfo(address: string) {
+    return tokenlist.find((t) => t.address.toLowerCase() === address.toLowerCase())
+  }
+
+  function buildCapabilities(method: 'login' | 'register') {
+    const authorizeAccessKey = accessKeyEnabled
+      ? (() => {
+          const filledLimits = limits.filter((l) => l.token && l.amount)
+          return {
+            expiry: Math.floor(Date.now() / 1000) + Number(expiry || '86400'),
+            ...(filledLimits.length > 0 && {
+              limits: filledLimits.map((l) => ({
+                token: l.token,
+                limit: Hex.fromNumber(parseUnits(l.amount, tokenInfo(l.token)?.decimals ?? 6)),
+                ...(l.period ? { period: Number(l.period) } : {}),
+              })),
+            }),
+            ...(scopeSelector && filledLimits[0]
+              ? { scopes: [{ address: filledLimits[0].token, selector: scopeSelector }] }
+              : {}),
+          }
+        })()
+      : undefined
+
+    // Server Authentication: native apps have no origin to absolutize a
+    // relative path against, so the App passes an absolute `/auth` URL.
+    const auth = authEnabled ? '/auth' : undefined
+    const identity = identityEmailEnabled ? { email: true } : undefined
+    const showDeposit = showDepositEnabled
+      ? (() => {
+          const amount = showDepositAmount.trim()
+          const token = showDepositToken.trim()
+          const value = { ...(amount ? { amount } : {}), ...(token ? { token } : {}) }
+          if (Object.keys(value).length === 0) return true
+          return value
+        })()
+      : undefined
+
+    return {
+      ...(method === 'register' ? { method: 'register' as const, ...(name ? { name } : {}) } : {}),
+      ...(digest ? { digest } : {}),
+      ...(authorizeAccessKey ? { authorizeAccessKey } : {}),
+      ...(auth ? { auth } : {}),
+      ...(identity ? { identity } : {}),
+      ...(showDeposit ? { showDeposit } : {}),
+    }
+  }
+
+  async function submit(method: 'login' | 'register') {
+    setPending(method)
+    try {
+      await onConnect(buildCapabilities(method))
+    } finally {
+      setPending(null)
+    }
+  }
+
+  const tokenItems = useMemo(
+    () => tokenlist.map((t) => ({ label: t.symbol, value: t.address })),
+    [tokenlist],
+  )
+
+  return (
+    <View style={{ gap: 12 }}>
+      <Field label="Name">
+        <TextField onChangeText={setName} placeholder="Account name (optional)" value={name} />
+      </Field>
+      <Field label="Digest">
+        <TextField mono onChangeText={setDigest} placeholder="0x... (optional)" value={digest} />
+      </Field>
+
+      <Fieldset
+        checked={accessKeyEnabled}
+        label="Authorize Access Key"
+        onChange={setAccessKeyEnabled}
+      >
+        <Field label="Expiry (seconds)">
+          <TextField
+            keyboardType="numeric"
+            onChangeText={setExpiry}
+            placeholder="86400"
+            value={expiry}
+          />
+        </Field>
+        <Text style={{ color: textColor(scheme), fontWeight: '600' }}>Limits</Text>
+        {limits.map((limit, i) => (
+          <View
+            key={i}
+            style={{
+              borderColor: borderColor(scheme),
+              borderRadius: 6,
+              borderWidth: 1,
+              gap: 8,
+              padding: 8,
+            }}
+          >
+            <Chips
+              items={tokenItems}
+              onChange={(token) => updateLimit(i, { token })}
+              value={limit.token}
+            />
+            <TextField
+              keyboardType="numeric"
+              onChangeText={(amount) => updateLimit(i, { amount })}
+              placeholder="100"
+              value={limit.amount}
+            />
+            <Toggle
+              label="Period"
+              onChange={(checked) => updateLimit(i, { period: checked ? '2592000' : '' })}
+              value={limit.period !== ''}
+            />
+            {limit.period !== '' && (
+              <Chips
+                items={periodOptions.map((o) => ({ label: o.label, value: o.value }))}
+                onChange={(period) => updateLimit(i, { period })}
+                value={limit.period}
+              />
+            )}
+            <Button
+              disabled={limits.length === 1}
+              onPress={() => removeLimit(i)}
+              title="Remove limit"
+            />
+          </View>
+        ))}
+        <Button onPress={addLimit} title="+ Add limit" />
+        <Field label="Scope">
+          <Chips
+            items={scopePresets.map((o) => ({ label: o.label, value: o.value }))}
+            onChange={setScopeSelector}
+            value={scopeSelector}
+          />
+        </Field>
+      </Fieldset>
+
+      <Fieldset checked={authEnabled} label="Authenticate with Server" onChange={setAuthEnabled} />
+      <Fieldset
+        checked={identityEmailEnabled}
+        label="Request Verified Email"
+        onChange={setIdentityEmailEnabled}
+      />
+
+      <Fieldset checked={showDepositEnabled} label="Show Deposit" onChange={setShowDepositEnabled}>
+        <Field label="Amount">
+          <TextField
+            keyboardType="numeric"
+            onChangeText={setShowDepositAmount}
+            placeholder="50"
+            value={showDepositAmount}
+          />
+        </Field>
+        <Field label="Token">
+          <Chips
+            items={[{ label: 'None', value: '' }, ...tokenItems]}
+            onChange={setShowDepositToken}
+            value={showDepositToken}
+          />
+        </Field>
+      </Fieldset>
+
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <View style={{ flex: 1 }}>
+          <Button
+            disabled={pending !== null}
+            onPress={() => submit('login')}
+            title={pending === 'login' ? 'Connecting…' : 'Login'}
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Button
+            disabled={pending !== null}
+            onPress={() => submit('register')}
+            title={pending === 'register' ? 'Connecting…' : 'Register'}
+          />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+function Field(props: { children: ReactNode; label: string }) {
+  const scheme = useColorScheme()
+  return (
+    <View style={{ gap: 4 }}>
+      <Text style={{ color: mutedColor(scheme), fontSize: 13 }}>{props.label}</Text>
+      {props.children}
+    </View>
+  )
+}
+
+function TextField(props: {
+  keyboardType?: 'numeric'
+  mono?: boolean
+  onChangeText: (value: string) => void
+  placeholder?: string
+  value: string
+}) {
+  const scheme = useColorScheme()
+  return (
+    <TextInput
+      autoCapitalize="none"
+      autoCorrect={false}
+      keyboardType={props.keyboardType}
+      onChangeText={props.onChangeText}
+      placeholder={props.placeholder}
+      placeholderTextColor={mutedColor(scheme)}
+      style={{
+        borderColor: borderColor(scheme),
+        borderRadius: 6,
+        borderWidth: 1,
+        color: textColor(scheme),
+        fontFamily: props.mono ? 'Courier' : undefined,
+        padding: 8,
+      }}
+      value={props.value}
+    />
+  )
+}
+
+function Toggle(props: { label: string; onChange: (value: boolean) => void; value: boolean }) {
+  const scheme = useColorScheme()
+  return (
+    <View style={{ alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' }}>
+      <Text style={{ color: textColor(scheme) }}>{props.label}</Text>
+      <Switch onValueChange={props.onChange} value={props.value} />
+    </View>
+  )
+}
+
+function Chips(props: {
+  items: { label: string; value: string }[]
+  onChange: (value: string) => void
+  value: string
+}) {
+  const scheme = useColorScheme()
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+      {props.items.map((item) => {
+        const selected = item.value === props.value
+        return (
+          <Pressable
+            key={item.value || 'none'}
+            onPress={() => props.onChange(item.value)}
+            style={{
+              borderColor: selected ? '#2563eb' : borderColor(scheme),
+              borderRadius: 6,
+              borderWidth: 1,
+              paddingHorizontal: 12,
+              paddingVertical: 6,
+            }}
+          >
+            <Text style={{ color: selected ? '#2563eb' : textColor(scheme) }}>{item.label}</Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+function Fieldset(props: {
+  checked: boolean
+  children?: ReactNode
+  label: string
+  onChange: (checked: boolean) => void
+}) {
+  const scheme = useColorScheme()
+  return (
+    <View
+      style={{
+        borderColor: borderColor(scheme),
+        borderRadius: 8,
+        borderWidth: 1,
+        gap: 12,
+        padding: 12,
+      }}
+    >
+      <Toggle label={props.label} onChange={props.onChange} value={props.checked} />
+      {props.checked && props.children}
+    </View>
+  )
+}
+
+/** Fetch the live token list for the current chain, with a static fallback. */
+function useTokenlist(chainId: number, fallbackTokens: Record<string, string>): TokenlistEntry[] {
+  const [list, setList] = useState<TokenlistEntry[]>(() =>
+    Object.entries(fallbackTokens).map(([symbol, address]) => ({
+      address,
+      chainId,
+      decimals: 6,
+      name: symbol,
+      symbol,
+    })),
+  )
+  useEffect(() => {
+    fetch(`https://tokenlist.tempo.xyz/list/${chainId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list = (data as { tokens?: TokenlistEntry[] } | null)?.tokens
+        if (list?.length) setList(list)
+      })
+      .catch(() => {})
+  }, [chainId])
+  return list
+}

--- a/playgrounds/react-native/README.md
+++ b/playgrounds/react-native/README.md
@@ -1,27 +1,33 @@
 # React Native Playground
 
-Run with the default Tempo Wallet:
+## Production wallet
 
 ```sh
 pnpm install
 cd playgrounds/react-native
-pnpm ios
+pnpm ios:prod
 ```
 
-The playground starts a local consumer discovery server at
-`http://localhost:21261/.well-known/urpc/consumer.json` and points the app at it
-with `EXPO_PUBLIC_WALLET_CONSUMER_URL`.
+This targets the default Tempo Wallet (`https://wallet.tempo.xyz`) and publishes
+the local consumer discovery document through a Cloudflare quick tunnel
+(`cloudflared` must be installed) so the production wallet can verify it. The
+tunnel closes when the dev server exits.
 
-Run against another wallet origin:
+## Local wallet
 
 ```sh
 EXPO_PUBLIC_WALLET_HOST=http://localhost:21260 \
 pnpm ios
 ```
 
-Use `EXPO_PUBLIC_WALLET_HOST` for the wallet web app origin. Use
-`CONSUMER_PORT` or `EXPO_PUBLIC_WALLET_CONSUMER_URL` only when the wallet needs
-a different consumer origin, such as a tunnel URL.
+`pnpm ios` starts a local consumer discovery server at
+`http://localhost:21261/.well-known/urpc/consumer.json` and points the app at it
+with `EXPO_PUBLIC_WALLET_CONSUMER_URL`.
+
+Use `EXPO_PUBLIC_WALLET_HOST` for the wallet web app origin (defaults to
+`https://wallet.tempo.xyz`). Set `TUNNEL=1` to publish the consumer through a
+quick tunnel, or set `CONSUMER_PORT` / `EXPO_PUBLIC_WALLET_CONSUMER_URL`
+explicitly to supply your own consumer origin.
 
 The wallet must allow the playground callback URI:
 

--- a/playgrounds/react-native/package.json
+++ b/playgrounds/react-native/package.json
@@ -7,6 +7,7 @@
     "android": "node scripts/expo.mjs run:android",
     "consumer": "node scripts/consumer-server.mjs",
     "ios": "node scripts/expo.mjs run:ios",
+    "ios:prod": "TUNNEL=1 node scripts/expo.mjs run:ios",
     "start": "node scripts/expo.mjs start"
   },
   "dependencies": {

--- a/playgrounds/react-native/scripts/consumer-server.mjs
+++ b/playgrounds/react-native/scripts/consumer-server.mjs
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
 
 const callback = 'xyz.tempo.accounts.playground:/auth'
@@ -8,6 +9,56 @@ let origin = process.env.EXPO_PUBLIC_WALLET_CONSUMER_URL
 
 export function getConsumerOrigin() {
   return origin
+}
+
+export function getConsumerPort() {
+  return port
+}
+
+/** Sets the origin advertised in the served discovery document. */
+export function setConsumerOrigin(value) {
+  origin = new URL(value).origin
+}
+
+/**
+ * Opens a Cloudflare quick tunnel to the local consumer server so a remote
+ * wallet (e.g. production) can fetch its discovery document. Resolves with the
+ * public `https://*.trycloudflare.com` origin and the tunnel child process.
+ */
+export function startTunnel(localPort) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'cloudflared',
+      ['tunnel', '--no-autoupdate', '--url', `http://localhost:${localPort}`],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    const pattern = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/
+    let settled = false
+    const onData = (chunk) => {
+      const match = chunk.toString().match(pattern)
+      if (!match || settled) return
+      settled = true
+      resolve({ child, url: match[0] })
+    }
+    child.stdout.on('data', onData)
+    child.stderr.on('data', onData)
+    child.once('error', (error) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    })
+    child.once('exit', (code) => {
+      if (settled) return
+      settled = true
+      reject(new Error(`cloudflared exited (${code}) before reporting a tunnel URL`))
+    })
+    setTimeout(() => {
+      if (settled) return
+      settled = true
+      child.kill()
+      reject(new Error('cloudflared tunnel timed out'))
+    }, 30_000)
+  })
 }
 
 export function createConsumerServer() {

--- a/playgrounds/react-native/scripts/expo.mjs
+++ b/playgrounds/react-native/scripts/expo.mjs
@@ -1,10 +1,27 @@
 import { spawn } from 'node:child_process'
 
-import { getConsumerOrigin, listen } from './consumer-server.mjs'
+import {
+  getConsumerOrigin,
+  getConsumerPort,
+  listen,
+  setConsumerOrigin,
+  startTunnel,
+} from './consumer-server.mjs'
 
 const command = process.argv[2] ?? 'start'
 const args = process.argv.slice(3)
 const server = await listen()
+
+// A remote wallet (e.g. production at wallet.tempo.xyz) can't reach the
+// localhost consumer server, so publish it through a Cloudflare quick tunnel.
+// Skipped when an explicit consumer URL is already provided.
+let tunnel
+if (process.env.TUNNEL === '1' && !process.env.EXPO_PUBLIC_WALLET_CONSUMER_URL) {
+  tunnel = await startTunnel(getConsumerPort())
+  setConsumerOrigin(tunnel.url)
+  console.log(`Consumer tunnel: ${tunnel.url}/.well-known/urpc/consumer.json`)
+}
+
 const consumerUrl = getConsumerOrigin()
 
 const child = spawn('pnpm', ['exec', 'expo', command, ...args], {
@@ -21,12 +38,14 @@ function close(signal) {
   if (closing) return
   closing = true
   child.kill(signal)
+  tunnel?.child.kill()
   server.close()
 }
 
 for (const signal of ['SIGINT', 'SIGTERM']) process.once(signal, () => close(signal))
 
 child.on('exit', (code, signal) => {
+  tunnel?.child.kill()
   server.close(() => {
     if (code !== null) process.exit(code)
     process.exit(signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1)


### PR DESCRIPTION
## Summary
Rebuild the React Native playground's UI natively (it previously rendered its connect form through an Expo DOM component — regen-ui in a WebView — which looked broken on device and only exercised `wallet_connect`), port the web playground's core method examples, and add one-command support for running against the production wallet.

## Changes
- **Native `ConnectForm`** — replaces the `'use dom'` / regen-ui WebView component with plain React Native (`View`/`TextInput`/`Switch`/`Pressable`). Preserves the full connect capability set: name, digest, authorize-access-key (expiry / limits / period / scope), authenticate-with-server, verified-email, and show-deposit. Same `onConnect(capabilities)` contract and capability-building logic, including the live tokenlist fetch with static fallback.
- **Core method examples** — ports the web playground's coverage natively via a small `useRequest` hook + `Method` card (title, controls, inline JSON result or red error). Grouped into Connection, Accounts & Chain, Balances & Funding, Transactions, Signing, and Access Keys: `eth_requestAccounts`, `wallet_disconnect`, `eth_accounts`, `eth_chainId`, `wallet_switchEthereumChain`, `wallet_getBalances`, `tempo_fundAddress`, `wallet_deposit`, `eth_sendTransaction`, `wallet_transfer`, `wallet_swap`, `personal_sign`, `eth_signTypedData_v4`, `wallet_authorizeAccessKey`, `wallet_revokeAccessKey`.
- **`pnpm ios:prod`** (`TUNNEL=1`) — publishes the local consumer discovery document through a Cloudflare quick tunnel (`cloudflared` required) so the production wallet (`wallet.tempo.xyz`) can fetch and verify it; the tunnel is torn down when the dev server exits. `pnpm ios` is unchanged for local/explicit-consumer setups.

No new dependencies (the DOM-component approach's `regen-ui` / `react-native-web` / `react-native-webview` are no longer needed); lockfile unchanged.

## Testing
- `tsc --noEmit` and `vp lint` clean on the playground files.
- Verified the production path end-to-end: quick tunnel → served `consumer.json` self-advertises the tunnel origin with the correct `callback_urls` → `https://wallet.tempo.xyz/api/mobile-web-auth/consumer-discovery` fetches and parses it (200, correct `id`/`origin`). Production already serves `host.json`, `consumer.json`, `/mobile-web-auth`, and the discovery proxy.

## Notes
- Network is Tempo Moderato (testnet); the production wallet host serves it, so no real funds are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)