### PR TITLE
fix: allow trusted postMessage hosts to use iframe

### DIFF
--- a/.changeset/postmessage-trusted-host-iframe.md
+++ b/.changeset/postmessage-trusted-host-iframe.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Changed `Mount.auto` to allow trusted hosts to use iframe mounts without IntersectionObserver v2 support.

--- a/src/core/adapters/postMessage/mount.test.ts
+++ b/src/core/adapters/postMessage/mount.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import * as Mount from './mount.js'
+import { postMessage } from './postMessage.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('auto', () => {
+  test('behavior: chooses popup without IO v2 for untrusted hosts', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      location: {
+        hostname: 'app.example',
+        protocol: 'https:',
+      },
+    })
+
+    expect(Mount.auto({ trustedHosts: ['trusted.example'] }).mode).toMatchInlineSnapshot(`"popup"`)
+  })
+
+  test('behavior: chooses iframe without IO v2 for trusted hosts', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      location: {
+        hostname: 'app.example',
+        protocol: 'https:',
+      },
+    })
+
+    expect(Mount.auto({ trustedHosts: ['app.example'] }).mode).toMatchInlineSnapshot(`"iframe"`)
+  })
+
+  test('behavior: chooses iframe without IO v2 for bundled trusted hosts', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      location: {
+        hostname: 'app.polyhedge.capital',
+        protocol: 'https:',
+      },
+    })
+
+    expect(Mount.auto({ source: 'wallet.tempo.xyz' }).mode).toMatchInlineSnapshot(`"iframe"`)
+  })
+
+  test('behavior: chooses iframe without IO v2 for same-site hosts', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      location: {
+        hostname: 'app.tempo.xyz',
+        protocol: 'https:',
+      },
+    })
+
+    expect(Mount.auto({ source: 'wallet.tempo.xyz' }).mode).toMatchInlineSnapshot(`"iframe"`)
+  })
+
+  test('behavior: chooses popup in insecure contexts even for trusted hosts', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      location: {
+        hostname: 'app.example',
+        protocol: 'http:',
+      },
+    })
+
+    expect(Mount.auto({ trustedHosts: ['app.example'] }).mode).toMatchInlineSnapshot(`"popup"`)
+  })
+})
+
+describe('postMessage', () => {
+  test('behavior: derives trusted hosts from the wallet host', () => {
+    const factory = Object.assign(
+      () => ({
+        close() {},
+        destroy() {},
+        hide() {},
+        mode: 'popup' as const,
+        show() {},
+        target: () => null,
+      }),
+      { mode: 'popup' as const },
+    )
+    const auto = vi.spyOn(Mount, 'auto').mockReturnValue(factory)
+    vi.stubGlobal('document', { body: {} })
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://app.example',
+      },
+    })
+
+    postMessage({
+      host: 'https://wallet.tempo.xyz/post-message',
+      name: 'Tempo Wallet',
+      rdns: 'xyz.tempo',
+    })
+
+    expect(auto.mock.calls[0]![0]).toMatchInlineSnapshot(`
+      {
+        "source": "wallet.tempo.xyz",
+      }
+    `)
+  })
+})

--- a/src/core/adapters/postMessage/mount.ts
+++ b/src/core/adapters/postMessage/mount.ts
@@ -1,5 +1,6 @@
 import { defaultSize, isInsecureContext } from '../../Dialog.js'
 import * as IO from '../../IntersectionObserver.js'
+import * as TrustedHosts from '../../TrustedHosts.js'
 
 /**
  * Wallet-window mounts for the postMessage adapter — the UI half of a wata
@@ -53,12 +54,41 @@ export declare namespace Factory {
 /**
  * Picks the default mount: an overlay iframe unless the context can't
  * support one — insecure contexts lack WebAuthn in iframes, and without
- * IntersectionObserver v2 the wallet can't run its occlusion defense.
+ * IntersectionObserver v2 an untrusted host can't run its occlusion
+ * defense.
  */
-export function auto(): Factory {
+export function auto(options: auto.Options = {}): Factory {
   if (typeof window === 'undefined') return popup()
-  if (isInsecureContext() || !IO.supported()) return popup()
+  if (isInsecureContext()) return popup()
+
+  const trusted = (() => {
+    const trustedHosts = options.trustedHosts ?? trustedHostsFor(options.source)
+    if (!trustedHosts) return false
+    const hostname = window.location.hostname.replace(/^www\./, '')
+    return TrustedHosts.match(trustedHosts, hostname, options.source)
+  })()
+
+  if (!IO.supported() && !trusted) return popup()
   return iframe()
+}
+
+export declare namespace auto {
+  /** Options for {@link auto}. */
+  type Options = {
+    /** Wallet hostname used for bundled and same-site trusted-host matching. */
+    source?: string | undefined
+    /** Hostnames trusted to render the wallet in an iframe without IO v2. */
+    trustedHosts?: readonly string[] | undefined
+  }
+}
+
+function trustedHostsFor(source: string | undefined) {
+  if (!source) return undefined
+
+  const hostname = source.replace(/^www\./, '')
+  for (const [source_, trustedHosts] of Object.entries(TrustedHosts.hosts))
+    if (TrustedHosts.sameRegistrableDomain(hostname, source_)) return trustedHosts
+  return undefined
 }
 
 /** Mounts the wallet page in a hidden full-viewport overlay iframe. */

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -46,7 +46,12 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
       session = create({ close, host: hostUrl(host), target })
       return session
     }
-    const factory = sticky_popup ? Mount.popup() : (options.mount ?? Mount.auto())
+    const factory = sticky_popup
+      ? Mount.popup()
+      : (options.mount ??
+        Mount.auto({
+          source: new URL(host).hostname.replace(/^www\./, ''),
+        }))
     const url = hostUrl(host, factory.mode)
     const mount_ = factory({
       host: url,
@@ -312,7 +317,7 @@ export declare namespace postMessage {
     /**
      * Where the wallet page lives and how it surfaces for requests.
      * @default `Mount.auto()` — an overlay iframe, or a popup where
-     * iframes can't work (insecure context, no IO v2).
+     * iframes can't work (insecure context, no IO v2 for untrusted hosts).
      */
     mount?: Mount.Factory | undefined
     /** Provider display name. */


### PR DESCRIPTION
## Summary
Allow trusted postMessage wallet hosts to stay on the iframe mount when IntersectionObserver v2 is unavailable.

## Motivation
`Mount.auto()` always fell back to popup without IO v2, even for hosts trusted by the wallet. That diverged from `Dialog.iframe()`, which treats trusted hosts as iframe-safe.

## Changes
- Update `src/core/adapters/postMessage/mount.ts` to treat `IO.supported() || trusted` as iframe-safe.
- Derive bundled trusted-host mappings from the wallet host passed as `source`.
- Pass the wallet hostname from `src/core/adapters/postMessage/postMessage.ts` into `Mount.auto()`.
- Add focused mount-selection coverage in `src/core/adapters/postMessage/mount.test.ts`.

## Testing
- `pnpm test src/core/adapters/postMessage/mount.test.ts` — 6 tests passed
- `pnpm exec tsc -b --noEmit` — passed
- Pre-commit hook ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; completed with existing warnings in `src/core/adapters/postMessage/postMessage.localnet.test.ts` and `src/server/internal/handlers/exchange.localnet.test.ts`.