### PR TITLE
feat(webauthn): add typed ceremony extensions

### DIFF
--- a/.changeset/webauthn-ceremony-extension.md
+++ b/.changeset/webauthn-ceremony-extension.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added opaque WebAuthn ceremony extensions that are stored with the challenge, passed to server hooks after verification, and returned through WebAuthn adapter results.

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -280,6 +280,8 @@ export declare namespace createAccount {
     keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Server Authentication result, if the auth capability was requested. */
     auth?: { token?: string | undefined } | undefined
+    /** Adapter-defined data returned by the account creation ceremony. */
+    extensions?: Record<string, unknown> | undefined
     /**
      * Consented identity claims (e.g. verified email), if the `identity`
      * capability was requested and the user approved sharing.
@@ -354,6 +356,8 @@ export declare namespace loadAccounts {
     keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Server Authentication result, if the auth capability was requested. */
     auth?: { token?: string | undefined } | undefined
+    /** Adapter-defined data returned by the account loading ceremony. */
+    extensions?: Record<string, unknown> | undefined
     /**
      * Consented identity claims (e.g. verified email), if the `identity`
      * capability was requested and the user approved sharing.

--- a/src/core/WebAuthnCeremony.browser.test.ts
+++ b/src/core/WebAuthnCeremony.browser.test.ts
@@ -198,6 +198,43 @@ describe('server (hooks)', () => {
     expect(res.headers.get('x-custom')).toBe('register-hook')
   })
 
+  test('behavior: onRegister receives challenge-bound extensions', async () => {
+    const regOptionsRes = await fetch(`${hooksUrl}/register/options`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        extensions: {
+          hostContext: {
+            expiresAt: 123,
+            requestId: 'register-request',
+            value: 'stored-register-context',
+          },
+        },
+        name: 'Hook Extension Test',
+      }),
+    })
+    const { options } = await regOptionsRes.json()
+    const credential = await Registration.create({ options })
+
+    const res = await fetch(`${hooksUrl}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...credential,
+        extensions: { hostContext: { value: 'final-body-register-context' } },
+      }),
+    })
+
+    const body = await res.json()
+    expect(body.extensions.hostContext).toMatchInlineSnapshot(`
+      {
+        "expiresAt": 123,
+        "requestId": "register-request",
+        "value": "stored-register-context",
+      }
+    `)
+  })
+
   test('behavior: onAuthenticate merges extra JSON and headers', async () => {
     // Register first
     const regOptionsRes = await fetch(`${hooksUrl}/register/options`, {
@@ -235,5 +272,57 @@ describe('server (hooks)', () => {
     expect(body.publicKey).toMatch(/^0x[0-9a-f]+$/)
     expect(body.sessionToken).toBe(`auth_${credentialId}`)
     expect(res.headers.get('x-custom')).toBe('authenticate-hook')
+  })
+
+  test('behavior: onAuthenticate receives challenge-bound extensions', async () => {
+    const regOptionsRes = await fetch(`${hooksUrl}/register/options`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hook Auth Extension Test' }),
+    })
+    const { options: regOptions } = await regOptionsRes.json()
+    const credential = await Registration.create({ options: regOptions })
+
+    const regRes = await fetch(`${hooksUrl}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(credential),
+    })
+    const { credentialId } = await regRes.json()
+
+    const authOptionsRes = await fetch(`${hooksUrl}/login/options`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        credentialId,
+        extensions: {
+          hostContext: {
+            expiresAt: 456,
+            requestId: 'login-request',
+            value: 'stored-login-context',
+          },
+        },
+      }),
+    })
+    const { options: authOptions } = await authOptionsRes.json()
+    const response = await Authentication.sign({ options: authOptions })
+
+    const res = await fetch(`${hooksUrl}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...response,
+        extensions: { hostContext: { value: 'final-body-login-context' } },
+      }),
+    })
+
+    const body = await res.json()
+    expect(body.extensions.hostContext).toMatchInlineSnapshot(`
+      {
+        "expiresAt": 456,
+        "requestId": "login-request",
+        "value": "stored-login-context",
+      }
+    `)
   })
 })

--- a/src/core/WebAuthnCeremony.test-d.ts
+++ b/src/core/WebAuthnCeremony.test-d.ts
@@ -1,0 +1,61 @@
+import { describe, expectTypeOf, test } from 'vp/test'
+
+import * as WebAuthnCeremony from './WebAuthnCeremony.js'
+
+type RequestExtensions = {
+  hostContext?: { value: string } | undefined
+}
+
+type ResponseExtensions = {
+  hostContext?: { id: string } | undefined
+}
+
+describe('WebAuthnCeremony extensions types', () => {
+  test('options calls accept extensions data', () => {
+    expectTypeOf<
+      WebAuthnCeremony.getRegistrationOptions.Parameters<RequestExtensions>['extensions']
+    >().toEqualTypeOf<RequestExtensions | undefined>()
+    expectTypeOf<
+      WebAuthnCeremony.getAuthenticationOptions.Parameters<RequestExtensions>['extensions']
+    >().toEqualTypeOf<RequestExtensions | undefined>()
+  })
+
+  test('server accepts a default extensions provider', () => {
+    expectTypeOf<WebAuthnCeremony.server.Options<RequestExtensions>>().toMatchTypeOf<{
+      getExtensions?:
+        | (() => RequestExtensions | undefined | Promise<RequestExtensions | undefined>)
+        | undefined
+      url: string
+    }>()
+  })
+
+  test('verify results expose host-defined data under extensions', () => {
+    expectTypeOf<
+      WebAuthnCeremony.verifyRegistration.ReturnType<ResponseExtensions>['extensions']
+    >().toEqualTypeOf<ResponseExtensions | undefined>()
+    expectTypeOf<
+      WebAuthnCeremony.verifyAuthentication.ReturnType<ResponseExtensions>['extensions']
+    >().toEqualTypeOf<ResponseExtensions | undefined>()
+  })
+
+  test('server ceremony carries request and response extension types', () => {
+    const ceremony = WebAuthnCeremony.server<RequestExtensions, ResponseExtensions>({
+      url: '/webauthn',
+      getExtensions: () => ({
+        hostContext: { value: 'example' },
+      }),
+    })
+
+    type AuthenticationOptions = NonNullable<
+      Parameters<typeof ceremony.getAuthenticationOptions>[number]
+    >
+    type AuthenticationResult = Awaited<ReturnType<typeof ceremony.verifyAuthentication>>
+
+    expectTypeOf<AuthenticationOptions['extensions']>().toEqualTypeOf<
+      RequestExtensions | undefined
+    >()
+    expectTypeOf<AuthenticationResult['extensions']>().toEqualTypeOf<
+      ResponseExtensions | undefined
+    >()
+  })
+})

--- a/src/core/WebAuthnCeremony.test.ts
+++ b/src/core/WebAuthnCeremony.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vp/test'
+import { afterEach, describe, expect, test } from 'vp/test'
 
 import * as WebAuthnCeremony from './WebAuthnCeremony.js'
 
@@ -147,5 +147,170 @@ describe('local', () => {
     const { options: a } = await ceremony.getAuthenticationOptions()
     const { options: b } = await ceremony.getAuthenticationOptions()
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
+  })
+})
+
+describe('server', () => {
+  const fetch_ = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = fetch_
+  })
+
+  function mock_fetch(calls: unknown[]) {
+    globalThis.fetch = (async (_input, init) => {
+      calls.push(JSON.parse(init?.body as string))
+      return Response.json({ options: {} })
+    }) as typeof fetch
+  }
+
+  test('behavior: sends call-time registration extensions', async () => {
+    const calls: unknown[] = []
+    mock_fetch(calls)
+    const ceremony = WebAuthnCeremony.server({ url: 'https://example.com/webauthn' })
+
+    await ceremony.getRegistrationOptions({
+      extensions: { source: 'call' },
+      name: 'Test',
+    })
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "extensions": {
+            "source": "call",
+          },
+          "name": "Test",
+        },
+      ]
+    `)
+  })
+
+  test('behavior: sends default authentication extensions', async () => {
+    const calls: unknown[] = []
+    mock_fetch(calls)
+    const ceremony = WebAuthnCeremony.server({
+      url: 'https://example.com/webauthn',
+      getExtensions: () => ({ source: 'default' }),
+    })
+
+    await ceremony.getAuthenticationOptions()
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "extensions": {
+            "source": "default",
+          },
+        },
+      ]
+    `)
+  })
+
+  test('behavior: call-time extensions override default extensions', async () => {
+    const calls: unknown[] = []
+    mock_fetch(calls)
+    const ceremony = WebAuthnCeremony.server<{ source: string }>({
+      url: 'https://example.com/webauthn',
+      getExtensions: () => ({ source: 'default' }),
+    })
+
+    await ceremony.getAuthenticationOptions({ extensions: { source: 'call' } })
+
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        {
+          "extensions": {
+            "source": "call",
+          },
+        },
+      ]
+    `)
+  })
+
+  test('behavior: verifyRegistration returns server extensions', async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        credentialId: 'cred-1',
+        extensions: { hostContext: { id: 'context-1' } },
+        publicKey: '0x1234',
+      })) as typeof fetch
+    const ceremony = WebAuthnCeremony.server({ url: 'https://example.com/webauthn' })
+
+    const result = await ceremony.verifyRegistration({
+      attestationObject: 'mock',
+      clientDataJSON: 'mock',
+      id: 'cred-1',
+      publicKey: '0x1234',
+      raw: {
+        id: 'cred-1',
+        type: 'public-key',
+        authenticatorAttachment: null,
+        rawId: 'cred-1',
+        response: { clientDataJSON: 'mock' },
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "credentialId": "cred-1",
+        "extensions": {
+          "hostContext": {
+            "id": "context-1",
+          },
+        },
+        "publicKey": "0x1234",
+      }
+    `)
+  })
+
+  test('behavior: verifyAuthentication returns server extensions', async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        credentialId: 'cred-1',
+        extensions: { hostContext: { id: 'context-1' } },
+        publicKey: '0x1234',
+      })) as typeof fetch
+    const ceremony = WebAuthnCeremony.server({ url: 'https://example.com/webauthn' })
+
+    const result = await ceremony.verifyAuthentication({
+      id: 'cred-1',
+      metadata: {
+        authenticatorData: '0x00',
+        clientDataJSON: '{}',
+      },
+      raw: {
+        id: 'cred-1',
+        type: 'public-key',
+        authenticatorAttachment: null,
+        rawId: 'cred-1',
+        response: { clientDataJSON: 'mock' },
+      },
+      signature: '0x00',
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "credentialId": "cred-1",
+        "extensions": {
+          "hostContext": {
+            "id": "context-1",
+          },
+        },
+        "publicKey": "0x1234",
+      }
+    `)
+  })
+
+  test('error: rejects non-serializable extensions data', async () => {
+    const ceremony = WebAuthnCeremony.server({ url: 'https://example.com/webauthn' })
+    const extensions: { self?: unknown } = {}
+    extensions.self = extensions
+
+    await expect(
+      ceremony.getAuthenticationOptions({ extensions }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: WebAuthn extensions must be JSON-serializable]`,
+    )
   })
 })

--- a/src/core/WebAuthnCeremony.ts
+++ b/src/core/WebAuthnCeremony.ts
@@ -5,30 +5,35 @@ import { Authentication, Registration } from 'webauthx/server'
 import * as Storage from './Storage.js'
 
 /** Pluggable strategy for WebAuthn registration and authentication ceremonies. */
-export type WebAuthnCeremony = {
+export type WebAuthnCeremony<
+  requestExtensions extends Record<string, unknown> = Record<string, unknown>,
+  responseExtensions extends Record<string, unknown> = Record<string, unknown>,
+> = {
   /** Get credential creation options for `navigator.credentials.create()`. */
   getRegistrationOptions: (
-    params: getRegistrationOptions.Parameters,
+    params: getRegistrationOptions.Parameters<requestExtensions>,
   ) => Promise<getRegistrationOptions.ReturnType>
   /** Verify a registration response and extract the public key. */
   verifyRegistration: (
     credential: Registration.Credential,
     options?: verifyRegistration.Options | undefined,
-  ) => Promise<verifyRegistration.ReturnType>
+  ) => Promise<verifyRegistration.ReturnType<responseExtensions>>
   /** Get credential request options for `navigator.credentials.get()`. */
   getAuthenticationOptions: (
-    params?: getAuthenticationOptions.Parameters | undefined,
+    params?: getAuthenticationOptions.Parameters<requestExtensions> | undefined,
   ) => Promise<getAuthenticationOptions.ReturnType>
   /** Verify an authentication response and extract the public key. */
   verifyAuthentication: (
     response: Authentication.Response,
-  ) => Promise<verifyAuthentication.ReturnType>
+  ) => Promise<verifyAuthentication.ReturnType<responseExtensions>>
 }
 
 export declare namespace getRegistrationOptions {
-  type Parameters = {
+  type Parameters<extensions extends Record<string, unknown> = Record<string, unknown>> = {
     /** Credential IDs to exclude (prevents re-registering existing credentials). */
     excludeCredentialIds?: readonly string[] | undefined
+    /** Host-defined, JSON-serializable data to bind to this ceremony challenge. */
+    extensions?: extensions | undefined
     /** Credential display name (e.g. `"alice"`). */
     name: string
     /** Opaque user identifier. Encoded as `user.id` in the WebAuthn creation options. */
@@ -42,9 +47,11 @@ export declare namespace verifyRegistration {
     /** Display name for the credential (e.g. user's email). */
     name?: string | undefined
   }
-  type ReturnType = {
+  type ReturnType<extensions extends Record<string, unknown> = Record<string, unknown>> = {
     /** The registered credential's ID. */
     credentialId: string
+    /** Host-defined data returned by the server hook. */
+    extensions?: extensions | undefined
     /** The credential's public key (uncompressed P256, hex-encoded). */
     publicKey: Hex
     /** Username associated with the account. */
@@ -53,13 +60,15 @@ export declare namespace verifyRegistration {
 }
 
 export declare namespace getAuthenticationOptions {
-  type Parameters = {
+  type Parameters<extensions extends Record<string, unknown> = Record<string, unknown>> = {
     /** Credential IDs to allow (restricts which credentials can be used). */
     allowCredentialIds?: readonly string[] | undefined
     /** Challenge to use. */
     challenge?: `0x${string}` | undefined
     /** Credential ID to restrict authentication to a specific credential. */
     credentialId?: string | undefined
+    /** Host-defined, JSON-serializable data to bind to this ceremony challenge. */
+    extensions?: extensions | undefined
     /** Mediation hint for passkey autofill / conditional UI. */
     mediation?: 'conditional' | 'optional' | 'required' | 'silent' | undefined
   }
@@ -67,9 +76,11 @@ export declare namespace getAuthenticationOptions {
 }
 
 export declare namespace verifyAuthentication {
-  type ReturnType = {
+  type ReturnType<extensions extends Record<string, unknown> = Record<string, unknown>> = {
     /** The authenticated credential's ID. */
     credentialId: string
+    /** Host-defined data returned by the server hook. */
+    extensions?: extensions | undefined
     /** The credential's public key (uncompressed P256, hex-encoded). */
     publicKey: Hex
     /** User identifier from the authenticator's `userHandle` (discoverable/conditional flows). */
@@ -80,7 +91,12 @@ export declare namespace verifyAuthentication {
 }
 
 /** Creates a {@link WebAuthnCeremony} from a custom implementation. */
-export function from(ceremony: WebAuthnCeremony): WebAuthnCeremony {
+export function from<
+  const requestExtensions extends Record<string, unknown> = Record<string, unknown>,
+  const responseExtensions extends Record<string, unknown> = Record<string, unknown>,
+>(
+  ceremony: WebAuthnCeremony<requestExtensions, responseExtensions>,
+): WebAuthnCeremony<requestExtensions, responseExtensions> {
   return ceremony
 }
 
@@ -164,24 +180,47 @@ export declare namespace local {
  * const ceremony = WebAuthnCeremony.server({ url: 'https://example.com/webauthn' })
  * ```
  */
-export function server(options: server.Options): WebAuthnCeremony {
-  const { url } = options
+export function server<
+  const requestExtensions extends Record<string, unknown> = Record<string, unknown>,
+  const responseExtensions extends Record<string, unknown> = Record<string, unknown>,
+>(
+  options: server.Options<requestExtensions>,
+): WebAuthnCeremony<requestExtensions, responseExtensions> {
+  const { getExtensions, url } = options
 
   async function request<returnType>(path: string, body: unknown): Promise<returnType> {
+    let json_body: string
+    try {
+      json_body = JSON.stringify(body)
+    } catch {
+      throw new Error('WebAuthn extensions must be JSON-serializable')
+    }
+
     const response = await fetch(`${url}${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: json_body,
     })
     const json = await response.json()
     if (!response.ok) throw new Error((json as { error?: string }).error ?? 'Request failed')
     return json as returnType
   }
 
+  async function resolveExtensions(parameters: { extensions?: requestExtensions | undefined }) {
+    if ('extensions' in parameters) return parameters.extensions
+    return await getExtensions?.()
+  }
+
   return from({
     async getRegistrationOptions(parameters) {
       const { excludeCredentialIds, name, userId } = parameters
-      return request('/register/options', { excludeCredentialIds, name, userId })
+      const extensions = await resolveExtensions(parameters)
+      return request('/register/options', {
+        excludeCredentialIds,
+        ...(extensions !== undefined ? { extensions } : {}),
+        name,
+        userId,
+      })
     },
 
     async verifyRegistration(credential) {
@@ -190,7 +229,14 @@ export function server(options: server.Options): WebAuthnCeremony {
 
     async getAuthenticationOptions(parameters = {}) {
       const { allowCredentialIds, challenge, credentialId, mediation } = parameters
-      return request('/login/options', { allowCredentialIds, challenge, credentialId, mediation })
+      const extensions = await resolveExtensions(parameters)
+      return request('/login/options', {
+        allowCredentialIds,
+        challenge,
+        credentialId,
+        ...(extensions !== undefined ? { extensions } : {}),
+        mediation,
+      })
     },
 
     async verifyAuthentication(response) {
@@ -200,7 +246,12 @@ export function server(options: server.Options): WebAuthnCeremony {
 }
 
 export declare namespace server {
-  type Options = {
+  type Options<extensions extends Record<string, unknown> = Record<string, unknown>> = {
+    /**
+     * Default extension payloads for each options request. Call-time
+     * `extensions` parameters take precedence.
+     */
+    getExtensions?: (() => extensions | undefined | Promise<extensions | undefined>) | undefined
     /** Base URL of the WebAuthn handler (e.g. `"https://example.com/webauthn"`). */
     url: string
   }

--- a/src/core/adapters/local.ts
+++ b/src/core/adapters/local.ts
@@ -130,7 +130,7 @@ export function local(options: local.Options): Adapter.Adapter {
 
             const digest = peronsalSign_digest ?? keyAuthorization_digest ?? rest.digest
 
-            const { accounts, signature, username } = await createAccount({
+            const { accounts, extensions, signature, username } = await createAccount({
               ...rest,
               digest,
             })
@@ -185,6 +185,7 @@ export function local(options: local.Options): Adapter.Adapter {
 
             return {
               accounts,
+              ...(extensions !== undefined ? { extensions } : {}),
               keyAuthorization,
               signature: signature_,
               username,
@@ -258,7 +259,10 @@ export function local(options: local.Options): Adapter.Adapter {
 
             // Pass the prepared digest (or the caller's) into loadAccounts so
             // the ceremony can sign it in a single biometric prompt.
-            const { accounts, signature, username } = await loadAccounts({ ...rest, digest })
+            const { accounts, extensions, signature, username } = await loadAccounts({
+              ...rest,
+              digest,
+            })
 
             // Hydrate here (not from the store) — same reason as createAccount.
             // Guard against empty accounts (e.g. user cancelled the ceremony).
@@ -310,6 +314,7 @@ export function local(options: local.Options): Adapter.Adapter {
 
             return {
               accounts,
+              ...(extensions !== undefined ? { extensions } : {}),
               keyAuthorization,
               signature: signature_,
               username,

--- a/src/core/adapters/webAuthn.test.ts
+++ b/src/core/adapters/webAuthn.test.ts
@@ -1,12 +1,47 @@
-import { describe, expect, test } from 'vp/test'
+import { P256, PublicKey } from 'ox'
+import { vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vp/test'
+
+const webauthn_mock = vi.hoisted(() => ({
+  create: vi.fn(),
+  sign: vi.fn(),
+}))
+
+vi.mock('webauthx/client', () => ({
+  Authentication: { sign: webauthn_mock.sign },
+  Registration: { create: webauthn_mock.create },
+}))
 
 import { chain } from '../../../test/config.js'
 import * as Provider from '../Provider.js'
 import * as Storage from '../Storage.js'
 import * as Store from '../Store.js'
+import * as WebAuthnCeremony from '../WebAuthnCeremony.js'
 import { webAuthn } from './webAuthn.js'
 
 describe('webAuthn', () => {
+  afterEach(() => {
+    webauthn_mock.create.mockReset()
+    webauthn_mock.sign.mockReset()
+  })
+
+  function setup(ceremony: WebAuthnCeremony.WebAuthnCeremony) {
+    return webAuthn({ ceremony })({
+      getAccount() {
+        throw new Error('Unexpected getAccount call.')
+      },
+      getClient() {
+        return { chain } as never
+      },
+      storage: Storage.memory({ key: crypto.randomUUID() }),
+      store: {} as never,
+    })
+  }
+
+  function publicKey() {
+    return PublicKey.toHex(P256.getPublicKey({ privateKey: P256.randomPrivateKey() }))
+  }
+
   test('behavior: does not hydrate account without credential', async () => {
     const storage = Storage.memory({ key: 'webauthn-invalid-account' })
     storage.setItem('store', {
@@ -27,5 +62,81 @@ describe('webAuthn', () => {
     await Store.waitForHydration(provider.store)
 
     await expect(provider.request({ method: 'eth_accounts' })).resolves.toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: createAccount returns ceremony extensions', async () => {
+    const publicKey_ = publicKey()
+    webauthn_mock.create.mockResolvedValue({ id: 'cred-1' })
+    const instance = setup(
+      WebAuthnCeremony.from({
+        async getRegistrationOptions() {
+          return { options: { publicKey: { rp: { id: 'localhost' } } } as never }
+        },
+        async verifyRegistration() {
+          return {
+            credentialId: 'cred-1',
+            extensions: { hostContext: { id: 'context-1' } },
+            publicKey: publicKey_,
+          }
+        },
+        async getAuthenticationOptions() {
+          return { options: {} as never }
+        },
+        async verifyAuthentication() {
+          throw new Error('Unexpected verifyAuthentication call.')
+        },
+      }),
+    )
+
+    const result = await instance.actions.createAccount(
+      { name: 'Test' },
+      { method: 'wallet_connect', params: undefined },
+    )
+
+    expect(result.extensions).toMatchInlineSnapshot(`
+      {
+        "hostContext": {
+          "id": "context-1",
+        },
+      }
+    `)
+  })
+
+  test('behavior: loadAccounts returns ceremony extensions', async () => {
+    const publicKey_ = publicKey()
+    webauthn_mock.sign.mockResolvedValue({ id: 'cred-1' })
+    const instance = setup(
+      WebAuthnCeremony.from({
+        async getRegistrationOptions() {
+          return { options: {} as never }
+        },
+        async verifyRegistration() {
+          throw new Error('Unexpected verifyRegistration call.')
+        },
+        async getAuthenticationOptions() {
+          return { options: { publicKey: { rpId: 'localhost' } } as never }
+        },
+        async verifyAuthentication() {
+          return {
+            credentialId: 'cred-1',
+            extensions: { hostContext: { id: 'context-1' } },
+            publicKey: publicKey_,
+          }
+        },
+      }),
+    )
+
+    const result = await instance.actions.loadAccounts(undefined, {
+      method: 'wallet_connect',
+      params: undefined,
+    })
+
+    expect(result.extensions).toMatchInlineSnapshot(`
+      {
+        "hostContext": {
+          "id": "context-1",
+        },
+      }
+    `)
   })
 })

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -59,7 +59,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
         const rpId = options.publicKey?.rp.id
         if (!rpId) throw new Error('rpId is required')
         const credential = await Registration.create({ options })
-        const { publicKey, username } = await ceremony.verifyRegistration(credential, {
+        const { extensions, publicKey, username } = await ceremony.verifyRegistration(credential, {
           name: parameters.name,
         })
         await storage.setItem('lastCredentialId', credential.id)
@@ -73,6 +73,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
               credential: { id: credential.id, publicKey, rpId },
             },
           ],
+          ...(extensions !== undefined ? { extensions } : {}),
           username,
         }
       },
@@ -95,7 +96,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
         if (!rpId) throw new Error('rpId is required')
 
         const response = await Authentication.sign({ options })
-        const { publicKey, username } = await ceremony.verifyAuthentication(response)
+        const { extensions, publicKey, username } = await ceremony.verifyAuthentication(response)
 
         await storage.setItem('lastCredentialId', response.id)
 
@@ -121,6 +122,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
               credential: { id: response.id, publicKey, rpId },
             },
           ],
+          ...(extensions !== undefined ? { extensions } : {}),
           signature,
           username,
         }

--- a/src/server/Handler.test-d.ts
+++ b/src/server/Handler.test-d.ts
@@ -53,6 +53,32 @@ describe('auth identity (OIDC)', () => {
   })
 })
 
+describe('webAuthn extensions', () => {
+  type Extensions = {
+    hostContext?: { value: string } | undefined
+  }
+
+  test('hook extensions are typed from the handler generic', () => {
+    void Handler.webAuthn<Extensions>({
+      kv: {
+        async get() {
+          return undefined
+        },
+        async set() {},
+        async delete() {},
+      },
+      origin: 'http://localhost',
+      rpId: 'localhost',
+      onRegister({ extensions }) {
+        expectTypeOf(extensions?.hostContext?.value).toEqualTypeOf<string | undefined>()
+      },
+      onAuthenticate({ extensions }) {
+        expectTypeOf(extensions?.hostContext?.value).toEqualTypeOf<string | undefined>()
+      },
+    })
+  })
+})
+
 describe('compose', () => {
   // Two ad-hoc schema-typed handlers to exercise schema merging.
   function makeAlpha() {

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -1,4 +1,21 @@
+import { Base64, Hex, P256, PublicKey } from 'ox'
+import { vi } from 'vitest'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
+
+const webauthn_mock = vi.hoisted(() => ({
+  verifyRegistration: vi.fn(),
+}))
+
+vi.mock('webauthx/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('webauthx/server')>()
+  return {
+    ...actual,
+    Registration: {
+      ...actual.Registration,
+      verify: webauthn_mock.verifyRegistration,
+    },
+  }
+})
 
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
@@ -7,6 +24,32 @@ import { type SessionPayload, webAuthn } from './webAuthn.js'
 
 let server: Server
 let ceremony: WebAuthnCeremony.WebAuthnCeremony
+
+function registrationCredential(options: {
+  challenge: Hex.Hex
+  credentialId: string
+  publicKey: Hex.Hex
+}) {
+  const { challenge, credentialId, publicKey } = options
+  const clientDataJSON = Base64.fromString(
+    JSON.stringify({
+      challenge: Base64.fromBytes(Hex.toBytes(challenge), { pad: false, url: true }),
+    }),
+  )
+  return {
+    attestationObject: Base64.fromString('attestation'),
+    clientDataJSON,
+    id: credentialId,
+    publicKey,
+    raw: {
+      id: credentialId,
+      type: 'public-key',
+      authenticatorAttachment: null,
+      rawId: Base64.fromString(credentialId),
+      response: { clientDataJSON },
+    },
+  }
+}
 
 beforeAll(async () => {
   server = await createServer(
@@ -17,6 +60,10 @@ beforeAll(async () => {
     }).listener,
   )
   ceremony = WebAuthnCeremony.server({ url: server.url })
+})
+
+afterEach(() => {
+  webauthn_mock.verifyRegistration.mockReset()
 })
 
 afterAll(async () => {
@@ -37,6 +84,66 @@ describe('POST /register/options', () => {
     const { options: b } = await ceremony.getRegistrationOptions({ name: 'Test' })
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
   })
+
+  test('error: rejects oversized extensions payloads', async () => {
+    const response = await fetch(`${server.url}/register/options`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ extensions: { value: 'x'.repeat(16 * 1024) }, name: 'Test' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toMatchInlineSnapshot(`"WebAuthn extensions exceed 16384 bytes"`)
+  })
+
+  test('behavior: stores extensions with generated challenge', async () => {
+    const entries = new Map<string, unknown>()
+    const kv: Kv.Kv = {
+      async get(key) {
+        return entries.get(key) as never
+      },
+      async set(key, value) {
+        entries.set(key, value)
+      },
+      async delete(key) {
+        entries.delete(key)
+      },
+    }
+    const s = await createServer(
+      webAuthn({ kv, origin: 'http://localhost', rpId: 'localhost' }).listener,
+    )
+
+    try {
+      await fetch(`${s.url}/register/options`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          extensions: { hostContext: { value: 'register-context' } },
+          name: 'Test',
+        }),
+      })
+
+      const [stored] = entries.values() as IterableIterator<{
+        created: number
+        extensions?: unknown | undefined
+        name: string
+      }>
+      const { created: _created, ...rest } = stored!
+      expect(rest).toMatchInlineSnapshot(`
+        {
+          "extensions": {
+            "hostContext": {
+              "value": "register-context",
+            },
+          },
+          "name": "Test",
+        }
+      `)
+    } finally {
+      await s.closeAsync()
+    }
+  })
 })
 
 describe('POST /login/options', () => {
@@ -51,6 +158,63 @@ describe('POST /login/options', () => {
     const { options: a } = await ceremony.getAuthenticationOptions()
     const { options: b } = await ceremony.getAuthenticationOptions()
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
+  })
+
+  test('error: rejects oversized extensions payloads', async () => {
+    const response = await fetch(`${server.url}/login/options`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ extensions: { value: 'x'.repeat(16 * 1024) } }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toMatchInlineSnapshot(`"WebAuthn extensions exceed 16384 bytes"`)
+  })
+
+  test('behavior: stores extensions with generated challenge', async () => {
+    const entries = new Map<string, unknown>()
+    const kv: Kv.Kv = {
+      async get(key) {
+        return entries.get(key) as never
+      },
+      async set(key, value) {
+        entries.set(key, value)
+      },
+      async delete(key) {
+        entries.delete(key)
+      },
+    }
+    const s = await createServer(
+      webAuthn({ kv, origin: 'http://localhost', rpId: 'localhost' }).listener,
+    )
+
+    try {
+      await fetch(`${s.url}/login/options`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          extensions: { hostContext: { value: 'login-context' } },
+        }),
+      })
+
+      const [stored] = entries.values() as IterableIterator<{
+        created: number
+        extensions?: unknown | undefined
+      }>
+      const { created: _created, ...rest } = stored!
+      expect(rest).toMatchInlineSnapshot(`
+        {
+          "extensions": {
+            "hostContext": {
+              "value": "login-context",
+            },
+          },
+        }
+      `)
+    } finally {
+      await s.closeAsync()
+    }
   })
 })
 
@@ -150,6 +314,44 @@ describe('hooks', () => {
     expect(called).toBe(false)
 
     await hookServer.closeAsync()
+  })
+
+  test('behavior: onRegister rejection removes created credential', async () => {
+    const kv = Kv.memory()
+    const challenge = Hex.random(32)
+    const credentialId = 'cred-register-rejected'
+    const publicKey = PublicKey.toHex(
+      P256.getPublicKey({ privateKey: P256.randomPrivateKey() }),
+    ) as Hex.Hex
+    await kv.set(`challenge:${challenge}`, { created: Date.now(), name: 'Rejected' })
+    webauthn_mock.verifyRegistration.mockReturnValue({ credential: { publicKey } })
+
+    const hookServer = await createServer(
+      webAuthn({
+        kv,
+        origin: 'http://localhost',
+        rpId: 'localhost',
+        onRegister() {
+          throw new Error('registration rejected')
+        },
+      }).listener,
+    )
+
+    try {
+      const response = await fetch(`${hookServer.url}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(registrationCredential({ challenge, credentialId, publicKey })),
+      })
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toMatchInlineSnapshot(`"registration rejected"`)
+      expect(await kv.get(`credential:${credentialId}`)).toBeUndefined()
+      expect(await kv.get(`challenge:${challenge}`)).toBeUndefined()
+    } finally {
+      await hookServer.closeAsync()
+    }
   })
 
   test('behavior: onAuthenticate error does not call hook', async () => {

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -20,6 +20,34 @@ const defaults = {
 
 const sessionKey = (token: string) => `session:${token}`
 
+const extensionsSizeLimit = 16 * 1024
+
+type Challenge<extensionMap extends Record<string, unknown> = Record<string, unknown>> = {
+  created: number
+  extensions?: extensionMap | undefined
+}
+
+type RegistrationChallenge<extensionMap extends Record<string, unknown> = Record<string, unknown>> =
+  Challenge<extensionMap> & {
+    name: string
+    userId?: string | undefined
+  }
+
+function validateExtensions<extensionMap extends Record<string, unknown>>(
+  extensions: unknown,
+): extensionMap | undefined {
+  if (extensions === undefined) return undefined
+  if (typeof extensions !== 'object' || extensions === null || Array.isArray(extensions))
+    throw new Error('WebAuthn extensions must be a JSON-serializable object')
+
+  const json = JSON.stringify(extensions)
+  if (json === undefined) throw new Error('WebAuthn extensions must be JSON-serializable')
+  if (new TextEncoder().encode(json).length > extensionsSizeLimit)
+    throw new Error(`WebAuthn extensions exceed ${extensionsSizeLimit} bytes`)
+
+  return extensions as extensionMap
+}
+
 async function createCredential(
   kv: Kv.Kv,
   key: string,
@@ -83,7 +111,9 @@ export type SessionPayload = {
  * @param options - Options.
  * @returns Request handler.
  */
-export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
+export function webAuthn<
+  const extensionMap extends Record<string, unknown> = Record<string, unknown>,
+>(options: webAuthn.Options<extensionMap>): webAuthn.ReturnType {
   const {
     cookie = true,
     cookieName = defaults.cookieName,
@@ -108,9 +138,11 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const body = await c.req.raw.json()
       const { excludeCredentialIds, name, userId } = body as {
         excludeCredentialIds?: string[]
+        extensions?: unknown
         name: string
         userId?: string
       }
+      const extensions_ = validateExtensions<extensionMap>(body.extensions)
 
       const { challenge, options } = Registration.getOptions({
         excludeCredentialIds,
@@ -121,7 +153,12 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
 
       await kv.set(
         `challenge:${challenge}`,
-        { created: Date.now(), name, ...(userId ? { userId } : {}) },
+        {
+          created: Date.now(),
+          ...(extensions_ !== undefined ? { extensions: extensions_ } : {}),
+          name,
+          ...(userId ? { userId } : {}),
+        },
         { ttl: challengeTtl },
       )
 
@@ -140,9 +177,7 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
         Bytes.toString(new Uint8Array(deserialized.clientDataJSON)),
       ) as { challenge: string }
       const challenge = Hex.fromBytes(Base64.toBytes(clientData.challenge))
-      const stored = await kv.get<{ created: number; name: string; userId?: string }>(
-        `challenge:${challenge}`,
-      )
+      const stored = await kv.get<RegistrationChallenge<extensionMap>>(`challenge:${challenge}`)
       if (!stored || Date.now() - stored.created > challengeTtl * 1_000)
         throw new Error('Missing or expired challenge')
 
@@ -166,16 +201,25 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       })
       if (!created) throw new Error('Credential already exists')
 
-      const [hook] = await Promise.all([
-        onRegister?.({
+      let hook: Response | void
+      try {
+        hook = await onRegister?.({
           credentialId,
+          ...(stored.extensions !== undefined ? { extensions: stored.extensions } : {}),
           name: stored.name,
           publicKey,
           request: c.req.raw,
           ...(userId ? { userId } : {}),
-        }),
-        kv.delete(`challenge:${challenge}`),
-      ])
+        })
+      } catch (error) {
+        await Promise.all([
+          kv.delete(`credential:${credentialId}`),
+          kv.delete(`challenge:${challenge}`),
+        ])
+        throw error
+      }
+
+      await kv.delete(`challenge:${challenge}`)
 
       // Successful registration is also a successful authentication for
       // the freshly-minted credential. Issue a session here so the
@@ -227,13 +271,16 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
         allowCredentialIds,
         challenge: requestChallenge,
         credentialId,
+        extensions,
         mediation,
       } = body as {
         allowCredentialIds?: string[]
         challenge?: Hex.Hex
         credentialId?: string
+        extensions?: unknown
         mediation?: string
       }
+      const extensions_ = validateExtensions<extensionMap>(extensions)
 
       const { challenge, options: authOptions } = Authentication.getOptions({
         challenge: requestChallenge,
@@ -242,7 +289,11 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       })
       const options = mediation ? { ...authOptions, mediation } : authOptions
 
-      await kv.set(`challenge:${challenge}`, Date.now(), { ttl: challengeTtl })
+      await kv.set(
+        `challenge:${challenge}`,
+        { created: Date.now(), ...(extensions_ !== undefined ? { extensions: extensions_ } : {}) },
+        { ttl: challengeTtl },
+      )
 
       return Response.json({ options })
     } catch (error) {
@@ -263,10 +314,11 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const challenge = Hex.fromBytes(Base64.toBytes(clientData.challenge))
 
       const [stored, credentialData] = await Promise.all([
-        kv.get<number>(`challenge:${challenge}`),
+        kv.get<number | Challenge<extensionMap>>(`challenge:${challenge}`),
         kv.get<{ publicKey: string; userId?: string }>(`credential:${response.id}`),
       ])
-      if (!stored || Date.now() - stored > challengeTtl * 1_000)
+      const challengeData = typeof stored === 'number' ? { created: stored } : stored
+      if (!challengeData || Date.now() - challengeData.created > challengeTtl * 1_000)
         throw new Error('Missing or expired challenge')
       if (!credentialData) throw new Error('Unknown credential')
 
@@ -292,6 +344,9 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
         try {
           const result = await onAuthenticate({
             credentialId,
+            ...(challengeData.extensions !== undefined
+              ? { extensions: challengeData.extensions }
+              : {}),
             publicKey,
             request: c.req.raw,
             ...(userId ? { userId } : {}),
@@ -393,77 +448,82 @@ export declare namespace webAuthn {
   /** Resolves the current session from a request's cookie or bearer token. */
   type getSession = (req: Session.SessionRequest) => Promise<SessionPayload | undefined>
 
-  type Options = from.Options & {
-    /**
-     * Whether to issue a session cookie on successful login. When
-     * `false`, the login response always contains `{ token }` in the
-     * body, no `Set-Cookie` header is sent, logout does not clear a
-     * cookie, and `getSession` ignores any incoming cookie — only
-     * `Authorization: Bearer <token>` is honored. Use this when the SDK
-     * lives in a non-browser context or the host app already manages
-     * its own auth cookies.
-     * @default true
-     */
-    cookie?: boolean | undefined
-    /** Cookie name for the session token. @default "accounts_webauthn" */
-    cookieName?: string | undefined
-    /**
-     * Key-value store for challenges, credentials, and sessions. When
-     * `create` is available, credential registration uses it to reject
-     * duplicates atomically. Otherwise, registration falls back to
-     * best-effort `get` then `set` storage.
-     */
-    kv: Kv.Kv
-    /** Called after a successful registration. The returned response is merged onto the default JSON response. */
-    onRegister?: (parameters: {
-      credentialId: string
-      /** The name provided during `/register/options` (e.g. user email). */
-      name: string
-      publicKey: string
-      request: Request
-      /** The `userId` provided during `/register/options`, if any. */
-      userId?: string | undefined
-    }) => Response | Promise<Response> | void | Promise<void>
-    /**
-     * Called after a successful authentication, before the session
-     * token is issued. Returning a `Response` merges its JSON body and
-     * status onto the default login response (legacy contract).
-     * Throwing rejects the request with `401` — the thrown error's
-     * `message` is surfaced as the response `error` field — and no
-     * session is issued.
-     */
-    onAuthenticate?: (parameters: {
-      credentialId: string
-      publicKey: string
-      userId?: string | undefined
-      request: Request
-    }) => Response | Promise<Response> | void | Promise<void>
-    /** Expected origin(s) (e.g. `"https://example.com"` or `["https://a.com", "https://b.com"]`). */
-    origin: string | readonly string[]
-    /** Path prefix for the WebAuthn endpoints (e.g. `"/webauthn"`). @default "" */
-    path?: string | undefined
-    /** Relying Party ID (e.g. `"example.com"`). */
-    rpId: string
-    /**
-     * Whether to issue a session on successful login. When `false`,
-     * login acts as a stateless WebAuthn verification — no token is
-     * generated, no entry is written to the kv, and no cookie is sent.
-     * The login response still carries `{ credentialId, publicKey,
-     * userId? }`. `getSession` always returns `undefined` and `/logout`
-     * is a no-op (still returns `204`). Use this when the host
-     * application mints its own session token (e.g. a JWT inside
-     * `onAuthenticate`).
-     * @default true
-     */
-    session?: boolean | undefined
-    /** TTLs in seconds. */
-    ttl?:
-      | {
-          /** Challenge TTL. @default 300 (5m) */
-          challenge?: number | undefined
-          /** Session TTL. @default 86400 (24h) */
-          session?: number | undefined
-        }
-      | undefined
-  }
+  type Options<extensionMap extends Record<string, unknown> = Record<string, unknown>> =
+    from.Options & {
+      /**
+       * Whether to issue a session cookie on successful login. When
+       * `false`, the login response always contains `{ token }` in the
+       * body, no `Set-Cookie` header is sent, logout does not clear a
+       * cookie, and `getSession` ignores any incoming cookie — only
+       * `Authorization: Bearer <token>` is honored. Use this when the SDK
+       * lives in a non-browser context or the host app already manages
+       * its own auth cookies.
+       * @default true
+       */
+      cookie?: boolean | undefined
+      /** Cookie name for the session token. @default "accounts_webauthn" */
+      cookieName?: string | undefined
+      /**
+       * Key-value store for challenges, credentials, and sessions. When
+       * `create` is available, credential registration uses it to reject
+       * duplicates atomically. Otherwise, registration falls back to
+       * best-effort `get` then `set` storage.
+       */
+      kv: Kv.Kv
+      /** Called after a successful registration. The returned response is merged onto the default JSON response. */
+      onRegister?: (parameters: {
+        credentialId: string
+        /** Host-defined data supplied to `/register/options`, bound to the verified challenge. */
+        extensions?: extensionMap | undefined
+        /** The name provided during `/register/options` (e.g. user email). */
+        name: string
+        publicKey: string
+        request: Request
+        /** The `userId` provided during `/register/options`, if any. */
+        userId?: string | undefined
+      }) => Response | Promise<Response> | void | Promise<void>
+      /**
+       * Called after a successful authentication, before the session
+       * token is issued. Returning a `Response` merges its JSON body and
+       * status onto the default login response (legacy contract).
+       * Throwing rejects the request with `401` — the thrown error's
+       * `message` is surfaced as the response `error` field — and no
+       * session is issued.
+       */
+      onAuthenticate?: (parameters: {
+        credentialId: string
+        /** Host-defined data supplied to `/login/options`, bound to the verified challenge. */
+        extensions?: extensionMap | undefined
+        publicKey: string
+        userId?: string | undefined
+        request: Request
+      }) => Response | Promise<Response> | void | Promise<void>
+      /** Expected origin(s) (e.g. `"https://example.com"` or `["https://a.com", "https://b.com"]`). */
+      origin: string | readonly string[]
+      /** Path prefix for the WebAuthn endpoints (e.g. `"/webauthn"`). @default "" */
+      path?: string | undefined
+      /** Relying Party ID (e.g. `"example.com"`). */
+      rpId: string
+      /**
+       * Whether to issue a session on successful login. When `false`,
+       * login acts as a stateless WebAuthn verification — no token is
+       * generated, no entry is written to the kv, and no cookie is sent.
+       * The login response still carries `{ credentialId, publicKey,
+       * userId? }`. `getSession` always returns `undefined` and `/logout`
+       * is a no-op (still returns `204`). Use this when the host
+       * application mints its own session token (e.g. a JWT inside
+       * `onAuthenticate`).
+       * @default true
+       */
+      session?: boolean | undefined
+      /** TTLs in seconds. */
+      ttl?:
+        | {
+            /** Challenge TTL. @default 300 (5m) */
+            challenge?: number | undefined
+            /** Session TTL. @default 86400 (24h) */
+            session?: number | undefined
+          }
+        | undefined
+    }
 }

--- a/test/setup.global.browser.ts
+++ b/test/setup.global.browser.ts
@@ -8,6 +8,12 @@ import { setupServer } from './prool.js'
 import { createServer } from './utils.js'
 import { hooksPort, port } from './webauthn.constants.js'
 
+function extensions_response(extensions: unknown) {
+  if (!extensions || typeof extensions !== 'object') return undefined
+  const { hostContext } = extensions as { hostContext?: unknown }
+  return hostContext === undefined ? undefined : { hostContext }
+}
+
 export default async function () {
   const teardowns: (() => Promise<void>)[] = []
 
@@ -26,15 +32,15 @@ export default async function () {
       kv: Kv.memory(),
       origin: 'http://localhost',
       rpId: 'localhost',
-      onRegister({ credentialId }) {
+      onRegister({ credentialId, extensions }) {
         return Response.json(
-          { sessionToken: `reg_${credentialId}` },
+          { extensions: extensions_response(extensions), sessionToken: `reg_${credentialId}` },
           { headers: { 'x-custom': 'register-hook' } },
         )
       },
-      onAuthenticate({ credentialId }) {
+      onAuthenticate({ credentialId, extensions }) {
         return Response.json(
-          { sessionToken: `auth_${credentialId}` },
+          { extensions: extensions_response(extensions), sessionToken: `auth_${credentialId}` },
           { headers: { 'x-custom': 'authenticate-hook' } },
         )
       },

--- a/test/webauthn.setup.global.ts
+++ b/test/webauthn.setup.global.ts
@@ -4,6 +4,12 @@ import * as Handler from '../src/server/Handler.js'
 import * as Kv from '../src/server/Kv.js'
 import { hooksPort, port } from './webauthn.constants.js'
 
+function extensions_response(extensions: unknown) {
+  if (!extensions || typeof extensions !== 'object') return undefined
+  const { hostContext } = extensions as { hostContext?: unknown }
+  return hostContext === undefined ? undefined : { hostContext }
+}
+
 export default async function () {
   const kv = Kv.memory()
   const server = Http.createServer((req, res) => {
@@ -20,15 +26,15 @@ export default async function () {
       kv: hooksKv,
       origin,
       rpId: 'localhost',
-      onRegister({ credentialId }) {
+      onRegister({ credentialId, extensions }) {
         return Response.json(
-          { sessionToken: `reg_${credentialId}` },
+          { extensions: extensions_response(extensions), sessionToken: `reg_${credentialId}` },
           { headers: { 'x-custom': 'register-hook' } },
         )
       },
-      onAuthenticate({ credentialId }) {
+      onAuthenticate({ credentialId, extensions }) {
         return Response.json(
-          { sessionToken: `auth_${credentialId}` },
+          { extensions: extensions_response(extensions), sessionToken: `auth_${credentialId}` },
           { headers: { 'x-custom': 'authenticate-hook' } },
         )
       },


### PR DESCRIPTION
## Summary
Add typed WebAuthn ceremony extensions for challenge-bound server handoffs.

## Motivation
Host apps need to attach server-owned JSON to WebAuthn registration and login challenges, then receive it in server hooks only after the credential proof succeeds. This keeps SDK behavior generic while allowing apps to validate flows like API signing key registration in their own hook code.

## Changes
- Added typed `extensions` and `getExtensions` to `src/core/WebAuthnCeremony.ts`.
- Stored `extensions` with registration/login challenges and passed them to `onRegister` / `onAuthenticate` in `src/server/internal/handlers/webAuthn.ts`.
- Added size and JSON-object guardrails for options endpoint extension payloads.
- Added unit and type coverage for typed client/server extension usage.

## Testing
- `./node_modules/.bin/tsc -b --noEmit`
- `./node_modules/.bin/vp test src/core/WebAuthnCeremony.test.ts src/server/internal/handlers/webAuthn.test.ts src/core/adapters/webAuthn.test.ts src/core/zod/rpc.test.ts`
- `git diff --check`
- Commit hook ran `pnpm check`; it completed with existing lint warnings in unrelated files.
