### PR TITLE
Add exact mppx access key selection

### DIFF
--- a/.changeset/mppx-access-key-selection.md
+++ b/.changeset/mppx-access-key-selection.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added exact access-key selection for provider-backed mppx parameters.

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -726,6 +726,38 @@ describe('get', () => {
     expect(keystore.stats.toAccountCalls).toBe(1)
   })
 
+  test('behavior: matches access key scopes against exact-key transaction calls', async () => {
+    const store = createStore()
+    const keyPair = await WebCryptoP256.createKeyPair()
+    const accessKey = TempoAccount.fromWebCryptoP256(keyPair, { access: rootAddress })
+    const token = '0x0000000000000000000000000000000000000abc' as const
+    await addAuthorization({
+      address: rootAddress,
+      keyAuthorization: createKeyAuthorization(accessKey.accessKeyAddress, {
+        scopes: [{ address: token, selector: 'transfer(address,uint256)' }],
+      }),
+      keyPair,
+      store,
+    })
+
+    const query = { accessKey: accessKey.accessKeyAddress, account: rootAddress, chainId: 1 }
+    const match = await store.accessKeys.get({
+      ...query,
+      calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
+    })
+    const miss = await store.accessKeys.get({
+      ...query,
+      calls: [{ to: '0x0000000000000000000000000000000000000def', data: '0xdeadbeef' }],
+    })
+
+    expect({ match: !!match, miss: !!miss }).toMatchInlineSnapshot(`
+      {
+        "match": true,
+        "miss": false,
+      }
+    `)
+  })
+
   test('behavior: unrecognized handles are unusable and retained', async () => {
     const foreign = testKeystore('foreign')
     const key = await foreign.createKey()

--- a/src/core/AccessKey.test.ts
+++ b/src/core/AccessKey.test.ts
@@ -741,6 +741,7 @@ describe('get', () => {
     })
 
     const query = { accessKey: accessKey.accessKeyAddress, account: rootAddress, chainId: 1 }
+    const channel = await store.accessKeys.get(query)
     const match = await store.accessKeys.get({
       ...query,
       calls: [{ to: token, data: '0xa9059cbb0000000000000000000000000000000000000001' }],
@@ -750,8 +751,9 @@ describe('get', () => {
       calls: [{ to: '0x0000000000000000000000000000000000000def', data: '0xdeadbeef' }],
     })
 
-    expect({ match: !!match, miss: !!miss }).toMatchInlineSnapshot(`
+    expect({ channel: !!channel, match: !!match, miss: !!miss }).toMatchInlineSnapshot(`
       {
+        "channel": true,
         "match": true,
         "miss": false,
       }

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -485,7 +485,7 @@ export async function get(options: get.Options): Promise<get.ReturnType> {
   const now = options.now ?? Date.now() / 1000
   const record = list({ account, accessKey, chainId, store })[0]
   if (!record) return undefined
-  if (!recordScopesMatch(record, { calls })) return undefined
+  if ('calls' in options && !recordScopesMatch(record, { calls })) return undefined
   if (isExpired(record.expiry, now)) {
     await remove({
       accessKey: record.address,

--- a/src/core/AccessKey.ts
+++ b/src/core/AccessKey.ts
@@ -159,6 +159,11 @@ type ListQuery = {
   store: ManagerOptions
 }
 
+type MatchQuery = {
+  /** Calls the access key must be able to sign. */
+  calls?: readonly Call[] | undefined
+}
+
 type ManagerOptions = {
   /** Keystores backing access-key records that carry an opaque `handle`. */
   keystores: Keystore.Keystores
@@ -475,11 +480,12 @@ export async function select(
 
 /** Returns a locally-signable access key account by exact address. */
 export async function get(options: get.Options): Promise<get.ReturnType> {
-  const { accessKey, account, chainId } = options
+  const { accessKey, account, calls, chainId } = options
   const { store } = options
   const now = options.now ?? Date.now() / 1000
   const record = list({ account, accessKey, chainId, store })[0]
   if (!record) return undefined
+  if (!recordScopesMatch(record, { calls })) return undefined
   if (isExpired(record.expiry, now)) {
     await remove({
       accessKey: record.address,
@@ -493,7 +499,7 @@ export async function get(options: get.Options): Promise<get.ReturnType> {
 }
 
 export declare namespace get {
-  type Options = {
+  type Options = MatchQuery & {
     /** Root account address. */
     account: Address.Address
     /** Specific access key address to match. */

--- a/src/core/Provider.test-d.ts
+++ b/src/core/Provider.test-d.ts
@@ -99,6 +99,7 @@ describe('create options', () => {
     const provider = Provider.create({ mpp: false })
     const account = {} as ReturnType<typeof provider.getAccount>
     const parameters = provider.getMppxParameters()
+    provider.getMppxParameters({ accessKey: '0x0000000000000000000000000000000000000001' })
 
     expectTypeOf(parameters).toMatchTypeOf<
       Pick<NonNullable<Parameters<typeof tempo>[0]>, 'getClient' | 'resolveAccount'>

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -162,15 +162,20 @@ describe('getMppxParameters', () => {
     const key = provider.store.getState().accessKeys[0]!
     provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
 
-    await expect(
-      provider.getMppxParameters({ accessKey: key.address }).resolveAccount({
-        account: { address: payer.address, type: 'json-rpc' },
-        chainId,
-        operation: { kind: 'authorizePaymentChannel', authority: accounts[2]!.address },
-      }),
-    ).rejects.toThrowError(
-      `Access key "${key.address}" cannot satisfy channel authority "${accounts[2]!.address}".`,
-    )
+    for (const authority of [
+      accounts[2]!.address,
+      payer.address,
+      '0x0000000000000000000000000000000000000000',
+    ] as const)
+      await expect(
+        provider.getMppxParameters({ accessKey: key.address }).resolveAccount({
+          account: { address: payer.address, type: 'json-rpc' },
+          chainId,
+          operation: { kind: 'authorizePaymentChannel', authority },
+        }),
+      ).rejects.toThrowError(
+        `Access key "${key.address}" cannot satisfy channel authority "${authority}".`,
+      )
   })
 
   test('error: rejects requested access key when transaction calls do not match scopes', async () => {
@@ -190,6 +195,16 @@ describe('getMppxParameters', () => {
     })
     const key = provider.store.getState().accessKeys[0]!
     provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    await expect(
+      provider.getMppxParameters({ accessKey: key.address }).resolveAccount({
+        account: { address: payer.address, type: 'json-rpc' },
+        chainId,
+        operation: { kind: 'executeCalls' },
+      }),
+    ).rejects.toThrowError(
+      `Access key "${key.address}" cannot be selected for executeCalls without transaction call details.`,
+    )
 
     await expect(
       provider.getMppxParameters({ accessKey: key.address }).resolveAccount({

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -63,6 +63,109 @@ describe('getMppxParameters', () => {
     expect(resolvedKey?.source).toBe('accessKey')
   })
 
+  test('behavior: resolves requested access key for connected account', async () => {
+    const payer = accounts[0]!
+    const provider = Provider.create({ storage: Storage.memory() })
+    const chainId = provider.store.getState().chainId
+
+    await provider.store.accessKeys.authorize({
+      account: payer,
+      chainId,
+      parameters: { expiry: 9999999999, privateKey: privateKeys[1] },
+    })
+    await provider.store.accessKeys.authorize({
+      account: payer,
+      chainId,
+      parameters: { expiry: 9999999999, privateKey: privateKeys[2] },
+    })
+    const requested = provider.store.getState().accessKeys[1]!
+    provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    const resolved = await provider
+      .getMppxParameters({ accessKey: requested.address })
+      .resolveAccount({
+        account: { address: payer.address, type: 'json-rpc' },
+        chainId,
+        operation: { kind: 'authorizePaymentChannel' },
+      })
+    const resolvedKey = resolved as
+      | { accessKeyAddress: string; address: string; source: string }
+      | undefined
+
+    expect(resolvedKey?.accessKeyAddress.toLowerCase()).toBe(requested.address.toLowerCase())
+    expect(resolvedKey?.address).toBe(payer.address)
+    expect(resolvedKey?.source).toBe('accessKey')
+  })
+
+  test('error: rejects requested access key that cannot sign for account', async () => {
+    const payer = accounts[0]!
+    const provider = Provider.create({ storage: Storage.memory() })
+    const chainId = provider.store.getState().chainId
+    provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    await expect(
+      provider.getMppxParameters({ accessKey: accounts[1]!.address }).resolveAccount({
+        account: { address: payer.address, type: 'json-rpc' },
+        chainId,
+        operation: { kind: 'authorizePaymentChannel' },
+      }),
+    ).rejects.toThrowError(`Access key "${accounts[1]!.address}" cannot sign`)
+  })
+
+  test('error: rejects requested access key that cannot satisfy channel authority', async () => {
+    const payer = accounts[0]!
+    const provider = Provider.create({ storage: Storage.memory() })
+    const chainId = provider.store.getState().chainId
+
+    await provider.store.accessKeys.authorize({
+      account: payer,
+      chainId,
+      parameters: { expiry: 9999999999, privateKey: privateKeys[1] },
+    })
+    const key = provider.store.getState().accessKeys[0]!
+    provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    await expect(
+      provider.getMppxParameters({ accessKey: key.address }).resolveAccount({
+        account: { address: payer.address, type: 'json-rpc' },
+        chainId,
+        operation: { kind: 'authorizePaymentChannel', authority: accounts[2]!.address },
+      }),
+    ).rejects.toThrowError(
+      `Access key "${key.address}" cannot satisfy channel authority "${accounts[2]!.address}".`,
+    )
+  })
+
+  test('error: rejects requested access key when transaction calls do not match scopes', async () => {
+    const payer = accounts[0]!
+    const provider = Provider.create({ storage: Storage.memory() })
+    const chainId = provider.store.getState().chainId
+    const token = '0x0000000000000000000000000000000000000abc' as const
+
+    await provider.store.accessKeys.authorize({
+      account: payer,
+      chainId,
+      parameters: {
+        expiry: 9999999999,
+        privateKey: privateKeys[2],
+        scopes: [{ address: token, selector: 'transfer(address,uint256)' }],
+      },
+    })
+    const key = provider.store.getState().accessKeys[0]!
+    provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    await expect(
+      provider.getMppxParameters({ accessKey: key.address }).resolveAccount({
+        account: { address: payer.address, type: 'json-rpc' },
+        chainId,
+        operation: {
+          kind: 'executeCalls',
+          calls: [{ to: '0x0000000000000000000000000000000000000def', data: '0xdeadbeef' }],
+        },
+      }),
+    ).rejects.toThrowError(`Access key "${key.address}" cannot sign`)
+  })
+
   test('error: does not resolve access keys for disconnected accounts', async () => {
     const payer = accounts[0]!
     const active = accounts[1]!

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -67,11 +67,16 @@ describe('getMppxParameters', () => {
     const payer = accounts[0]!
     const provider = Provider.create({ storage: Storage.memory() })
     const chainId = provider.store.getState().chainId
+    const token = '0x0000000000000000000000000000000000000abc' as const
 
     await provider.store.accessKeys.authorize({
       account: payer,
       chainId,
-      parameters: { expiry: 9999999999, privateKey: privateKeys[1] },
+      parameters: {
+        expiry: 9999999999,
+        privateKey: privateKeys[1],
+        scopes: [{ address: token, selector: 'transfer(address,uint256)' }],
+      },
     })
     await provider.store.accessKeys.authorize({
       account: payer,
@@ -93,6 +98,38 @@ describe('getMppxParameters', () => {
       | undefined
 
     expect(resolvedKey?.accessKeyAddress.toLowerCase()).toBe(requested.address.toLowerCase())
+    expect(resolvedKey?.address).toBe(payer.address)
+    expect(resolvedKey?.source).toBe('accessKey')
+  })
+
+  test('behavior: resolves scoped access key for channel authority', async () => {
+    const payer = accounts[0]!
+    const provider = Provider.create({ storage: Storage.memory() })
+    const chainId = provider.store.getState().chainId
+    const token = '0x0000000000000000000000000000000000000abc' as const
+
+    await provider.store.accessKeys.authorize({
+      account: payer,
+      chainId,
+      parameters: {
+        expiry: 9999999999,
+        privateKey: privateKeys[1],
+        scopes: [{ address: token, selector: 'transfer(address,uint256)' }],
+      },
+    })
+    const key = provider.store.getState().accessKeys[0]!
+    provider.store.setState({ accounts: [{ address: payer.address }], activeAccount: 0 })
+
+    const resolved = await provider.getMppxParameters().resolveAccount({
+      account: { address: payer.address, type: 'json-rpc' },
+      chainId,
+      operation: { kind: 'authorizePaymentChannel', authority: key.address },
+    })
+    const resolvedKey = resolved as
+      | { accessKeyAddress: string; address: string; source: string }
+      | undefined
+
+    expect(resolvedKey?.accessKeyAddress.toLowerCase()).toBe(key.address.toLowerCase())
     expect(resolvedKey?.address).toBe(payer.address)
     expect(resolvedKey?.source).toBe('accessKey')
   })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -808,11 +808,10 @@ export function create(options: create.Options = {}): create.ReturnType {
         throw new ox_Provider.UnauthorizedError({
           message: `Access key "${options_.accessKey}" cannot satisfy channel authority "${authority}".`,
         })
-      const calls = info.operation.kind === 'executeCalls' ? info.operation.calls : undefined
       const accessKey = await store.accessKeys.get({
         account,
         accessKey: options_.accessKey,
-        ...(calls ? { calls } : {}),
+        ...(info.operation.kind === 'executeCalls' ? { calls: info.operation.calls } : {}),
         chainId: info.chainId,
       })
       if (!accessKey)

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -799,25 +799,33 @@ export function create(options: create.Options = {}): create.ReturnType {
         info.operation.kind === 'authorizePaymentChannel'
           ? AddressUtil.from(info.operation.authority)
           : undefined
-      if (
-        authority &&
-        !AddressUtil.isZero(authority) &&
-        !AddressUtil.isEqual(authority, account) &&
-        !AddressUtil.isEqual(authority, options_.accessKey)
-      )
+      if (authority && !AddressUtil.isEqual(authority, options_.accessKey))
         throw new ox_Provider.UnauthorizedError({
           message: `Access key "${options_.accessKey}" cannot satisfy channel authority "${authority}".`,
         })
-      const accessKey = await store.accessKeys.get({
+      const query = {
         account,
         accessKey: options_.accessKey,
-        ...(info.operation.kind === 'executeCalls' ? { calls: info.operation.calls } : {}),
         chainId: info.chainId,
+      } as const
+      if (info.operation.kind === 'executeCalls' && !info.operation.calls) {
+        const accessKey = await store.accessKeys.get(query)
+        const record = store.accessKeys.list(query)[0]
+        if (accessKey && record?.scopes)
+          throw new ox_Provider.UnauthorizedError({
+            message: `Access key "${options_.accessKey}" cannot be selected for executeCalls without transaction call details.`,
+          })
+        if (accessKey) return accessKey
+      }
+      const accessKey = await store.accessKeys.get({
+        ...query,
+        ...(info.operation.kind === 'executeCalls' ? { calls: info.operation.calls } : {}),
       })
-      if (!accessKey)
+      if (!accessKey) {
         throw new ox_Provider.UnauthorizedError({
           message: `Access key "${options_.accessKey}" cannot sign for account "${account}".`,
         })
+      }
       return accessKey
     }
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -60,7 +60,7 @@ export type Provider = ox_Provider.Provider<{ schema: Schema.Ox }> &
       feePayer?: string | undefined
     }): ViemClient<Transport, typeof tempo>
     /** Returns mppx Tempo client parameters backed by this provider. */
-    getMppxParameters(): MppxParameters
+    getMppxParameters(options?: getMppxParameters.Options | undefined): MppxParameters
     /** Reactive state store. */
     store: Store.Store
   }
@@ -786,10 +786,41 @@ export function create(options: create.Options = {}): create.ReturnType {
       throw new ox_Provider.UnauthorizedError({ message: `Account "${address}" not found.` })
   }
 
-  async function resolveMppAccount(info: ResolveAccountInfo) {
+  async function resolveMppAccount(
+    info: ResolveAccountInfo,
+    options_: { accessKey?: Address.Address | undefined } = {},
+  ) {
     const account = AddressUtil.from(info.account.address)
     if (!account) return undefined
     assertMppAccountConnected(account)
+
+    if (options_.accessKey) {
+      const authority =
+        info.operation.kind === 'authorizePaymentChannel'
+          ? AddressUtil.from(info.operation.authority)
+          : undefined
+      if (
+        authority &&
+        !AddressUtil.isZero(authority) &&
+        !AddressUtil.isEqual(authority, account) &&
+        !AddressUtil.isEqual(authority, options_.accessKey)
+      )
+        throw new ox_Provider.UnauthorizedError({
+          message: `Access key "${options_.accessKey}" cannot satisfy channel authority "${authority}".`,
+        })
+      const calls = info.operation.kind === 'executeCalls' ? info.operation.calls : undefined
+      const accessKey = await store.accessKeys.get({
+        account,
+        accessKey: options_.accessKey,
+        ...(calls ? { calls } : {}),
+        chainId: info.chainId,
+      })
+      if (!accessKey)
+        throw new ox_Provider.UnauthorizedError({
+          message: `Access key "${options_.accessKey}" cannot sign for account "${account}".`,
+        })
+      return accessKey
+    }
 
     if (info.operation.kind === 'executeCalls')
       return await store.accessKeys.select({
@@ -809,7 +840,17 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
-  function getMppxParameters(): MppxParameters {
+  function getMppxParameters(options_: getMppxParameters.Options = {}): MppxParameters {
+    const accessKey = (() => {
+      if (!options_.accessKey) return undefined
+      const accessKey = AddressUtil.from(options_.accessKey)
+      if (!accessKey)
+        throw new RpcResponse.InvalidParamsError({
+          message: `Invalid access key address "${options_.accessKey}".`,
+        })
+      return accessKey
+    })()
+
     return {
       getClient({ chainId }: { chainId?: number | undefined }) {
         if (chainId !== undefined && !chains.some((chain) => chain.id === chainId))
@@ -826,7 +867,7 @@ export function create(options: create.Options = {}): create.ReturnType {
           },
         })
       },
-      resolveAccount: (info: ResolveAccountInfo) => resolveMppAccount(info),
+      resolveAccount: (info: ResolveAccountInfo) => resolveMppAccount(info, { accessKey }),
     }
   }
 
@@ -1927,6 +1968,14 @@ export declare namespace getAccessKeyStatus {
 
   /** Access-key publication status. */
   type ReturnType = 'missing' | 'pending' | 'published' | 'expired'
+}
+
+export declare namespace getMppxParameters {
+  /** Options for {@link Provider.getMppxParameters}. */
+  type Options = {
+    /** Specific access key address to use for mppx signing. */
+    accessKey?: Address.Address | undefined
+  }
 }
 
 export declare namespace mpp {


### PR DESCRIPTION
## Summary

Adds `provider.getMppxParameters({ accessKey })` so mppx can ask the Accounts SDK to resolve a specific locally managed access key.

The resolver validates that the requested key belongs to the payer, can satisfy session channel authority, and matches charge call scopes before returning it. If the key cannot sign, it throws instead of letting mppx fall back to another account.

## Validation

- `pnpm test src/core/Provider.test.ts src/core/AccessKey.test.ts`
- `pnpm exec tsc -b --noEmit`
- `pnpm check`