### PR TITLE
feat: add `wallet_updateAccessKey`

### DIFF
--- a/.changeset/add-wallet-update-access-key.md
+++ b/.changeset/add-wallet-update-access-key.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `wallet_updateAccessKey` to update an access key's spending limits in place.

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -190,6 +190,9 @@ export function cli(options: cli.Options): Adapter.Adapter {
         async revokeAccessKey() {
           throw unsupported('`wallet_revokeAccessKey` not supported by CLI adapter.')
         },
+        async updateAccessKey() {
+          throw unsupported('`wallet_updateAccessKey` not supported by CLI adapter.')
+        },
       },
       async getAccount(options = {}) {
         const { accounts, activeAccount, chainId } = store.getState()

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -84,6 +84,13 @@ export type Instance = {
           request: EncodedRequest<Rpc.wallet_revokeAccessKey.Encoded>,
         ) => Promise<void>)
       | undefined
+    /** Update an access key's spending limits. */
+    updateAccessKey?:
+      | ((
+          params: updateAccessKey.Parameters,
+          request: EncodedRequest<Rpc.wallet_updateAccessKey.Encoded>,
+        ) => Promise<void>)
+      | undefined
     /** Open the send-token flow. */
     transfer?:
       | ((
@@ -456,6 +463,19 @@ export declare namespace revokeAccessKey {
     address: Address
     /** Address of the access key to revoke. */
     accessKeyAddress: Address
+  }
+}
+
+export declare namespace updateAccessKey {
+  type Parameters = {
+    /** Root account address. */
+    address: Address
+    /** Address of the access key to update. */
+    accessKeyAddress: Address
+    /** Chain ID the access key is scoped to. Defaults to the active chain. */
+    chainId?: bigint | undefined
+    /** New spending limits per token. */
+    limits: readonly { token: Address; limit: bigint }[]
   }
 }
 

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -2051,6 +2051,76 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
     })
   })
 
+  describe('wallet_updateAccessKey', () => {
+    test('default: updates spending limits in place', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const address = await connect(provider)
+      await fund(address)
+
+      const { keyAuthorization } = await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [
+          {
+            expiry: Expiry.days(1),
+            limits: [{ token: Addresses.pathUsd, limit: Hex.fromNumber(parseUnits('5', 6)) }],
+          },
+        ],
+      })
+      // Publish the key (and spend 1 pathUSD of its allowance).
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+
+      await provider.request({
+        method: 'wallet_updateAccessKey',
+        params: [
+          {
+            address,
+            accessKeyAddress: keyAuthorization.address!,
+            limits: [{ token: Addresses.pathUsd, limit: Hex.fromNumber(parseUnits('9', 6)) }],
+          },
+        ],
+      })
+
+      // `updateSpendingLimit` writes the remaining allowance directly — the
+      // key keeps its address and the prior spend is not subtracted.
+      const client = getClient()
+      const { remaining } = await Actions.accessKey.getRemainingLimit(client, {
+        account: address,
+        accessKey: keyAuthorization.address!,
+        token: Addresses.pathUsd,
+      })
+      expect(remaining).toBe(parseUnits('9', 6))
+
+      // The key remains usable under the new allowance.
+      const receipt = await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+      expect(receipt.status).toMatchInlineSnapshot(`"0x1"`)
+    })
+
+    test('error: rejects for an unknown access key', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+      const address = await connect(provider)
+      await fund(address)
+
+      await expect(
+        provider.request({
+          method: 'wallet_updateAccessKey',
+          params: [
+            {
+              address,
+              accessKeyAddress: '0x000000000000000000000000000000000000dEaD',
+              limits: [{ token: Addresses.pathUsd, limit: Hex.fromNumber(1n) }],
+            },
+          ],
+        }),
+      ).rejects.toThrow(/key.*not.*found|KeyNotFound/i)
+    })
+  })
+
   describe('wallet_revokeAccessKey', () => {
     test('default: revokes a granted access key on-chain', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -579,6 +579,36 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
+  async function updateAccessKey(parameters: Adapter.updateAccessKey.Parameters) {
+    const selected = await getAdapterAccount({ address: parameters.address })
+    const chainId = Number(parameters.chainId ?? getClient().chain.id)
+    if (selected.account.type === 'json-rpc') {
+      const client = getWalletClient({
+        account: selected.account,
+        chainId,
+        transport: selected.transport,
+      })
+      await client.request({
+        method: 'wallet_updateAccessKey' as never,
+        params: [z.encode(Rpc.wallet_updateAccessKey.parameters, parameters)] as never,
+      })
+      return
+    }
+    // One transaction; `updateSpendingLimit` writes each token's remaining
+    // allowance directly, preserving period configuration.
+    const calls = parameters.limits.map((limit) =>
+      Actions.accessKey.updateLimit.call({
+        accessKey: parameters.accessKeyAddress,
+        limit: limit.limit,
+        token: limit.token,
+      }),
+    )
+    await viem_sendTransactionSync(getClient({ chainId }), {
+      account: selected.account,
+      calls,
+    })
+  }
+
   async function signTransactionAction(
     parameters: TransactionParameters,
     request: Pick<Rpc.eth_signTransaction.Encoded, 'method' | 'params'>,
@@ -640,6 +670,15 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (actions.revokeAccessKey) return await actions.revokeAccessKey(parameters, request)
     if (instance.getAccount) return await revokeAccessKey(parameters)
     unsupported('revokeAccessKey')
+  }
+
+  async function updateAccessKeyAction(
+    parameters: Adapter.updateAccessKey.Parameters,
+    request: Pick<Rpc.wallet_updateAccessKey.Encoded, 'method' | 'params'>,
+  ) {
+    if (actions.updateAccessKey) return await actions.updateAccessKey(parameters, request)
+    if (instance.getAccount) return await updateAccessKey(parameters)
+    unsupported('updateAccessKey')
   }
 
   /** Returns accounts to persist. When `persistAccounts` is set, merges new accounts with existing ones. */
@@ -1505,6 +1544,13 @@ export function create(options: create.Options = {}): create.ReturnType {
                     assertConnected()
                     const [decoded] = request._decoded.params
                     await revokeAccessKeyAction({ ...decoded }, request)
+                    return
+                  }
+
+                  case 'wallet_updateAccessKey': {
+                    assertConnected()
+                    const [decoded] = request._decoded.params
+                    await updateAccessKeyAction({ ...decoded }, request)
                     return
                   }
 

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -260,7 +260,7 @@ describe('Ox', () => {
 describe('Viem', () => {
   test('is a tuple of all provider methods', () => {
     expectTypeOf<Schema.Viem[0]['Method']>().toEqualTypeOf<'eth_accounts'>()
-    expectTypeOf<Schema.Viem[22]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
+    expectTypeOf<Schema.Viem[23]['Method']>().toEqualTypeOf<'wallet_switchEthereumChain'>()
   })
 })
 
@@ -289,6 +289,7 @@ describe('Request', () => {
       | 'wallet_depositZone'
       | 'wallet_getBalances'
       | 'wallet_revokeAccessKey'
+      | 'wallet_updateAccessKey'
       | 'wallet_transfer'
       | 'wallet_swap'
       | 'wallet_withdrawZone'

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -95,6 +95,7 @@ export const schema = from([
   Rpc.wallet_getCallsStatus.schema,
   Rpc.wallet_getCapabilities.schema,
   Rpc.wallet_revokeAccessKey.schema,
+  Rpc.wallet_updateAccessKey.schema,
   Rpc.wallet_transfer.schema,
   Rpc.wallet_sendCalls.schema,
   Rpc.wallet_swap.schema,

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -576,6 +576,29 @@ export namespace wallet_revokeAccessKey {
   export type Decoded = Schema.Decoded<typeof schema>
 }
 
+export namespace wallet_updateAccessKey {
+  export const parameters = z.object({
+    /** Root account address. */
+    address: u.address(),
+    /** Address of the access key to update. */
+    accessKeyAddress: u.address(),
+    /** Chain ID the access key is scoped to. Defaults to the active chain. */
+    chainId: z.optional(u.bigint()),
+    /** New spending limits per token. */
+    limits: z.readonly(
+      z.array(z.object({ token: u.address(), limit: u.bigint() })).check(z.minLength(1)),
+    ),
+  })
+
+  export const schema = Schema.defineItem({
+    method: z.literal('wallet_updateAccessKey'),
+    params: z.readonly(z.tuple([parameters])),
+    returns: undefined,
+  })
+  export type Encoded = Schema.Encoded<typeof schema>
+  export type Decoded = Schema.Decoded<typeof schema>
+}
+
 export namespace wallet_connect {
   export const authorizeAccessKey = z.optional(
     z.omit(wallet_authorizeAccessKey.parameters, { showDeposit: true }),


### PR DESCRIPTION
Adds a `wallet_updateAccessKey` RPC method that updates an access key's spending limits in place via the keychain's `updateSpendingLimit` -- the key keeps its address, and any period configuration is preserved since the precompile writes the remaining allowance directly.

Local accounts batch one `updateLimit` call per token into a single transaction; `json-rpc` accounts forward the request to the wallet. The CLI adapter rejects the method explicitly.

The wallet-side approval flow lands separately in `wallet-next`.
