### PR TITLE
Use GitHub token for PR audit comments

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,7 +1,7 @@
 name: Pull request audit
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   issue_comment:
     types: [created]
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && (github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit')
+    if: github.event_name == 'pull_request_target' && (github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit')
     steps:
       - name: Publish event
         run: |
@@ -49,24 +49,15 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Check org membership
+      - name: Check commenter permission
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
-            const org = 'tempoxyz';
-            const checkMembership = async (username) => {
-              try {
-                const { status } = await github.rest.orgs.checkMembershipForUser({ org, username });
-                return status === 204 || status === 302;
-              } catch {
-                return false;
-              }
-            };
-
-            const commenter = context.payload.comment.user.login;
-            if (!await checkMembership(commenter)) {
-              core.setFailed(`@${commenter} is not a member of ${org}`);
+            const allowed = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const commenterAssociation = context.payload.comment.author_association;
+            if (!allowed.has(commenterAssociation)) {
+              core.setFailed(`@${context.payload.comment.user.login} is not allowed to trigger Cyclops audits (${commenterAssociation})`);
               return;
             }
 
@@ -75,16 +66,15 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
-            const prAuthor = pr.user.login;
-            if (!await checkMembership(prAuthor)) {
-              core.setFailed(`PR author @${prAuthor} is not a member of ${org}`);
+            if (!allowed.has(pr.author_association)) {
+              core.setFailed(`PR author @${pr.user.login} is not allowed to trigger Cyclops audits (${pr.author_association})`);
             }
 
       - name: Parse arguments
         id: args
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const usage = [
               '**Usage:** `cyclops audit [fast] [iterations=N] [hours=N] [config=pr-review.yaml] ',
@@ -227,7 +217,7 @@ jobs:
           ACTOR: ${{ steps.args.outputs.actor }}
           SUMMARY: ${{ steps.args.outputs.summary }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             try {
               await github.rest.reactions.createForIssueComment({
@@ -277,7 +267,7 @@ jobs:
           ACTOR: ${{ steps.args.outputs.actor }}
           SUMMARY: ${{ steps.args.outputs.summary }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             if (!process.env.COMMENT_ID) {
               core.setFailed('Missing acknowledgement comment id');


### PR DESCRIPTION
## Summary

Applies the Cyclops audit workflow pattern from alloy-rs/evm2#241 to accounts.

- switches label-triggered audits to `pull_request_target` so repository/org secrets are available without running PR code
- uses the built-in `github.token` for comment parsing, reactions, and status comments
- replaces the org-membership token check with author-association checks for owners, members, and collaborators

Prompted by: @0xalpharush

## Validation

- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-audit.yml')); print('yaml ok')"`
- `actionlint .github/workflows/pr-audit.yml`