### PR TITLE
fix(adapters): keep postMessage session warm across disconnect

### DIFF
--- a/.changeset/postmessage-disconnect-freeze.md
+++ b/.changeset/postmessage-disconnect-freeze.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Fixed the `postMessage`/`tempoWallet` adapter freezing on the next login after a disconnect. `wallet_disconnect` no longer tears down the wallet-page session — the session and its iframe mount are a persistent channel that stays warm across disconnect, so the next login reuses the already-handshaked session instead of stranding on a stale handshake.

--- a/.changeset/postmessage-disconnect-freeze.md
+++ b/.changeset/postmessage-disconnect-freeze.md
@@ -1,5 +1,0 @@
----
-"accounts": patch
----
-
-Fixed the `postMessage`/`tempoWallet` adapter freezing on the next login after a disconnect. `wallet_disconnect` no longer tears down the wallet-page session — the session and its iframe mount are a persistent channel that stays warm across disconnect, so the next login reuses the already-handshaked session instead of stranding on a stale handshake.

--- a/src/core/adapters/postMessage/postMessage.localnet.test.ts
+++ b/src/core/adapters/postMessage/postMessage.localnet.test.ts
@@ -362,7 +362,7 @@ describe('create', () => {
     expect(wallet.opened()).toHaveLength(1)
   })
 
-  test('behavior: reopens the wallet page after disconnect', async () => {
+  test('behavior: reuses the wallet page session across disconnect', async () => {
     const wallet = createWallet()
     const provider = createProvider(wallet, { storage: Storage.memory() })
 
@@ -370,13 +370,25 @@ describe('create', () => {
       method: 'wallet_connect',
       params: [{ capabilities: { method: 'login' } }],
     })
+    expect(provider.store.getState().accounts).toHaveLength(1)
+
+    // `wallet_disconnect` is a local teardown (logout + clear); it never
+    // reaches the wallet. The wallet-page session is a persistent channel, so
+    // reconnecting reuses the already-handshaked session rather than reopening
+    // a new one — the second login must still round-trip and succeed.
     await provider.request({ method: 'wallet_disconnect' })
-    await provider.request({
+    expect(provider.store.getState().accounts).toHaveLength(0)
+
+    const result = await provider.request({
       method: 'wallet_connect',
       params: [{ capabilities: { method: 'login' } }],
     })
 
-    expect(wallet.opened()).toHaveLength(2)
+    expect(result.accounts[0]!.address).toBe(root.address)
+    expect(wallet.opened()).toHaveLength(1)
+    expect(wallet.requests().filter((request) => request.method === 'wallet_connect')).toHaveLength(
+      2,
+    )
   })
 
   test('behavior: serializes overlapping requests over one session', async () => {
@@ -751,6 +763,43 @@ describe('mount', () => {
     expect(events.filter((event) => event === 'show')).toHaveLength(2)
     await vi.waitFor(() => expect(events.at(-1)).toBe('hide'))
     // One mount, one session for the provider's lifetime.
+    expect(events.filter((event) => event.startsWith('mount:'))).toHaveLength(1)
+    expect(events.filter((event) => event === 'target')).toHaveLength(1)
+  })
+
+  test('behavior: keeps the iframe mount up across disconnect', async () => {
+    const { consumerRealm } = installBrowser()
+    const events: string[] = []
+    const scripted = scriptedMount(events, consumerRealm)
+
+    const provider = Provider.create({
+      adapter: postMessage({
+        host: `${walletOrigin}/post-message`,
+        mount: scripted.factory,
+        name: 'Accounts Web Test',
+        rdns: 'xyz.tempo.accounts.playground',
+      }),
+      chains: [chain],
+      storage: Storage.memory(),
+    })
+
+    await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login' } }],
+    })
+    await provider.request({ method: 'wallet_disconnect' })
+
+    // Disconnect is a local teardown — the mount and its handshaked session
+    // stay up, so the iframe is never destroyed and the next login reuses the
+    // same session instead of stranding on a stale handshake.
+    expect(events).not.toContain('destroy')
+
+    const result = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login' } }],
+    })
+
+    expect(result.accounts[0]!.address).toBe(root.address)
     expect(events.filter((event) => event.startsWith('mount:'))).toHaveLength(1)
     expect(events.filter((event) => event === 'target')).toHaveLength(1)
   })

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -184,10 +184,15 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
         store.disconnect()
       }
     },
-    async close() {
-      await session?.close()
-      mount?.hide()
-    },
+    // No `close` (disconnect) hook: `wallet_disconnect` is handled SDK-side
+    // (logout + `store.disconnect()`) and never reaches the wallet, so there
+    // is nothing to forward. The session and its mount are a persistent
+    // channel that outlives any single connection — like the eager warm
+    // state — so disconnect leaves them up and the next login reuses the
+    // already-handshaked session. Tearing the session down here instead
+    // strands the next login: the iframe's wallet page stays `ready` and
+    // ignores the fresh session's hello, so the request buffers forever.
+    // Only `cleanup` (provider teardown) closes the session and mount.
     cleanup() {
       void session?.close()
       mount?.destroy()

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -184,15 +184,8 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
         store.disconnect()
       }
     },
-    // No `close` (disconnect) hook: `wallet_disconnect` is handled SDK-side
-    // (logout + `store.disconnect()`) and never reaches the wallet, so there
-    // is nothing to forward. The session and its mount are a persistent
-    // channel that outlives any single connection — like the eager warm
-    // state — so disconnect leaves them up and the next login reuses the
-    // already-handshaked session. Tearing the session down here instead
-    // strands the next login: the iframe's wallet page stays `ready` and
-    // ignores the fresh session's hello, so the request buffers forever.
-    // Only `cleanup` (provider teardown) closes the session and mount.
+    // No `close` (disconnect) hook: the session and mount stay warm across
+    // disconnect so the next login reuses the already-handshaked session.
     cleanup() {
       void session?.close()
       mount?.destroy()


### PR DESCRIPTION
## Summary
Fixes the `postMessage`/`tempoWallet` adapter freezing on the next login after a disconnect (open playground → disconnect → Login → iframe mounts over the screen but nothing renders).

## Motivation
`wallet_disconnect` is handled entirely SDK-side in `Provider.ts` (logout fetch + `store.disconnect()`) and is never sent to the wallet, so the adapter has nothing to forward. But `postMessage` alone wired its `disconnect` action to `close()`, which tore down the wata session while leaving the iframe loaded. The wallet page (host) stays handshake-`ready`, so on the next login the fresh consumer session sends `consumerHello`, the already-ready host ignores it and never re-sends `hostReady`, and the request buffers forever.

The sibling `fromRequest` adapters (`deviceCode`, `mobileWebAuth`) never wired `close` — disconnect for them is just `store.disconnect()`. `postMessage` was the outlier.

## Changes
- `src/core/adapters/postMessage/postMessage.ts`: drop the `close` (disconnect) hook. The session and its mount are a persistent channel that outlives any single connection (like the eager warm state); disconnect leaves them warm and the next login reuses the already-handshaked session. Only `cleanup()` (provider teardown) closes the session and destroys the mount.
- `postMessage.localnet.test.ts`: reworked the target-mode test to `reuses the wallet page session across disconnect` (session reused, `opened` stays 1, both logins round-trip), and added `keeps the iframe mount up across disconnect` (asserts no `destroy` on disconnect and that the second login resolves).

## Testing
- `pnpm test src/core/adapters/postMessage/postMessage.localnet.test.ts` → 20 passed.
- `pnpm exec tsc -b --noEmit` → clean.
- Confirmed the new `keeps the iframe mount up across disconnect` test **times out (freeze) without the fix** and passes with it.
