### PR TITLE
feat: add credits wallet deposit intent

### DIFF
--- a/site/src/pages/docs/rpc/wallet_deposit.mdx
+++ b/site/src/pages/docs/rpc/wallet_deposit.mdx
@@ -23,6 +23,8 @@ type Request = {
     chainId?: number
     /** Display name shown in the deposit UI (e.g. the app name). */
     displayName?: string
+    /** Preferred funding path to show first. */
+    intent?: 'applePay' | 'credits' | 'crypto' | 'faucet' | 'referralCode' | 'x'
     /** Token contract address to pre-fill. Omit to let the user choose. */
     token?: `0x${string}`
     /** Human-readable amount to pre-fill (e.g. `"1.5"`). */

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -971,6 +971,17 @@ export namespace wallet_deposit {
             amount: z.optional(z.string()),
             chainId: z.optional(u.number()),
             displayName: z.optional(z.string()),
+            /** Preferred funding path to show first. */
+            intent: z.optional(
+              z.union([
+                z.literal('applePay'),
+                z.literal('credits'),
+                z.literal('crypto'),
+                z.literal('faucet'),
+                z.literal('referralCode'),
+                z.literal('x'),
+              ]),
+            ),
             /**
              * Token to pre-fill, accepted as either a contract address or a
              * supported deposit token symbol (case-insensitive, e.g. `"USDC"`).


### PR DESCRIPTION
## Summary
- add `credits` as a supported `wallet_deposit` intent
- document the deposit intent field in RPC docs

## Test
- `pnpm exec tsc -b --pretty false --force`
