### PR TITLE
feat: accept exact email in `wallet_connect` `identity.email`

### DIFF
--- a/.changeset/identity-email-address.md
+++ b/.changeset/identity-email-address.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added string and `{ address }` forms to the `wallet_connect` `identity.email` capability for requiring a specific email.

--- a/.changeset/identity-email-address.md
+++ b/.changeset/identity-email-address.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added string and `{ address }` forms to the `wallet_connect` `identity.email` capability for requiring a specific email.

--- a/site/src/pages/docs/guides/identity.mdx
+++ b/site/src/pages/docs/guides/identity.mdx
@@ -181,6 +181,42 @@ app.post('/verify-email', async (c) => {
 
 ::::
 
+## Require a Specific Email
+
+Pass an email address instead of `true` to require that exact email. The wallet
+pre-fills and locks the sign-in entry to it: the user must authenticate with
+the account that owns the email (verifying it with a one-time code first when
+needed), and connecting an account whose verified email differs is rejected.
+Use this when your app already knows who is signing in — an invite link, a
+pre-auth session, or a server-side allowlist.
+
+```tsx twoslash [src/App.tsx]
+// @noErrors
+import { useConnect, useConnectors } from 'wagmi'
+
+function Connect() {
+  const { connectAsync } = useConnect()
+  const [connector] = useConnectors()
+
+  return (
+    <button
+      onClick={() =>
+        connectAsync({
+          connector,
+          capabilities: { identity: { email: 'user@example.com' } }, // [!code focus]
+        })
+      }
+    >
+      Sign in
+    </button>
+  )
+}
+```
+
+To also bind an explicit nonce into the issued token, use the object form:
+`identity: { email: { address: 'user@example.com', nonce } }` (see
+[`wallet_connect`](/docs/rpc/wallet_connect#requiring-a-specific-email)).
+
 ## Verify From Any Stack
 
 The token is a standard OIDC ID token, so any JWT/OIDC library can verify it against the JWKS above. You do not need the Accounts SDK. For example, with [`jose`](https://github.com/panva/jose):

--- a/site/src/pages/docs/rpc/wallet_connect.mdx
+++ b/site/src/pages/docs/rpc/wallet_connect.mdx
@@ -78,10 +78,14 @@ type Identity = {
    *
    * - `true` — request the email; the wallet auto-issues the signed token,
    *   reusing the `auth` (SIWE) challenge nonce when present.
-   * - `{ nonce }` — same, with an explicit nonce baked into the token (for
-   *   standalone use without the `auth` capability).
+   * - `'user@example.com'` — require this exact email: the wallet forces the
+   *   user to authenticate with the account owning it (verifying it first
+   *   when needed) instead of a free-form entry.
+   * - `{ address, nonce }` — same as above, with an explicit nonce baked into
+   *   the token (for standalone use without the `auth` capability). Both
+   *   fields are optional; `{ nonce }` alone requests any email.
    */
-  email?: boolean | { nonce?: string }
+  email?: boolean | string | { address?: string; nonce?: string }
 }
 
 type ShowDeposit = boolean | {
@@ -225,3 +229,35 @@ const { email, idToken } = identity ?? {}
 The token is a standard OIDC ID token (JWT) bound to your app origin (`aud`) and
 the connected account address (`sub`). Verify it with any OIDC-aware library, or
 with [`Identity.verify`](/docs/server/identity.verify).
+
+### Requiring a specific email
+
+Set `capabilities.identity.email` to an email address to require that exact
+email. The wallet pre-fills and locks the sign-in entry to it: the user must
+authenticate with the account that owns the email (verifying it with a one-time
+code first when needed) and cannot substitute another one. Connecting an
+account whose verified email differs is rejected. Use this when your app
+already knows who is signing in — an invite link, a pre-auth session, or a
+server-side allowlist.
+
+```ts
+const { accounts } = await provider.request({
+  method: 'wallet_connect',
+  params: [{ capabilities: { identity: { email: 'user@example.com' } } }],
+})
+```
+
+Use the object form to also bind an explicit nonce into the issued token:
+
+```ts
+const { accounts } = await provider.request({
+  method: 'wallet_connect',
+  params: [
+    {
+      capabilities: {
+        identity: { email: { address: 'user@example.com', nonce } },
+      },
+    },
+  ],
+})
+```

--- a/src/core/zod/rpc.test-d.ts
+++ b/src/core/zod/rpc.test-d.ts
@@ -20,9 +20,13 @@ describe('wallet_connect.auth', () => {
 })
 
 describe('wallet_connect.identity', () => {
-  type EmailRequest = boolean | { nonce?: string | undefined } | undefined
+  type EmailRequest =
+    | boolean
+    | string
+    | { address?: string | undefined; nonce?: string | undefined }
+    | undefined
 
-  test('infers email as boolean | { nonce } | undefined', () => {
+  test('infers email as boolean | string | { address, nonce } | undefined', () => {
     type Identity = z.output<typeof Rpc.wallet_connect.identity>
     expectTypeOf<Identity>().toEqualTypeOf<{ email?: EmailRequest } | undefined>()
   })

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -387,6 +387,41 @@ describe('wallet_connect.capabilities.request: identity', () => {
     `)
   })
 
+  test('accepts identity.email as string (required email)', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        identity: { email: 'user@example.com' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "identity": {
+          "email": "user@example.com",
+        },
+        "method": "login",
+      }
+    `)
+  })
+
+  test('accepts identity.email as { address, nonce } object', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'register',
+        identity: { email: { address: 'user@example.com', nonce: 'abc123' } },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "identity": {
+          "email": {
+            "address": "user@example.com",
+            "nonce": "abc123",
+          },
+        },
+        "method": "register",
+      }
+    `)
+  })
+
   test('accepts identity.email as empty { } object (no nonce)', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
@@ -403,11 +438,11 @@ describe('wallet_connect.capabilities.request: identity', () => {
     `)
   })
 
-  test('rejects identity.email as string', () => {
+  test('rejects identity.email as number', () => {
     expect(() =>
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'login',
-        identity: { email: 'yes' },
+        identity: { email: 1 },
       }),
     ).toThrow()
   })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -667,13 +667,20 @@ export namespace wallet_connect {
        *
        * - `true` — request the email; the wallet auto-issues the signed token,
        *   reusing the `auth` (SIWE) challenge nonce when present.
-       * - `{ nonce }` — same, with an explicit nonce baked into the token
-       *   (for standalone use without the `auth` capability).
+       * - `'user@example.com'` — require this exact email: the wallet forces
+       *   the user to authenticate with the account owning it (verifying it
+       *   first when needed) instead of a free-form entry.
+       * - `{ address, nonce }` — same as above, with an explicit nonce baked
+       *   into the token (for standalone use without the `auth` capability).
+       *   Both fields are optional; `{ nonce }` alone requests any email.
        */
       email: z.optional(
         z.union([
           z.boolean(),
+          z.string(),
           z.object({
+            /** Exact email the user must authenticate with. */
+            address: z.optional(z.string()),
             /** Nonce to bind into the issued identity token (replay protection). */
             nonce: z.optional(z.string()),
           }),


### PR DESCRIPTION
Extends the `wallet_connect` `identity.email` capability to accept `'user@example.com'` and `{ address?, nonce? }`, letting apps require the user to authenticate with a specific email.

Wallet: https://github.com/tempoxyz/wallet-next/pull/607
