### PR TITLE
fix: guard provider announcement on `crypto.randomUUID` availability

### DIFF
--- a/.changeset/announce-randomuuid-guard.md
+++ b/.changeset/announce-randomuuid-guard.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Skipped EIP-6963 provider announcement when `crypto.randomUUID` is unavailable (e.g. insecure contexts).

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1810,7 +1810,11 @@ export function create(options: create.Options = {}): create.ReturnType {
     },
   )
 
-  if (typeof window !== 'undefined' && typeof CustomEvent !== 'undefined') {
+  if (
+    typeof window !== 'undefined' &&
+    typeof CustomEvent !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
     const rdns =
       adapter.rdns ?? `com.${(adapter.name ?? 'Injected Wallet').toLowerCase().replace(/\s+/g, '')}`
 


### PR DESCRIPTION
Skips EIP-6963 provider announcement when `crypto.randomUUID` is unavailable (e.g. insecure contexts), preventing `Provider.create` from throwing at startup.
