### PR TITLE
feat(auth): move SIWE statements to server config

### DIFF
--- a/.changeset/siwe-auth-resources.md
+++ b/.changeset/siwe-auth-resources.md
@@ -2,4 +2,4 @@
 "accounts": minor
 ---
 
-Add SIWE resources and statement support to wallet_connect auth challenges, and preserve extra auth verify JSON fields.
+Add SIWE resources to wallet_connect auth challenges, support server-provided SIWE statements in Handler.auth, and preserve extra auth verify JSON fields.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -222,10 +222,9 @@ describe('wallet_connect', () => {
       options: {
         chainId?: `0x${string}` | undefined
         resources: readonly string[]
-        statement?: string | undefined
       },
     ) {
-      const { chainId, resources, statement } = options
+      const { chainId, resources } = options
       return provider.request({
         method: 'wallet_connect',
         params: [
@@ -235,7 +234,6 @@ describe('wallet_connect', () => {
               auth: {
                 url: 'https://app.example.com/auth',
                 resources,
-                ...(statement ? { statement } : {}),
               },
             },
           },
@@ -243,7 +241,7 @@ describe('wallet_connect', () => {
       })
     }
 
-    test('behavior: sends resources and statement to the challenge endpoint', async () => {
+    test('behavior: sends resources and accepts a server-provided statement', async () => {
       const resources = ['urn:tempo:api-signing-key:test', 'https://api.example.com/signing-keys/1']
       let challengeBody: Record<string, unknown> | undefined
       stubAuthFetch({
@@ -259,7 +257,6 @@ describe('wallet_connect', () => {
       await connect(provider, {
         chainId: Hex.fromNumber(1),
         resources,
-        statement: 'Authorize a scoped API signing key.',
       })
 
       expect(challengeBody).toMatchInlineSnapshot(`
@@ -269,7 +266,6 @@ describe('wallet_connect', () => {
             "urn:tempo:api-signing-key:test",
             "https://api.example.com/signing-keys/1",
           ],
-          "statement": "Authorize a scoped API signing key.",
         }
       `)
     })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -2007,7 +2007,6 @@ function absolutizeAuth(
       ? { resources: auth.resources }
       : {}),
     ...(typeof auth === 'object' && auth.returnToken ? { returnToken: true } : {}),
-    ...(typeof auth === 'object' && auth.statement ? { statement: auth.statement } : {}),
   }
   assertSameAuthOrigin(resolved)
   return resolved
@@ -2062,7 +2061,6 @@ function validateAuthMessage(
     options.url ??
     (typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge'))
   const resources = typeof auth === 'object' ? auth.resources : undefined
-  const statement = typeof auth === 'object' ? auth.statement : undefined
   const parsed = parseSiweMessage(message)
   const expected = new URL(url)
 
@@ -2090,10 +2088,6 @@ function validateAuthMessage(
     throw new RpcResponse.InvalidParamsError({
       message: `Server Authentication challenge endpoint \`${url}\` did not echo the requested SIWE resources.`,
     })
-  if (statement && parsed.statement !== statement)
-    throw new RpcResponse.InvalidParamsError({
-      message: `Server Authentication challenge endpoint \`${url}\` did not echo the requested SIWE statement.`,
-    })
 }
 
 /**
@@ -2117,14 +2111,12 @@ async function fetchAuthChallenge(
 ): Promise<{ message: string }> {
   const url = typeof auth === 'object' ? auth.challenge! : resolveAuthEndpoint(auth, 'challenge')
   const resources = typeof auth === 'object' ? auth.resources : undefined
-  const statement = typeof auth === 'object' ? auth.statement : undefined
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       chainId,
       ...(resources !== undefined ? { resources } : {}),
-      ...(statement ? { statement } : {}),
     }),
   })
   if (!res.ok)

--- a/src/core/zod/rpc.test-d.ts
+++ b/src/core/zod/rpc.test-d.ts
@@ -4,11 +4,10 @@ import type * as z from 'zod/mini'
 import type * as Rpc from './rpc.js'
 
 describe('wallet_connect.auth', () => {
-  test('request exposes resources and statement', () => {
+  test('request exposes resources', () => {
     type Auth = Exclude<z.output<typeof Rpc.wallet_connect.auth>, string | undefined>
     expectTypeOf<Auth>().toMatchTypeOf<{
       resources?: readonly string[] | undefined
-      statement?: string | undefined
     }>()
   })
 

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -180,14 +180,13 @@ describe('wallet_connect.capabilities.request: auth', () => {
     `)
   })
 
-  test('accepts object with `resources` and `statement`', () => {
+  test('accepts object with `resources`', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'login',
         auth: {
           url: '/api/auth',
           resources: ['urn:tempo:api-signing-key:test'],
-          statement: 'Authorize a scoped API signing key.',
         },
       }),
     ).toMatchInlineSnapshot(`
@@ -196,7 +195,6 @@ describe('wallet_connect.capabilities.request: auth', () => {
           "resources": [
             "urn:tempo:api-signing-key:test",
           ],
-          "statement": "Authorize a scoped API signing key.",
           "url": "/api/auth",
         },
         "method": "login",

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -632,11 +632,6 @@ export namespace wallet_connect {
          * to surface the JWT alongside a cookie in dual-transport setups.
          */
         returnToken: z.optional(z.boolean()),
-        /**
-         * Human-readable SIWE statement to pair with machine-readable
-         * `resources`. The server-issued challenge must echo it exactly.
-         */
-        statement: z.optional(z.string()),
       }),
     ]),
   )

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -4,7 +4,7 @@ import { KeyAuthorization } from 'ox/tempo'
 import { hashMessage } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
-import { afterAll, beforeAll, describe, expect, test } from 'vp/test'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vp/test'
 
 import { createServer } from '../../../../test/utils.js'
 import * as Handler from '../../Handler.js'
@@ -83,14 +83,13 @@ describe('challenge', () => {
     expect(parsed.nonce).toMatch(/^[a-z0-9]+$/)
   })
 
-  test('includes requested resources and statement in the challenge message', async () => {
-    const { app } = setup()
+  test('includes requested resources and configured statement in the challenge message', async () => {
+    const { app } = setup({ statement: 'Authorize account access.' })
     const resources = ['urn:tempo:api-signing-key:test', 'https://api.example.com/signing-keys/1']
 
     const { status, body } = await getChallenge(app, {
       chainId: 1,
       resources,
-      statement: 'Authorize a scoped API signing key.',
     })
 
     expect(status).toBe(200)
@@ -101,9 +100,95 @@ describe('challenge', () => {
           "urn:tempo:api-signing-key:test",
           "https://api.example.com/signing-keys/1",
         ],
-        "statement": "Authorize a scoped API signing key.",
+        "statement": "Authorize account access.",
       }
     `)
+  })
+
+  test('uses statement callback output in the challenge message', async () => {
+    const resources = ['https://api.example.com/signing-keys/1']
+    let params_seen:
+      | {
+          chainId: number
+          resources?: readonly string[] | undefined
+          url: string
+        }
+      | undefined
+    const statement = vi.fn(
+      (params: {
+        chainId: number
+        resources?: readonly string[] | undefined
+        request: Request
+      }) => {
+        params_seen = {
+          chainId: params.chainId,
+          resources: params.resources,
+          url: params.request.url,
+        }
+        return `Authorize ${params.resources?.length ?? 0} resource.`
+      },
+    )
+    const { app } = setup({ statement })
+
+    const { status, body } = await getChallenge(app, {
+      chainId: 1,
+      resources,
+    })
+
+    expect(status).toBe(200)
+    const parsed = parseSiweMessage(body.message!)
+    expect({ params: params_seen, statement: parsed.statement }).toMatchInlineSnapshot(`
+      {
+        "params": {
+          "chainId": 1,
+          "resources": [
+            "https://api.example.com/signing-keys/1",
+          ],
+          "url": "http://localhost/challenge",
+        },
+        "statement": "Authorize 1 resource.",
+      }
+    `)
+  })
+
+  test('supports async statement callbacks', async () => {
+    const resources = ['https://api.example.com/signing-keys/1']
+    const statement = vi.fn(async (params: { resources?: readonly string[] | undefined }) => {
+      return `Authorize ${params.resources?.length ?? 0} resource.`
+    })
+    const { app } = setup({ statement })
+
+    const { status, body } = await getChallenge(app, {
+      chainId: 1,
+      resources,
+    })
+
+    expect(status).toBe(200)
+    const parsed = parseSiweMessage(body.message!)
+    expect({ calls: statement.mock.calls.length, statement: parsed.statement })
+      .toMatchInlineSnapshot(`
+      {
+        "calls": 1,
+        "statement": "Authorize 1 resource.",
+      }
+    `)
+  })
+
+  test('ignores requester-provided statement', async () => {
+    const { app } = setup({ statement: 'Server statement.' })
+
+    const res = await app.request('/challenge', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'wallet.example' },
+      body: JSON.stringify({
+        chainId: 1,
+        statement: 'Requester statement.',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const { message } = (await res.json()) as { message: string }
+    expect(parseSiweMessage(message).statement).toMatchInlineSnapshot(`"Server statement."`)
   })
 
   test('rejects invalid resource URIs', async () => {
@@ -122,17 +207,14 @@ describe('challenge', () => {
     `)
   })
 
-  test('rejects line breaks in resources and statements', async () => {
+  test('rejects line breaks in resources and configured statement', async () => {
     const { app } = setup()
 
     const resource = await getChallenge(app, {
       chainId: 1,
       resources: ['urn:tempo:one\ntwo'],
     })
-    const statement = await getChallenge(app, {
-      chainId: 1,
-      statement: 'one\ntwo',
-    })
+    const statement = await getChallenge(setup({ statement: 'one\ntwo' }).app, { chainId: 1 })
 
     expect({
       resource: { body: resource.body, status: resource.status },
@@ -1291,7 +1373,6 @@ async function getChallenge(
   body: {
     chainId: number
     resources?: readonly string[] | undefined
-    statement?: string | undefined
   },
 ) {
   const res = await app.request('/challenge', {

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -89,8 +89,6 @@ export namespace schema {
       chainId: z.optional(z.number()),
       /** SIWE resources to bind into the issued challenge message. */
       resources: z.optional(z.readonly(z.array(resource).check(z.maxLength(maxResources)))),
-      /** Human-readable SIWE statement to bind into the issued challenge message. */
-      statement: z.optional(z.string()),
     })
 
     /** Response body schema. */
@@ -163,6 +161,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     path = '/',
     origin: origin_option,
     session = true,
+    statement,
     store = Kv.memory(),
     transport = http(),
     // Cloudflare Workers always run behind Cloudflare's edge proxy, which
@@ -211,11 +210,15 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
   const logoutPath = path === '/' ? '/logout' : `${path}/logout`
 
   router.post(challengePath, Hono.validate('json', schema.challenge.parameters), async (c) => {
-    const { chainId = 0, resources, statement } = c.req.valid('json')
+    const { chainId = 0, resources } = c.req.valid('json')
 
     if (resources?.some((resource) => lineBreak.test(resource)))
       return c.json({ error: 'resources must not include line breaks' }, 400)
-    if (statement !== undefined && lineBreak.test(statement))
+    const statementValue =
+      typeof statement === 'function'
+        ? await statement({ chainId, resources, request: c.req.raw })
+        : statement
+    if (statementValue !== undefined && lineBreak.test(statementValue))
       return c.json({ error: 'statement must not include line breaks' }, 400)
 
     const { protocol, host: reqHost } = resolveReqOrigin(c.req.raw)
@@ -237,7 +240,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
           issuedAt,
           expirationTime,
           ...(resources?.length ? { resources: [...resources] } : {}),
-          ...(statement ? { statement } : {}),
+          ...(statementValue ? { statement: statementValue } : {}),
         })
       } catch (error) {
         return error instanceof Error ? error : new Error('invalid SIWE challenge parameters')
@@ -522,6 +525,22 @@ export declare namespace auth {
      * @default true
      */
     session?: boolean | undefined
+    /**
+     * Human-readable SIWE statement to bind into issued challenges. Static
+     * strings are used verbatim; callbacks can derive copy from the accepted
+     * `resources` while keeping the user-facing text under server control.
+     */
+    statement?:
+      | string
+      | ((params: {
+          /** Chain ID requested for the SIWE challenge. */
+          chainId: number
+          /** SIWE resources requested by the caller. */
+          resources?: readonly string[] | undefined
+          /** Underlying request — useful for headers, IP, etc. */
+          request: Request
+        }) => string | Promise<string | undefined> | undefined)
+      | undefined
     /**
      * Backing store for both single-use challenges (nonces) and issued
      * sessions. Keys are namespaced internally (`challenge:…`, `session:…`).


### PR DESCRIPTION
## Summary
Move SIWE `statement` control from `wallet_connect` callers to `Handler.auth`, while keeping requester-provided `resources`.

## Motivation
ERC-4361 defines `statement` as human-readable text shown by wallets as part of the relying party's SIWE message. The verifier should own that copy when issuing a challenge under its domain; requesters can still supply machine-readable `resources` for the server to accept, reject, and bind into the signed message.

## Changes
- Remove `statement` from `src/core/zod/rpc.ts` `wallet_connect.auth` and stop posting or validating it in `src/core/Provider.ts`.
- Add static and callback `statement` support to `src/server/internal/handlers/auth.ts`, with line-break validation before `createSiweMessage`.
- Update provider, handler, zod, type tests, and the changeset for server-owned statements.

## Testing
- `env PATH=/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH pnpm_config_verify_deps_before_run=false /Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm test src/core/Provider.test.ts src/server/internal/handlers/auth.test.ts src/core/zod/rpc.test.ts` - 3 files, 118 tests passed
- `env PATH=/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH pnpm_config_verify_deps_before_run=false /Users/tony/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm exec tsc -b --noEmit`
- `git diff --check`
- Pre-commit ran `vp lint --fix --ignore-pattern package.json && vp fmt src examples playgrounds ref-impls scripts test`; completed with two existing warnings in unrelated test files.