### PR TITLE
feat: add `identity` minting option to `Provider.create`

### DIFF
--- a/.changeset/provider-identity-minting.md
+++ b/.changeset/provider-identity-minting.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Added `identity` to `Provider.create`, minting verified-email id tokens from a configured OIDC issuer when local adapters fulfill `wallet_connect`.

--- a/site/src/pages/docs/api/provider.mdx
+++ b/site/src/pages/docs/api/provider.mdx
@@ -293,6 +293,27 @@ const provider = Provider.create({
 })
 ```
 
+### identity
+
+- **Type:** `{ audience?: string; issuer: string }`
+- **Optional**
+
+Identity (verified email) token minting for local adapters. When a `wallet_connect` request asks for `identity.email` and the adapter returns no identity claims — local adapters have no wallet host to mint them — the provider mints the id token from this issuer's `/token` route (the `Handler.oidcProvider` shape) and attaches it to the connect result.
+
+The issuer must trust body-supplied subjects (`Handler.oidcProvider` without `authenticate`), so this is for development deployments — for example, signing in to a local app with the `secp256k1` adapter and an auto-verified email.
+
+- `audience` — the `aud` claim bound into minted tokens. Defaults to `location.origin`.
+- `issuer` — the OIDC issuer whose `/token` route mints the id token.
+
+```ts twoslash
+import { Provider, secp256k1 } from 'accounts'
+
+const provider = Provider.create({
+  adapter: secp256k1(),
+  identity: { issuer: 'http://localhost:8787/v1/auth/dev-oidc' }, // [!code focus]
+})
+```
+
 ### maxAccounts
 
 - **Type:** `number`

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -853,6 +853,67 @@ describe.each(adapters)('$name', ({ adapter, name }: (typeof adapters)[number]) 
         })
         expect(res.status).toBe(400)
       })
+
+      test('behavior: provider mints identity when configured with an issuer', async () => {
+        const provider = Provider.create({
+          adapter: adapter(),
+          identity: { audience: 'https://app.example.com', issuer },
+        })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [
+            { capabilities: { identity: { email: { nonce: 'n-provider' } }, method: 'register' } },
+          ],
+        })
+
+        const capabilities = result.accounts[0]!.capabilities
+        expect(capabilities.identity?.email).toBe('alice@tempo.xyz')
+
+        // The token verifies against the issuer's JWKS and binds the app
+        // (`aud`), the connected account (`sub`), and the request nonce.
+        const { keys } = (await fetch(`${issuer}/.well-known/jwks.json`).then((r) => r.json())) as {
+          keys: JsonWebKey[]
+        }
+        const claims = (await verify(
+          capabilities.identity!.idToken!,
+          { ...keys[0]!, alg: 'EdDSA' },
+          'EdDSA',
+        )) as Record<string, unknown>
+        expect(claims.aud).toBe('https://app.example.com')
+        expect(claims.email).toBe('alice@tempo.xyz')
+        expect(claims.email_verified).toBe(true)
+        expect(claims.nonce).toBe('n-provider')
+        expect(claims.sub).toBe(result.accounts[0]!.address)
+      })
+
+      test('behavior: provider identity mint is best-effort (failure omits the claim)', async () => {
+        const provider = Provider.create({
+          adapter: adapter(),
+          identity: { audience: 'https://app.example.com', issuer: `${server.url}/nowhere` },
+        })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { identity: { email: true }, method: 'register' } }],
+        })
+
+        expect(result.accounts[0]!.address).toBeDefined()
+        expect(result.accounts[0]!.capabilities.identity).toBeUndefined()
+      })
+
+      test('behavior: provider identity is not minted unless requested', async () => {
+        const provider = Provider.create({
+          adapter: adapter(),
+          identity: { audience: 'https://app.example.com', issuer },
+        })
+
+        const result = await provider.request({
+          method: 'wallet_connect',
+          params: [{ capabilities: { method: 'register' } }],
+        })
+        expect(result.accounts[0]!.capabilities.identity).toBeUndefined()
+      })
     })
   })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1441,6 +1441,29 @@ export function create(options: create.Options = {}): create.ReturnType {
                       keyAuthorization,
                     })
 
+                    // Local adapters return no identity claims — there is no
+                    // wallet host to mint them. When the request asks for the
+                    // email and an issuer is configured, mint the id token
+                    // provider-side. Best-effort, mirroring the wallet host: a
+                    // failed mint omits the claim, never the connect.
+                    const identity_result =
+                      identity ??
+                      (await (async () => {
+                        const email = capabilities?.identity?.email
+                        if (!email || !options.identity || instance.forwardsAuth) return undefined
+                        if (!accountAddress) return undefined
+                        const audience = options.identity.audience ?? globalThis.location?.origin
+                        if (!audience) return undefined
+                        const nonce =
+                          (typeof email === 'object' ? email.nonce : undefined) ??
+                          (auth ? parseAuthNonce(auth.message) : undefined)
+                        return await mintIdentity(options.identity.issuer, {
+                          audience,
+                          nonce,
+                          subject: accountAddress,
+                        }).catch(() => undefined)
+                      })())
+
                     // Server Authentication verify: POST the signed SIWE message
                     // to the verify endpoint. Skipped when the auth capability
                     // omits `verify` — typical when the wallet host strips it
@@ -1470,9 +1493,11 @@ export function create(options: create.Options = {}): create.ReturnType {
                             // Forward the verified-email id token so a
                             // `Handler.auth({ identity })` can verify it and fold
                             // the email onto the session in the same round-trip.
-                            // The wallet minted it reusing this SIWE nonce, so
-                            // the handler's nonce check passes.
-                            ...(identity?.idToken ? { idToken: identity.idToken } : {}),
+                            // The minter reused this SIWE nonce, so the
+                            // handler's nonce check passes.
+                            ...(identity_result?.idToken
+                              ? { idToken: identity_result.idToken }
+                              : {}),
                             ...(personalSign?.keyAuthorization
                               ? { keyAuthorization: personalSign.keyAuthorization }
                               : {}),
@@ -1500,7 +1525,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                                 ...((auth_result ?? auth_capability)
                                   ? { auth: auth_result ?? auth_capability }
                                   : {}),
-                                ...(identity ? { identity } : {}),
+                                ...(identity_result ? { identity: identity_result } : {}),
                                 ...(personalSign
                                   ? {
                                       personalSign: {
@@ -1895,6 +1920,22 @@ export declare namespace create {
     chains?: readonly [Chain, ...Chain[]] | undefined
     /** Fee payer configuration. @see {@link Client.fromChainId.Options.feePayer} */
     feePayer?: Client.fromChainId.Options['feePayer']
+    /**
+     * Identity (verified email) token minting for local adapters. When a
+     * `wallet_connect` request asks for `identity.email` and the adapter
+     * returns no identity claims (local adapters have no wallet host to mint
+     * them), the provider mints the id token from this issuer's `/token`
+     * route (`Handler.oidcProvider` shape). The issuer must trust
+     * body-supplied subjects, so this is for development deployments.
+     */
+    identity?:
+      | {
+          /** Audience (`aud`) bound into minted tokens. @default `location.origin` */
+          audience?: string | undefined
+          /** OIDC issuer whose `/token` route mints the id token. */
+          issuer: string
+        }
+      | undefined
     /** Maximum number of accounts to persist. Oldest accounts are evicted when exceeded (LRU). */
     maxAccounts?: number | undefined
     /**
@@ -2239,6 +2280,42 @@ async function fetchAuthChallenge(
   validateAuthMessage(auth, { chainId, message: body.message, url })
 
   return { message: body.message }
+}
+
+/**
+ * Extracts the nonce from an EIP-4361 (SIWE) challenge message so a minted
+ * identity token binds to the same single-use value the server checks.
+ */
+function parseAuthNonce(message: string) {
+  return message.match(/^Nonce: (.+)$/m)?.[1]
+}
+
+/**
+ * Mints a verified-email identity token from an OIDC issuer's `/token` route
+ * (`Handler.oidcProvider` shape). Local adapters fulfill the connect ceremony
+ * without a wallet host, so the provider mints the token itself when
+ * configured (see `create.Options.identity`).
+ */
+async function mintIdentity(
+  issuer: string,
+  body: { audience: string; nonce?: string | undefined; subject: string },
+): Promise<{ email: string | null; idToken: string }> {
+  const res = await fetch(`${issuer.replace(/\/+$/, '')}/token`, {
+    body: JSON.stringify({
+      audience: body.audience,
+      ...(body.nonce ? { nonce: body.nonce } : {}),
+      subject: body.subject,
+    }),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+  if (!res.ok) throw new Error(`Identity issuer \`${issuer}\` returned ${res.status}.`)
+  const { idToken } = (await res.json()) as { idToken: string }
+  // Display-only claim read; server-side trust comes from JWKS verification.
+  const payload = JSON.parse(
+    atob(idToken.split('.')[1]!.replace(/-/g, '+').replace(/_/g, '/')),
+  ) as { email?: string | undefined }
+  return { email: payload.email ?? null, idToken }
 }
 
 /**


### PR DESCRIPTION
Adds `identity: { audience?, issuer }` to `Provider.create`: the provider mints verified-email id tokens from a `Handler.oidcProvider` issuer when local adapters fulfill `wallet_connect`. Enables local dev sign-in with auto-verified emails, no wallet host required.
