### PR TITLE
fix(provider): size eth_fillTransaction gas for the signing key type

### DIFF
--- a/.changeset/fill-transaction-key-type.md
+++ b/.changeset/fill-transaction-key-type.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Include the signing key type in `eth_fillTransaction` so the node estimates intrinsic gas for the correct signature size. Root accounts signing with p256/webAuthn were filled as secp256k1 (the smallest signature), underestimating gas. The root fill path now resolves the signer's key type (a caller's explicit `keyType` wins, otherwise the stored root account's) and hands viem's tempo formatter an account carrying it, which forwards `keyType` and derives the webAuthn `keyData` size hint. secp256k1 (the node default) is unaffected. The managed access-key path already carried its key type via the viem account and still attaches a pending `keyAuthorization` when present so the estimate prices its on-chain authorization.

--- a/.changeset/fill-transaction-key-type.md
+++ b/.changeset/fill-transaction-key-type.md
@@ -2,4 +2,4 @@
 "accounts": patch
 ---
 
-Include the signing key type in `eth_fillTransaction` so the node estimates intrinsic gas for the correct signature size. Root accounts signing with p256/webAuthn were filled as secp256k1 (the smallest signature), underestimating gas. The root fill path now resolves the signer's key type (a caller's explicit `keyType` wins, otherwise the stored root account's) and hands viem's tempo formatter an account carrying it, which forwards `keyType` and derives the webAuthn `keyData` size hint. secp256k1 (the node default) is unaffected. The managed access-key path already carried its key type via the viem account and still attaches a pending `keyAuthorization` when present so the estimate prices its on-chain authorization.
+Fixed `eth_fillTransaction` to estimate gas for the signing key's signature size instead of always assuming secp256k1.

--- a/src/core/Account.test.ts
+++ b/src/core/Account.test.ts
@@ -86,6 +86,70 @@ describe('hydrate', () => {
   })
 })
 
+describe('signatureKeyType', () => {
+  test('default: maps secp256k1 to secp256k1', () => {
+    expect(
+      Account.signatureKeyType({
+        address: accounts[0].address,
+        keyType: 'secp256k1',
+        privateKey: privateKeys[0],
+      }),
+    ).toMatchInlineSnapshot(`"secp256k1"`)
+  })
+
+  test('behavior: maps p256 to p256', () => {
+    expect(
+      Account.signatureKeyType({
+        address: accounts[0].address,
+        keyType: 'p256',
+        privateKey: privateKeys[0],
+      }),
+    ).toMatchInlineSnapshot(`"p256"`)
+  })
+
+  test('behavior: maps webCrypto to p256', () => {
+    expect(
+      Account.signatureKeyType({
+        address: accounts[0].address,
+        keyType: 'webCrypto',
+        keyPair: undefined as never,
+      }),
+    ).toMatchInlineSnapshot(`"p256"`)
+  })
+
+  test('behavior: maps webAuthn to webAuthn', () => {
+    expect(
+      Account.signatureKeyType({
+        address: accounts[0].address,
+        keyType: 'webAuthn',
+        credential: { id: 'a', publicKey: '0x', rpId: 'example.com' },
+      }),
+    ).toMatchInlineSnapshot(`"webAuthn"`)
+  })
+
+  test('behavior: maps webAuthn_headless to webAuthn', () => {
+    expect(
+      Account.signatureKeyType({
+        address: accounts[0].address,
+        keyType: 'webAuthn_headless',
+        privateKey: privateKeys[0],
+        rpId: 'example.com',
+        origin: 'https://example.com',
+      }),
+    ).toMatchInlineSnapshot(`"webAuthn"`)
+  })
+
+  test('behavior: returns undefined for accounts without a key type', () => {
+    expect(Account.signatureKeyType({ address: accounts[0].address })).toMatchInlineSnapshot(
+      `undefined`,
+    )
+  })
+
+  test('behavior: returns undefined for undefined account', () => {
+    expect(Account.signatureKeyType(undefined)).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
 describe('find', () => {
   function setup(storeAccounts: readonly Account.Store[] = []) {
     const store = Store.create({ chainId: tempoLocalnet.id })

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -30,6 +30,31 @@ export type Store = {
     }
 >
 
+/**
+ * Maps a stored account's key type to the signature key type used on the wire.
+ *
+ * The node sizes intrinsic gas in `eth_fillTransaction` from the request's
+ * `keyType`. Store-only key types (`webCrypto`, `webAuthn_headless`) sign with
+ * a `p256` / `webAuthn` signature envelope respectively, so they must be
+ * reported as their on-chain signature type — otherwise gas is underestimated.
+ */
+export function signatureKeyType(
+  account: Store | undefined,
+): 'secp256k1' | 'p256' | 'webAuthn' | undefined {
+  switch (account?.keyType) {
+    case 'secp256k1':
+    case 'p256':
+    case 'webAuthn':
+      return account.keyType
+    case 'webCrypto':
+      return 'p256'
+    case 'webAuthn_headless':
+      return 'webAuthn'
+    default:
+      return undefined
+  }
+}
+
 /** Resolves a viem Account from the store by address (or active account). */
 export function find(options: find.Options & { signable: true }): TempoAccount.Account
 export function find(options: find.Options): TempoAccount.Account | JsonRpcAccount

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1,7 +1,14 @@
 import { verify } from 'hono/jwt'
 import { Hex, Provider as core_Provider, WebCryptoP256 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { type Address, createClient, createWalletClient, custom, parseUnits } from 'viem'
+import {
+  type Address,
+  createClient,
+  createWalletClient,
+  custom,
+  parseUnits,
+  type Transport,
+} from 'viem'
 import {
   getBalance,
   sendCalls,
@@ -31,7 +38,7 @@ const adapters = [
   { name: 'secp256k1', adapter: secp256k1 },
 ] as const
 
-describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
+describe.each(adapters)('$name', ({ adapter, name }: (typeof adapters)[number]) => {
   function transfer(amount: string) {
     return Actions.token.transfer.call({
       to: '0x0000000000000000000000000000000000000001',
@@ -2223,6 +2230,97 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
   describe('eth_fillTransaction', () => {
     const fillTx = { to: transferCall.to, data: transferCall.data } as const
 
+    /** Wraps the node transport to capture `eth_fillTransaction` request params. */
+    function recordingTransport(captures: Record<string, unknown>[]): Transport {
+      const base = http()
+      return (args) => {
+        const instance = base(args)
+        return {
+          ...instance,
+          async request(body: { method: string; params?: unknown }, opts?: unknown) {
+            if (body.method === 'eth_fillTransaction')
+              captures.push((body.params as Record<string, unknown>[])[0]!)
+            return instance.request(body as never, opts as never)
+          },
+        }
+      }
+    }
+
+    test('behavior: includes the root account key type for gas estimation', async () => {
+      const captures: Record<string, unknown>[] = []
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        transports: { [chain.id]: recordingTransport(captures) },
+      })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'eth_fillTransaction',
+        params: [{ from: address, ...fillTx }],
+      })
+
+      expect(captures).toHaveLength(1)
+      const sent = captures[0]!
+      if (name === 'headlessWebAuthn') {
+        expect(sent.keyType).toBe('webAuthn')
+        // viem derives the 1400-byte big-endian size hint from the key type so
+        // the node sizes the (larger) WebAuthn signature when estimating gas.
+        expect(sent.keyData).toBe('0x0578')
+      } else {
+        // secp256k1 is the node's default gas assumption, so no hint is needed.
+        expect(sent.keyType).toBeUndefined()
+      }
+    })
+
+    test('behavior: does not override a caller-provided key type', async () => {
+      const captures: Record<string, unknown>[] = []
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        transports: { [chain.id]: recordingTransport(captures) },
+      })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'eth_fillTransaction',
+        params: [{ from: address, ...fillTx, keyType: 'p256' }],
+      })
+
+      expect(captures).toHaveLength(1)
+      expect(captures[0]!.keyType).toBe('p256')
+    })
+
+    test('behavior: includes the access key type for gas estimation', async () => {
+      const captures: Record<string, unknown>[] = []
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        transports: { [chain.id]: recordingTransport(captures) },
+      })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      captures.length = 0
+      const result = await provider.request({
+        method: 'eth_fillTransaction',
+        params: [{ from: address, ...fillTx }],
+      })
+      expect((result.tx as { keyAuthorization?: unknown }).keyAuthorization).toBeDefined()
+
+      expect(captures.length).toBeGreaterThan(0)
+      // Access keys default to p256; the key type flows via the viem account so
+      // the node estimates gas for the larger p256 signature.
+      expect(captures.at(-1)!.keyType).toBe('p256')
+    })
+
     test('default: proxies to the node without modification', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
       const address = await connect(provider)
@@ -2233,7 +2331,11 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         params: [{ from: address, ...fillTx }],
       })
       expect(result.tx.gas).toBeDefined()
-      expect(result.tx.to).toBeDefined()
+      // secp256k1 root fills keep the legacy shape (top-level `to`); p256/webAuthn
+      // roots are routed through the tempo envelope, which carries the target in
+      // `calls` so the node can size gas for the larger signature.
+      const tx = result.tx as { to?: unknown; calls?: { to?: unknown }[] }
+      expect(tx.to ?? tx.calls?.[0]?.to).toBeDefined()
     })
 
     test('behavior: fills stored keyAuthorization for access key accounts', async () => {
@@ -2301,6 +2403,42 @@ describe.each(adapters)('$name', ({ adapter }: (typeof adapters)[number]) => {
         ],
       })
       expect(result.tx.gas).toBeDefined()
+    })
+
+    test('behavior: published access key uses its key type without re-authorizing', async () => {
+      const captures: Record<string, unknown>[] = []
+      const provider = Provider.create({
+        adapter: adapter(),
+        chains: [chain],
+        transports: { [chain.id]: recordingTransport(captures) },
+      })
+      const address = await connect(provider)
+      await fund(address)
+
+      await provider.request({
+        method: 'wallet_authorizeAccessKey',
+        params: [{ expiry: Expiry.days(1) }],
+      })
+
+      // Publish the access key on-chain so its stored keyAuthorization is no
+      // longer pending.
+      await provider.request({
+        method: 'eth_sendTransactionSync',
+        params: [{ calls: [transferCall] }],
+      })
+      await expect(provider.getAccessKeyStatus()).resolves.toMatchInlineSnapshot(`"published"`)
+
+      captures.length = 0
+      const result = await provider.request({
+        method: 'eth_fillTransaction',
+        params: [{ from: address, ...fillTx }],
+      })
+
+      // The access key still signs (p256 key type flows to the node), but with
+      // no keyAuthorization attached — it's already authorized on-chain.
+      expect(captures.length).toBeGreaterThan(0)
+      expect(captures.at(-1)!.keyType).toBe('p256')
+      expect((result.tx as { keyAuthorization?: unknown }).keyAuthorization ?? null).toBeNull()
     })
   })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -922,17 +922,40 @@ export function create(options: create.Options = {}): create.ReturnType {
                   case 'eth_fillTransaction': {
                     const [decoded] = request._decoded.params
                     const parameters = { ...decoded }
-                    const chainId = parameters.chainId
                     const feePayer = resolveFeePayer(parameters.feePayer)
+                    const client = getClient({ chainId: parameters.chainId, feePayer })
+                    const state = store.getState()
+                    const chainId = parameters.chainId ?? state.chainId
+                    const address = parameters.from ?? state.accounts[state.activeAccount]?.address
 
-                    type FillParams = z.output<typeof Rpc.transactionRequest> & {
-                      keyAuthorization?: unknown
-                    }
-                    const client = getClient({ chainId, feePayer })
-                    const fill = (params: FillParams) => {
+                    // The node sizes intrinsic gas from the signing key's signature
+                    // type; absent it, it assumes secp256k1 (the smallest signature)
+                    // and underestimates gas for p256/webAuthn signers. The key type
+                    // is the *signer's*, not the embedded `keyAuthorization`'s (which
+                    // is just a registration payload). The `fill` path below always
+                    // signs with the root account, so resolve its key type (a caller's
+                    // explicit `keyType` wins) and hand viem's tempo formatter an
+                    // account carrying it — viem forwards `keyType` and derives the
+                    // webAuthn `keyData` hint. secp256k1 (the node default) flows
+                    // through the legacy formatter unchanged. The managed access-key
+                    // path carries the access key's type via its own viem account.
+                    const signer = ((): JsonRpcAccount | undefined => {
+                      if (!address) return undefined
+                      const keyType =
+                        parameters.keyType ??
+                        Account.signatureKeyType(
+                          state.accounts.find(
+                            (a) => a.address.toLowerCase() === address.toLowerCase(),
+                          ),
+                        )
+                      if (!keyType) return undefined
+                      return { address, keyType, type: 'json-rpc' } as JsonRpcAccount
+                    })()
+                    const fill = (account = signer) => {
                       const fillRequest = {
-                        ...params,
-                        chainId: params.chainId ?? client.chain?.id,
+                        ...parameters,
+                        ...(account ? { account, from: account.address } : {}),
+                        chainId,
                         ...(feePayer ? { feePayer: true } : {}),
                       }
                       const formatter = client.chain?.formatters?.transactionRequest
@@ -945,45 +968,43 @@ export function create(options: create.Options = {}): create.ReturnType {
                       })
                     }
 
-                    // Route through the managed access-key account so viem can
-                    // attach stored key authorizations during fill.
-                    if (!parameters.keyAuthorization) {
-                      const state = store.getState()
-                      const address =
-                        parameters.from ?? state.accounts[state.activeAccount]?.address
-                      if (address) {
-                        const calls =
-                          parameters.calls ??
-                          (parameters.to
-                            ? [
-                                {
-                                  data: parameters.data,
-                                  to: parameters.to,
-                                },
-                              ]
-                            : undefined)
-                        const transaction = await AccessKeyTransaction.create({
-                          address,
-                          calls,
-                          chainId: parameters.chainId ?? state.chainId,
-                          client,
-                          store,
-                        })
-                        if (transaction)
-                          try {
-                            return await transaction.fill({
-                              ...parameters,
-                              chainId: parameters.chainId ?? state.chainId,
-                              from: parameters.from ?? address,
-                              ...(feePayer ? { feePayer: true } : {}),
-                            })
-                          } catch {
-                            return await fill(parameters)
-                          }
-                      }
+                    // Dapp-provided `keyAuthorization`: the root account signs and
+                    // the authorization rides along in `parameters` (so the node
+                    // prices its on-chain registration). Skip managed access-key
+                    // routing, which would otherwise attach a second authorization.
+                    if (parameters.keyAuthorization) return await fill()
+
+                    // Locally-managed access key: the access key signs, and viem
+                    // attaches a stored `keyAuthorization` if one is still pending
+                    // (i.e. not yet authorized on-chain). When it does, the estimate
+                    // must include the gas to authorize the key on-chain — so this
+                    // path can't be collapsed into the plain root fill. Falls back to
+                    // the root account on failure.
+                    if (address) {
+                      const calls =
+                        parameters.calls ??
+                        (parameters.to ? [{ data: parameters.data, to: parameters.to }] : undefined)
+                      const transaction = await AccessKeyTransaction.create({
+                        address,
+                        calls,
+                        chainId,
+                        client,
+                        store,
+                      })
+                      if (transaction)
+                        try {
+                          return await transaction.fill({
+                            ...parameters,
+                            chainId,
+                            from: address,
+                            ...(feePayer ? { feePayer: true } : {}),
+                          })
+                        } catch {
+                          // Fall through to the root account fill.
+                        }
                     }
 
-                    return await fill(parameters)
+                    return await fill()
                   }
 
                   case 'eth_signTransaction': {


### PR DESCRIPTION
## Summary
`eth_fillTransaction` now includes the signing key's type so the node estimates intrinsic gas for the correct signature size.

## Motivation
The node sizes intrinsic gas from the signer's signature type and falls back to secp256k1 (the smallest signature) when none is given. Root accounts signing with p256/webAuthn were filled as secp256k1, underestimating gas. The fix is to always pass the effective signer key type through fill.

## Changes
- `src/core/Provider.ts` — root fill path resolves the signer key type (caller `keyType` wins, else the stored root account via `Account.signatureKeyType`) and hands viem's tempo formatter an account carrying it, so `keyType`/`keyData` reach the node. Three explicit branches: dapp-provided `keyAuthorization` → root fill; matching managed access key → `AccessKeyTransaction.fill` (attaches a pending `keyAuthorization` so the estimate prices its on-chain authorization); otherwise root fill.
- `src/core/Account.ts` — add `signatureKeyType` mapping stored key types to on-chain signature types (`webCrypto -> p256`, `webAuthn_headless -> webAuthn`, etc.).
- Tests cover the full matrix: root, caller-override, pending access key, published (already-authorized) access key, and dapp-provided `keyAuthorization`.

## Testing
```
./node_modules/.bin/tsc -b --noEmit
pnpm test src/core/Account.test.ts            # 19 passed
pnpm test src/core/Provider.localnet.test.ts  # 290 passed (18 in eth_fillTransaction)
```
