### PR TITLE
fix: default postMessage access keys to p256

### DIFF
--- a/src/core/adapters/internal/fromRequest.ts
+++ b/src/core/adapters/internal/fromRequest.ts
@@ -31,7 +31,7 @@ export function fromRequest(options: fromRequest.Options): Adapter.Adapter {
         throw new RpcResponse.InvalidParamsError({
           message: `\`keyType: "${keyType}"\` requires externally generated key material; provide \`publicKey\` or \`address\`.`,
         })
-      const type = keyType ?? 'secp256k1'
+      const type = keyType ?? 'p256'
       const privateKey = type === 'p256' ? P256.randomPrivateKey() : Secp256k1.randomPrivateKey()
       const account =
         type === 'p256' ? TempoAccount.fromP256(privateKey) : TempoAccount.fromSecp256k1(privateKey)

--- a/src/core/adapters/mobileWebAuth/mobileWebAuth.localnet.test.ts
+++ b/src/core/adapters/mobileWebAuth/mobileWebAuth.localnet.test.ts
@@ -177,7 +177,7 @@ async function signKeyAuthorization(parameters: AdapterAuthorizeParameters) {
   return await root.signKeyAuthorization(
     {
       accessKeyAddress: accessKeyAddress(parameters),
-      keyType: parameters.keyType ?? 'secp256k1',
+      keyType: parameters.keyType ?? 'p256',
     },
     {
       chainId: parameters.chainId ?? BigInt(chain.id),
@@ -331,6 +331,9 @@ describe('create', () => {
       params: [{ capabilities: { method: 'register', name: 'Accounts RN Test' } }],
     })
     expect(result.accounts[0]!.address).toBe(root.address)
+    expect(
+      connectParameters(wallet, 0)?.capabilities?.authorizeAccessKey?.keyType,
+    ).toMatchInlineSnapshot(`"p256"`)
 
     await fund(root.address)
 

--- a/src/core/adapters/postMessage/postMessage.localnet.test.ts
+++ b/src/core/adapters/postMessage/postMessage.localnet.test.ts
@@ -143,7 +143,7 @@ async function signKeyAuthorization(parameters: AdapterAuthorizeParameters) {
   return await root.signKeyAuthorization(
     {
       accessKeyAddress: accessKeyAddress(parameters),
-      keyType: parameters.keyType ?? 'secp256k1',
+      keyType: parameters.keyType ?? 'p256',
     },
     {
       chainId: parameters.chainId ?? BigInt(chain.id),
@@ -158,6 +158,12 @@ function accessKeyAddress(parameters: AdapterAuthorizeParameters) {
   if (!parameters.publicKey)
     throw new Error('Expected access key address or public key in wallet request.')
   return Address.fromPublicKey(PublicKey.fromHex(parameters.publicKey))
+}
+
+function connectParameters(wallet: ReturnType<typeof createWallet>, index: number) {
+  const [parameters] =
+    z.decode(Rpc.wallet_connect.schema.params!, wallet.requests()[index]!.params as never) ?? []
+  return parameters
 }
 
 async function signature(
@@ -310,6 +316,9 @@ describe('create', () => {
       params: [{ capabilities: { method: 'register', name: 'Accounts Web Test' } }],
     })
     expect(result.accounts[0]!.address).toBe(root.address)
+    expect(
+      connectParameters(wallet, 0)?.capabilities?.authorizeAccessKey?.keyType,
+    ).toMatchInlineSnapshot(`"p256"`)
 
     await fund(root.address)
 


### PR DESCRIPTION
## Summary
Default request-backed wallet adapters to P256 managed access keys.

## Motivation
postMessage should generate P256 access keys unless callers explicitly request secp256k1.

## Changes
- Changed `src/core/adapters/internal/fromRequest.ts` to default generated access keys to `p256`.
- Updated postMessage localnet fixtures to sign implicit key authorizations as P256.
- Added postMessage and mobile web auth assertions for forwarded `authorizeAccessKey.keyType`.

## Testing
`pnpm test src/core/adapters/postMessage/postMessage.localnet.test.ts src/core/adapters/mobileWebAuth/mobileWebAuth.localnet.test.ts`

2 files passed, 33 tests passed.

Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; it completed with existing warnings only.