### PR TITLE
fix(postmessage): use popup for Safari account requests

### DIFF
--- a/.changeset/safari-postmessage-wallet-connect.md
+++ b/.changeset/safari-postmessage-wallet-connect.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Restored popup treatment in Safari for wallet_connect in the postMessage adapter.

--- a/site/src/pages/docs/api/postMessage.mdx
+++ b/site/src/pages/docs/api/postMessage.mdx
@@ -69,7 +69,7 @@ Reverse-DNS provider identifier.
 
 ## Mounts
 
-The mount decides where the wallet page lives and how it surfaces for requests. By default the adapter picks for you: an overlay iframe, falling back to a popup in insecure contexts, in Safari (no WebAuthn in cross-origin iframes), or when the browser lacks IntersectionObserver v2 (the wallet can't run its occlusion defense). If the wallet detects its iframe is occluded mid-session, it asks to continue in a popup and the adapter remounts there, replaying the request. Pass a mount to pin one explicitly:
+The mount decides where the wallet page lives and how it surfaces for requests. By default the adapter picks for you: an overlay iframe, falling back to a popup in insecure contexts or when the browser lacks IntersectionObserver v2 (the wallet can't run its occlusion defense). On Safari, account requests use a temporary popup because Safari rejects WebAuthn creation inside cross-origin iframes. If the wallet detects its iframe is occluded mid-session, it asks to continue in a popup and the adapter remounts there, replaying the request. Pass a mount to pin one explicitly:
 
 ```ts twoslash
 import { popup, postMessage } from 'accounts/postMessage'

--- a/src/core/adapters/postMessage/mount.ts
+++ b/src/core/adapters/postMessage/mount.ts
@@ -1,4 +1,4 @@
-import { defaultSize, isInsecureContext, isSafari } from '../../Dialog.js'
+import { defaultSize, isInsecureContext } from '../../Dialog.js'
 import * as IO from '../../IntersectionObserver.js'
 
 /**
@@ -52,13 +52,12 @@ export declare namespace Factory {
 
 /**
  * Picks the default mount: an overlay iframe unless the context can't
- * support one — insecure contexts and Safari lack WebAuthn in cross-origin
- * iframes, and without IntersectionObserver v2 the wallet can't run its
- * occlusion defense.
+ * support one — insecure contexts lack WebAuthn in iframes, and without
+ * IntersectionObserver v2 the wallet can't run its occlusion defense.
  */
 export function auto(): Factory {
   if (typeof window === 'undefined') return popup()
-  if (isInsecureContext() || isSafari() || !IO.supported()) return popup()
+  if (isInsecureContext() || !IO.supported()) return popup()
   return iframe()
 }
 

--- a/src/core/adapters/postMessage/postMessage.localnet.test.ts
+++ b/src/core/adapters/postMessage/postMessage.localnet.test.ts
@@ -610,22 +610,25 @@ describe('mount', () => {
    * global `window` (with `window.open` minting a fresh in-process wallet
    * window per call) and a `document` stub for `Mount.popup()`'s overlay.
    */
-  function installBrowser() {
+  function installBrowser(wire = wireWallet) {
     const consumerRealm = realm()
     const opened: string[] = []
+    const opened_handles: ReturnType<typeof walletWindow>['handle'][] = []
     const window_ = Object.assign(consumerRealm, {
       innerWidth: 1024,
       location: { origin: consumerOrigin },
       open: (url: string) => {
         opened.push(url)
-        return walletWindow(consumerRealm).handle
+        const window_wallet = walletWindow(consumerRealm, wire)
+        opened_handles.push(window_wallet.handle)
+        return window_wallet.handle
       },
       screenX: 0,
       screenY: 0,
     })
     vi.stubGlobal('window', window_)
     vi.stubGlobal('document', fakeDocument())
-    return { consumerRealm, opened }
+    return { consumerRealm, opened, opened_handles }
   }
 
   /** Minimal DOM for `Mount.popup()`'s overlay. */
@@ -809,6 +812,40 @@ describe('mount', () => {
     expect(result.accounts[0]!.address).toBe(root.address)
     expect(events.filter((event) => event.startsWith('mount:'))).toHaveLength(1)
     expect(events.filter((event) => event === 'target')).toHaveLength(1)
+  })
+
+  test('behavior: cleanup closes in-flight Safari popup fallback', async () => {
+    const { consumerRealm, opened_handles } = installBrowser((host) => host.on('request', () => {}))
+    vi.stubGlobal('navigator', { userAgent: 'Version/17.0 Safari/605.1.15' })
+    const events: string[] = []
+    const scripted = scriptedMount(events, consumerRealm)
+    const storage = Storage.memory()
+    const store = Store.create({ chainId: chain.id, storage })
+    const adapter = postMessage({
+      host: `${walletOrigin}/post-message`,
+      mount: scripted.factory,
+      name: 'Accounts Web Test',
+      rdns: 'xyz.tempo.accounts.playground',
+    })({
+      getAccount: () => ({ address: root.address, type: 'json-rpc' }) as never,
+      getClient: () => ({}) as never,
+      storage,
+      store,
+    })
+
+    const pending = adapter.actions.loadAccounts(undefined, {
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'login' } }],
+    })
+    void pending.catch(() => {})
+
+    await vi.waitFor(() => expect(opened_handles).toHaveLength(1))
+    expect(opened_handles[0]!.closed).toBe(false)
+
+    adapter.cleanup?.()
+
+    await vi.waitFor(() => expect(opened_handles[0]!.closed).toBe(true))
+    await expect(pending).rejects.toMatchObject({ code: 4001 })
   })
 
   test('behavior: dismissing the mount cancels the in-flight request', async () => {

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -2,6 +2,7 @@ import { Provider as core_Provider } from 'ox'
 import { PostMessage, Transport, Wata, postMessage as core_postMessage } from 'wata'
 
 import type * as Adapter from '../../Adapter.js'
+import { isSafari } from '../../Dialog.js'
 import * as Store from '../../Store.js'
 import { fromRequest } from '../internal/fromRequest.js'
 import * as Mount from './mount.js'
@@ -17,8 +18,10 @@ import * as Mount from './mount.js'
  * popup closes. Dismissing the UI or closing the window rejects the
  * in-flight request; `wallet_disconnect` tears the session down.
  *
- * When the wallet detects its iframe is occluded it asks to continue in a
- * popup; the adapter remounts and re-sends the in-flight request there.
+ * Safari account requests use a temporary popup because Safari rejects
+ * WebAuthn creation inside cross-origin iframes. When the wallet detects its
+ * iframe is occluded it asks to continue in a popup; the adapter remounts and
+ * re-sends the in-flight request there.
  */
 export function postMessage(options: postMessage.Options): Adapter.Adapter {
   const { close, host, icon, name, rdns, target } = options
@@ -28,14 +31,16 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
   let queue: Promise<unknown> = Promise.resolve()
   /** Reconciles local connection state against the wallet's asserted accounts. */
   let reconcile: ((accounts: readonly string[]) => void) | undefined
+  let fallback: Target | undefined
+  let inflight: Target | undefined
   /** Rejects the in-flight send when the user dismisses the mount UI. */
   let reject_inflight: ((error: Error) => void) | undefined
   let resend = false
-  let session: ReturnType<typeof create> | undefined
+  let session: Session | undefined
   /** The wallet asked to continue in a popup; stick to it for this provider. */
   let sticky_popup = false
 
-  function ensure(): NonNullable<typeof session> {
+  function ensure(): Session {
     if (session) return session
     if (target) {
       session = create({ close, host: hostUrl(host), target })
@@ -61,7 +66,7 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
     close: ((handle: Window | MessagePort) => void | Promise<void>) | undefined
     host: string
     target: NonNullable<postMessage.Options['target']>
-  }) {
+  }): Session {
     const wata = Wata.create({
       transports: [
         core_postMessage({
@@ -110,9 +115,9 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
    * wallet so it tears down its own pending request and returns to idle.
    */
   function cancel() {
-    void session?.notify({ method: 'cancel', params: [] })
+    void inflight?.session.notify({ method: 'cancel', params: [] })
     reject_inflight?.(new core_Provider.UserRejectedRequestError())
-    mount?.hide()
+    inflight?.mount?.hide()
   }
 
   async function send(request: {
@@ -125,20 +130,11 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
     // resolved, locally cancelled (dismiss), or rejected (window closed).
     for (;;) {
       const wata = ensure()
-      mount?.show()
-      const cancelled = new Promise<never>((_, reject) => {
-        reject_inflight = reject
-      })
+      if (requiresSafariPopup(request) && !target && !sticky_popup && mount?.mode !== 'popup')
+        return await sendWithPopup(request)
+
       try {
-        const sent = wata.send({
-          method: request.method,
-          params: request.params ?? [],
-          ...(request.context ? { context: request.context } : {}),
-        })
-        // Once `cancelled` wins the race, the wallet's eventual answer is
-        // ignored; swallow it so it never surfaces as an unhandled rejection.
-        void sent.catch(() => {})
-        return (await Promise.race([sent, cancelled])).result
+        return await sendWith(request, { mount, session: wata })
       } catch (error) {
         if (error instanceof Transport.ClosedError) {
           // The wallet asked to continue in a popup — replay there.
@@ -150,9 +146,76 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
           throw new core_Provider.UserRejectedRequestError()
         }
         throw error
-      } finally {
-        reject_inflight = undefined
       }
+    }
+  }
+
+  async function sendWith(
+    request: {
+      method: string
+      params?: readonly unknown[] | undefined
+      context?: { account?: string | undefined; chainId?: number | undefined } | undefined
+    },
+    active: Target,
+  ) {
+    active.mount?.show()
+    inflight = active
+    const cancelled = new Promise<never>((_, reject) => {
+      reject_inflight = reject
+    })
+    try {
+      const sent = active.session.send({
+        method: request.method,
+        params: request.params ?? [],
+        ...(request.context ? { context: request.context } : {}),
+      })
+      // Once `cancelled` wins the race, the wallet's eventual answer is
+      // ignored; swallow it so it never surfaces as an unhandled rejection.
+      void sent.catch(() => {})
+      return (await Promise.race([sent, cancelled])).result
+    } finally {
+      reject_inflight = undefined
+      inflight = undefined
+    }
+  }
+
+  async function sendWithPopup(request: {
+    method: string
+    params?: readonly unknown[] | undefined
+    context?: { account?: string | undefined; chainId?: number | undefined } | undefined
+  }) {
+    let session_popup: Session | undefined
+    const factory = Mount.popup()
+    const url = hostUrl(host, factory.mode)
+    const mount_popup = factory({
+      host: url,
+      onDismiss: cancel,
+      onInvalidate: () => void session_popup?.close(),
+    })
+    let closed = false
+    const active: Target = {
+      close: async () => {
+        if (closed) return
+        closed = true
+        mount_popup.destroy()
+        await session_popup?.close()
+      },
+      mount: mount_popup,
+      session: (session_popup = create({
+        close: (handle) => mount_popup.close(handle),
+        host: url,
+        target: () => mount_popup.target(),
+      })),
+    }
+    fallback = active
+    try {
+      return await sendWith(request, active)
+    } catch (error) {
+      if (error instanceof Transport.ClosedError) throw new core_Provider.UserRejectedRequestError()
+      throw error
+    } finally {
+      if (fallback === active) fallback = undefined
+      await active.close?.()
     }
   }
 
@@ -188,6 +251,8 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
     // disconnect so the next login reuses the already-handshaked session.
     cleanup() {
       void session?.close()
+      void fallback?.close?.()
+      fallback = undefined
       mount?.destroy()
       mount = undefined
     },
@@ -206,6 +271,31 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
   })
 }
 
+type Target = {
+  close?: (() => Promise<void>) | undefined
+  mount: Mount.Mount | undefined
+  session: Session
+}
+
+type Session = {
+  close: (cause?: Error | undefined) => Promise<void>
+  notify: (event: { method: string; params: readonly unknown[] }) => void | Promise<void>
+  send: (request: {
+    method: string
+    params: readonly unknown[]
+    context?: { account?: string | undefined; chainId?: number | undefined } | undefined
+  }) => Promise<{ result: unknown }>
+  start: () => Promise<void>
+}
+
+function requiresSafariPopup(request: {
+  method: string
+  params?: readonly unknown[] | undefined
+}): boolean {
+  if (!isSafari()) return false
+  return ['wallet_connect', 'eth_requestAccounts'].includes(request.method)
+}
+
 export declare namespace postMessage {
   /** Options for {@link postMessage}. */
   export type Options = {
@@ -222,7 +312,7 @@ export declare namespace postMessage {
     /**
      * Where the wallet page lives and how it surfaces for requests.
      * @default `Mount.auto()` — an overlay iframe, or a popup where
-     * iframes can't work (insecure context, Safari, no IO v2).
+     * iframes can't work (insecure context, no IO v2).
      */
     mount?: Mount.Factory | undefined
     /** Provider display name. */


### PR DESCRIPTION
## Summary
Use a temporary popup for Safari postMessage account requests while keeping iframe as the default mount.

## Motivation
Safari rejects WebAuthn in cross-origin iframes, but making all Safari postMessage sessions popup-only is broader than the legacy dialog behavior. The adapter should keep the iframe warm for normal requests, route Safari account requests through a popup fallback, and close that fallback if cleanup runs while it is still pending.

## Changes
- Remove Safari from `Mount.auto()` so iframe remains the default when the context is otherwise supported
- Route Safari `wallet_connect` / `eth_requestAccounts` through a temporary popup fallback in `src/core/adapters/postMessage/postMessage.ts`
- Track the temporary popup fallback so adapter `cleanup()` closes it if the request is still in flight
- Update postMessage docs to describe request-scoped Safari popup fallback
- Add `.changeset/safari-postmessage-wallet-connect.md`
- Add a localnet regression test for cleanup closing an in-flight Safari popup

## Testing
- `./node_modules/.bin/tsc -b --noEmit`
- `pnpm test src/core/adapters/postMessage/postMessage.localnet.test.ts`