### PR TITLE
Bump mppx to 0.8.0

### DIFF
--- a/examples/mpp/README.md
+++ b/examples/mpp/README.md
@@ -44,7 +44,7 @@ const account = privateKeyToAccount('0x...')
 const mppx = Mppx.create({
   methods: [tempo({ account, currency: '0x...', feePayer: true, testnet: true })],
   realm: 'mpp',
-  secretKey: '...',
+  secretKey: 'dev-secret-key-change-me-in-production',
 })
 
 const app = new Hono()

--- a/examples/subscriptions/worker/index.ts
+++ b/examples/subscriptions/worker/index.ts
@@ -30,6 +30,7 @@ const mppx = Mppx.create({
       testnet: true,
     }),
   ],
+  secretKey: 'dev-secret-key-change-me-in-production',
 })
 
 app.get(

--- a/examples/transfers/worker/index.ts
+++ b/examples/transfers/worker/index.ts
@@ -6,6 +6,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   methods: [tempo.charge()],
+  secretKey: 'dev-secret-key-change-me-in-production',
 })
 
 app.get(

--- a/playgrounds/wagmi/worker/index.ts
+++ b/playgrounds/wagmi/worker/index.ts
@@ -9,7 +9,7 @@ const payment = Mppx.create({
       testnet: true,
     }),
   ],
-  secretKey: 'top-secret',
+  secretKey: 'dev-secret-key-change-me-in-production',
 })
 
 const handler = Handler.relay({ path: '/relay' })

--- a/playgrounds/web/.env.example
+++ b/playgrounds/web/.env.example
@@ -3,7 +3,7 @@ ORIGIN=
 # Trust x-forwarded-* from the local dev proxies (OrbStack domains, vite)
 TRUST_PROXY=true
 RP_ID=localhost
-MPP_SECRET_KEY=secret-key
+MPP_SECRET_KEY=dev-secret-key-change-me-in-production
 # note: "test test ..." mnemonic private key
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 VITE_ENV=testnet

--- a/playgrounds/web/worker/index.ts
+++ b/playgrounds/web/worker/index.ts
@@ -19,6 +19,11 @@ const subscriptions = Subscription.fromStore(store)
 const inspections = new Map<string, unknown>()
 let activationCount = 0
 let renewalCount = 0
+const secretKey =
+  !process.env.MPP_SECRET_KEY ||
+  new TextEncoder().encode(process.env.MPP_SECRET_KEY).byteLength < 32
+    ? 'dev-secret-key-change-me-in-production'
+    : process.env.MPP_SECRET_KEY
 
 const payment = Mppx.create({
   methods: [
@@ -86,7 +91,7 @@ const payment = Mppx.create({
       testnet,
     }),
   ],
-  secretKey: process.env.MPP_SECRET_KEY,
+  secretKey,
 })
 
 payment.onPaymentSuccess(recordInspection)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^4.12.25
       version: 4.12.25
     mppx:
-      specifier: ^0.7.0
-      version: 0.7.0
+      specifier: ^0.8.0
+      version: 0.8.0
     prool:
       specifier: ~0.2.4
       version: 0.2.4
@@ -118,7 +118,7 @@ importers:
         version: 0.0.7(typescript@5.9.3)
       mppx:
         specifier: 'catalog:'
-        version: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       ox:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.3.6)
@@ -892,7 +892,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        version: 0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -944,7 +944,7 @@ importers:
         version: link:../..
       mppx:
         specifier: 'catalog:'
-        version: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        version: 0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1109,7 +1109,7 @@ importers:
         version: 11.15.0
       mppx:
         specifier: 'catalog:'
-        version: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        version: 0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       ox:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.4.3)
@@ -4569,8 +4569,8 @@ packages:
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
-  '@stripe/stripe-js@9.7.0':
-    resolution: {integrity: sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==}
+  '@stripe/stripe-js@9.8.0':
+    resolution: {integrity: sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==}
     engines: {node: '>=12.16'}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
@@ -7371,6 +7371,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -8873,14 +8877,14 @@ packages:
       hono:
         optional: true
 
-  mppx@0.7.0:
-    resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
+  mppx@0.8.0:
+    resolution: {integrity: sha512-8zOfrzmFrvv0fatTaAziUQoGT44yfZQ5z2dbsw7hmuZD1TSEOl0hMw1D7zbthEEbx9b3GkDqmRdmwFeENEVQ7w==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: 4.12.25
+      hono: '>=4.12.25'
       viem: 2.52.2
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -16542,7 +16546,7 @@ snapshots:
 
   '@stitches/core@1.2.8': {}
 
-  '@stripe/stripe-js@9.7.0': {}
+  '@stripe/stripe-js@9.8.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.6)':
     dependencies:
@@ -21191,6 +21195,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
   eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
@@ -23369,9 +23375,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
-      '@stripe/stripe-js': 9.7.0
+      '@stripe/stripe-js': 9.8.0
+      eventsource-parser: 3.0.6
       incur: 0.4.8
       ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -23384,9 +23391,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  mppx@0.8.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(elysia@1.4.28(@sinclair/typebox@0.34.41)(exact-mirror@0.2.5(@sinclair/typebox@0.34.41))(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3))(express@5.2.1)(hono@4.12.25)(typescript@5.9.3)(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.7.0
+      '@stripe/stripe-js': 9.8.0
+      eventsource-parser: 3.0.6
       incur: 0.4.8
       ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@vitejs/plugin-react': ^5.2.0
   '@wagmi/core': ^3.5.0
   hono: ^4.12.25
-  mppx: ^0.7.0
+  mppx: ^0.8.0
   ox: 0.14.29
   prool: ~0.2.4
   react: ^19.2.5

--- a/site/src/pages/_api/api/transfer.ts
+++ b/site/src/pages/_api/api/transfer.ts
@@ -9,7 +9,7 @@ const mppx = Mppx.create({
     }),
   ],
   realm: 'accounts.tempo.xyz',
-  secretKey: 'demo',
+  secretKey: 'dev-secret-key-change-me-in-production',
 })
 
 export async function GET(request: Request) {

--- a/site/src/pages/docs/guides/subscriptions.mdx
+++ b/site/src/pages/docs/guides/subscriptions.mdx
@@ -95,6 +95,7 @@ const mppx = Mppx.create({
       testnet: true,
     }),
   ],
+  secretKey: process.env.MPP_SECRET_KEY,
 })
 ```
 
@@ -222,6 +223,7 @@ const mppx = Mppx.create({
       store,
     }),
   ],
+  secretKey: process.env.MPP_SECRET_KEY,
 })
 ```
 

--- a/site/src/pages/docs/guides/transfers.mdx
+++ b/site/src/pages/docs/guides/transfers.mdx
@@ -216,6 +216,7 @@ const pathUsd = '0x20c0000000000000000000000000000000000000'
 
 const mppx = Mppx.create({
   methods: [tempo.charge({ testnet: true })],
+  secretKey: process.env.MPP_SECRET_KEY,
 })
 
 const app = new Hono()

--- a/site/src/subscriptions.ts
+++ b/site/src/subscriptions.ts
@@ -48,5 +48,5 @@ export const subscriptions: Subscriptions = Mppx.create({
     }),
   ],
   realm: 'accounts.tempo.xyz',
-  secretKey: 'demo',
+  secretKey: 'dev-secret-key-change-me-in-production',
 })

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -22,7 +22,7 @@ const payment = ServerMppx.create({
     }),
   ],
   realm: 'mppx-test',
-  secretKey: 'test-secret-key',
+  secretKey: 'test-secret-key-test-secret-key-32',
 })
 
 let server: Server


### PR DESCRIPTION
Updates the workspace to consume mppx 0.8.0 so follow-up MPP account integration work can use the released client surface. The playground, example, docs-demo, and localnet test secret defaults were adjusted to satisfy mppx secret-key validation during Worker uploads, docs builds, and CI.

Validation:
- pnpm install --frozen-lockfile
- pnpm build
- pnpm check:types
- env -u MPP_SECRET_KEY pnpm test src/core/mppx.localnet.test.ts
- pnpm --filter site build
- pnpm --dir playgrounds/wagmi build
- pnpm --dir playgrounds/wagmi exec wrangler versions upload --dry-run --config dist/accounts_wagmi/wrangler.json
- MPP_SECRET_KEY=secret-key pnpm --dir playgrounds/web build
- MPP_SECRET_KEY=secret-key pnpm --dir playgrounds/web exec wrangler versions upload --dry-run --config dist/accounts_playground/wrangler.json