### PR TITLE
chore: add trusted host

### DIFF
--- a/.changeset/trusted-host-paradigm.md
+++ b/.changeset/trusted-host-paradigm.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added `paradigm.xyz` to the list of trusted hosts.

--- a/src/trusted-hosts.json
+++ b/src/trusted-hosts.json
@@ -3,6 +3,7 @@
     "localhost",
     "*.localhost",
     "*.tempo.xyz",
+    "paradigm.xyz",
     "promptgolf.sh",
     "app.polyhedge.capital",
     "tempodex.vercel.app",


### PR DESCRIPTION
Adds paradigm.xyz to the list of trusted hosts.