### PR TITLE
feat(react-native): add secure mmkv storage

### DIFF
--- a/.changeset/secure-mmkv-storage.md
+++ b/.changeset/secure-mmkv-storage.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+Add encrypted MMKV-backed React Native storage that manages its SecureStore encryption key internally.

--- a/.changeset/secure-mmkv-storage.md
+++ b/.changeset/secure-mmkv-storage.md
@@ -1,5 +1,7 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
 Add encrypted MMKV-backed React Native storage that manages its SecureStore encryption key internally.
+
+Remove `secureStorage` from `accounts/react-native/expo-secure-store`; use `secureMmkv` from `accounts/react-native/secure-mmkv` instead.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "prool": "catalog:",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-native-mmkv": "^4.3.1",
+    "react-native-nitro-modules": "^0.35.9",
     "simple-git-hooks": "^2.13.1",
     "testcontainers": "^11.14.0",
     "tsx": "^4.21.0",
@@ -90,6 +92,8 @@
     "expo-secure-store": "^55.0.12",
     "expo-web-browser": "^55.0.13",
     "react": ">=18",
+    "react-native-mmkv": "^4.3.1",
+    "react-native-nitro-modules": "^0.35.9",
     "viem": ">=2.50.4",
     "wagmi": ">=0.0.0"
   },
@@ -110,6 +114,12 @@
       "optional": true
     },
     "expo-secure-store": {
+      "optional": true
+    },
+    "react-native-mmkv": {
+      "optional": true
+    },
+    "react-native-nitro-modules": {
       "optional": true
     },
     "@react-native-async-storage/async-storage": {
@@ -193,6 +203,12 @@
       "src": "./src/react-native/expoSecureStore.ts",
       "react-native": "./dist/react-native/expoSecureStore.js",
       "default": "./dist/react-native/expoSecureStore.js"
+    },
+    "./react-native/secure-mmkv": {
+      "types": "./dist/react-native/secureMmkv.d.ts",
+      "src": "./src/react-native/secureMmkv.ts",
+      "react-native": "./dist/react-native/secureMmkv.js",
+      "default": "./dist/react-native/secureMmkv.js"
     }
   }
 }

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -266,7 +266,7 @@ export default function App() {
           <ConnectForm chainId={chain.id} fallbackTokens={tokens} onConnect={connect} />
           {(connectReq.error || connectReq.result !== undefined) && (
             <Method error={connectReq.error} result={connectReq.result} title="wallet_connect">
-              {connectReq.pending && <ThemedText>Connecting...</ThemedText>}
+              {connectReq.pending && <ThemedText>Connecting…</ThemedText>}
             </Method>
           )}
         </Section>

--- a/playgrounds/react-native/App.tsx
+++ b/playgrounds/react-native/App.tsx
@@ -1,7 +1,7 @@
 import { Provider } from 'accounts'
 import { mobileWebAuth, tempoWallet } from 'accounts/mobileWebAuth'
-import { secureStorage } from 'accounts/react-native/expo-secure-store'
 import { openAuthSession } from 'accounts/react-native/expo-web-browser'
+import { secureMmkv } from 'accounts/react-native/secure-mmkv'
 import { StatusBar } from 'expo-status-bar'
 import { Hex, Json } from 'ox'
 import { type ReactNode, useCallback, useEffect, useState } from 'react'
@@ -63,7 +63,7 @@ const provider = Provider.create({
       },
     ],
   }),
-  storage: secureStorage(),
+  storage: secureMmkv(),
 })
 
 const text = (scheme: ColorSchemeName) => (scheme === 'dark' ? 'white' : 'black')
@@ -266,7 +266,7 @@ export default function App() {
           <ConnectForm chainId={chain.id} fallbackTokens={tokens} onConnect={connect} />
           {(connectReq.error || connectReq.result !== undefined) && (
             <Method error={connectReq.error} result={connectReq.result} title="wallet_connect">
-              {connectReq.pending && <ThemedText>Connecting…</ThemedText>}
+              {connectReq.pending && <ThemedText>Connecting...</ThemedText>}
             </Method>
           )}
         </Section>

--- a/playgrounds/react-native/package.json
+++ b/playgrounds/react-native/package.json
@@ -11,9 +11,8 @@
     "start": "node scripts/expo.mjs start"
   },
   "dependencies": {
-    "accounts": "workspace:*",
     "@react-native-async-storage/async-storage": "^3.0.2",
-    "react-native-get-random-values": "~2.0.0",
+    "accounts": "workspace:*",
     "expo": "~55.0.12",
     "expo-secure-store": "~55.0.12",
     "expo-status-bar": "~55.0.5",
@@ -21,6 +20,9 @@
     "ox": "catalog:",
     "react": "catalog:",
     "react-native": "0.83.4",
+    "react-native-get-random-values": "~2.0.0",
+    "react-native-mmkv": "^4.3.1",
+    "react-native-nitro-modules": "^0.35.9",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.24.0",
     "viem": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,12 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-native-mmkv:
+        specifier: ^4.3.1
+        version: 4.3.1(react-native-nitro-modules@0.35.9(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
+      react-native-nitro-modules:
+        specifier: ^0.35.9
+        version: 0.35.9(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
       simple-git-hooks:
         specifier: ^2.13.1
         version: 2.13.1
@@ -841,6 +847,12 @@ importers:
       react-native-get-random-values:
         specifier: ~2.0.0
         version: 2.0.0(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))
+      react-native-mmkv:
+        specifier: ^4.3.1
+        version: 4.3.1(react-native-nitro-modules@0.35.9(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
+      react-native-nitro-modules:
+        specifier: ^0.35.9
+        version: 0.35.9(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
       react-native-safe-area-context:
         specifier: ~5.7.0
         version: 5.7.0(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
@@ -10013,6 +10025,19 @@ packages:
       react: ^19.2.5
       react-native: '*'
 
+  react-native-mmkv@4.3.1:
+    resolution: {integrity: sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg==}
+    peerDependencies:
+      react: ^19.2.5
+      react-native: '*'
+      react-native-nitro-modules: '*'
+
+  react-native-nitro-modules@0.35.9:
+    resolution: {integrity: sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA==}
+    peerDependencies:
+      react: ^19.2.5
+      react-native: '*'
+
   react-native-safe-area-context@5.7.0:
     resolution: {integrity: sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==}
     peerDependencies:
@@ -14202,7 +14227,7 @@ snapshots:
       postcss: 8.5.14
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14258,7 +14283,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3(supports-color@10.2.2)
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -21422,7 +21447,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -22750,7 +22775,7 @@ snapshots:
 
   expo-keep-awake@55.0.6(expo@55.0.15)(react@19.2.5):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 19.2.5
 
   expo-modules-autolinking@55.0.17(typescript@5.9.3):
@@ -22784,7 +22809,7 @@ snapshots:
 
   expo-secure-store@55.0.13(expo@55.0.15):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo: 55.0.15(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react-server-dom-webpack@19.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.27.7)))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
   expo-server@55.0.8: {}
 
@@ -25834,6 +25859,28 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-native: 0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
+
+  react-native-mmkv@4.3.1(react-native-nitro-modules@0.35.9(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-native: 0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
+      react-native-nitro-modules: 0.35.9(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
+
+  react-native-mmkv@4.3.1(react-native-nitro-modules@0.35.9(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5))(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-native: 0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
+      react-native-nitro-modules: 0.35.9(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)
+
+  react-native-nitro-modules@0.35.9(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-native: 0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
+
+  react-native-nitro-modules@0.35.9(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-native: 0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
 
   react-native-safe-area-context@5.7.0(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5):
     dependencies:

--- a/site/src/pages/docs/guides/react-native.mdx
+++ b/site/src/pages/docs/guides/react-native.mdx
@@ -12,7 +12,7 @@ This guide covers the platform setup. For choosing and configuring the adapter i
 ## Install
 
 ```sh
-npx expo install expo-web-browser expo-secure-store react-native-get-random-values
+npx expo install expo-web-browser expo-secure-store react-native-get-random-values react-native-mmkv react-native-nitro-modules
 ```
 
 ## Connect
@@ -20,8 +20,8 @@ npx expo install expo-web-browser expo-secure-store react-native-get-random-valu
 ```ts twoslash
 import { Provider } from 'accounts'
 import { tempoWallet } from 'accounts/mobileWebAuth'
-import { secureStorage } from 'accounts/react-native/expo-secure-store'
 import { openAuthSession } from 'accounts/react-native/expo-web-browser'
+import { secureMmkv } from 'accounts/react-native/secure-mmkv'
 
 const provider = Provider.create({
   adapter: tempoWallet({
@@ -29,7 +29,7 @@ const provider = Provider.create({
     openAuthSession,
     redirectUri: 'com.example.app:/auth',
   }),
-  storage: secureStorage(),
+  storage: secureMmkv(),
 })
 ```
 
@@ -77,11 +77,12 @@ import { openAuthSession } from 'accounts/react-native/expo-web-browser'
 
 ## Storage
 
-Provider state persists through a storage adapter. Two React Native adapters ship as optional subpaths:
+Provider state persists through a storage adapter. React Native adapters ship as optional subpaths:
 
 ```ts twoslash
 import { asyncStorage } from 'accounts/react-native/async-storage'
-import { secureStorage } from 'accounts/react-native/expo-secure-store'
+import { getOrCreateMmkvEncryptionKey } from 'accounts/react-native/expo-secure-store'
+import { secureMmkv } from 'accounts/react-native/secure-mmkv'
 ```
 
-Use `secureStorage` (backed by `expo-secure-store`, stored in the device Keychain/Keystore) when the provider manages access keys. Use `asyncStorage` (backed by `@react-native-async-storage/async-storage`) for non-sensitive state.
+Use `secureMmkv` when the provider manages access keys. It stores the larger SDK snapshot in encrypted MMKV and keeps only the small encryption key in the device Keychain/Keystore through `getOrCreateMmkvEncryptionKey`.

--- a/src/react-native/expoSecureStore.test.ts
+++ b/src/react-native/expoSecureStore.test.ts
@@ -1,43 +1,26 @@
 import { vi } from 'vitest'
 import { beforeEach, describe, expect, test } from 'vp/test'
 
-type Mock = {
-  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: number
-  get_calls: unknown[][]
-  items: Map<string, string>
-  set_calls: unknown[][]
-}
+const mock = vi.hoisted(() => ({
+  get_calls: [] as unknown[][],
+  items: new Map<string, string>(),
+  set_calls: [] as unknown[][],
+}))
 
-type Global = typeof globalThis & {
-  __tempo_secure_store_mock?: Mock | undefined
-}
-
-vi.mock('expo-secure-store', () => {
-  const root = globalThis as Global
-  root.__tempo_secure_store_mock ??= {
-    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
-    get_calls: [],
-    items: new Map<string, string>(),
-    set_calls: [],
-  }
-  return {
-    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY:
-      root.__tempo_secure_store_mock.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
-    getItemAsync(name: string, store: unknown) {
-      root.__tempo_secure_store_mock!.get_calls.push([name, store])
-      return Promise.resolve(root.__tempo_secure_store_mock!.items.get(name) ?? null)
-    },
-    setItemAsync(name: string, value: string, store: unknown) {
-      root.__tempo_secure_store_mock!.set_calls.push([name, value, store])
-      root.__tempo_secure_store_mock!.items.set(name, value)
-      return Promise.resolve()
-    },
-  }
-})
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
+  getItemAsync(name: string, store: unknown) {
+    mock.get_calls.push([name, store])
+    return Promise.resolve(mock.items.get(name) ?? null)
+  },
+  setItemAsync(name: string, value: string, store: unknown) {
+    mock.set_calls.push([name, value, store])
+    mock.items.set(name, value)
+    return Promise.resolve()
+  },
+}))
 
 import { getOrCreateMmkvEncryptionKey } from './expoSecureStore.js'
-
-const mock = (globalThis as Global).__tempo_secure_store_mock!
 
 beforeEach(() => {
   mock.get_calls.length = 0
@@ -61,7 +44,7 @@ describe('getOrCreateMmkvEncryptionKey', () => {
 
   test('behavior: creates and stores a key when one does not exist', async () => {
     await expect(getOrCreateMmkvEncryptionKey()).resolves.toMatchInlineSnapshot(
-      `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"`,
+      `"AAECAwQFBgcICQoLDA0ODxAREhMUFRYX"`,
     )
     expect(mock.get_calls).toMatchInlineSnapshot(`
       [
@@ -77,7 +60,7 @@ describe('getOrCreateMmkvEncryptionKey', () => {
       [
         [
           "tempo.mmkvEncryptionKey",
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+          "AAECAwQFBgcICQoLDA0ODxAREhMUFRYX",
           {
             "keychainAccessible": 1,
           },

--- a/src/react-native/expoSecureStore.test.ts
+++ b/src/react-native/expoSecureStore.test.ts
@@ -1,0 +1,104 @@
+import { vi } from 'vitest'
+import { beforeEach, describe, expect, test } from 'vp/test'
+
+type Mock = {
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: number
+  get_calls: unknown[][]
+  items: Map<string, string>
+  set_calls: unknown[][]
+}
+
+type Global = typeof globalThis & {
+  __tempo_secure_store_mock?: Mock | undefined
+}
+
+vi.mock('expo-secure-store', () => {
+  const root = globalThis as Global
+  root.__tempo_secure_store_mock ??= {
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
+    get_calls: [],
+    items: new Map<string, string>(),
+    set_calls: [],
+  }
+  return {
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY:
+      root.__tempo_secure_store_mock.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+    getItemAsync(name: string, store: unknown) {
+      root.__tempo_secure_store_mock!.get_calls.push([name, store])
+      return Promise.resolve(root.__tempo_secure_store_mock!.items.get(name) ?? null)
+    },
+    setItemAsync(name: string, value: string, store: unknown) {
+      root.__tempo_secure_store_mock!.set_calls.push([name, value, store])
+      root.__tempo_secure_store_mock!.items.set(name, value)
+      return Promise.resolve()
+    },
+  }
+})
+
+import { getOrCreateMmkvEncryptionKey } from './expoSecureStore.js'
+
+const mock = (globalThis as Global).__tempo_secure_store_mock!
+
+beforeEach(() => {
+  mock.get_calls.length = 0
+  mock.items.clear()
+  mock.set_calls.length = 0
+  vi.stubGlobal('crypto', {
+    getRandomValues(bytes: Uint8Array) {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = i
+      return bytes
+    },
+  })
+})
+
+describe('getOrCreateMmkvEncryptionKey', () => {
+  test('default: returns an existing key', async () => {
+    mock.items.set('tempo.mmkvEncryptionKey', 'existing')
+
+    await expect(getOrCreateMmkvEncryptionKey()).resolves.toMatchInlineSnapshot(`"existing"`)
+    expect(mock.set_calls).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: creates and stores a key when one does not exist', async () => {
+    await expect(getOrCreateMmkvEncryptionKey()).resolves.toMatchInlineSnapshot(
+      `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"`,
+    )
+    expect(mock.get_calls).toMatchInlineSnapshot(`
+      [
+        [
+          "tempo.mmkvEncryptionKey",
+          {
+            "keychainAccessible": 1,
+          },
+        ],
+      ]
+    `)
+    expect(mock.set_calls).toMatchInlineSnapshot(`
+      [
+        [
+          "tempo.mmkvEncryptionKey",
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+          {
+            "keychainAccessible": 1,
+          },
+        ],
+      ]
+    `)
+  })
+
+  test('behavior: accepts a custom key name and SecureStore options', async () => {
+    await getOrCreateMmkvEncryptionKey({
+      name: 'custom',
+      store: { keychainService: 'wallet' },
+    })
+
+    expect(mock.get_calls[0]).toMatchInlineSnapshot(`
+      [
+        "custom",
+        {
+          "keychainService": "wallet",
+        },
+      ]
+    `)
+  })
+})

--- a/src/react-native/expoSecureStore.ts
+++ b/src/react-native/expoSecureStore.ts
@@ -1,12 +1,13 @@
-import * as SecureStore from 'expo-secure-store'
+import type * as SecureStoreTypes from 'expo-secure-store'
+import { Base64, Bytes } from 'ox'
 
 const key_name = 'tempo.mmkvEncryptionKey'
-const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
 /** Loads or creates the key used to encrypt an MMKV-backed SDK storage instance. */
 export async function getOrCreateMmkvEncryptionKey(
   options: getOrCreateMmkvEncryptionKey.Options = {},
 ): Promise<string> {
+  const SecureStore = await import('expo-secure-store')
   const name = options.name ?? key_name
   const store = options.store ?? {
     keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
@@ -24,14 +25,11 @@ export declare namespace getOrCreateMmkvEncryptionKey {
     /** SecureStore item name. @default "tempo.mmkvEncryptionKey" */
     name?: string | undefined
     /** SecureStore options used for reading and writing the key. */
-    store?: SecureStore.SecureStoreOptions | undefined
+    store?: SecureStoreTypes.SecureStoreOptions | undefined
   }
 }
 
+// 24 random bytes encode to 32 base64 characters, MMKV's maximum AES-256 key length.
 function createKey(): string {
-  const bytes = new Uint8Array(32)
-  globalThis.crypto.getRandomValues(bytes)
-  let out = ''
-  for (let i = 0; i < bytes.length; i++) out += charset[bytes[i]! % charset.length]
-  return out
+  return Base64.fromBytes(Bytes.random(24))
 }

--- a/src/react-native/expoSecureStore.ts
+++ b/src/react-native/expoSecureStore.ts
@@ -1,35 +1,37 @@
-import { Json } from 'ox'
+import * as SecureStore from 'expo-secure-store'
 
-import * as Storage from '../core/Storage.js'
+const key_name = 'tempo.mmkvEncryptionKey'
+const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
-/** Creates a storage adapter backed by `expo-secure-store`. */
-export function secureStorage(options: secureStorage.Options = {}): Storage.Storage {
-  return Storage.from(
-    {
-      async getItem(name) {
-        const { getItemAsync } = await import('expo-secure-store')
-        const raw = await getItemAsync(name)
-        if (raw === null) return null
-        try {
-          return Json.parse(raw)
-        } catch {
-          return null
-        }
-      },
-      async setItem(name, value) {
-        const { setItemAsync } = await import('expo-secure-store')
-        await setItemAsync(name, Json.stringify(value))
-      },
-      async removeItem(name) {
-        const { deleteItemAsync } = await import('expo-secure-store')
-        await deleteItemAsync(name)
-      },
-    },
-    options,
-  )
+/** Loads or creates the key used to encrypt an MMKV-backed SDK storage instance. */
+export async function getOrCreateMmkvEncryptionKey(
+  options: getOrCreateMmkvEncryptionKey.Options = {},
+): Promise<string> {
+  const name = options.name ?? key_name
+  const store = options.store ?? {
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+  }
+  const existing = await SecureStore.getItemAsync(name, store)
+  if (existing) return existing
+  const key = createKey()
+  await SecureStore.setItemAsync(name, key, store)
+  return key
 }
 
-export declare namespace secureStorage {
-  /** Options for `secureStorage`. */
-  type Options = Storage.from.Options
+export declare namespace getOrCreateMmkvEncryptionKey {
+  /** Options for `getOrCreateMmkvEncryptionKey`. */
+  type Options = {
+    /** SecureStore item name. @default "tempo.mmkvEncryptionKey" */
+    name?: string | undefined
+    /** SecureStore options used for reading and writing the key. */
+    store?: SecureStore.SecureStoreOptions | undefined
+  }
+}
+
+function createKey(): string {
+  const bytes = new Uint8Array(32)
+  globalThis.crypto.getRandomValues(bytes)
+  let out = ''
+  for (let i = 0; i < bytes.length; i++) out += charset[bytes[i]! % charset.length]
+  return out
 }

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -1,2 +1,1 @@
 export { asyncStorage } from './asyncStorage.js'
-export { secureStorage } from './expoSecureStore.js'

--- a/src/react-native/secureMmkv.test.ts
+++ b/src/react-native/secureMmkv.test.ts
@@ -1,82 +1,62 @@
 import { vi } from 'vitest'
 import { beforeEach, describe, expect, test } from 'vp/test'
 
-type MmkvMock = {
-  instances: {
+const mmkv_mock = vi.hoisted(() => ({
+  instances: [] as {
     configuration: Record<string, unknown>
     store: Map<string, string>
-  }[]
-  stores: Map<string, Map<string, string>>
-}
+  }[],
+  stores: new Map<string, Map<string, string>>(),
+}))
 
-type SecureStoreMock = {
-  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: number
-  get_calls: unknown[][]
-  items: Map<string, string>
-  set_calls: unknown[][]
-}
+const secure_store_mock = vi.hoisted(() => ({
+  fail_once: false,
+  get_calls: [] as unknown[][],
+  items: new Map<string, string>(),
+  set_calls: [] as unknown[][],
+}))
 
-type Global = typeof globalThis & {
-  __tempo_mmkv_mock?: MmkvMock | undefined
-  __tempo_secure_store_mock?: SecureStoreMock | undefined
-}
+vi.mock('react-native-mmkv', () => ({
+  createMMKV(configuration: Record<string, unknown>) {
+    const id = String(configuration.id)
+    const store = mmkv_mock.stores.get(id) ?? new Map<string, string>()
+    mmkv_mock.stores.set(id, store)
+    mmkv_mock.instances.push({ configuration, store })
+    return {
+      getString: (name: string) => store.get(name),
+      remove: (name: string) => {
+        store.delete(name)
+      },
+      set: (name: string, value: string) => {
+        store.set(name, value)
+      },
+    }
+  },
+}))
 
-vi.mock('react-native-mmkv', () => {
-  const root = globalThis as Global
-  root.__tempo_mmkv_mock ??= {
-    instances: [],
-    stores: new Map<string, Map<string, string>>(),
-  }
-  return {
-    createMMKV(configuration: Record<string, unknown>) {
-      const id = String(configuration.id)
-      const store = root.__tempo_mmkv_mock!.stores.get(id) ?? new Map<string, string>()
-      root.__tempo_mmkv_mock!.stores.set(id, store)
-      root.__tempo_mmkv_mock!.instances.push({ configuration, store })
-      return {
-        getString: (name: string) => store.get(name),
-        remove: (name: string) => {
-          store.delete(name)
-        },
-        set: (name: string, value: string) => {
-          store.set(name, value)
-        },
-      }
-    },
-  }
-})
-
-vi.mock('expo-secure-store', () => {
-  const root = globalThis as Global
-  root.__tempo_secure_store_mock ??= {
-    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
-    get_calls: [],
-    items: new Map<string, string>(),
-    set_calls: [],
-  }
-  return {
-    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY:
-      root.__tempo_secure_store_mock.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
-    getItemAsync(name: string, store: unknown) {
-      root.__tempo_secure_store_mock!.get_calls.push([name, store])
-      return Promise.resolve(root.__tempo_secure_store_mock!.items.get(name) ?? null)
-    },
-    setItemAsync(name: string, value: string, store: unknown) {
-      root.__tempo_secure_store_mock!.set_calls.push([name, value, store])
-      root.__tempo_secure_store_mock!.items.set(name, value)
-      return Promise.resolve()
-    },
-  }
-})
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
+  getItemAsync(name: string, store: unknown) {
+    if (secure_store_mock.fail_once) {
+      secure_store_mock.fail_once = false
+      return Promise.reject(new Error('keychain unavailable'))
+    }
+    secure_store_mock.get_calls.push([name, store])
+    return Promise.resolve(secure_store_mock.items.get(name) ?? null)
+  },
+  setItemAsync(name: string, value: string, store: unknown) {
+    secure_store_mock.set_calls.push([name, value, store])
+    secure_store_mock.items.set(name, value)
+    return Promise.resolve()
+  },
+}))
 
 import { secureMmkv } from './secureMmkv.js'
-
-const mmkv_mock = (globalThis as Global).__tempo_mmkv_mock!
-const secure_store_mock = (globalThis as Global).__tempo_secure_store_mock!
 
 beforeEach(() => {
   mmkv_mock.instances.length = 0
   mmkv_mock.stores.clear()
+  secure_store_mock.fail_once = false
   secure_store_mock.get_calls.length = 0
   secure_store_mock.items.clear()
   secure_store_mock.set_calls.length = 0
@@ -96,7 +76,7 @@ describe('secureMmkv', () => {
 
     expect(mmkv_mock.instances[0]?.configuration).toMatchInlineSnapshot(`
       {
-        "encryptionKey": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+        "encryptionKey": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYX",
         "encryptionType": "AES-256",
         "id": "tempo-secure",
       }
@@ -108,7 +88,7 @@ describe('secureMmkv', () => {
       [
         [
           "tempo.mmkvEncryptionKey",
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+          "AAECAwQFBgcICQoLDA0ODxAREhMUFRYX",
           {
             "keychainAccessible": 1,
           },
@@ -137,6 +117,20 @@ describe('secureMmkv', () => {
     mmkv_mock.instances[0]?.store.set('tempo.store', '{')
 
     expect(await storage.getItem('store')).toMatchInlineSnapshot(`null`)
+  })
+
+  test('behavior: retries MMKV creation after an encryption key failure', async () => {
+    const storage = secureMmkv()
+    secure_store_mock.fail_once = true
+
+    await expect(storage.getItem('store')).rejects.toThrow('keychain unavailable')
+
+    await storage.setItem('store', { ok: true })
+    expect(await storage.getItem('store')).toMatchInlineSnapshot(`
+      {
+        "ok": true,
+      }
+    `)
   })
 
   test('behavior: forwards custom MMKV options', async () => {

--- a/src/react-native/secureMmkv.test.ts
+++ b/src/react-native/secureMmkv.test.ts
@@ -1,0 +1,166 @@
+import { vi } from 'vitest'
+import { beforeEach, describe, expect, test } from 'vp/test'
+
+type MmkvMock = {
+  instances: {
+    configuration: Record<string, unknown>
+    store: Map<string, string>
+  }[]
+  stores: Map<string, Map<string, string>>
+}
+
+type SecureStoreMock = {
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: number
+  get_calls: unknown[][]
+  items: Map<string, string>
+  set_calls: unknown[][]
+}
+
+type Global = typeof globalThis & {
+  __tempo_mmkv_mock?: MmkvMock | undefined
+  __tempo_secure_store_mock?: SecureStoreMock | undefined
+}
+
+vi.mock('react-native-mmkv', () => {
+  const root = globalThis as Global
+  root.__tempo_mmkv_mock ??= {
+    instances: [],
+    stores: new Map<string, Map<string, string>>(),
+  }
+  return {
+    createMMKV(configuration: Record<string, unknown>) {
+      const id = String(configuration.id)
+      const store = root.__tempo_mmkv_mock!.stores.get(id) ?? new Map<string, string>()
+      root.__tempo_mmkv_mock!.stores.set(id, store)
+      root.__tempo_mmkv_mock!.instances.push({ configuration, store })
+      return {
+        getString: (name: string) => store.get(name),
+        remove: (name: string) => {
+          store.delete(name)
+        },
+        set: (name: string, value: string) => {
+          store.set(name, value)
+        },
+      }
+    },
+  }
+})
+
+vi.mock('expo-secure-store', () => {
+  const root = globalThis as Global
+  root.__tempo_secure_store_mock ??= {
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
+    get_calls: [],
+    items: new Map<string, string>(),
+    set_calls: [],
+  }
+  return {
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY:
+      root.__tempo_secure_store_mock.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+    getItemAsync(name: string, store: unknown) {
+      root.__tempo_secure_store_mock!.get_calls.push([name, store])
+      return Promise.resolve(root.__tempo_secure_store_mock!.items.get(name) ?? null)
+    },
+    setItemAsync(name: string, value: string, store: unknown) {
+      root.__tempo_secure_store_mock!.set_calls.push([name, value, store])
+      root.__tempo_secure_store_mock!.items.set(name, value)
+      return Promise.resolve()
+    },
+  }
+})
+
+import { secureMmkv } from './secureMmkv.js'
+
+const mmkv_mock = (globalThis as Global).__tempo_mmkv_mock!
+const secure_store_mock = (globalThis as Global).__tempo_secure_store_mock!
+
+beforeEach(() => {
+  mmkv_mock.instances.length = 0
+  mmkv_mock.stores.clear()
+  secure_store_mock.get_calls.length = 0
+  secure_store_mock.items.clear()
+  secure_store_mock.set_calls.length = 0
+  vi.stubGlobal('crypto', {
+    getRandomValues(bytes: Uint8Array) {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = i
+      return bytes
+    },
+  })
+})
+
+describe('secureMmkv', () => {
+  test('default: creates an encrypted tempo-secure MMKV storage with a SecureStore key', async () => {
+    const storage = secureMmkv()
+
+    await storage.setItem('store', { count: 1n })
+
+    expect(mmkv_mock.instances[0]?.configuration).toMatchInlineSnapshot(`
+      {
+        "encryptionKey": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+        "encryptionType": "AES-256",
+        "id": "tempo-secure",
+      }
+    `)
+    expect(mmkv_mock.instances[0]?.store.get('tempo.store')).toMatchInlineSnapshot(
+      `"{"count":"1#__bigint"}"`,
+    )
+    expect(secure_store_mock.set_calls).toMatchInlineSnapshot(`
+      [
+        [
+          "tempo.mmkvEncryptionKey",
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+          {
+            "keychainAccessible": 1,
+          },
+        ],
+      ]
+    `)
+    expect(await storage.getItem('store')).toMatchInlineSnapshot(`
+      {
+        "count": 1n,
+      }
+    `)
+  })
+
+  test('behavior: scopes keys and removes values', async () => {
+    const storage = secureMmkv({ encryptionKey: 'a'.repeat(32), key: 'wallet' })
+
+    await storage.setItem('store', { ok: true })
+    await storage.removeItem('store')
+
+    expect(mmkv_mock.instances[0]?.store).toMatchInlineSnapshot(`Map {}`)
+  })
+
+  test('behavior: malformed values read as null', async () => {
+    const storage = secureMmkv({ encryptionKey: 'a'.repeat(32) })
+    await storage.setItem('other', { ok: true })
+    mmkv_mock.instances[0]?.store.set('tempo.store', '{')
+
+    expect(await storage.getItem('store')).toMatchInlineSnapshot(`null`)
+  })
+
+  test('behavior: forwards custom MMKV options', async () => {
+    const storage = secureMmkv({
+      compareBeforeSet: true,
+      encryptionKey: 'a'.repeat(32),
+      encryptionType: 'AES-128',
+      id: 'custom',
+      mode: 'multi-process',
+      path: '/tmp/mmkv',
+      readOnly: true,
+    })
+    await storage.getItem('store')
+
+    expect(mmkv_mock.instances[0]?.configuration).toMatchInlineSnapshot(`
+      {
+        "compareBeforeSet": true,
+        "encryptionKey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "encryptionType": "AES-128",
+        "id": "custom",
+        "mode": "multi-process",
+        "path": "/tmp/mmkv",
+        "readOnly": true,
+      }
+    `)
+  })
+})

--- a/src/react-native/secureMmkv.ts
+++ b/src/react-native/secureMmkv.ts
@@ -1,0 +1,82 @@
+import { Json } from 'ox'
+import { createMMKV, type Configuration } from 'react-native-mmkv'
+
+import * as Storage from '../core/Storage.js'
+import { getOrCreateMmkvEncryptionKey } from './expoSecureStore.js'
+
+/** Creates an encrypted storage adapter backed by `react-native-mmkv`. */
+export function secureMmkv(options: secureMmkv.Options = {}): Storage.Storage {
+  let mmkv: ReturnType<typeof createMMKV> | undefined
+  let pending: Promise<ReturnType<typeof createMMKV>> | undefined
+
+  async function getMmkv() {
+    if (mmkv) return mmkv
+    pending ??= create(options)
+      .then((value) => {
+        mmkv = value
+        return value
+      })
+      .catch((error: unknown) => {
+        pending = undefined
+        throw error
+      })
+    return pending
+  }
+
+  return Storage.from(
+    {
+      async getItem(name) {
+        const mmkv = await getMmkv()
+        const raw = mmkv.getString(name)
+        if (raw == null) return null
+        try {
+          return Json.parse(raw)
+        } catch {
+          return null
+        }
+      },
+      async setItem(name, value) {
+        const mmkv = await getMmkv()
+        mmkv.set(name, Json.stringify(value))
+      },
+      async removeItem(name) {
+        const mmkv = await getMmkv()
+        mmkv.remove(name)
+      },
+    },
+    options,
+  )
+}
+
+export declare namespace secureMmkv {
+  /** Options for `secureMmkv`. */
+  type Options = Storage.from.Options & {
+    /** MMKV instance id. @default "tempo-secure" */
+    id?: string | undefined
+    /** MMKV root path. */
+    path?: string | undefined
+    /** MMKV encryption key. Defaults to a key loaded from Expo SecureStore. */
+    encryptionKey?: string | undefined
+    /** MMKV encryption type. @default "AES-256" when `encryptionKey` is set */
+    encryptionType?: Configuration['encryptionType'] | undefined
+    /** MMKV process mode. */
+    mode?: Configuration['mode'] | undefined
+    /** Whether the MMKV instance is read-only. */
+    readOnly?: boolean | undefined
+    /** Whether MMKV should skip writes when the value is unchanged. */
+    compareBeforeSet?: boolean | undefined
+  }
+}
+
+async function create(options: secureMmkv.Options): Promise<ReturnType<typeof createMMKV>> {
+  const encryption_key = options.encryptionKey ?? (await getOrCreateMmkvEncryptionKey())
+  const configuration: Configuration = { id: options.id ?? 'tempo-secure' }
+  if (options.path) configuration.path = options.path
+  configuration.encryptionKey = encryption_key
+  configuration.encryptionType = options.encryptionType ?? 'AES-256'
+  if (options.mode) configuration.mode = options.mode
+  if (options.readOnly !== undefined) configuration.readOnly = options.readOnly
+  if (options.compareBeforeSet !== undefined)
+    configuration.compareBeforeSet = options.compareBeforeSet
+  return createMMKV(configuration)
+}

--- a/src/react-native/secureMmkv.ts
+++ b/src/react-native/secureMmkv.ts
@@ -57,7 +57,7 @@ export declare namespace secureMmkv {
     path?: string | undefined
     /** MMKV encryption key. Defaults to a key loaded from Expo SecureStore. */
     encryptionKey?: string | undefined
-    /** MMKV encryption type. @default "AES-256" when `encryptionKey` is set */
+    /** MMKV encryption type. @default "AES-256" */
     encryptionType?: Configuration['encryptionType'] | undefined
     /** MMKV process mode. */
     mode?: Configuration['mode'] | undefined

--- a/test/vitest.d.ts
+++ b/test/vitest.d.ts
@@ -1,3 +1,6 @@
+// Vitest only hoists `vi.mock` calls when `vi` is imported from 'vitest', but
+// 'vitest' is not a direct dependency (it ships inside `vp`), so type the bare
+// specifier here. Import everything else from 'vp/test'.
 declare module 'vitest' {
   export const vi: typeof import('vp/test').vi
 }

--- a/test/vitest.d.ts
+++ b/test/vitest.d.ts
@@ -1,0 +1,3 @@
+declare module 'vitest' {
+  export const vi: typeof import('vp/test').vi
+}


### PR DESCRIPTION
## Summary
Adds encrypted MMKV storage for React Native SDK state.

## Motivation
`expo-secure-store` is too small for the full accounts SDK snapshot once access-key state grows. Keep only the MMKV encryption key in SecureStore and store the larger SDK payload in encrypted MMKV.

## Changes
- Add `secureMmkv` in `src/react-native/secureMmkv.ts` and export it at `accounts/react-native/secure-mmkv`.
- Have `secureMmkv()` lazily load or create its MMKV encryption key through `getOrCreateMmkvEncryptionKey`.
- Replace the old `secureStorage` adapter in `src/react-native/expoSecureStore.ts` with the key helper.
- Update the React Native guide and playground to use `storage: secureMmkv()`.
- Add regression tests for SecureStore key reuse/creation and MMKV serialization/key scoping.

## Testing
- `./node_modules/.bin/vp test src/react-native/secureMmkv.test.ts src/react-native/expoSecureStore.test.ts` — 2 files, 7 tests passed
- `./node_modules/.bin/tsc -b --noEmit`
- `./node_modules/.bin/zile`
- `git diff --check`
- Pre-commit ran `pnpm check`; completed with existing lint warnings in `site/src/pages.gen.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`, no errors.