### PR TITLE
fix(playground): simulate postmessage iframe occlusion

### DIFF
--- a/playgrounds/web/src/App.tsx
+++ b/playgrounds/web/src/App.tsx
@@ -2944,7 +2944,9 @@ function OcclusionSimulator() {
     }
 
     function sync() {
-      const dialog = document.querySelector('dialog[data-tempo-wallet][open]')
+      const dialog = document.querySelector(
+        'dialog[data-tempo-wallet][open], dialog[data-tempo-wallet-postmessage][open]',
+      )
       if (!dialog) {
         overlay?.remove()
         overlay = null


### PR DESCRIPTION
## Summary
Fix the playground occlusion simulator so it can target postMessage iframe mounts.

## Motivation
The simulator only queried the legacy dialog iframe marker, so clicking Simulate Occlusion did not add the overlay for tempoWallet/postMessage iframe sessions.

## Changes
- Update playgrounds/web/src/App.tsx to query both data-tempo-wallet and data-tempo-wallet-postmessage dialogs.

## Testing
- ./node_modules/.bin/tsc --noEmit -p playgrounds/web/tsconfig.json