### PR TITLE
fix: refresh single-exchange Wata sessions

### DIFF
--- a/src/core/adapters/mobileWebAuth/mobileWebAuth.ts
+++ b/src/core/adapters/mobileWebAuth/mobileWebAuth.ts
@@ -28,17 +28,6 @@ export function mobileWebAuth(options: mobileWebAuth.Options): Adapter.Adapter {
     return hostDocument
   }
 
-  const wata = Wata.create({
-    baseUrl,
-    transports: [
-      core_mobileWebAuth({
-        callback: redirectUri,
-        openAuthSession,
-        ...(fetch !== undefined ? { fetch } : {}),
-      }),
-    ],
-  })
-
   return fromRequest({
     // React Native may lack WebCrypto and persists through string-based
     // storage, so this opts into pure-JS P-256 (the access key lives app-side
@@ -53,7 +42,18 @@ export function mobileWebAuth(options: mobileWebAuth.Options): Adapter.Adapter {
       // document served at `baseUrl`, not from session metadata.
       const host = await resolveHost()
       if (host === undefined) throw new Error('`mobileWebAuth` requires a `host`.')
-      const session = wata.start({ host })
+      const wata = Wata.create({
+        baseUrl,
+        transports: [
+          core_mobileWebAuth({
+            callback: redirectUri,
+            host,
+            openAuthSession,
+            ...(fetch !== undefined ? { fetch } : {}),
+          }),
+        ],
+      })
+      const session = wata.start()
       return (await session.send({ method: request.method, params: request.params ?? [] })).result
     },
   })

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -270,6 +270,7 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
     // No `close` (disconnect) hook: the session and mount stay warm across
     // disconnect so the next login reuses the already-handshaked session.
     cleanup() {
+      reject_inflight?.(new core_Provider.UserRejectedRequestError())
       void session?.close().catch(() => {})
       void fallback?.close?.()
       fallback = undefined


### PR DESCRIPTION
Refreshes mobile web auth's Wata instance per request so each single-exchange auth flow starts from a fresh transport session. This avoids reusing an already-started Wata handle after the Wata 0.4 sync-start change.

Also rejects the active postMessage request during adapter cleanup before closing mounted sessions. That keeps Safari popup fallback cleanup from waiting on transport close propagation when the wallet request remains pending.
