### PR TITLE
feat(auth): bind SIWE resources into challenges

### DIFF
--- a/.changeset/siwe-auth-resources.md
+++ b/.changeset/siwe-auth-resources.md
@@ -1,0 +1,5 @@
+---
+"accounts": minor
+---
+
+Add SIWE resources and statement support to wallet_connect auth challenges, and preserve extra auth verify JSON fields.

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -17,6 +17,8 @@ type EncodedRequest<encoded extends { method: unknown; params: unknown }> = Pick
   encoded,
   'method' | 'params'
 >
+type AuthCapability =
+  Rpc.wallet_connect.Encoded['returns']['accounts'][number]['capabilities']['auth']
 
 /** Adapter interface for the provider. */
 export type Adapter = SetupFn & Meta
@@ -279,7 +281,7 @@ export declare namespace createAccount {
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Server Authentication result, if the auth capability was requested. */
-    auth?: { token?: string | undefined } | undefined
+    auth?: AuthCapability | undefined
     /**
      * Consented identity claims (e.g. verified email), if the `identity`
      * capability was requested and the user approved sharing.
@@ -353,7 +355,7 @@ export declare namespace loadAccounts {
     /** Signed key authorization, if an access key was granted. */
     keyAuthorization?: KeyAuthorization.Rpc | undefined
     /** Server Authentication result, if the auth capability was requested. */
-    auth?: { token?: string | undefined } | undefined
+    auth?: AuthCapability | undefined
     /**
      * Consented identity claims (e.g. verified email), if the `identity`
      * capability was requested and the user approved sharing.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,3 +1,5 @@
+import { Hex } from 'ox'
+import { createSiweMessage } from 'viem/siwe'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Adapter from './Adapter.js'
@@ -146,6 +148,230 @@ describe('wallet_connect', () => {
       })
 
       expect(verifyBody?.idToken).toBe('eyJhbG.payload.sig')
+    })
+  })
+
+  describe('auth resources', () => {
+    afterEach(() => vi.unstubAllGlobals())
+
+    function authAdapter() {
+      return Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+        actions: {
+          async createAccount() {
+            return { accounts: [{ address }], signature: '0xabc' }
+          },
+          async loadAccounts() {
+            return { accounts: [{ address }], signature: '0xabc' }
+          },
+        },
+      }))
+    }
+
+    function message(options: {
+      chainId: number
+      resources?: readonly string[] | undefined
+      statement?: string | undefined
+    }) {
+      const { chainId, resources, statement } = options
+      return createSiweMessage({
+        address,
+        chainId,
+        domain: 'app.example.com',
+        uri: 'https://app.example.com',
+        version: '1',
+        nonce: 'deadbeef00',
+        issuedAt: new Date('2025-01-01T00:00:00Z'),
+        ...(resources ? { resources: [...resources] } : {}),
+        ...(statement ? { statement } : {}),
+      })
+    }
+
+    function stubAuthFetch(options: {
+      resources?: readonly string[] | undefined
+      statement?: string | undefined
+      onChallenge?: ((body: Record<string, unknown>) => void) | undefined
+      verify?: Record<string, unknown> | undefined
+    }) {
+      vi.stubGlobal('fetch', async (input: string | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.endsWith('/auth/challenge')) {
+          const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+          options.onChallenge?.(body)
+          const { chainId } = body as { chainId: number }
+          return new Response(
+            JSON.stringify({
+              message: message({
+                chainId,
+                resources: options.resources,
+                statement: options.statement,
+              }),
+            }),
+            { status: 200 },
+          )
+        }
+        if (url === 'https://app.example.com/auth')
+          return new Response(JSON.stringify(options.verify ?? { token: 'session' }), {
+            status: 200,
+          })
+        throw new Error(`unexpected fetch: ${url}`)
+      })
+    }
+
+    function connect(
+      provider: ReturnType<typeof Provider.create>,
+      options: {
+        chainId?: `0x${string}` | undefined
+        resources: readonly string[]
+        statement?: string | undefined
+      },
+    ) {
+      const { chainId, resources, statement } = options
+      return provider.request({
+        method: 'wallet_connect',
+        params: [
+          {
+            ...(chainId ? { chainId } : {}),
+            capabilities: {
+              auth: {
+                url: 'https://app.example.com/auth',
+                resources,
+                ...(statement ? { statement } : {}),
+              },
+            },
+          },
+        ],
+      })
+    }
+
+    test('behavior: sends resources and statement to the challenge endpoint', async () => {
+      const resources = ['urn:tempo:api-signing-key:test', 'https://api.example.com/signing-keys/1']
+      let challengeBody: Record<string, unknown> | undefined
+      stubAuthFetch({
+        resources,
+        statement: 'Authorize a scoped API signing key.',
+        onChallenge(body) {
+          challengeBody = body
+        },
+      })
+
+      const provider = Provider.create({ adapter: authAdapter(), storage: Storage.memory() })
+
+      await connect(provider, {
+        chainId: Hex.fromNumber(1),
+        resources,
+        statement: 'Authorize a scoped API signing key.',
+      })
+
+      expect(challengeBody).toMatchInlineSnapshot(`
+        {
+          "chainId": 1,
+          "resources": [
+            "urn:tempo:api-signing-key:test",
+            "https://api.example.com/signing-keys/1",
+          ],
+          "statement": "Authorize a scoped API signing key.",
+        }
+      `)
+    })
+
+    test('error: rejects when the challenge omits requested resources', async () => {
+      const resources = ['https://api.example.com/signing-keys/1']
+      stubAuthFetch({})
+      const provider = Provider.create({ adapter: authAdapter(), storage: Storage.memory() })
+
+      await expect(
+        connect(provider, {
+          resources,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[RpcResponse.InvalidParamsError: Server Authentication challenge endpoint \`https://app.example.com/auth/challenge\` did not echo the requested SIWE resources.]`,
+      )
+    })
+
+    test('error: rejects when the challenge changes requested resources', async () => {
+      const resources = ['https://api.example.com/signing-keys/1']
+      stubAuthFetch({
+        resources: ['https://api.example.com/signing-keys/2'],
+      })
+      const provider = Provider.create({ adapter: authAdapter(), storage: Storage.memory() })
+
+      await expect(
+        connect(provider, {
+          resources,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[RpcResponse.InvalidParamsError: Server Authentication challenge endpoint \`https://app.example.com/auth/challenge\` did not echo the requested SIWE resources.]`,
+      )
+    })
+
+    test('error: rejects when forwarded auth message omits requested resources', async () => {
+      const resources = ['https://api.example.com/signing-keys/1']
+      const signed = message({ chainId: 1 })
+      let verifyCalled = false
+      vi.stubGlobal('fetch', async (input: string | URL) => {
+        const url = String(input)
+        if (url === 'https://app.example.com/auth') {
+          verifyCalled = true
+          return new Response(JSON.stringify({ token: 'session' }), { status: 200 })
+        }
+        throw new Error(`unexpected fetch: ${url}`)
+      })
+      const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+        actions: {
+          async createAccount() {
+            return {
+              accounts: [{ address }],
+              personalSign: { message: signed },
+              signature: '0xabc',
+            }
+          },
+          async loadAccounts() {
+            return {
+              accounts: [{ address }],
+              personalSign: { message: signed },
+              signature: '0xabc',
+            }
+          },
+        },
+        forwardsAuth: true,
+      }))
+      const provider = Provider.create({ adapter, storage: Storage.memory() })
+
+      await expect(
+        connect(provider, {
+          chainId: Hex.fromNumber(1),
+          resources,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[RpcResponse.InvalidParamsError: Server Authentication challenge endpoint \`https://app.example.com/auth/challenge\` did not echo the requested SIWE resources.]`,
+      )
+      expect(verifyCalled).toMatchInlineSnapshot(`false`)
+    })
+
+    test('behavior: preserves extra verify JSON under capabilities.auth', async () => {
+      const resources = ['https://api.example.com/signing-keys/1']
+      stubAuthFetch({
+        resources,
+        verify: {
+          apiSigningKey: { id: 'key_1', scope: 'read' },
+          token: 'session',
+        },
+      })
+      const provider = Provider.create({ adapter: authAdapter(), storage: Storage.memory() })
+
+      const result = await connect(provider, {
+        resources,
+      })
+
+      expect(result.accounts[0]?.capabilities.auth).toMatchInlineSnapshot(`
+        {
+          "apiSigningKey": {
+            "id": "key_1",
+            "scope": "read",
+          },
+          "token": "session",
+        }
+      `)
     })
   })
 })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -69,6 +69,9 @@ type TransactionParameters = Adapter.ActionRequest<typeof Rpc.eth_sendTransactio
 type WalletConnectCapabilities = NonNullable<
   NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']
 >
+type AuthCapabilityResult = NonNullable<
+  Rpc.wallet_connect.Encoded['returns']['accounts'][number]['capabilities']['auth']
+>
 
 function isBrowserWebCrypto() {
   return typeof document !== 'undefined' && !!globalThis.crypto?.subtle
@@ -1207,6 +1210,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                           '`auth` and `personalSign` cannot both be set on `wallet_connect`.',
                       })
 
+                    const authChainId = chainId ?? store.getState().chainId ?? 0
                     const accessKey = authorizeAccessKey
                       ? await prepareAuthorizeAccessKey(authorizeAccessKey, chainId)
                       : undefined
@@ -1238,10 +1242,7 @@ export function create(options: create.Options = {}): create.ReturnType {
 
                     const auth =
                       auth_request && !instance.forwardsAuth
-                        ? await fetchAuthChallenge(
-                            auth_request,
-                            chainId ?? store.getState().chainId ?? 0,
-                          )
+                        ? await fetchAuthChallenge(auth_request, authChainId)
                         : undefined
 
                     const personalSign_request = auth
@@ -1349,6 +1350,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                         ? auth_request.verify
                         : undefined
                     const verifyMessage = auth?.message ?? personalSign?.message
+                    if (auth_request && verifyUrl && verifyMessage && signature && accountAddress)
+                      validateAuthMessage(auth_request, {
+                        chainId: authChainId,
+                        message: verifyMessage,
+                      })
                     const auth_result =
                       auth_request && verifyUrl && verifyMessage && signature && accountAddress
                         ? await verifyAuthMessage(auth_request, {
@@ -1997,7 +2003,11 @@ function absolutizeAuth(
     ...(hasChallenge ? { challenge: resolveAuthEndpoint(auth, 'challenge') } : {}),
     ...(hasVerify ? { verify: resolveAuthEndpoint(auth, 'verify') } : {}),
     ...(hasLogout ? { logout: resolveAuthEndpoint(auth, 'logout') } : {}),
+    ...(typeof auth === 'object' && auth.resources !== undefined
+      ? { resources: auth.resources }
+      : {}),
     ...(typeof auth === 'object' && auth.returnToken ? { returnToken: true } : {}),
+    ...(typeof auth === 'object' && auth.statement ? { statement: auth.statement } : {}),
   }
   assertSameAuthOrigin(resolved)
   return resolved
@@ -2034,42 +2044,26 @@ function assertSameAuthOrigin(auth: NonNullable<z.output<typeof Rpc.wallet_conne
 const authOriginHint =
   ' Hint: if the server is behind a reverse proxy or tunnel, set `Handler.auth({ trustProxy: true })` to honor `x-forwarded-*` headers, or pin the public origin with `Handler.auth({ origin: "https://app.example.com" })`.'
 
-/**
- * Fetches an auth challenge from the auth endpoint and validates that the
- * server-supplied message is bound to the auth endpoint's origin and the
- * requested chain.
- *
- * Expects an absolutized auth capability (post-`absolutizeAuth`).
- *
- * The signature produced from this challenge is a portable artifact: once
- * the wallet signs, anyone holding the bytes can replay it against any
- * auth verifier that accepts the embedded domain. We therefore refuse to
- * sign a message whose `domain`/`uri` doesn't match the auth endpoint —
- * otherwise a compromised auth provider could trick the wallet into
- * signing "Sign in to attacker.com" and use it to log in as the user
- * elsewhere.
- */
-async function fetchAuthChallenge(
-  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
-  chainId: number,
-): Promise<{ message: string }> {
-  const url = typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge')
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ chainId }),
-  })
-  if (!res.ok)
-    throw new RpcResponse.InvalidParamsError({
-      message: `Server Authentication challenge endpoint \`${url}\` returned ${res.status}.`,
-    })
-  const body = (await res.json().catch(() => ({}))) as { message?: string }
-  if (!body.message)
-    throw new RpcResponse.InvalidParamsError({
-      message: `Server Authentication challenge endpoint \`${url}\` response missing \`message\`.`,
-    })
+function stringsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((value, index) => value === b[index])
+}
 
-  const parsed = parseSiweMessage(body.message)
+function validateAuthMessage(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+  options: {
+    chainId: number
+    message: string
+    url?: string | undefined
+  },
+): void {
+  const { chainId, message } = options
+  const url =
+    options.url ??
+    (typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge'))
+  const resources = typeof auth === 'object' ? auth.resources : undefined
+  const statement = typeof auth === 'object' ? auth.statement : undefined
+  const parsed = parseSiweMessage(message)
   const expected = new URL(url)
 
   if (parsed.version !== '1')
@@ -2092,14 +2086,67 @@ async function fetchAuthChallenge(
     throw new RpcResponse.InvalidParamsError({
       message: `Server Authentication challenge endpoint \`${url}\` returned a message bound to chainId \`${parsed.chainId}\` (expected \`${chainId}\`).`,
     })
+  if (resources !== undefined && !stringsEqual(parsed.resources ?? [], resources))
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` did not echo the requested SIWE resources.`,
+    })
+  if (statement && parsed.statement !== statement)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` did not echo the requested SIWE statement.`,
+    })
+}
+
+/**
+ * Fetches an auth challenge from the auth endpoint and validates that the
+ * server-supplied message is bound to the auth endpoint's origin and the
+ * requested chain.
+ *
+ * Expects an absolutized auth capability (post-`absolutizeAuth`).
+ *
+ * The signature produced from this challenge is a portable artifact: once
+ * the wallet signs, anyone holding the bytes can replay it against any
+ * auth verifier that accepts the embedded domain. We therefore refuse to
+ * sign a message whose `domain`/`uri` doesn't match the auth endpoint —
+ * otherwise a compromised auth provider could trick the wallet into
+ * signing "Sign in to attacker.com" and use it to log in as the user
+ * elsewhere.
+ */
+async function fetchAuthChallenge(
+  auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
+  chainId: number,
+): Promise<{ message: string }> {
+  const url = typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge')
+  const resources = typeof auth === 'object' ? auth.resources : undefined
+  const statement = typeof auth === 'object' ? auth.statement : undefined
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      chainId,
+      ...(resources !== undefined ? { resources } : {}),
+      ...(statement ? { statement } : {}),
+    }),
+  })
+  if (!res.ok)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` returned ${res.status}.`,
+    })
+  const body = (await res.json().catch(() => ({}))) as { message?: string }
+  if (!body.message)
+    throw new RpcResponse.InvalidParamsError({
+      message: `Server Authentication challenge endpoint \`${url}\` response missing \`message\`.`,
+    })
+
+  validateAuthMessage(auth, { chainId, message: body.message, url })
 
   return { message: body.message }
 }
 
 /**
  * Posts the signed message to the auth `verify` endpoint and returns
- * the SDK-shaped `auth` capability output (`{ token }` in token mode,
- * `{}` in cookie mode).
+ * the SDK-shaped `auth` capability output. `{ token }` remains reserved
+ * for token mode; other JSON fields returned by the verify endpoint are
+ * preserved for application-specific metadata.
  */
 async function verifyAuthMessage(
   auth: NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
@@ -2110,7 +2157,7 @@ async function verifyAuthMessage(
     signature: Hex.Hex
     keyAuthorization?: Hex.Hex | undefined
   },
-): Promise<{ token?: string }> {
+): Promise<AuthCapabilityResult> {
   const url = typeof auth === 'object' ? auth.verify! : resolveAuthEndpoint(auth, 'verify')
   // Auto-request the token in environments without a cookie jar (React
   // Native / Node / CLI). Browser lets the cookie do the work; explicit
@@ -2130,6 +2177,7 @@ async function verifyAuthMessage(
     throw new RpcResponse.InternalError({
       message: `Server Authentication verify endpoint \`${url}\` returned ${res.status}.`,
     })
-  const json = (await res.json().catch(() => ({}))) as { token?: string }
-  return json.token ? { token: json.token } : {}
+  const json = await res.json().catch(() => ({}))
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return {}
+  return json as AuthCapabilityResult
 }

--- a/src/core/zod/rpc.test-d.ts
+++ b/src/core/zod/rpc.test-d.ts
@@ -3,6 +3,23 @@ import type * as z from 'zod/mini'
 
 import type * as Rpc from './rpc.js'
 
+describe('wallet_connect.auth', () => {
+  test('request exposes resources and statement', () => {
+    type Auth = Exclude<z.output<typeof Rpc.wallet_connect.auth>, string | undefined>
+    expectTypeOf<Auth>().toMatchTypeOf<{
+      resources?: readonly string[] | undefined
+      statement?: string | undefined
+    }>()
+  })
+
+  test('result preserves token plus arbitrary JSON fields', () => {
+    type Result = z.output<typeof Rpc.wallet_connect.capabilities.result>
+    expectTypeOf<Result['auth']>().toMatchTypeOf<
+      ({ token?: string | undefined } & Record<string, unknown>) | undefined
+    >()
+  })
+})
+
 describe('wallet_connect.identity', () => {
   type EmailRequest = boolean | { nonce?: string | undefined } | undefined
 

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -180,6 +180,30 @@ describe('wallet_connect.capabilities.request: auth', () => {
     `)
   })
 
+  test('accepts object with `resources` and `statement`', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: {
+          url: '/api/auth',
+          resources: ['urn:tempo:api-signing-key:test'],
+          statement: 'Authorize a scoped API signing key.',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "resources": [
+            "urn:tempo:api-signing-key:test",
+          ],
+          "statement": "Authorize a scoped API signing key.",
+          "url": "/api/auth",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
   test('accepts explicit endpoints (challenge + verify + logout)', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
@@ -272,6 +296,15 @@ describe('wallet_connect.capabilities.request: auth', () => {
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'login',
         auth: { returnToken: 'yes' },
+      }),
+    ).toThrow()
+  })
+
+  test('rejects auth.resources as string', () => {
+    expect(() =>
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        auth: { resources: 'urn:tempo:api-signing-key:test' },
       }),
     ).toThrow()
   })
@@ -411,6 +444,26 @@ describe('wallet_connect.capabilities.result: auth + personalSign', () => {
     ).toMatchInlineSnapshot(`
       {
         "auth": {},
+      }
+    `)
+  })
+
+  test('accepts extra auth JSON fields', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.result, {
+        auth: {
+          apiSigningKey: { id: 'key_1' },
+          token: 'sess_abc',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "auth": {
+          "apiSigningKey": {
+            "id": "key_1",
+          },
+          "token": "sess_abc",
+        },
       }
     `)
   })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -620,12 +620,23 @@ export namespace wallet_connect {
         verify: z.optional(z.string()),
         logout: z.optional(z.string()),
         /**
+         * SIWE resources to bind into the server-issued challenge. The server
+         * decides their meaning; the SDK only requires the issued SIWE message
+         * to echo them exactly before signing.
+         */
+        resources: z.optional(z.readonly(z.array(z.string()))),
+        /**
          * Ask the verify endpoint to also return `{ token }` in the JSON body.
          * Default `false` — cookie mode relies on `Set-Cookie` only.
          * Set this for non-browser clients (RN, CLI) that can't store cookies, or
          * to surface the JWT alongside a cookie in dual-transport setups.
          */
         returnToken: z.optional(z.boolean()),
+        /**
+         * Human-readable SIWE statement to pair with machine-readable
+         * `resources`. The server-issued challenge must echo it exactly.
+         */
+        statement: z.optional(z.string()),
       }),
     ]),
   )
@@ -747,10 +758,11 @@ export namespace wallet_connect {
       /**
        * SIWE round-trip output, populated when the request `auth` capability was set.
        * `token` is present in JWT mode or when the request set `returnToken: true`.
+       * Additional JSON fields returned by the verify endpoint are preserved.
        * Cookie-mode default = `{}` (the session arrived via `Set-Cookie`).
        */
       auth: z.optional(
-        z.object({
+        z.looseObject({
           token: z.optional(z.string()),
         }),
       ),

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -83,6 +83,78 @@ describe('challenge', () => {
     expect(parsed.nonce).toMatch(/^[a-z0-9]+$/)
   })
 
+  test('includes requested resources and statement in the challenge message', async () => {
+    const { app } = setup()
+    const resources = ['urn:tempo:api-signing-key:test', 'https://api.example.com/signing-keys/1']
+
+    const { status, body } = await getChallenge(app, {
+      chainId: 1,
+      resources,
+      statement: 'Authorize a scoped API signing key.',
+    })
+
+    expect(status).toBe(200)
+    const parsed = parseSiweMessage(body.message!)
+    expect({ resources: parsed.resources, statement: parsed.statement }).toMatchInlineSnapshot(`
+      {
+        "resources": [
+          "urn:tempo:api-signing-key:test",
+          "https://api.example.com/signing-keys/1",
+        ],
+        "statement": "Authorize a scoped API signing key.",
+      }
+    `)
+  })
+
+  test('rejects invalid resource URIs', async () => {
+    const { app } = setup()
+
+    const { status, body } = await getChallenge(app, {
+      chainId: 1,
+      resources: ['not a uri'],
+    })
+
+    expect(status).toBe(400)
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "error": "invalid SIWE challenge parameters",
+      }
+    `)
+  })
+
+  test('rejects line breaks in resources and statements', async () => {
+    const { app } = setup()
+
+    const resource = await getChallenge(app, {
+      chainId: 1,
+      resources: ['urn:tempo:one\ntwo'],
+    })
+    const statement = await getChallenge(app, {
+      chainId: 1,
+      statement: 'one\ntwo',
+    })
+
+    expect({
+      resource: { body: resource.body, status: resource.status },
+      statement: { body: statement.body, status: statement.status },
+    }).toMatchInlineSnapshot(`
+      {
+        "resource": {
+          "body": {
+            "error": "resources must not include line breaks",
+          },
+          "status": 400,
+        },
+        "statement": {
+          "body": {
+            "error": "statement must not include line breaks",
+          },
+          "status": 400,
+        },
+      }
+    `)
+  })
+
   test('defaults chainId to 0 when omitted', async () => {
     const { app } = setup()
 
@@ -225,6 +297,34 @@ describe('verify (EOA, cookie mode)', () => {
     const tampered = message.replace(
       /(0x0000000000000000000000000000000000000000\n)\n/,
       '$1\nSign to prove you are human\n\n',
+    )
+    expect(tampered).not.toBe(message)
+    const signature = await account.signMessage({ message: tampered })
+
+    const res = await postVerify(app, {
+      address: account.address,
+      message: tampered,
+      signature,
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "error": "message mismatch",
+      }
+    `)
+  })
+
+  test('rejects tampered message resources with 400', async () => {
+    const { app } = setup()
+
+    const { body: challengeBody } = await getChallenge(app, {
+      chainId: 1,
+      resources: ['https://api.example.com/signing-keys/1'],
+    })
+    const message = challengeBody.message!
+    const tampered = message.replace(
+      'https://api.example.com/signing-keys/1',
+      'https://api.example.com/signing-keys/2',
     )
     expect(tampered).not.toBe(message)
     const signature = await account.signMessage({ message: tampered })
@@ -1186,7 +1286,14 @@ function setup(options: Parameters<typeof auth>[0] = {}) {
   return { handler, app }
 }
 
-async function getChallenge(app: Hono, body: { chainId: number }) {
+async function getChallenge(
+  app: Hono,
+  body: {
+    chainId: number
+    resources?: readonly string[] | undefined
+    statement?: string | undefined
+  },
+) {
   const res = await app.request('/challenge', {
     method: 'POST',
     headers: { 'content-type': 'application/json', host: 'wallet.example' },

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -21,6 +21,9 @@ const defaults = {
     session: 24 * 60 * 60, // 24 hours
   },
 } as const
+const maxResources = 10
+const maxResourceLength = 2_048
+const lineBreak = /[\r\n]/
 
 /**
  * Default OIDC issuer — the Tempo wallet's production OIDC mount. Apps that opt
@@ -79,9 +82,15 @@ const sessionKey = (token: string) => `session:${token}`
 export namespace schema {
   /** Schemas for `POST {path}/challenge`. */
   export namespace challenge {
+    const resource = z.string().check(z.maxLength(maxResourceLength))
+
     /** Request body schema. */
     export const parameters = z.object({
       chainId: z.optional(z.number()),
+      /** SIWE resources to bind into the issued challenge message. */
+      resources: z.optional(z.readonly(z.array(resource).check(z.maxLength(maxResources)))),
+      /** Human-readable SIWE statement to bind into the issued challenge message. */
+      statement: z.optional(z.string()),
     })
 
     /** Response body schema. */
@@ -121,7 +130,8 @@ export namespace schema {
     })
 
     /** Response body schema. */
-    export const returns = z.object({
+    export const returns = z.looseObject({
+      /** Session token in bearer-token mode. */
       token: z.optional(z.string()),
     })
   }
@@ -201,7 +211,12 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
   const logoutPath = path === '/' ? '/logout' : `${path}/logout`
 
   router.post(challengePath, Hono.validate('json', schema.challenge.parameters), async (c) => {
-    const { chainId = 0 } = c.req.valid('json')
+    const { chainId = 0, resources, statement } = c.req.valid('json')
+
+    if (resources?.some((resource) => lineBreak.test(resource)))
+      return c.json({ error: 'resources must not include line breaks' }, 400)
+    if (statement !== undefined && lineBreak.test(statement))
+      return c.json({ error: 'statement must not include line breaks' }, 400)
 
     const { protocol, host: reqHost } = resolveReqOrigin(c.req.raw)
     const resolvedDomain = domain ?? reqHost
@@ -210,16 +225,25 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     const issuedAt = new Date()
     const expirationTime = new Date(issuedAt.getTime() + challengeTtl * 1000)
 
-    const message = createSiweMessage({
-      address: zeroAddress,
-      chainId,
-      domain: resolvedDomain,
-      uri: `${protocol}//${resolvedDomain}`,
-      version: '1',
-      nonce,
-      issuedAt,
-      expirationTime,
-    })
+    const message = (() => {
+      try {
+        return createSiweMessage({
+          address: zeroAddress,
+          chainId,
+          domain: resolvedDomain,
+          uri: `${protocol}//${resolvedDomain}`,
+          version: '1',
+          nonce,
+          issuedAt,
+          expirationTime,
+          ...(resources?.length ? { resources: [...resources] } : {}),
+          ...(statement ? { statement } : {}),
+        })
+      } catch (error) {
+        return error instanceof Error ? error : new Error('invalid SIWE challenge parameters')
+      }
+    })()
+    if (message instanceof Error) return c.json({ error: 'invalid SIWE challenge parameters' }, 400)
 
     await store.set(
       challengeKey(nonce),


### PR DESCRIPTION
## Summary
Bind `wallet_connect.auth` SIWE resources and statements into `Handler.auth` challenges, and preserve extra verify JSON under `capabilities.auth`.

## Motivation
SIWE already has a standard `resources` field for binding the exact objects, grants, scopes, policy documents, or app-defined references a user is authorizing. Exposing that through `wallet_connect.auth` lets apps put authorization context in the signed server challenge instead of adding parallel nonce stores, custom wallet fields, or one-off extension paths.

## Changes
- Add `resources` and `statement` to `src/core/zod/rpc.ts` auth capability input and loosen `capabilities.auth` output for extra JSON fields.
- Post requested resources/statements from `src/core/Provider.ts`, validate exact SIWE echo before signing and before forwarded verify, and return the full verify JSON body.
- Accept and validate challenge resources in `src/server/internal/handlers/auth.ts`, then pass them into `createSiweMessage`.
- Add provider, handler, zod, and type tests for resource echo, forwarded auth messages, tampering, and extra verify fields.

## Testing
- `env PATH=/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH pnpm_config_verify_deps_before_run=false /Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm test src/core/Provider.test.ts src/server/internal/handlers/auth.test.ts src/core/zod/rpc.test.ts` - 3 files, 115 tests passed
- `git diff --check`
- `PATH=/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH ./node_modules/.bin/vp fmt src/core/Provider.ts src/core/Provider.test.ts`
- `env PATH=/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH pnpm_config_verify_deps_before_run=false /Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm exec tsc -b --noEmit` - currently fails on upstream `src/core/adapters/mobileWebAuth/*` and `src/core/adapters/postMessage/*` session type errors after rebasing on `origin/main`
- Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; completed with two existing warnings in unrelated test files.