### PR TITLE
fix(playground): default to tempoWallet

### DIFF
--- a/playgrounds/web/src/provider.ts
+++ b/playgrounds/web/src/provider.ts
@@ -85,7 +85,7 @@ export const initialAdapter: AdapterType = (() => {
     'tempoWallet',
     'dialogRefImpl',
   ]
-  return adapters.includes(param as AdapterType) ? (param as AdapterType) : 'dialog'
+  return adapters.includes(param as AdapterType) ? (param as AdapterType) : 'tempoWallet'
 })()
 
 export let dialogMode: DialogMode =
@@ -207,13 +207,13 @@ export function switchAdapter(adapterType: AdapterType) {
   provider = createProvider(adapterType)
 }
 
-export function switchDialogMode(mode: DialogMode, adapterType: AdapterType = 'dialog') {
+export function switchDialogMode(mode: DialogMode, adapterType: AdapterType = 'tempoWallet') {
   dialogMode = mode
   Mppx.restore()
   provider = createProvider(adapterType)
 }
 
-export function switchMppMode(mode: MppMode, adapterType: AdapterType = 'dialog') {
+export function switchMppMode(mode: MppMode, adapterType: AdapterType = 'tempoWallet') {
   mppMode = mode
   Mppx.restore()
   provider = createProvider(adapterType)
@@ -232,7 +232,10 @@ function getTurnkeyAdapterClient() {
   return turnkeyClient as TurnkeyPlaygroundClient
 }
 
-export function switchTheme(next: DialogNs.Theme | undefined, adapterType: AdapterType = 'dialog') {
+export function switchTheme(
+  next: DialogNs.Theme | undefined,
+  adapterType: AdapterType = 'tempoWallet',
+) {
   theme = next
   Mppx.restore()
   provider = createProvider(adapterType)


### PR DESCRIPTION
## Summary
Default the accounts web playground to the tempoWallet adapter.

## Motivation
The playground should exercise Tempo Wallet by default instead of the legacy dialog adapter when no adapter query parameter is set.

## Changes
- Updated playgrounds/web/src/provider.ts to fall back to tempoWallet for initialAdapter.
- Updated provider recreation helper defaults for dialog mode, MPP mode, and theme changes to use tempoWallet.

## Testing
- pnpm --filter './playgrounds/web' check:types
- Pre-commit hook: vp lint --fix --ignore-pattern package.json and vp fmt src examples playgrounds ref-impls scripts test passed with existing warnings in site/src/pages.gen.ts, src/core/adapters/postMessage/postMessage.localnet.test.ts, and src/server/internal/handlers/exchange.localnet.test.ts.