### PR TITLE
feat!: replace `identity.email` `domains` with `verify` endpoint gate

### DIFF
--- a/.changeset/identity-email-domains.md
+++ b/.changeset/identity-email-domains.md
@@ -1,5 +1,0 @@
----
-'accounts': patch
----
-
-Added `{ domains }` form to the `wallet_connect` `identity.email` capability for restricting email entry to allowed domains.

--- a/.changeset/identity-email-verify.md
+++ b/.changeset/identity-email-verify.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `{ verify }` form to the `wallet_connect` `identity.email` capability for gating email entry through an app endpoint.

--- a/site/src/pages/docs/guides/identity.mdx
+++ b/site/src/pages/docs/guides/identity.mdx
@@ -217,12 +217,13 @@ To also bind an explicit nonce into the issued token, use the object form:
 `identity: { email: { address: 'user@example.com', nonce } }` (see
 [`wallet_connect`](/docs/rpc/wallet_connect#requiring-a-specific-email)).
 
-## Restrict Email Domains
+## Gate Email Entry
 
-Pass `{ domains }` to restrict email entry to an allowlist of domains. The
-wallet rejects entering an email outside them, so users whose sign-ups your
-server would refuse get immediate feedback instead of a rejection after
-authenticating.
+Pass `{ verify }` to gate email entry through an app endpoint. The wallet
+POSTs `{ email }` to it when the user enters an email and blocks entry on a
+4xx response (showing the response's `message` when present), so users whose
+sign-ups your server would refuse get immediate feedback instead of a
+rejection after authenticating.
 
 ```tsx twoslash [src/App.tsx]
 // @noErrors
@@ -237,7 +238,7 @@ function Connect() {
       onClick={() =>
         connectAsync({
           connector,
-          capabilities: { identity: { email: { domains: ['tempo.xyz'] } } }, // [!code focus]
+          capabilities: { identity: { email: { verify: '/api/email/check' } } }, // [!code focus]
         })
       }
     >
@@ -247,11 +248,10 @@ function Connect() {
 }
 ```
 
-The restriction applies to email entry only: an account whose email is already
-verified still shares it, since your server may accept existing or invited
-users beyond the allowlist. Always enforce the policy server-side by verifying
-the `idToken` (see
-[`wallet_connect`](/docs/rpc/wallet_connect#restricting-email-domains)).
+Relative URLs resolve against the app's origin. The gate applies to email
+entry only: an account whose email is already verified still shares it.
+Always enforce the policy server-side by verifying the `idToken` (see
+[`wallet_connect`](/docs/rpc/wallet_connect#gating-email-entry)).
 
 ## Verify From Any Stack
 

--- a/site/src/pages/docs/rpc/wallet_connect.mdx
+++ b/site/src/pages/docs/rpc/wallet_connect.mdx
@@ -84,11 +84,12 @@ type Identity = {
    * - `{ address, nonce }` — same as above, with an explicit nonce baked into
    *   the token (for standalone use without the `auth` capability). Both
    *   fields are optional; `{ nonce }` alone requests any email.
-   * - `{ domains }` — restrict email entry to these domains: the wallet
-   *   rejects entering an email outside them. An account's already-verified
-   *   email is still shared; verify server-side.
+   * - `{ verify }` — app endpoint that gates email entry: the wallet POSTs
+   *   `{ email }` to it and blocks entry on a 4xx (showing the response's
+   *   `message` when present). An account's already-verified email is still
+   *   shared; enforce the policy server-side.
    */
-  email?: boolean | string | { address?: string; domains?: string[]; nonce?: string }
+  email?: boolean | string | { address?: string; nonce?: string; verify?: string }
 }
 
 type ShowDeposit = boolean | {
@@ -265,13 +266,15 @@ const { accounts } = await provider.request({
 })
 ```
 
-### Restricting email domains
+### Gating email entry
 
-Set `capabilities.identity.email` to `{ domains }` to restrict email entry to
-an allowlist of domains. The wallet rejects entering an email outside them
-(matched case-insensitively) in both the sign-in entry and the in-flow email
-prompt. Use this when your server restricts sign-ups to approved domains, so
-users get immediate feedback instead of a rejection after authenticating.
+Set `capabilities.identity.email` to `{ verify }` to gate email entry through
+an app endpoint. The wallet POSTs `{ email }` (JSON) to the URL when the user
+enters an email — in both the sign-in entry and the in-flow email prompt — and
+blocks entry on a 4xx response, showing the response body's `message` when
+present. Use this when your server restricts sign-ups (e.g. an allowlist with
+invited exceptions), so users get immediate feedback instead of a rejection
+after authenticating.
 
 ```ts
 const { accounts } = await provider.request({
@@ -279,14 +282,16 @@ const { accounts } = await provider.request({
   params: [
     {
       capabilities: {
-        identity: { email: { domains: ['tempo.xyz'] } },
+        identity: { email: { verify: '/api/email/check' } },
       },
     },
   ],
 })
 ```
 
-The restriction applies to email *entry* only: an account whose email is
-already verified still shares it, since your server may accept existing or
-invited users beyond the allowlist. Always enforce the policy server-side by
-verifying the `idToken`. An exact `address` takes precedence over `domains`.
+Relative URLs resolve against the app's origin. The endpoint must allow
+cross-origin requests from the wallet host (CORS), and a network failure or
+5xx fails open (entry proceeds). The gate applies to email *entry* only: an
+account whose email is already verified still shares it. Always enforce the
+policy server-side by verifying the `idToken`. An exact `address` takes
+precedence over `verify`.

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1305,6 +1305,21 @@ export function create(options: create.Options = {}): create.ReturnType {
                           auth_input as NonNullable<z.output<typeof Rpc.wallet_connect.auth>>,
                         )
                       : undefined
+
+                    // Same origin problem for `identity.email.verify`: resolve
+                    // it dapp-side so the wallet host receives an absolute URL.
+                    const identity_request = (() => {
+                      const email = capabilities?.identity?.email
+                      if (typeof email !== 'object' || !email?.verify) return undefined
+                      const verify = (() => {
+                        const value = email.verify
+                        if (value.startsWith('http://') || value.startsWith('https://'))
+                          return value
+                        if (typeof window === 'undefined') return value
+                        return new URL(value, window.location.origin).href
+                      })()
+                      return { ...capabilities!.identity, email: { ...email, verify } }
+                    })()
                     if (auth_request && typeof auth_request === 'object' && !auth_request.challenge)
                       throw new RpcResponse.InvalidParamsError({
                         message:
@@ -1324,7 +1339,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                     // Patch the raw request so forwarding adapters carry the
                     // absolutized auth URLs and prepared access-key material
                     // downstream.
-                    if (auth_request || accessKey)
+                    if (auth_request || accessKey || identity_request)
                       request = {
                         ...request,
                         params: [
@@ -1333,6 +1348,7 @@ export function create(options: create.Options = {}): create.ReturnType {
                             capabilities: {
                               ...request.params?.[0]?.capabilities,
                               ...(auth_request ? { auth: auth_request } : {}),
+                              ...(identity_request ? { identity: identity_request } : {}),
                               ...(accessKey
                                 ? {
                                     authorizeAccessKey: z.encode(

--- a/src/core/zod/rpc.test-d.ts
+++ b/src/core/zod/rpc.test-d.ts
@@ -25,12 +25,12 @@ describe('wallet_connect.identity', () => {
     | string
     | {
         address?: string | undefined
-        domains?: string[] | undefined
         nonce?: string | undefined
+        verify?: string | undefined
       }
     | undefined
 
-  test('infers email as boolean | string | { address, domains, nonce } | undefined', () => {
+  test('infers email as boolean | string | { address, nonce, verify } | undefined', () => {
     type Identity = z.output<typeof Rpc.wallet_connect.identity>
     expectTypeOf<Identity>().toEqualTypeOf<{ email?: EmailRequest } | undefined>()
   })

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -422,20 +422,17 @@ describe('wallet_connect.capabilities.request: identity', () => {
     `)
   })
 
-  test('accepts identity.email as { domains } object', () => {
+  test('accepts identity.email as { verify } object', () => {
     expect(
       z.parse(Rpc.wallet_connect.capabilities.request, {
         method: 'login',
-        identity: { email: { domains: ['tempo.xyz', 'example.com'] } },
+        identity: { email: { verify: 'https://example.com/api/email/check' } },
       }),
     ).toMatchInlineSnapshot(`
       {
         "identity": {
           "email": {
-            "domains": [
-              "tempo.xyz",
-              "example.com",
-            ],
+            "verify": "https://example.com/api/email/check",
           },
         },
         "method": "login",

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -673,21 +673,22 @@ export namespace wallet_connect {
        * - `{ address, nonce }` — same as above, with an explicit nonce baked
        *   into the token (for standalone use without the `auth` capability).
        *   Both fields are optional; `{ nonce }` alone requests any email.
-       * - `{ domains }` — restrict email entry to these domains: the wallet
-       *   rejects entering an email outside them. An account's
-       *   already-verified email is still shared; verify server-side.
+       * - `{ verify }` — app endpoint that gates email entry: the wallet
+       *   POSTs `{ email }` to it and blocks entry on a 4xx (showing the
+       *   response's `message` when present). An account's already-verified
+       *   email is still shared; enforce the policy server-side.
        */
       email: z.optional(
         z.union([
           z.boolean(),
           z.string(),
           z.object({
-            /** Exact email the user must authenticate with. Takes precedence over `domains`. */
+            /** Exact email the user must authenticate with. Takes precedence over `verify`. */
             address: z.optional(z.string()),
-            /** Allowed email domains for entry (e.g. `['tempo.xyz']`), matched case-insensitively. */
-            domains: z.optional(z.array(z.string())),
             /** Nonce to bind into the issued identity token (replay protection). */
             nonce: z.optional(z.string()),
+            /** URL the wallet POSTs `{ email }` to at entry time (2xx allows, 4xx blocks); relative URLs resolve against the app origin. */
+            verify: z.optional(z.string()),
           }),
         ]),
       ),


### PR DESCRIPTION
Replaces the just-merged `identity.email.domains` allowlist (https://github.com/tempoxyz/accounts/pull/704, unreleased) with a dynamic `{ verify }` endpoint gate: the wallet POSTs `{ email }` to the app's URL at entry time and blocks on a 4xx, showing the response `message`. Relative URLs resolve dapp-side against the app origin. A static domain list could not express server policies like invited-exception allowlists.
