### PR TITLE
feat: add `domains` allowlist to `wallet_connect` `identity.email`

### DIFF
--- a/.changeset/identity-email-domains.md
+++ b/.changeset/identity-email-domains.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `{ domains }` form to the `wallet_connect` `identity.email` capability for restricting email entry to allowed domains.

--- a/site/src/pages/docs/guides/identity.mdx
+++ b/site/src/pages/docs/guides/identity.mdx
@@ -217,6 +217,42 @@ To also bind an explicit nonce into the issued token, use the object form:
 `identity: { email: { address: 'user@example.com', nonce } }` (see
 [`wallet_connect`](/docs/rpc/wallet_connect#requiring-a-specific-email)).
 
+## Restrict Email Domains
+
+Pass `{ domains }` to restrict email entry to an allowlist of domains. The
+wallet rejects entering an email outside them, so users whose sign-ups your
+server would refuse get immediate feedback instead of a rejection after
+authenticating.
+
+```tsx twoslash [src/App.tsx]
+// @noErrors
+import { useConnect, useConnectors } from 'wagmi'
+
+function Connect() {
+  const { connectAsync } = useConnect()
+  const [connector] = useConnectors()
+
+  return (
+    <button
+      onClick={() =>
+        connectAsync({
+          connector,
+          capabilities: { identity: { email: { domains: ['tempo.xyz'] } } }, // [!code focus]
+        })
+      }
+    >
+      Sign in
+    </button>
+  )
+}
+```
+
+The restriction applies to email entry only: an account whose email is already
+verified still shares it, since your server may accept existing or invited
+users beyond the allowlist. Always enforce the policy server-side by verifying
+the `idToken` (see
+[`wallet_connect`](/docs/rpc/wallet_connect#restricting-email-domains)).
+
 ## Verify From Any Stack
 
 The token is a standard OIDC ID token, so any JWT/OIDC library can verify it against the JWKS above. You do not need the Accounts SDK. For example, with [`jose`](https://github.com/panva/jose):

--- a/site/src/pages/docs/rpc/wallet_connect.mdx
+++ b/site/src/pages/docs/rpc/wallet_connect.mdx
@@ -84,8 +84,11 @@ type Identity = {
    * - `{ address, nonce }` — same as above, with an explicit nonce baked into
    *   the token (for standalone use without the `auth` capability). Both
    *   fields are optional; `{ nonce }` alone requests any email.
+   * - `{ domains }` — restrict email entry to these domains: the wallet
+   *   rejects entering an email outside them. An account's already-verified
+   *   email is still shared; verify server-side.
    */
-  email?: boolean | string | { address?: string; nonce?: string }
+  email?: boolean | string | { address?: string; domains?: string[]; nonce?: string }
 }
 
 type ShowDeposit = boolean | {
@@ -261,3 +264,29 @@ const { accounts } = await provider.request({
   ],
 })
 ```
+
+### Restricting email domains
+
+Set `capabilities.identity.email` to `{ domains }` to restrict email entry to
+an allowlist of domains. The wallet rejects entering an email outside them
+(matched case-insensitively) in both the sign-in entry and the in-flow email
+prompt. Use this when your server restricts sign-ups to approved domains, so
+users get immediate feedback instead of a rejection after authenticating.
+
+```ts
+const { accounts } = await provider.request({
+  method: 'wallet_connect',
+  params: [
+    {
+      capabilities: {
+        identity: { email: { domains: ['tempo.xyz'] } },
+      },
+    },
+  ],
+})
+```
+
+The restriction applies to email *entry* only: an account whose email is
+already verified still shares it, since your server may accept existing or
+invited users beyond the allowlist. Always enforce the policy server-side by
+verifying the `idToken`. An exact `address` takes precedence over `domains`.

--- a/src/core/zod/rpc.test-d.ts
+++ b/src/core/zod/rpc.test-d.ts
@@ -23,10 +23,14 @@ describe('wallet_connect.identity', () => {
   type EmailRequest =
     | boolean
     | string
-    | { address?: string | undefined; nonce?: string | undefined }
+    | {
+        address?: string | undefined
+        domains?: string[] | undefined
+        nonce?: string | undefined
+      }
     | undefined
 
-  test('infers email as boolean | string | { address, nonce } | undefined', () => {
+  test('infers email as boolean | string | { address, domains, nonce } | undefined', () => {
     type Identity = z.output<typeof Rpc.wallet_connect.identity>
     expectTypeOf<Identity>().toEqualTypeOf<{ email?: EmailRequest } | undefined>()
   })

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -422,6 +422,27 @@ describe('wallet_connect.capabilities.request: identity', () => {
     `)
   })
 
+  test('accepts identity.email as { domains } object', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        method: 'login',
+        identity: { email: { domains: ['tempo.xyz', 'example.com'] } },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "identity": {
+          "email": {
+            "domains": [
+              "tempo.xyz",
+              "example.com",
+            ],
+          },
+        },
+        "method": "login",
+      }
+    `)
+  })
+
   test('accepts identity.email as empty { } object (no nonce)', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -673,14 +673,19 @@ export namespace wallet_connect {
        * - `{ address, nonce }` — same as above, with an explicit nonce baked
        *   into the token (for standalone use without the `auth` capability).
        *   Both fields are optional; `{ nonce }` alone requests any email.
+       * - `{ domains }` — restrict email entry to these domains: the wallet
+       *   rejects entering an email outside them. An account's
+       *   already-verified email is still shared; verify server-side.
        */
       email: z.optional(
         z.union([
           z.boolean(),
           z.string(),
           z.object({
-            /** Exact email the user must authenticate with. */
+            /** Exact email the user must authenticate with. Takes precedence over `domains`. */
             address: z.optional(z.string()),
+            /** Allowed email domains for entry (e.g. `['tempo.xyz']`), matched case-insensitively. */
+            domains: z.optional(z.array(z.string())),
             /** Nonce to bind into the issued identity token (replay protection). */
             nonce: z.optional(z.string()),
           }),


### PR DESCRIPTION
Adds a `{ domains }` form to the `wallet_connect` `identity.email` capability so apps can restrict email entry to an allowlist of domains. Entry-time UX only; servers remain the authority (an already-verified email is still shared).

Wallet: https://github.com/tempoxyz/wallet/pull/610
