### PR TITLE
fix: patch audit transitive dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ overrides:
   '@grpc/grpc-js': 1.14.4
   '@sinclair/typebox': ^0.34.0
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
-  dompurify@<3.4.9: 3.4.9
+  dompurify@<=3.4.10: 3.4.11
   esbuild: 0.28.1
   viem: 2.52.2
   file-type: 22.0.1
@@ -84,6 +84,8 @@ overrides:
   react-dom: ^19.2.5
   tar: 7.5.16
   tmp@<0.2.7: 0.2.7
+  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=8.0.0 <8.5.0: 8.5.0
   uuid@<11.1.1: 11.1.1
   vite@8: 8.0.16
   vite-plus: ~0.1.24
@@ -7074,8 +7076,8 @@ packages:
     resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
     engines: {node: '>= 8.0'}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -10695,16 +10697,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -20840,7 +20838,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -22621,7 +22619,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0
@@ -23289,7 +23287,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260424.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 4.1.0-beta.10
@@ -23301,7 +23299,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260603.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 4.1.0-beta.10
@@ -25557,7 +25555,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
-      undici: 7.25.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -25744,11 +25742,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
-  undici@7.25.0: {}
-
-  undici@8.1.0: {}
+  undici@8.5.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -26021,14 +26017,14 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       supports-color: 10.2.2
-      undici: 8.1.0
+      undici: 8.5.0
       vite: 8.0.16(@types/node@25.9.1)(@vitejs/devtools@0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@pnpm/logger@1001.0.1)(bufferutil@4.1.0)(idb-keyval@6.2.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vite-plugin-mkcert@2.0.0(vite@8.0.16(@types/node@25.9.3)(@vitejs/devtools@0.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       supports-color: 10.2.2
-      undici: 8.1.0
+      undici: 8.5.0
       vite: 8.0.16(@types/node@25.9.3)(@vitejs/devtools@0.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vite-plugin-wasm@3.6.0(vite@8.0.16(@types/node@25.9.3)(@vitejs/devtools@0.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,8 +83,8 @@ overrides:
   '@grpc/grpc-js': '1.14.4'
   '@sinclair/typebox': '^0.34.0'
   'brace-expansion@>=5.0.0 <5.0.6': '5.0.6'
-  # GHSA-rp9w-3fw7-7cwq et al: DOMPurify IN_PLACE/hook sanitization bypasses (3.4.9 patches the trailing Trusted-Types advisories too).
-  'dompurify@<3.4.9': '3.4.9'
+  # GHSA-rp9w-3fw7-7cwq et al: DOMPurify hook/config sanitization bypasses.
+  'dompurify@<=3.4.10': '3.4.11'
   esbuild: '0.28.1'
   viem: 2.52.2
   file-type: '22.0.1'
@@ -113,6 +113,9 @@ overrides:
   react-dom: 'catalog:'
   tar: '7.5.16'
   'tmp@<0.2.7': '0.2.7'
+  # GHSA-vmh5-mc38-953g + GHSA-38rv-x7px-6hhq + GHSA-pr7r-676h-xcf6: undici proxy TLS/cache/WebSocket advisories.
+  'undici@>=7.0.0 <7.28.0': '7.28.0'
+  'undici@>=8.0.0 <8.5.0': '8.5.0'
   'uuid@<11.1.1': '11.1.1'
   # GHSA-fx2h-pf6j-xcff: vite server.fs.deny bypass on Windows alternate paths (dev tooling).
   # Unconditional pin: range-keyed override does not rewrite `latest` importer specifiers (examples/basic).


### PR DESCRIPTION
## Summary
Patch transitive dependency ranges that currently make `pnpm audit` fail in CI.

## Motivation
The verify workflow runs `pnpm audit`. New advisories for `undici` and `dompurify` caused that step to fail after pulling latest `origin/main`.

## Changes
- Update `pnpm-workspace.yaml` overrides for `dompurify <=3.4.10` to `3.4.11`.
- Add `undici` v7 and v8 range overrides for the patched advisory releases.
- Refresh `pnpm-lock.yaml` so transitive consumers resolve to patched versions.

## Testing
- `pnpm audit` exits 0 with only the existing ignored moderate advisory.
- `CI=true pnpm -w check` passes; existing unrelated lint warnings remain in localnet tests.
- `git diff --check` passes.