### PR TITLE
Resolve MPP accounts with access keys

### DIFF
--- a/.changeset/mpp-resolve-account.md
+++ b/.changeset/mpp-resolve-account.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added provider MPP account resolution parameters for locally managed access keys.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -7,7 +7,7 @@ description: Create an EIP-1193 provider for managing accounts on Tempo.
 
 Creates an EIP-1193 provider with a pluggable adapter for managing accounts on Tempo.
 
-The returned object implements [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) (`request`, `on`, `removeListener`, `emit`, ...) and exposes a few convenience helpers (`getAccount`, `getAccessKeyStatus`, `getClient`, `store`, `chains`). See [Return Type](#return-type) for the full surface.
+The returned object implements [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) (`request`, `on`, `removeListener`, `emit`, ...) and exposes a few convenience helpers (`getAccount`, `getAccessKeyStatus`, `getClient`, `getMppxParameters`, `store`, `chains`). See [Return Type](#return-type) for the full surface.
 
 ## Usage
 
@@ -325,6 +325,8 @@ const provider = Provider.create({
 
 MPP session endpoints can use `deposit` or `maxDeposit` so the client opens and tops up a payment channel before sending vouchers.
 
+Use `provider.getMppxParameters()` when composing an mppx client with `tempo({ account, ...provider.getMppxParameters() })`.
+
 ```ts twoslash
 import { Provider } from 'accounts'
 
@@ -429,6 +431,7 @@ The provider type is exported as `Provider` and is the intersection of [`ox.Prov
 
 ```ts
 import type { Address, Hex, Provider as ox_Provider } from 'ox'
+import type { tempo as mppx_tempo } from 'mppx/client'
 import type { Chain, Client as ViemClient, Transport } from 'viem'
 import type { JsonRpcAccount } from 'viem/accounts'
 import type { tempo } from 'viem/tempo/chains'
@@ -450,6 +453,11 @@ export type Provider = ox_Provider.Provider & ox_Provider.Emitter & {
     chainId?: number | undefined
     feePayer?: string | undefined
   }): ViemClient<Transport, typeof tempo>
+  /** Returns mppx Tempo client parameters backed by this provider. */
+  getMppxParameters(): {
+    getClient: NonNullable<mppx_tempo.Parameters['getClient']>
+    resolveAccount: NonNullable<mppx_tempo.Parameters['resolveAccount']>
+  }
   /** Reactive state store. */
   store: Store
 }

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -1,3 +1,4 @@
+import { tempo } from 'mppx/client'
 import type { RpcSchema } from 'ox'
 import { describe, expectTypeOf, test } from 'vp/test'
 
@@ -85,5 +86,23 @@ describe('create options', () => {
           }
         | undefined
     }>()
+
+    Provider.create({
+      mpp: {
+        // @ts-expect-error accounts resolves MPP accounts internally.
+        resolveAccount: () => undefined,
+      },
+    })
+  })
+
+  test('getMppxParameters returns mppx tempo parameters', () => {
+    const provider = Provider.create({ mpp: false })
+    const account = {} as ReturnType<typeof provider.getAccount>
+    const parameters = provider.getMppxParameters()
+
+    expectTypeOf(parameters).toMatchTypeOf<
+      Pick<NonNullable<Parameters<typeof tempo>[0]>, 'getClient' | 'resolveAccount'>
+    >()
+    tempo({ account, ...parameters })
   })
 })

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,12 +1,114 @@
 import { Hex } from 'ox'
+import { KeyAuthorization } from 'ox/tempo'
+import { custom } from 'viem'
 import { createSiweMessage } from 'viem/siwe'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
+import { accounts, privateKeys } from '../../test/config.js'
 import * as Adapter from './Adapter.js'
 import * as Provider from './Provider.js'
 import * as Storage from './Storage.js'
 
 const address = '0x0000000000000000000000000000000000000001'
+
+describe('getMppxParameters', () => {
+  test('error: rejects unsupported chain IDs', () => {
+    const provider = Provider.create({ storage: Storage.memory() })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    expect(() =>
+      provider.getMppxParameters().getClient({ chainId: 1 }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Provider.UnsupportedChainIdError: Chain 1 not configured.]`,
+    )
+  })
+
+  test('behavior: returns account-scoped client without mutating cached client', () => {
+    const provider = Provider.create({ storage: Storage.memory() })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const client = provider.getClient()
+    const mppxClient = provider.getMppxParameters().getClient({})
+
+    expect(mppxClient).not.toBe(client)
+    expect((mppxClient as { account?: unknown }).account).toEqual({
+      address,
+      type: 'json-rpc',
+    })
+    expect((client as { account?: unknown }).account).toBeUndefined()
+  })
+
+  test('behavior: does not store a JSON-RPC access key for the wrong root account', async () => {
+    const payer = accounts[0]!
+    const active = accounts[1]!
+    const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+      actions: {
+        async createAccount() {
+          return { accounts: [{ address: active.address }] }
+        },
+        async loadAccounts() {
+          return { accounts: [{ address: active.address }] }
+        },
+      },
+      getAccount(options = {}) {
+        return {
+          account: {
+            address: options.address ?? active.address,
+            type: 'json-rpc' as const,
+          },
+          transport: custom({
+            async request({ method, params }: { method: string; params?: unknown[] }) {
+              if (method !== 'wallet_authorizeAccessKey')
+                throw new Error(`unexpected wallet method: ${method}`)
+              const [parameters] = params as [
+                {
+                  address: `0x${string}`
+                  chainId: `0x${string}`
+                  expiry: `0x${string}`
+                  keyType: 'secp256k1'
+                },
+              ]
+              const signed = await active.signKeyAuthorization(
+                { address: parameters.address, type: parameters.keyType },
+                {
+                  chainId: BigInt(parameters.chainId),
+                  expiry: Number(parameters.expiry),
+                },
+              )
+              return {
+                keyAuthorization: KeyAuthorization.toRpc(signed),
+                rootAddress: active.address,
+              }
+            },
+          }),
+        }
+      },
+    }))
+    const provider = Provider.create({
+      accessKey: {
+        authorize: {
+          expiry: 123,
+          privateKey: privateKeys[2],
+        },
+      },
+      adapter,
+      storage: Storage.memory(),
+    })
+    provider.store.setState({
+      accounts: [{ address: payer.address }, { address: active.address }],
+      activeAccount: 1,
+    })
+
+    const resolved = await provider.getMppxParameters().resolveAccount({
+      account: provider.getAccount({ address: payer.address }),
+      chainId: provider.store.getState().chainId,
+      operation: { kind: 'authorizePaymentChannel' },
+    })
+
+    expect(resolved).toBeUndefined()
+    expect(provider.store.getState().accessKeys).toEqual([])
+  })
+})
 
 describe('wallet_connect', () => {
   test('behavior: validates auth before preparing access key material', async () => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1,5 +1,5 @@
 import { announceProvider } from 'mipd'
-import { Mppx, tempo as mppx_tempo } from 'mppx/client'
+import { Mppx, tempo as mppx_tempo, type ResolveAccountInfo } from 'mppx/client'
 import { Address, Hash, Hex, Json, Provider as ox_Provider, RpcResponse } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import {
@@ -58,6 +58,8 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
       chainId?: number | undefined
       feePayer?: string | undefined
     }): ViemClient<Transport, typeof tempo>
+    /** Returns mppx Tempo client parameters backed by this provider. */
+    getMppxParameters(): MppxParameters
     /** Reactive state store. */
     store: Store.Store
   }
@@ -72,6 +74,11 @@ type WalletConnectCapabilities = NonNullable<
 type AuthCapabilityResult = NonNullable<
   Rpc.wallet_connect.Encoded['returns']['accounts'][number]['capabilities']['auth']
 >
+
+type MppxParameters = {
+  getClient: NonNullable<mppx_tempo.Parameters['getClient']>
+  resolveAccount: NonNullable<mppx_tempo.Parameters['resolveAccount']>
+}
 
 function isBrowserWebCrypto() {
   return typeof document !== 'undefined' && !!globalThis.crypto?.subtle
@@ -430,8 +437,11 @@ export function create(options: create.Options = {}): create.ReturnType {
     return await selected.account.sign!({ hash: hashTypedData(typedData as never) })
   }
 
-  async function authorizeAccessKey(parameters: Adapter.authorizeAccessKey.Parameters) {
-    const selected = await getAdapterAccount()
+  async function authorizeAccessKey(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+    options_: { address?: Address.Address | undefined } = {},
+  ) {
+    const selected = await getAdapterAccount({ address: options_.address })
     const chainId = parameters.chainId ?? getClient().chain.id
     if (selected.account.type !== 'json-rpc') {
       const keyAuthorization = await store.accessKeys.authorize({
@@ -452,6 +462,7 @@ export function create(options: create.Options = {}): create.ReturnType {
       method: 'wallet_authorizeAccessKey' as never,
       params: [z.encode(Rpc.wallet_authorizeAccessKey.parameters, prepared.parameters)] as never,
     })) as Adapter.authorizeAccessKey.ReturnType
+    if (options_.address && !isSameMppAddress(result.rootAddress, options_.address)) return result
     await savePreparedAccessKey({
       account: result.rootAddress,
       accessKey: prepared,
@@ -655,6 +666,31 @@ export function create(options: create.Options = {}): create.ReturnType {
     unsupported('authorizeAccessKey')
   }
 
+  async function authorizeAccessKeyForAddress(
+    parameters: Adapter.authorizeAccessKey.Parameters,
+    request: Pick<Rpc.wallet_authorizeAccessKey.Encoded, 'method' | 'params'>,
+    address: Address.Address,
+  ) {
+    if (instance.getAccount) {
+      const result = await authorizeAccessKey(parameters, { address })
+      return isSameMppAddress(result.rootAddress, address) ? result : undefined
+    }
+
+    const activeAccount = store.getState().accounts[store.getState().activeAccount]?.address
+    if (!activeAccount || !isSameMppAddress(activeAccount, address)) return undefined
+    if (!actions.authorizeAccessKey) return undefined
+
+    const result = await actions.authorizeAccessKey(parameters, request)
+    if (isSameMppAddress(result.rootAddress, address)) return result
+
+    store.accessKeys.remove({
+      account: result.rootAddress,
+      accessKey: result.keyAuthorization.keyId,
+      chainId: Number(result.keyAuthorization.chainId),
+    })
+    return undefined
+  }
+
   async function revokeAccessKeyAction(
     parameters: Adapter.revokeAccessKey.Parameters,
     request: Pick<Rpc.wallet_revokeAccessKey.Encoded, 'method' | 'params'>,
@@ -764,10 +800,80 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (existing) return
     if (!AccessKey.canAuthorizeCalls({ parameters, calls: options_.calls })) return
     const decoded = stripAuthorizeAccessKey(parameters)
-    await authorizeAccessKeyAction(decoded, {
-      method: 'wallet_authorizeAccessKey',
-      params: [z.encode(Rpc.wallet_authorizeAccessKey.parameters, decoded)!],
+    await authorizeAccessKeyForAddress(
+      decoded,
+      {
+        method: 'wallet_authorizeAccessKey',
+        params: [z.encode(Rpc.wallet_authorizeAccessKey.parameters, decoded)!],
+      },
+      options_.address,
+    )
+  }
+
+  async function selectOrAuthorizeAccessKey(options_: {
+    address: Address.Address
+    calls?: readonly AccessKey.Call[] | undefined
+    chainId: number
+  }) {
+    const existing = await store.accessKeys.select({
+      account: options_.address,
+      ...(options_.calls ? { calls: options_.calls } : {}),
+      chainId: options_.chainId,
     })
+    if (existing) return existing
+    await authorizeDefaultAccessKeyForTransaction(options_)
+    return await store.accessKeys.select({
+      account: options_.address,
+      ...(options_.calls ? { calls: options_.calls } : {}),
+      chainId: options_.chainId,
+    })
+  }
+
+  async function resolveMppAccount(info: ResolveAccountInfo) {
+    const account = readMppAddress(info.account.address)
+    if (!account) return undefined
+
+    if (info.operation.kind === 'executeCalls')
+      return await selectOrAuthorizeAccessKey({
+        address: account,
+        ...(info.operation.calls ? { calls: info.operation.calls } : {}),
+        chainId: info.chainId,
+      })
+
+    const accessKey = readMppAddress(info.operation.authority)
+    if (!accessKey)
+      return await selectOrAuthorizeAccessKey({
+        address: account,
+        chainId: info.chainId,
+      })
+    if (isZeroMppAddress(accessKey) || isSameMppAddress(accessKey, account)) return undefined
+
+    return await store.accessKeys.get({
+      account,
+      accessKey,
+      chainId: info.chainId,
+    })
+  }
+
+  function getMppxParameters(): MppxParameters {
+    return {
+      getClient({ chainId }: { chainId?: number | undefined }) {
+        if (chainId !== undefined && !chains.some((chain) => chain.id === chainId))
+          throw new ox_Provider.UnsupportedChainIdError({
+            message: `Chain ${chainId} not configured.`,
+          })
+        const client = provider.getClient({ chainId })
+        const account = store.getState().accounts[store.getState().activeAccount]
+        if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
+        return Object.assign(Object.create(Object.getPrototypeOf(client)), client, {
+          account: {
+            address: account.address,
+            type: 'json-rpc' as const,
+          },
+        })
+      },
+      resolveAccount: (info: ResolveAccountInfo) => resolveMppAccount(info),
+    }
   }
 
   const provider = Object.assign(
@@ -1674,6 +1780,7 @@ export function create(options: create.Options = {}): create.ReturnType {
           transports,
         })
       },
+      getMppxParameters,
       store,
     },
   )
@@ -1706,22 +1813,14 @@ export function create(options: create.Options = {}): create.ReturnType {
     // Skip polyfill on runtimes where `globalThis.fetch` is read-only (e.g.
     // Cloudflare Workers). Caller can also explicitly opt out via `mpp.polyfill`.
     const polyfill = polyfill_option ?? isFetchWritable()
-    const getClient = ({ chainId }: { chainId?: number | undefined }) => {
-      const client = provider.getClient({ chainId })
-      const account = store.getState().accounts[store.getState().activeAccount]
-      if (!account) throw new ox_Provider.DisconnectedError({ message: 'No active account.' })
-      return Object.assign(client, {
-        account: {
-          address: account.address,
-          type: 'json-rpc' as const,
-        },
-      })
+    const parameters = provider.getMppxParameters()
+    const tempoOptions = {
+      ...methodOptions,
+      ...parameters,
+      mode,
     }
     Mppx.create({
-      methods: [
-        mppx_tempo({ ...methodOptions, getClient, mode }),
-        mppx_tempo.subscription({ getClient }),
-      ],
+      methods: [mppx_tempo(tempoOptions), mppx_tempo.subscription(parameters)],
       polyfill,
     })
   }
@@ -1880,7 +1979,7 @@ export declare namespace getAccessKeyStatus {
 
 export declare namespace mpp {
   /** Options for Machine Payment Protocol (mppx) integration. */
-  type Options = Omit<mppx_tempo.Parameters, 'account' | 'getClient'> & {
+  type Options = Omit<mppx_tempo.Parameters, 'account' | 'getClient' | 'resolveAccount'> & {
     /**
      * Whether to polyfill `globalThis.fetch` with the payment-aware wrapper.
      *
@@ -1922,6 +2021,19 @@ function isFetchWritable(): boolean {
   } catch {
     return false
   }
+}
+
+function readMppAddress(value: unknown): Address.Address | undefined {
+  if (typeof value === 'string' && Address.validate(value)) return value
+  return undefined
+}
+
+function isSameMppAddress(a: Address.Address, b: Address.Address): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+function isZeroMppAddress(address: Address.Address): boolean {
+  return BigInt(address) === 0n
 }
 
 /**

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -1,4 +1,4 @@
-import { Fetch } from 'mppx/client'
+import { Fetch, Mppx as ClientMppx, tempo as clientTempo } from 'mppx/client'
 import { Mppx as ServerMppx, tempo } from 'mppx/server'
 import { parseUnits } from 'viem'
 import { Addresses } from 'viem/tempo'
@@ -64,6 +64,95 @@ describe('mppx integration', () => {
         "fortune": "Your code will compile on the first try.",
       }
     `)
+  })
+
+  test('mppx front door works without global polyfill', async () => {
+    const provider = Provider.create({
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: false,
+    })
+
+    const address = await connect(provider)
+    await fund(address)
+
+    const mppx = ClientMppx.create({
+      methods: [
+        clientTempo({
+          account: provider.getAccount(),
+          ...provider.getMppxParameters(),
+        }),
+      ],
+      polyfill: false,
+    })
+
+    const res = await mppx.fetch(`${server.url}/fortune`)
+    expect(res.status).toMatchInlineSnapshot(`200`)
+  })
+
+  test('mppx global front door uses provider access keys', async () => {
+    const provider = Provider.create({
+      accessKey: { authorize: { expiry: Expiry.days(1) } },
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: false,
+    })
+
+    const address = await connect(provider)
+    await fund(address)
+
+    ClientMppx.create({
+      methods: [
+        clientTempo({
+          account: provider.getAccount(),
+          ...provider.getMppxParameters(),
+          mode: 'pull',
+        }),
+      ],
+    })
+    const res = await fetch(`${server.url}/fortune`)
+    expect(res.status).toMatchInlineSnapshot(`200`)
+
+    const key = provider.store.getState().accessKeys[0]!
+    expect(await provider.getAccessKeyStatus({ accessKey: key.address })).toMatchInlineSnapshot(
+      `"published"`,
+    )
+  })
+
+  test('mppx access-key authorization targets the payer account', async () => {
+    const provider = Provider.create({
+      accessKey: { authorize: { expiry: Expiry.days(1) } },
+      adapter: headlessWebAuthn(),
+      chains: [chain],
+      mpp: false,
+    })
+
+    const payer = await connect(provider)
+    const payerAccount = provider.store.getState().accounts[0]!
+    await fund(payer)
+    await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'register' } }],
+    })
+    const activeAccount = provider.store.getState().accounts[0]!
+    provider.store.setState({ accounts: [payerAccount, activeAccount], activeAccount: 1 })
+    const active = activeAccount.address
+    expect(active.toLowerCase()).not.toBe(payer.toLowerCase())
+
+    ClientMppx.create({
+      methods: [
+        clientTempo({
+          account: provider.getAccount({ address: payer }),
+          ...provider.getMppxParameters(),
+          mode: 'pull',
+        }),
+      ],
+    })
+    const res = await fetch(`${server.url}/fortune`)
+    expect(res.status).toMatchInlineSnapshot(`200`)
+
+    const [key] = provider.store.getState().accessKeys
+    expect(key?.access.toLowerCase()).toBe(payer.toLowerCase())
   })
 
   test('pull mode publishes a pending access key authorization', async () => {


### PR DESCRIPTION
## Summary

- Added `Provider.getMppxParameters()` so mppx can use the Provider client and account resolver when mppx is the front door.
- Resolved mppx account requests to locally managed access keys for charge and session operations.
- Scoped default MPP access-key authorization to the requested payer account and rejected unsupported MPP chain IDs.
- Documented the mppx composition surface without exposing an Accounts-owned mppx client.

## Why

mppx should ask which account signs an MPP action. Accounts can answer with an access key without mppx knowing about Accounts internals, while preserving account isolation when the active account differs from the mppx payer.

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm test src/core/Provider.test.ts`
- `VITE_NODE_ENV=localnet pnpm test src/core/mppx.localnet.test.ts`
- `pnpm docs:build`
- `git diff --check`
