### PR TITLE
docs: add Storage reference section with React Native adapters

### DIFF
--- a/.changeset/remove-react-native-index.md
+++ b/.changeset/remove-react-native-index.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Remove the `accounts/react-native` subpath; import `asyncStorage` from `accounts/react-native/async-storage` instead.

--- a/package.json
+++ b/package.json
@@ -174,12 +174,6 @@
       "src": "./src/wagmi/index.ts",
       "default": "./dist/wagmi/index.js"
     },
-    "./react-native": {
-      "types": "./dist/react-native/index.d.ts",
-      "src": "./src/react-native/index.ts",
-      "react-native": "./dist/react-native/index.js",
-      "default": "./dist/react-native/index.js"
-    },
     "./mobileWebAuth": {
       "types": "./dist/core/adapters/mobileWebAuth/index.d.ts",
       "src": "./src/core/adapters/mobileWebAuth/index.ts",

--- a/site/src/pages/docs/api/storage.asyncStorage.mdx
+++ b/site/src/pages/docs/api/storage.asyncStorage.mdx
@@ -1,0 +1,47 @@
+---
+title: asyncStorage
+description: React Native Storage adapter backed by AsyncStorage.
+---
+
+# `asyncStorage`
+
+Creates a [`Storage`](/docs/api/storage) adapter backed by [`@react-native-async-storage/async-storage`](https://react-native-async-storage.github.io/async-storage/).
+
+Values are JSON-serialized and stored in plain text. Use it for non-sensitive provider state; when the provider manages access keys, use [`secureMmkv`](/docs/api/storage.secureMmkv) instead.
+
+The adapter ships as an optional subpath — `accounts/react-native/async-storage` — so apps that do not use it do not install AsyncStorage:
+
+```sh
+npx expo install @react-native-async-storage/async-storage
+```
+
+## Usage
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { asyncStorage } from 'accounts/react-native/async-storage'
+
+const provider = Provider.create({
+  storage: asyncStorage(),
+})
+```
+
+## Parameters
+
+### options.key
+
+- **Type:** `string`
+- **Default:** `'tempo'`
+
+Key prefix applied to every entry written to AsyncStorage. Useful to avoid collisions with other AsyncStorage usage in the app.
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { asyncStorage } from 'accounts/react-native/async-storage'
+
+const provider = Provider.create({
+  storage: asyncStorage({
+    key: 'my-app', // [!code focus]
+  }),
+})
+```

--- a/site/src/pages/docs/api/storage.mdx
+++ b/site/src/pages/docs/api/storage.mdx
@@ -52,6 +52,25 @@ The default is `Storage.idb()` in the browser and `Storage.memory()` otherwise.
   />
 </Cards>
 
+## React Native
+
+React Native adapters ship as optional subpaths so apps only install the native dependencies they use. See the [React Native guide](/docs/guides/react-native) for platform setup.
+
+<Cards>
+  <Card
+    description="Persist non-sensitive state to AsyncStorage"
+    icon="lucide:smartphone"
+    to="/docs/api/storage.asyncStorage"
+    title="asyncStorage"
+  />
+  <Card
+    description="Persist state to encrypted MMKV, key in the Keychain/Keystore"
+    icon="lucide:lock"
+    to="/docs/api/storage.secureMmkv"
+    title="secureMmkv"
+  />
+</Cards>
+
 ## Comparison
 
 | Adapter | Persistence | Environment | Notes |
@@ -60,5 +79,7 @@ The default is `Storage.idb()` in the browser and `Storage.memory()` otherwise.
 | [`Storage.localStorage`](/docs/api/storage.localStorage) | Persistent | Browser | Synchronous; values are JSON-serialized. |
 | [`Storage.cookie`](/docs/api/storage.cookie) | Persistent | Browser | Uses `SameSite=None; Secure`. Deep objects are flattened to stay within the 4 KB-per-cookie limit. |
 | [`Storage.memory`](/docs/api/storage.memory) | Ephemeral | Any | Default outside the browser. Useful for SSR and tests. |
+| [`asyncStorage`](/docs/api/storage.asyncStorage) | Persistent | React Native | Plain-text AsyncStorage; for non-sensitive state. |
+| [`secureMmkv`](/docs/api/storage.secureMmkv) | Persistent | React Native | AES-256-encrypted MMKV with the key in the Keychain/Keystore; use when the provider manages access keys. |
 | [`Storage.combine`](/docs/api/storage.combine) | — | Any | Reads return the first non-null result; writes propagate to every storage. |
 | [`Storage.from`](/docs/api/storage.from) | — | Any | Wraps a custom implementation, optionally scoping all keys under a prefix. |

--- a/site/src/pages/docs/api/storage.secureMmkv.mdx
+++ b/site/src/pages/docs/api/storage.secureMmkv.mdx
@@ -1,0 +1,123 @@
+---
+title: secureMmkv
+description: Encrypted React Native Storage adapter backed by MMKV.
+---
+
+# `secureMmkv`
+
+Creates a [`Storage`](/docs/api/storage) adapter backed by an AES-256-encrypted [`react-native-mmkv`](https://github.com/mrousavy/react-native-mmkv) instance.
+
+Provider state can outgrow the device Keychain/Keystore (iOS limits SecureStore items to a few kilobytes), so `secureMmkv` stores the full snapshot in encrypted MMKV and keeps only the 32-byte encryption key in the Keychain/Keystore. Use it whenever the provider manages access keys.
+
+The adapter ships as an optional subpath — `accounts/react-native/secure-mmkv` — so apps that do not use it do not install MMKV:
+
+```sh
+npx expo install react-native-mmkv react-native-nitro-modules expo-secure-store
+```
+
+## Usage
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { secureMmkv } from 'accounts/react-native/secure-mmkv'
+
+const provider = Provider.create({
+  storage: secureMmkv(),
+})
+```
+
+## Encryption Key
+
+On first use the adapter loads its MMKV encryption key from Expo SecureStore, creating and persisting one when none exists. The key is stored with `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`: it is readable by background work once the device has been unlocked, but it never leaves the device — state does not restore onto a new device from a backup.
+
+The key helper is exported from `accounts/react-native/expo-secure-store` for apps that need a custom SecureStore item name or options:
+
+```ts twoslash
+import { getOrCreateMmkvEncryptionKey } from 'accounts/react-native/expo-secure-store'
+import { secureMmkv } from 'accounts/react-native/secure-mmkv'
+
+const storage = secureMmkv({
+  encryptionKey: await getOrCreateMmkvEncryptionKey({
+    name: 'my-app.mmkvEncryptionKey',
+    store: { keychainService: 'my-app' },
+  }),
+})
+```
+
+Create one `secureMmkv()` instance per MMKV `id`. Two instances racing to create the key on first launch can each persist a different key, leaving one instance's data unreadable on the next launch.
+
+## Parameters
+
+### options.key
+
+- **Type:** `string`
+- **Default:** `'tempo'`
+
+Key prefix applied to every entry written to the MMKV instance.
+
+### options.id
+
+- **Type:** `string`
+- **Default:** `'tempo-secure'`
+
+MMKV instance id. Use distinct ids to keep multiple MMKV instances separate.
+
+### options.encryptionKey
+
+- **Type:** `string`
+- **Default:** a key loaded from Expo SecureStore
+
+MMKV encryption key. Pass one to manage the key yourself — the adapter then never touches SecureStore. Keys can be at most 16 bytes with `AES-128` encryption and 32 bytes with `AES-256`.
+
+### options.encryptionType
+
+- **Type:** `'AES-128' | 'AES-256'`
+- **Default:** `'AES-256'`
+
+MMKV encryption algorithm.
+
+### options.path
+
+- **Type:** `string`
+- **Optional**
+
+MMKV root path. By default MMKV stores files inside the app's documents directory.
+
+### options.mode
+
+- **Type:** `'single-process' | 'multi-process'`
+- **Default:** `'single-process'`
+
+MMKV process mode. Use `multi-process` when the instance is shared with app extensions or background services.
+
+### options.readOnly
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Open the MMKV instance read-only.
+
+### options.compareBeforeSet
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Skip the file write when the new value equals what is already stored.
+
+## getOrCreateMmkvEncryptionKey
+
+Loads or creates the SecureStore-persisted encryption key used by `secureMmkv`. Returns the existing key when one is stored, otherwise generates a random 32-byte key and persists it.
+
+### options.name
+
+- **Type:** `string`
+- **Default:** `'tempo.mmkvEncryptionKey'`
+
+SecureStore item name the key is stored under.
+
+### options.store
+
+- **Type:** `SecureStore.SecureStoreOptions`
+- **Default:** `{ keychainAccessible: AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY }`
+
+SecureStore options used for both reading and writing the key.

--- a/site/src/pages/docs/guides/react-native.mdx
+++ b/site/src/pages/docs/guides/react-native.mdx
@@ -81,8 +81,7 @@ Provider state persists through a storage adapter. React Native adapters ship as
 
 ```ts twoslash
 import { asyncStorage } from 'accounts/react-native/async-storage'
-import { getOrCreateMmkvEncryptionKey } from 'accounts/react-native/expo-secure-store'
 import { secureMmkv } from 'accounts/react-native/secure-mmkv'
 ```
 
-Use `secureMmkv` when the provider manages access keys. It stores the larger SDK snapshot in encrypted MMKV and keeps only the small encryption key in the device Keychain/Keystore through `getOrCreateMmkvEncryptionKey`.
+Use [`secureMmkv`](/docs/api/storage.secureMmkv) when the provider manages access keys. It stores the larger SDK snapshot in encrypted MMKV and keeps only the small encryption key in the device Keychain/Keystore. Use [`asyncStorage`](/docs/api/storage.asyncStorage) for non-sensitive state. See the [Storage reference](/docs/api/storage) for all adapters and options.

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -103,19 +103,6 @@ const config: Config = defineConfig({
               { text: 'Provider', link: '/docs/api/provider' },
               { text: 'Rpc', link: '/docs/api/rpc' },
               { text: 'Schema', link: '/docs/api/schema' },
-              {
-                text: 'Storage',
-                collapsed: true,
-                items: [
-                  { text: 'Overview', link: '/docs/api/storage' },
-                  { text: '.combine', link: '/docs/api/storage.combine' },
-                  { text: '.cookie', link: '/docs/api/storage.cookie' },
-                  { text: '.from', link: '/docs/api/storage.from' },
-                  { text: '.idb', link: '/docs/api/storage.idb' },
-                  { text: '.localStorage', link: '/docs/api/storage.localStorage' },
-                  { text: '.memory', link: '/docs/api/storage.memory' },
-                ],
-              },
               { text: 'TrustedHosts', link: '/docs/api/trustedHosts' },
               {
                 text: 'WebAuthnCeremony',
@@ -206,6 +193,27 @@ const config: Config = defineConfig({
                   { text: '.durableObject', link: '/docs/server/kv.durableObject' },
                   { text: '.from', link: '/docs/server/kv.from' },
                   { text: '.memory', link: '/docs/server/kv.memory' },
+                ],
+              },
+            ],
+          },
+          {
+            text: 'Storage',
+            collapsed: true,
+            items: [
+              { text: 'Overview', link: '/docs/api/storage' },
+              { text: '.combine', link: '/docs/api/storage.combine' },
+              { text: '.cookie', link: '/docs/api/storage.cookie' },
+              { text: '.from', link: '/docs/api/storage.from' },
+              { text: '.idb', link: '/docs/api/storage.idb' },
+              { text: '.localStorage', link: '/docs/api/storage.localStorage' },
+              { text: '.memory', link: '/docs/api/storage.memory' },
+              {
+                text: 'React Native',
+                collapsed: true,
+                items: [
+                  { text: 'asyncStorage', link: '/docs/api/storage.asyncStorage' },
+                  { text: 'secureMmkv', link: '/docs/api/storage.secureMmkv' },
                 ],
               },
             ],

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -1,1 +1,0 @@
-export { asyncStorage } from './asyncStorage.js'


### PR DESCRIPTION
## Summary
Adds a dedicated **Storage** section under Reference covering all storage adapters, including the React Native ones added in #633, and tightens the export surface.

## Changes
- Promote Storage out of Reference → Core into its own sidebar group, with a React Native subsection.
- Add reference pages for `asyncStorage` (`accounts/react-native/async-storage`) and `secureMmkv` (`accounts/react-native/secure-mmkv`), following the existing per-adapter page format (intro, install, usage, parameters).
- Document `getOrCreateMmkvEncryptionKey` and the key lifecycle (SecureStore persistence, `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`, device-only restore, single-instance expectation) on the `secureMmkv` page.
- Add the React Native adapters to the storage overview cards and comparison table.
- Link the React Native guide's Storage section to the new reference pages.
- Remove the `accounts/react-native` index subpath — it only re-exported `asyncStorage`, and `secureMmkv` can't join it without forcing `react-native-mmkv` on every RN app. Every RN adapter now has exactly one import path, named after its native dependency. Patch changeset included.

## Testing
- `./node_modules/.bin/tsc -b --noEmit`
- `./node_modules/.bin/zile` — package builds with the trimmed export map
- `pnpm build` in `site/` — new pages compile (twoslash), no new dead links (two pre-existing warnings on adapter pages are untouched)
- `./node_modules/.bin/vp test src/react-native/` — 8 tests pass