### PR TITLE
refactor: remove TIP-1053 witness hardfork gate

### DIFF
--- a/.changeset/remove-witness-hardfork-gate.md
+++ b/.changeset/remove-witness-hardfork-gate.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Always use TIP-1053 witness binding to collapse access-key authorization and the auth proof into a single passkey ceremony. Previously this was gated behind the T5 hardfork; now that TIP-1053 is live on mainnet, the hardfork check is removed.
+Removed the T5 hardfork gate so TIP-1053 witness binding always collapses access-key authorization and the auth proof into a single passkey ceremony.

--- a/.changeset/remove-witness-hardfork-gate.md
+++ b/.changeset/remove-witness-hardfork-gate.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Always use TIP-1053 witness binding to collapse access-key authorization and the auth proof into a single passkey ceremony. Previously this was gated behind the T5 hardfork; now that TIP-1053 is live on mainnet, the hardfork check is removed.

--- a/src/core/adapters/local.test.ts
+++ b/src/core/adapters/local.test.ts
@@ -1,7 +1,7 @@
 import { KeyAuthorization } from 'ox/tempo'
 import type { Chain, Hex } from 'viem'
 import { hashMessage, verifyMessage } from 'viem'
-import { tempo, tempoLocalnet, tempoModerato } from 'viem/tempo/chains'
+import { tempoLocalnet, tempoModerato } from 'viem/tempo/chains'
 import { describe, expect, test } from 'vp/test'
 
 import {
@@ -143,8 +143,6 @@ describe('local', () => {
 
     test('default: personalSign + authorizeAccessKey binds the message via TIP-1053 witness (one ceremony)', async () => {
       const captured: { digest: Hex | undefined }[] = []
-      // tempoModerato is at the T5 hardfork, which introduces TIP-1053 witness
-      // binding (tempoLocalnet/tempoDevnet are still on T3).
       const { adapter } = setup(
         {
           loadAccounts: makeLoadAccounts(0, captured),
@@ -175,40 +173,6 @@ describe('local', () => {
       expect(decoded.witness).toBe(hashMessage('hello'))
       expect(captured[0]!.digest).toBe(KeyAuthorization.getSignPayload(decoded))
       expect(result.keyAuthorization?.signature).toBeDefined()
-    })
-
-    test('behavior: personalSign + authorizeAccessKey on a non-witness chain produces two distinct signatures', async () => {
-      const captured: { digest: Hex | undefined }[] = []
-      // tempo mainnet does not support TIP-1053 yet — fall back to two prompts.
-      const { adapter } = setup({ loadAccounts: makeLoadAccounts(0, captured) }, { chain: tempo })
-
-      const result = await adapter.actions.loadAccounts(
-        {
-          personalSign: { message: 'hello' },
-          authorizeAccessKey: { expiry: 0, chainId: BigInt(tempo.id) },
-        },
-        { method: 'wallet_connect', params: undefined },
-      )
-
-      // loadAccounts saw the personalSign digest, NOT the keyAuthorization digest.
-      expect(captured[0]!.digest).toBe(hashMessage('hello'))
-      // No witness binding on the fallback path.
-      expect(result.personalSign).toEqual({ message: 'hello' })
-
-      // The personalSign signature is a real EIP-191 signature over 'hello'.
-      expect(
-        await verifyMessage({
-          address: core_accounts[0]!.address,
-          message: 'hello',
-          signature: result.signature!,
-        }),
-      ).toBe(true)
-
-      // The key-auth signature was produced by a *separate* ceremony — it
-      // signs the key-auth digest, not the personalSign digest, so the two
-      // signatures must differ.
-      expect(result.keyAuthorization?.signature).toBeDefined()
-      expect(result.keyAuthorization?.signature).not.toBe(result.signature)
     })
 
     test('error: rejects when personalSign and digest are both set', async () => {

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -1,7 +1,7 @@
 import { Provider as ox_Provider, type WebCryptoP256 } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import { type Chain, hashMessage } from 'viem'
-import { Account as TempoAccount, Hardfork } from 'viem/tempo'
+import { hashMessage } from 'viem'
+import { Account as TempoAccount } from 'viem/tempo'
 import * as z from 'zod/mini'
 
 import * as AccessKey from '../AccessKey.js'
@@ -113,11 +113,9 @@ export function local(options: local.Options): Adapter.Adapter {
 
             // TIP-1053 witness binding (see `loadAccounts`): fold the auth
             // message into the access-key authorization and sign both in the
-            // single create-account ceremony when the chain supports it.
+            // single create-account ceremony.
             const witness =
-              personalSign && grantOptions && supportsWitness(client.chain)
-                ? hashMessage(personalSign.message)
-                : undefined
+              personalSign && grantOptions ? hashMessage(personalSign.message) : undefined
 
             const peronsalSign_digest =
               personalSign && !witness ? hashMessage(personalSign.message) : undefined
@@ -221,14 +219,12 @@ export function local(options: local.Options): Adapter.Adapter {
             const chainId = authorizeAccessKey?.chainId ?? client.chain.id
 
             // TIP-1053 witness binding: when both a `personalSign` challenge and
-            // an `authorizeAccessKey` are requested on a witness-capable chain,
-            // bind the message into the key authorization's `witness` and sign
-            // both in ONE ceremony. The signed key authorization doubles as the
-            // auth proof. Otherwise fall back to the two-ceremony path below.
+            // an `authorizeAccessKey` are requested, bind the message into the
+            // key authorization's `witness` and sign both in ONE ceremony. The
+            // signed key authorization doubles as the auth proof. Otherwise fall
+            // back to the two-ceremony path below.
             const witness =
-              personalSign && authorizeAccessKey && supportsWitness(client.chain)
-                ? hashMessage(personalSign.message)
-                : undefined
+              personalSign && authorizeAccessKey ? hashMessage(personalSign.message) : undefined
 
             // Only claim the ceremony slot with the `personalSign` digest when
             // NOT binding via witness — the witness path signs the key-auth
@@ -355,15 +351,3 @@ export declare namespace local {
   }
 }
 
-/**
- * Returns whether the given chain supports TIP-1053 witness binding, which
- * lets the wallet collapse access-key authorization and the auth proof into a
- * single passkey ceremony. Witness binding ships in the T5 hardfork, so a
- * chain qualifies only once it is at T5 or later.
- *
- * @param chain - Chain to check (reads its `hardfork`).
- * @returns `true` when the chain supports witness binding.
- */
-function supportsWitness(chain: Chain & { hardfork?: Hardfork.Hardfork | undefined }) {
-  return Boolean(chain.hardfork && !Hardfork.lt(chain.hardfork, 't5'))
-}

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -350,4 +350,3 @@ export declare namespace local {
     rdns?: string | undefined
   }
 }
-


### PR DESCRIPTION
## Summary

TIP-1053 witness binding is now live on mainnet, so the T5 hardfork gate that conditionally enabled it is no longer needed. Witness binding now always applies when both a `personalSign` and an access-key authorization are requested in the same ceremony.

## Changes

- Removed the `supportsWitness(chain)` helper and its `Chain`/`Hardfork` imports in `src/core/adapters/local.ts`.
- Simplified the `witness` computation in both the `createAccount` and `loadAccounts` paths to drop the chain/hardfork check.
- Removed the now-obsolete "non-witness chain produces two distinct signatures" mainnet fallback test and the stale T5 comments in `local.test.ts` (plus the unused `tempo` import).
- Added a changeset.

The server verifier (`src/server/internal/handlers/auth.ts`) had no hardfork gate — it already verifies the witness unconditionally.

## Verification

- `tsc -b --noEmit` clean
- `src/core/adapters/local.test.ts` — 11 passed
- `src/server/internal/handlers/auth.test.ts` — 49 passed