### PR TITLE
fix: restore fee token for raw sponsorship

### DIFF
--- a/.changeset/raw-sponsored-fee-token.md
+++ b/.changeset/raw-sponsored-fee-token.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed raw sponsored transaction signing to restore the configured fee token when the serialized transaction omits it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,7 @@ catalogs:
 
 overrides:
   accounts: workspace:*
+  '@grpc/grpc-js': 1.14.4
   '@sinclair/typebox': ^0.34.0
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
   viem: 2.52.2
@@ -2554,8 +2555,8 @@ packages:
     peerDependencies:
       viem: 2.52.2
 
-  '@grpc/grpc-js@1.14.2':
-    resolution: {integrity: sha512-QzVUtEFyu05UNx2xr0fCQmStUO17uVQhGNowtxs00IgTZT6/W2PBLfUkj30s0FKJ29VtTa3ArVNIhNP6akQhqA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
@@ -14422,7 +14423,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@grpc/grpc-js@1.14.2':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -22265,7 +22266,7 @@ snapshots:
   dockerode@4.0.10:
     dependencies:
       '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.2
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
       protobufjs: 7.5.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,6 +75,7 @@ nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=Deprecatio
 
 overrides:
   accounts: 'workspace:*'
+  '@grpc/grpc-js': '1.14.4'
   '@sinclair/typebox': '^0.34.0'
   'brace-expansion@>=5.0.0 <5.0.6': '5.0.6'
   viem: 2.52.2

--- a/src/server/internal/handlers/relay.localnet.test.ts
+++ b/src/server/internal/handlers/relay.localnet.test.ts
@@ -403,6 +403,51 @@ describe('behavior: with feePayer.feeToken', () => {
 
     expect(feeToken?.toLowerCase()).toBe(sponsorFeeToken)
   })
+
+  test('behavior: raw sponsor signing restores token-list default before validation', async () => {
+    let feeToken_validated: Address | undefined
+    const customServer = await createServer(
+      relay({
+        chains: [chain],
+        transports: { [chain.id]: http() },
+        feePayer: {
+          account: feePayerAccount,
+          validate: (request) => {
+            feeToken_validated = request.feeToken as Address | undefined
+            return true
+          },
+        },
+        resolveTokens: () => localnetTokens,
+      }).listener,
+    )
+    const rpc = getClient({ account: userAccount, chain, transport: http() })
+    const { transaction } = await fillTransaction(rpc, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: true as never,
+    })
+    const partial = await userAccount.signTransaction({ ...transaction, feePayer: true } as never)
+
+    try {
+      const response = await fetch(customServer.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_signRawTransaction',
+          params: [partial],
+        }),
+      })
+      const body = (await response.json()) as { result: `0x76${string}` }
+      const feeToken = Transaction.deserialize(body.result).feeToken as Address | undefined
+
+      expect(feeToken_validated?.toLowerCase()).toBe(sponsorFeeToken)
+      expect(feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+    } finally {
+      customServer.close()
+    }
+  })
 })
 
 describe('behavior: with app-provided feePayer URL', () => {

--- a/src/server/internal/handlers/relay.localnet.test.ts
+++ b/src/server/internal/handlers/relay.localnet.test.ts
@@ -375,6 +375,34 @@ describe('behavior: with feePayer.feeToken', () => {
     expect(receipt.feePayer).toBe(feePayerAccount.address.toLowerCase())
     expect(receipt.feeToken?.toLowerCase()).toBe(sponsorFeeToken)
   })
+
+  test('behavior: raw sponsor signing restores sponsor.feeToken when envelope omits feeToken', async () => {
+    const rpc = getClient({ account: userAccount, chain, transport: http() })
+    const { transaction } = await fillTransaction(rpc, {
+      account: userAccount.address,
+      calls: [transferCall()],
+      feePayer: true as never,
+    })
+    const partial = await userAccount.signTransaction({ ...transaction, feePayer: true } as never)
+    expect([null, undefined]).toContain(
+      Transaction.deserialize(partial as `0x76${string}`).feeToken,
+    )
+
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_signRawTransaction',
+        params: [partial],
+      }),
+    })
+    const body = (await response.json()) as { result: `0x76${string}` }
+    const feeToken = Transaction.deserialize(body.result).feeToken as Address | undefined
+
+    expect(feeToken?.toLowerCase()).toBe(sponsorFeeToken)
+  })
 })
 
 describe('behavior: with app-provided feePayer URL', () => {

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -549,6 +549,7 @@ export function relay(options: relay.Options = {}): Handler {
           const result = await Sponsorship.handleRawTransaction({
             account: feePayerOptions.account,
             feeToken: feePayerOptions.feeToken,
+            getFeeToken: async (chainId) => (await getTokens(chainId))[0],
             getClient,
             method: request.method as Sponsorship.handleRawTransaction.Options['method'],
             request: { params: 'params' in request ? request.params : undefined },

--- a/src/server/internal/handlers/relay.ts
+++ b/src/server/internal/handlers/relay.ts
@@ -548,6 +548,7 @@ export function relay(options: relay.Options = {}): Handler {
 
           const result = await Sponsorship.handleRawTransaction({
             account: feePayerOptions.account,
+            feeToken: feePayerOptions.feeToken,
             getClient,
             method: request.method as Sponsorship.handleRawTransaction.Options['method'],
             request: { params: 'params' in request ? request.params : undefined },

--- a/src/server/internal/handlers/sponsorship.ts
+++ b/src/server/internal/handlers/sponsorship.ts
@@ -128,21 +128,25 @@ export async function handleRawTransaction(options: handleRawTransaction.Options
       message: 'Transaction must be signed by the sender before fee payer signing.',
     })
 
-  if (validate && !(await validate(transaction as Transaction.TransactionRequest)))
+  const client = getClient(transaction.chainId)
+  const feeToken_chain = (client.chain as { feeToken?: Address | undefined } | undefined)?.feeToken
+  const feeToken =
+    (transaction.feeToken as Address | null | undefined) ??
+    sponsorFeeToken ??
+    (await options.getFeeToken?.(transaction.chainId)) ??
+    feeToken_chain
+  const transaction_sponsored = feeToken ? { ...transaction, feeToken } : transaction
+
+  if (validate && !(await validate(transaction_sponsored as Transaction.TransactionRequest)))
     throw new RpcResponse.InvalidParamsError({
       message: 'Sponsorship rejected.',
     })
 
-  const client = getClient(transaction.chainId)
-  const chainFeeToken = (client.chain as { feeToken?: Address | undefined } | undefined)?.feeToken
-  const feeToken =
-    (transaction.feeToken as Address | null | undefined) ?? sponsorFeeToken ?? chainFeeToken
   const serializedTransaction = toSerializedTransaction(
     await signTransaction(client, {
-      ...transaction,
+      ...transaction_sponsored,
       account,
       feePayer: account,
-      ...(feeToken ? { feeToken } : {}),
     } as never),
   )
 
@@ -159,6 +163,8 @@ export declare namespace handleRawTransaction {
     account: LocalAccount
     /** Optional token the fee payer prefers for sponsored raw transactions. */
     feeToken?: Address | undefined
+    /** Optional fee-token resolver used when the raw envelope omits `feeToken`. */
+    getFeeToken?: ((chainId: number) => Promise<Address | undefined>) | undefined
     /** Client resolver keyed by transaction `chainId`. */
     getClient: (chainId?: number | undefined) => Client
     /** Raw transaction method to handle. */

--- a/src/server/internal/handlers/sponsorship.ts
+++ b/src/server/internal/handlers/sponsorship.ts
@@ -113,7 +113,7 @@ export declare namespace sign {
 
 /** Handles `eth_signRawTransaction` and broadcast methods for sponsored Tempo transactions. */
 export async function handleRawTransaction(options: handleRawTransaction.Options) {
-  const { account, getClient, method, request, validate } = options
+  const { account, feeToken: sponsorFeeToken, getClient, method, request, validate } = options
   const serialized = request.params?.[0] as `0x76${string}` | undefined
 
   if (!serialized?.startsWith('0x76') && !serialized?.startsWith('0x78'))
@@ -134,11 +134,15 @@ export async function handleRawTransaction(options: handleRawTransaction.Options
     })
 
   const client = getClient(transaction.chainId)
+  const chainFeeToken = (client.chain as { feeToken?: Address | undefined } | undefined)?.feeToken
+  const feeToken =
+    (transaction.feeToken as Address | null | undefined) ?? sponsorFeeToken ?? chainFeeToken
   const serializedTransaction = toSerializedTransaction(
     await signTransaction(client, {
       ...transaction,
       account,
       feePayer: account,
+      ...(feeToken ? { feeToken } : {}),
     } as never),
   )
 
@@ -153,6 +157,8 @@ export declare namespace handleRawTransaction {
   type Options = {
     /** Account used as the fee payer. */
     account: LocalAccount
+    /** Optional token the fee payer prefers for sponsored raw transactions. */
+    feeToken?: Address | undefined
     /** Client resolver keyed by transaction `chainId`. */
     getClient: (chainId?: number | undefined) => Client
     /** Raw transaction method to handle. */


### PR DESCRIPTION
## Summary

- Restore the configured fee token when raw sponsored transaction envelopes omit it
- Thread the relay fee payer fee token into raw sponsorship signing
- Add localnet regression coverage for raw sponsored signing