### PR TITLE
feat(provider): serve wallet_authorizeChallenge and expose provider.mpp

### DIFF
--- a/.changeset/provider-wallet-authorize-challenge.md
+++ b/.changeset/provider-wallet-authorize-challenge.md
@@ -1,0 +1,7 @@
+---
+"accounts": patch
+---
+
+Added the `wallet_authorizeChallenge` RPC method — creates a Machine Payment Protocol credential for a serialized challenge, advertised via the `mpp` capability on `wallet_getCapabilities`. Rejects as unsupported when MPP is disabled so clients can fall back to local signing.
+
+Added `provider.mpp` — the payment-aware `fetch` and configured MPP method clients, for runtimes where the global `fetch` polyfill is unavailable (e.g. Cloudflare Workers). `undefined` when MPP is disabled.

--- a/.changeset/provider-wallet-authorize-challenge.md
+++ b/.changeset/provider-wallet-authorize-challenge.md
@@ -2,6 +2,4 @@
 "accounts": patch
 ---
 
-Added the `wallet_authorizeChallenge` RPC method — creates a Machine Payment Protocol credential for a serialized challenge, advertised via the `mpp` capability on `wallet_getCapabilities`. Rejects as unsupported when MPP is disabled so clients can fall back to local signing.
-
-Added `provider.mpp` — the payment-aware `fetch` and configured MPP method clients, for runtimes where the global `fetch` polyfill is unavailable (e.g. Cloudflare Workers). `undefined` when MPP is disabled.
+Added the `wallet_authorizeChallenge` method.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -398,6 +398,7 @@ const provider = Provider.create({
 The provider type is exported as `Provider` and is the intersection of [`ox.Provider.Provider`](https://oxlib.sh/Provider) (the EIP-1193 surface) and [`ox.Provider.Emitter`](https://oxlib.sh/Provider#emitter) plus a few extra accessors:
 
 ```ts
+import type { Mppx } from 'mppx/client'
 import type { Address, Hex, Provider as ox_Provider } from 'ox'
 import type { Chain, Client as ViemClient, Transport } from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
@@ -420,6 +421,8 @@ export type Provider = ox_Provider.Provider & ox_Provider.Emitter & {
     chainId?: number | undefined
     feePayer?: string | undefined
   }): ViemClient<Transport, typeof tempo>
+  /** Payment-aware `fetch` and MPP method clients. `undefined` when MPP is disabled. */
+  mpp: Pick<Mppx.Mppx, 'fetch' | 'methods'> | undefined
   /** Reactive state store. */
   store: Store
 }

--- a/site/src/pages/docs/api/rpc.mdx
+++ b/site/src/pages/docs/api/rpc.mdx
@@ -48,6 +48,7 @@ The full list of method namespaces is:
 - `eth_signTypedData_v4`
 - `personal_sign`
 - `wallet_authorizeAccessKey`
+- `wallet_authorizeChallenge`
 - `wallet_connect`
 - `wallet_deposit`
 - `wallet_depositZone`

--- a/site/src/pages/docs/rpc/wallet_authorizeChallenge.mdx
+++ b/site/src/pages/docs/rpc/wallet_authorizeChallenge.mdx
@@ -1,0 +1,50 @@
+---
+title: wallet_authorizeChallenge
+description: Authorize Machine Payment Protocol (MPP) challenges.
+---
+
+# `wallet_authorizeChallenge`
+
+Creates a [Machine Payment Protocol](https://mpp.dev) (MPP) credential for the first of the given challenges. Servers issue challenges on `402 Payment Required` responses (via the `WWW-Authenticate` header); clients forward them here so the wallet settles the payment and returns a credential to retry with. Every challenge must be valid and supported by the wallet — a malformed, unsupported, or foreign-chain entry rejects the whole request with invalid params.
+
+Wallets advertise support via the `mpp` capability on [`wallet_getCapabilities`](/docs/rpc/wallet_getCapabilities). When MPP is disabled, the method rejects as unsupported (EIP-1193 `4200`) — clients should treat this like `-32601` and fall back to their own signing path.
+
+## Request
+
+```ts
+type Request = {
+  method: 'wallet_authorizeChallenge'
+  params: [{
+    /** Serialized MPP challenges (`Challenge.serialize` format). */
+    challenges: string[]
+  }]
+}
+```
+
+## Response
+
+```ts
+type Response = {
+  /** Serialized MPP credential for the first challenge (`Credential.deserialize` format). */
+  authorization: string
+}
+```
+
+## Example
+
+```ts
+const response = await fetch('https://api.example.com/paid-resource')
+
+if (response.status === 402) {
+  const challenge = response.headers.get('www-authenticate')!
+
+  const { authorization } = await provider.request({
+    method: 'wallet_authorizeChallenge',
+    params: [{ challenges: [challenge] }],
+  })
+
+  const retry = await fetch('https://api.example.com/paid-resource', {
+    headers: { Authorization: authorization },
+  })
+}
+```

--- a/site/src/pages/docs/rpc/wallet_getCapabilities.mdx
+++ b/site/src/pages/docs/rpc/wallet_getCapabilities.mdx
@@ -26,6 +26,8 @@ type Response = Record<Hex, {
   atomic: { status: 'supported' | 'ready' | 'unsupported' }
   /** Whether the relay can sponsor fees on this chain. */
   feePayer?: { status: 'supported' | 'unsupported' }
+  /** Machine Payment Protocol (`wallet_authorizeChallenge`) support. Omitted when MPP is disabled. */
+  mpp?: { status: 'supported' }
 }>
 ```
 

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -134,6 +134,7 @@ const config: Config = defineConfig({
               { text: 'eth_signTypedData_v4', link: '/docs/rpc/eth_signTypedData_v4' },
               { text: 'personal_sign', link: '/docs/rpc/personal_sign' },
               { text: 'wallet_authorizeAccessKey', link: '/docs/rpc/wallet_authorizeAccessKey' },
+              { text: 'wallet_authorizeChallenge', link: '/docs/rpc/wallet_authorizeChallenge' },
               { text: 'wallet_connect', link: '/docs/rpc/wallet_connect' },
               { text: 'wallet_deposit', link: '/docs/rpc/wallet_deposit' },
               { text: 'wallet_depositZone', link: '/docs/rpc/wallet_depositZone' },

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1399,6 +1399,9 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       	    "atomic": {
       	      "status": "supported",
       	    },
+      	    "mpp": {
+      	      "status": "supported",
+      	    },
       	  },
       	  "0x7a56": {
       	    "accessKeys": {
@@ -1407,12 +1410,18 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
       	    "atomic": {
       	      "status": "supported",
       	    },
+      	    "mpp": {
+      	      "status": "supported",
+      	    },
       	  },
       	  "0xa5bf": {
       	    "accessKeys": {
       	      "status": "supported",
       	    },
       	    "atomic": {
+      	      "status": "supported",
+      	    },
+      	    "mpp": {
       	      "status": "supported",
       	    },
       	  },
@@ -1436,6 +1445,9 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
               "status": "supported",
             },
             "atomic": {
+              "status": "supported",
+            },
+            "mpp": {
               "status": "supported",
             },
           },
@@ -1498,6 +1510,13 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
 
       const result = await provider.request({ method: 'wallet_getCapabilities' })
       expect(result[Hex.fromNumber(tempo.id)]!.feePayer).toBeUndefined()
+    })
+
+    test('behavior: excludes mpp when disabled', async () => {
+      const provider = Provider.create({ adapter: adapter(), mpp: false })
+
+      const result = await provider.request({ method: 'wallet_getCapabilities' })
+      expect(result[Hex.fromNumber(tempo.id)]!.mpp).toBeUndefined()
     })
   })
 

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,3 +1,4 @@
+import { Challenge } from 'mppx'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Adapter from './Adapter.js'
@@ -5,6 +6,18 @@ import * as Provider from './Provider.js'
 import * as Storage from './Storage.js'
 
 const address = '0x0000000000000000000000000000000000000001'
+
+const testAdapter = () =>
+  Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+    actions: {
+      async createAccount() {
+        return { accounts: [{ address }] }
+      },
+      async loadAccounts() {
+        return { accounts: [{ address }] }
+      },
+    },
+  }))
 
 describe('wallet_connect', () => {
   test('behavior: validates auth before preparing access key material', async () => {
@@ -135,6 +148,193 @@ describe('wallet_connect', () => {
 
       expect(verifyBody?.idToken).toBe('eyJhbG.payload.sig')
     })
+  })
+})
+
+describe('mpp', () => {
+  test('default: exposes payment-aware fetch and method clients', () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+
+    expect(typeof provider.mpp?.fetch).toMatch(/function/)
+    expect(provider.mpp?.methods.map((m) => `${m.name}/${m.intent}`)).toMatchInlineSnapshot(`
+      [
+        "tempo/charge",
+        "tempo/session",
+        "tempo/subscription",
+      ]
+    `)
+  })
+
+  test('behavior: undefined when disabled', () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: false,
+      storage: Storage.memory(),
+    })
+
+    expect(provider.mpp).toBeUndefined()
+  })
+})
+
+describe('wallet_authorizeChallenge', () => {
+  function serializedChallenge(
+    options: { amount?: string; chainId?: number; intent?: string; method?: string } = {},
+  ) {
+    const { amount = '1', chainId, intent = 'charge', method = 'tempo' } = options
+    return Challenge.serialize(
+      Challenge.from({
+        id: 'test-challenge',
+        intent,
+        method,
+        realm: 'api.example.com',
+        request: {
+          amount,
+          currency: '0x20c0000000000000000000000000000000000001',
+          ...(chainId !== undefined && { methodDetails: { chainId } }),
+        },
+      }),
+    )
+  }
+
+  test('behavior: wallet-internal method clients do not re-enter wallet_authorizeChallenge', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    // The tempo method clients probe their wallet (`wallet_authorizeChallenge`)
+    // before signing locally, routed back through this provider — a second
+    // `wallet_authorizeChallenge` entering `request` means the handler
+    // re-entered itself.
+    let entries = 0
+    const request = provider.request.bind(provider)
+    provider.request = (async (args: { method: string }) => {
+      if (args.method === 'wallet_authorizeChallenge' && ++entries > 1)
+        throw new Error('nested wallet_authorizeChallenge detected')
+      return request(args as never)
+    }) as typeof provider.request
+
+    // Zero-amount keeps the local fallback on the signing path, which the
+    // bare test adapter rejects — only the absence of re-entrancy matters.
+    const result = await provider
+      .request({
+        method: 'wallet_authorizeChallenge',
+        params: [{ challenges: [serializedChallenge({ amount: '0' })] }],
+      })
+      .catch((error) => error)
+
+    expect(entries).toBe(1)
+    expect(String(result)).not.toContain('nested wallet_authorizeChallenge detected')
+  })
+
+  test('error: throws UnsupportedMethodError when mpp is disabled', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: false,
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({
+        method: 'wallet_authorizeChallenge',
+        params: [{ challenges: [serializedChallenge()] }],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Provider.UnsupportedMethodError: \`wallet_authorizeChallenge\` not supported. MPP is disabled.]`,
+    )
+  })
+
+  test('error: throws DisconnectedError when no account is connected', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+
+    await expect(
+      provider.request({
+        method: 'wallet_authorizeChallenge',
+        params: [{ challenges: [serializedChallenge()] }],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Provider.DisconnectedError: No accounts connected.]`,
+    )
+  })
+
+  test('error: throws InvalidParamsError when challenges is empty', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({ method: 'wallet_authorizeChallenge', params: [{ challenges: [] }] }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: Invalid params: params.0.challenges: Invalid input]`,
+    )
+  })
+
+  test('error: throws InvalidParamsError when a challenge is malformed', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({
+        method: 'wallet_authorizeChallenge',
+        params: [{ challenges: ['not-a-challenge'] }],
+      }),
+    ).rejects.toThrow(/`challenges\[0\]` is not a valid MPP challenge/)
+  })
+
+  test('error: throws InvalidParamsError when a challenge targets an unsupported chain', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({
+        method: 'wallet_authorizeChallenge',
+        params: [{ challenges: [serializedChallenge({ chainId: 999 })] }],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`challenges[0]\` targets unsupported chain 999.]`,
+    )
+  })
+
+  test('error: throws InvalidParamsError when any challenge is unsupported', async () => {
+    const provider = Provider.create({
+      adapter: testAdapter(),
+      mpp: { polyfill: false },
+      storage: Storage.memory(),
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    await expect(
+      provider.request({
+        method: 'wallet_authorizeChallenge',
+        params: [
+          { challenges: [serializedChallenge(), serializedChallenge({ method: 'stripe' })] },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[RpcResponse.InvalidParamsError: \`challenges[1]\` has unsupported method "stripe/charge". Supported: tempo/charge, tempo/session, tempo/subscription.]`,
+    )
   })
 })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,4 +1,5 @@
 import { announceProvider } from 'mipd'
+import { Challenge } from 'mppx'
 import { Mppx, tempo as mppx_tempo } from 'mppx/client'
 import {
   Address,
@@ -66,6 +67,8 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
       chainId?: number | undefined
       feePayer?: string | undefined
     }): ViemClient<Transport, typeof tempo>
+    /** Payment-aware `fetch` and MPP method clients. `undefined` when MPP is disabled. */
+    mpp: mpp.Mpp | undefined
     /** Reactive state store. */
     store: Store.Store
   }
@@ -737,6 +740,61 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
+  // Machine Payment Protocol (mppx) integration. The method clients resolve
+  // their viem Client lazily through `providerRef` (assigned below) so
+  // signing routes through the provider like any other wallet request.
+  const mpp = ((): Provider['mpp'] => {
+    const mppOptions = (() => {
+      if (options.mpp === false) return undefined
+      if (typeof options.mpp === 'object') return options.mpp
+      return {}
+    })()
+    if (!mppOptions) return undefined
+    const { mode = 'push', polyfill: polyfill_option, ...methodOptions } = mppOptions
+    // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
+    // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
+    const polyfill = polyfill_option ?? isFetchWritable()
+    const getMppClient = ({ chainId }: { chainId?: number | undefined }) => {
+      const client = Client.fromChainId(chainId, {
+        chains,
+        provider: providerRef,
+        store,
+        transports,
+      })
+      const account = store.getState().accounts[store.getState().activeAccount]
+      if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
+      // The provider IS the wallet: mppx method clients probe their `json-rpc`
+      // account's wallet (`wallet_authorizeChallenge`) before signing locally,
+      // which would re-enter the handler and recurse forever. Answer the
+      // nested call with `4200` so mppx falls back to its local signing path.
+      const request = (async (args: { method: string; params?: unknown }, options?: unknown) => {
+        if (args.method === 'wallet_authorizeChallenge')
+          throw new ox_Provider.UnsupportedMethodError({
+            message:
+              '`wallet_authorizeChallenge` is not re-entrant: wallet-internal MPP clients sign locally.',
+          })
+        return client.request(args as never, options as never)
+      }) as typeof client.request
+      // Copy the client — the cached instance is shared with `provider.getClient()`,
+      // which must keep its unguarded `request` and stay account-less.
+      return Object.assign({}, client, {
+        account: {
+          address: account.address,
+          type: 'json-rpc' as const,
+        },
+        request,
+      })
+    }
+    const { fetch, methods } = Mppx.create({
+      methods: [
+        mppx_tempo({ ...methodOptions, getClient: getMppClient, mode }),
+        mppx_tempo.subscription({ getClient: getMppClient }),
+      ],
+      polyfill,
+    })
+    return { fetch, methods }
+  })()
+
   const provider = Object.assign(
     ox_Provider.from(
       {
@@ -1107,6 +1165,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' }
                         atomic: { status: 'supported' }
                         feePayer?: { status: 'supported' } | undefined
+                        mpp?: { status: 'supported' } | undefined
                       }
                     > = {}
                     for (const chain of filtered)
@@ -1114,6 +1173,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                         accessKeys: { status: 'supported' },
                         atomic: { status: 'supported' },
                         ...(feePayerConfig ? { feePayer: { status: 'supported' } } : {}),
+                        ...(mpp ? { mpp: { status: 'supported' } } : {}),
                       }
                     return result as Rpc.wallet_getCapabilities.Encoded['returns']
                   }
@@ -1397,6 +1457,50 @@ export function create(options: create.Options = {}): create.ReturnType {
                     } satisfies Rpc.wallet_authorizeAccessKey.Encoded['returns']
                   }
 
+                  case 'wallet_authorizeChallenge': {
+                    if (!mpp)
+                      throw new ox_Provider.UnsupportedMethodError({
+                        message: '`wallet_authorizeChallenge` not supported. MPP is disabled.',
+                      })
+                    assertConnected()
+                    const [{ challenges }] = request._decoded.params
+                    // Every challenge must deserialize and match a configured
+                    // MPP method client; the credential is created for the
+                    // first one, routed through `getMppClient` exactly like
+                    // the internal payment-aware fetch.
+                    const candidates = challenges.map((serialized, index) => {
+                      let challenge: Challenge.Challenge
+                      try {
+                        challenge = Challenge.deserialize(serialized)
+                      } catch (error) {
+                        throw new RpcResponse.InvalidParamsError({
+                          message: `\`challenges[${index}]\` is not a valid MPP challenge: ${withDetails(error).message}`,
+                        })
+                      }
+                      const method = mpp.methods.find(
+                        (m) => m.name === challenge.method && m.intent === challenge.intent,
+                      )
+                      if (!method)
+                        throw new RpcResponse.InvalidParamsError({
+                          message: `\`challenges[${index}]\` has unsupported method "${challenge.method}/${challenge.intent}". Supported: ${mpp.methods.map((m) => `${m.name}/${m.intent}`).join(', ')}.`,
+                        })
+                      // `Client.fromChainId` falls back to the first chain for
+                      // unknown IDs — reject foreign-chain challenges instead
+                      // of settling them on the wrong chain.
+                      const chainId = (challenge.request.methodDetails as { chainId?: unknown })
+                        ?.chainId
+                      if (chainId !== undefined && !chains.some((c) => c.id === chainId))
+                        throw new RpcResponse.InvalidParamsError({
+                          message: `\`challenges[${index}]\` targets unsupported chain ${chainId}.`,
+                        })
+                      return { challenge, method }
+                    })
+                    const { challenge, method } = candidates[0]!
+                    return {
+                      authorization: await method.createCredential({ challenge } as never),
+                    } satisfies Rpc.wallet_authorizeChallenge.Encoded['returns']
+                  }
+
                   case 'wallet_revokeAccessKey': {
                     assertConnected()
                     const [decoded] = request._decoded.params
@@ -1610,6 +1714,7 @@ export function create(options: create.Options = {}): create.ReturnType {
           transports,
         })
       },
+      mpp,
       store,
     },
   )
@@ -1630,36 +1735,6 @@ export function create(options: create.Options = {}): create.ReturnType {
         provider,
       } as never)
     }
-  }
-
-  const mpp = (() => {
-    if (options.mpp === false) return undefined
-    if (typeof options.mpp === 'object') return options.mpp
-    return {}
-  })()
-  if (mpp) {
-    const { mode = 'push', polyfill: polyfill_option, ...methodOptions } = mpp
-    // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
-    // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
-    const polyfill = polyfill_option ?? isFetchWritable()
-    const getClient = ({ chainId }: { chainId?: number | undefined }) => {
-      const client = provider.getClient({ chainId })
-      const account = store.getState().accounts[store.getState().activeAccount]
-      if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
-      return Object.assign(client, {
-        account: {
-          address: account.address,
-          type: 'json-rpc' as const,
-        },
-      })
-    }
-    Mppx.create({
-      methods: [
-        mppx_tempo({ ...methodOptions, getClient, mode }),
-        mppx_tempo.subscription({ getClient }),
-      ],
-      polyfill,
-    })
   }
 
   providerRef = provider
@@ -1794,6 +1869,14 @@ export declare namespace mpp {
      */
     polyfill?: boolean | undefined
   }
+
+  /** MPP integration handle exposed as {@link Provider.mpp}. */
+  type Mpp = Pick<
+    Mppx.Mppx<
+      readonly [...ReturnType<typeof mppx_tempo>, ReturnType<typeof mppx_tempo.subscription>]
+    >,
+    'fetch' | 'methods'
+  >
 }
 
 function withDetails(error: unknown): Error & { details: string } {

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -260,7 +260,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[21]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[22]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -283,6 +283,7 @@ describe('Request', () => {
       | 'wallet_sendCalls'
       | 'wallet_switchEthereumChain'
       | 'wallet_authorizeAccessKey'
+      | 'wallet_authorizeChallenge'
       | 'eth_sendTransactionSync'
       | 'wallet_deposit'
       | 'wallet_depositZone'

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -86,6 +86,7 @@ export const schema = from([
   Rpc.eth_signTypedData_v4.schema,
   Rpc.personal_sign.schema,
   Rpc.wallet_authorizeAccessKey.schema,
+  Rpc.wallet_authorizeChallenge.schema,
   Rpc.wallet_connect.schema,
   Rpc.wallet_deposit.schema,
   Rpc.wallet_depositZone.schema,

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -1,3 +1,4 @@
+import { Challenge, Credential } from 'mppx'
 import { Fetch } from 'mppx/client'
 import { Mppx as ServerMppx, tempo } from 'mppx/server'
 import { parseUnits } from 'viem'
@@ -136,6 +137,55 @@ describe('mppx integration', () => {
     } finally {
       await failingServer.closeAsync()
     }
+  })
+
+  test('wallet_authorizeChallenge creates a credential for a serialized challenge', async () => {
+    const provider = Provider.create({
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      // Keep the global fetch raw so the 402 challenge surfaces directly
+      // instead of being handled by the payment-aware fetch.
+      mpp: { polyfill: false },
+    })
+    const address = await connect(provider)
+    await fund(address)
+
+    const response = await fetch(`${server.url}/fortune`)
+    expect(response.status).toBe(402)
+    const header = response.headers.get('www-authenticate')!
+
+    const result = await provider.request({
+      method: 'wallet_authorizeChallenge',
+      params: [{ challenges: [header] }],
+    })
+
+    const credential = Credential.deserialize(result.authorization)
+    expect(credential.challenge.id).toBe(Challenge.deserialize(header).id)
+
+    const retry = await fetch(`${server.url}/fortune`, {
+      headers: { Authorization: result.authorization },
+    })
+    expect(retry.status).toBe(200)
+  })
+
+  test('provider.mpp.fetch handles 402 without the global polyfill', async () => {
+    const provider = Provider.create({
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: { polyfill: false },
+    })
+    const address = await connect(provider)
+    await fund(address)
+
+    const res = await provider.mpp!.fetch(`${server.url}/fortune`)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "fortune": "Your code will compile on the first try.",
+      }
+    `)
   })
 
   test('push mode publishes pending access key authorization', async () => {

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -440,6 +440,11 @@ export namespace wallet_getCapabilities {
             status: z.union([z.literal('supported'), z.literal('unsupported')]),
           }),
         ),
+        mpp: z.optional(
+          z.object({
+            status: z.union([z.literal('supported'), z.literal('unsupported')]),
+          }),
+        ),
       }),
     ),
   })
@@ -536,6 +541,27 @@ export namespace wallet_authorizeAccessKey_strict {
     ),
     showDeposit: wallet_authorizeAccessKey.showDeposit,
   })
+}
+
+/** Creates a Machine Payment Protocol (MPP) credential for the first challenge (all must be supported). */
+export namespace wallet_authorizeChallenge {
+  export const schema = Schema.defineItem({
+    method: z.literal('wallet_authorizeChallenge'),
+    params: z.readonly(
+      z.tuple([
+        z.object({
+          /** Serialized MPP challenges (`Challenge.serialize` format). */
+          challenges: z.readonly(z.array(z.string()).check(z.minLength(1))),
+        }),
+      ]),
+    ),
+    returns: z.object({
+      /** Serialized MPP credential (deserializable via `Credential.deserialize`). */
+      authorization: z.string(),
+    }),
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
 }
 
 export namespace wallet_revokeAccessKey {


### PR DESCRIPTION
## Summary

- Serve the `wallet_authorizeChallenge` wallet RPC: apps and agents hand the provider a serialized MPP Challenge and get back a complete authorization credential, paid through the connected account's access keys (the same internal mppx method clients the fetch integration uses). Challenges targeting chains outside the provider's configured set are rejected instead of settling on the default chain.
- Advertise `mpp: { status: 'supported' }` per chain in `wallet_getCapabilities` (iff the handler will serve).
- Expose `provider.mpp = { fetch, methods }` instead of discarding the `Mppx.create` handler — the payment-aware scoped fetch and pre-wired method clients for runtimes where the global fetch polyfill is unavailable (e.g. Cloudflare Workers) or for handing to an MCP client wrapper.
- Re-entrancy guard: the provider's internal mppx clients answer nested `wallet_authorizeChallenge` with `4200`, so the wallet's own payment machinery never re-enters the handler (it signs locally, as today). This also stops mutating the shared cached client with an attached account.
- Docs: RPC page, capability, and the `mpp` provider handle.

Client-side counterpart (probes the capability and calls the RPC for JSON-RPC accounts): wevm/mppx#540. Independently shippable — until the client side lands, the RPC is simply unused; the wire protocol degrades gracefully in both directions.

## Validation

- `tsc -b`, lint/format; 490 unit tests including the re-entrancy termination regression test and the foreign-chain rejection test. Localnet suites (`mppx.localnet.test.ts`) require a running localnet — exercised in CI.
