### PR TITLE
test: update auth + authorizeAccessKey ceremony expectations

### DIFF
--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -526,7 +526,7 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         )
       })
 
-      test('default: auth + authorizeAccessKey surfaces both capabilities (two ceremonies)', async () => {
+      test('default: auth + authorizeAccessKey surfaces both capabilities (one witness-bound ceremony)', async () => {
         const provider = Provider.create({ adapter: adapter() })
 
         const result = await provider.request({
@@ -544,7 +544,10 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
         expect(result.accounts[0]!.capabilities.auth).toEqual({ token: expect.any(String) })
         expect(result.accounts[0]!.capabilities.keyAuthorization).toBeDefined()
+        // TIP-1053 witness binding: the auth message is folded into the
+        // access-key authorization, which doubles as the auth proof.
         expect(result.accounts[0]!.capabilities.personalSign).toEqual({
+          keyAuthorization: expect.stringMatching(/^0x[0-9a-f]+$/),
           message: expect.any(String),
         })
         expect(result.accounts[0]!.capabilities.signature).toMatch(/^0x[0-9a-f]+$/)


### PR DESCRIPTION
#637 removed the TIP-1053 witness hardfork gate, so `wallet_connect` with both `auth` and `authorizeAccessKey` now always binds the auth message into the key authorization and signs both in **one** ceremony — `capabilities.personalSign` carries the RLP-serialized signed key authorization. The localnet test still asserted the old two-ceremony shape, so the `lib/localnet` suite currently fails on `main` (and on every PR whose Verify workflow runs it, e.g. #638):

```
FAIL  wallet_connect > auth (Server Authentication) > default: auth + authorizeAccessKey surfaces both capabilities (two ceremonies)
AssertionError: expected { …(2) } to deeply equal { message: Any<String> }
+ "keyAuthorization": "0xf9016c…"
```

Updates the assertions (and the test name) to the witness-bound shape. Full `lib/localnet` suite passes locally with this change.