### PR TITLE
Revert "fix: open wallet popup for passkey extensions"

### DIFF
--- a/.changeset/passkey-extension-popup.md
+++ b/.changeset/passkey-extension-popup.md
@@ -1,5 +1,0 @@
----
-"accounts": patch
----
-
-Fixed wallet mounts to use a top-level popup when passkey extensions shim WebAuthn APIs.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -90,32 +90,6 @@ export function isSafari(): boolean {
   return ua.includes('safari') && !ua.includes('chrome')
 }
 
-/** Detects browser extensions that monkey-patch WebAuthn APIs in the top page. */
-export function hasWebAuthnShim(): boolean {
-  if (typeof navigator === 'undefined') return false
-  const credentials = navigator.credentials
-  if (!credentials) return false
-  const prototype = (() => {
-    if (typeof CredentialsContainer !== 'undefined') return CredentialsContainer.prototype
-    const constructor = credentials.constructor as { prototype?: CredentialsContainer } | undefined
-    return constructor?.prototype
-  })()
-  if (typeof prototype?.create === 'function' && typeof prototype.get === 'function') {
-    if (credentials.create !== prototype.create || credentials.get !== prototype.get) return true
-  }
-  if (
-    credentials.create?.name === 'createCredentials' &&
-    credentials.get?.name === 'getCredentials'
-  )
-    return true
-  if (typeof PublicKeyCredential === 'undefined') return false
-  return (
-    PublicKeyCredential.isConditionalMediationAvailable?.name === 'mediationAvailable' &&
-    PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable?.name ===
-      'authenticatorAvailable'
-  )
-}
-
 type Cached = {
   host: string
   instance: Instance

--- a/src/core/adapters/dialog.ts
+++ b/src/core/adapters/dialog.ts
@@ -26,9 +26,7 @@ import * as Rpc from '../zod/rpc.js'
  */
 export function dialog(options: dialog.Options = {}): Adapter.Adapter {
   const {
-    dialog = Dialog.isInsecureContext() || Dialog.hasWebAuthnShim()
-      ? Dialog.popup()
-      : Dialog.iframe(),
+    dialog = Dialog.isInsecureContext() ? Dialog.popup() : Dialog.iframe(),
     host = 'https://wallet.tempo.xyz/embed',
     icon = 'data:image/svg+xml,<svg width="269" height="269" viewBox="0 0 269 269" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="269" height="269" fill="black"/><path d="M123.273 190.794H93.445L121.09 105.318H85.7334L93.445 80.2642H191.95L184.238 105.318H150.773L123.273 190.794Z" fill="white"/></svg>',
     name = 'Tempo Wallet',
@@ -160,7 +158,7 @@ export function dialog(options: dialog.Options = {}): Adapter.Adapter {
 
 export declare namespace dialog {
   type Options = {
-    /** Dialog to use for the embed app. @default `Dialog.iframe()` or `Dialog.popup()` when passkey extensions need a top-level page. */
+    /** Dialog to use for the embed app. @default `Dialog.iframe()` (or `Dialog.popup()` in Safari/insecure contexts) */
     dialog?: Dialog.Dialog | undefined
     /** URL of the embed app. @default `'https://wallet.tempo.xyz/embed'` */
     host?: string | undefined

--- a/src/core/adapters/postMessage/mount.ts
+++ b/src/core/adapters/postMessage/mount.ts
@@ -1,4 +1,4 @@
-import { defaultSize, hasWebAuthnShim, isInsecureContext, isSafari } from '../../Dialog.js'
+import { defaultSize, isInsecureContext, isSafari } from '../../Dialog.js'
 import * as IO from '../../IntersectionObserver.js'
 
 /**
@@ -58,7 +58,7 @@ export declare namespace Factory {
  */
 export function auto(): Factory {
   if (typeof window === 'undefined') return popup()
-  if (isInsecureContext() || isSafari() || hasWebAuthnShim() || !IO.supported()) return popup()
+  if (isInsecureContext() || isSafari() || !IO.supported()) return popup()
   return iframe()
 }
 


### PR DESCRIPTION
Reverts #656 by reverting merge commit ff2092723b1c849c113b31b73c158167fbe15318.

This removes the WebAuthn shim detection fallback and restores the prior iframe/popup selection behavior.

Validation:
- pnpm check:types
- pnpm test (fails: localnet setup HTTP 400 from localhost:8545 in 8 suites; CliAuth RPC fetch to https://rpc.tempo.xyz timed out)

Prompted by: @alexrisch