### PR TITLE
fix: forward fee payer URLs to JSON-RPC wallets

### DIFF
--- a/.changeset/fresh-memes-open.md
+++ b/.changeset/fresh-memes-open.md
@@ -1,0 +1,5 @@
+---
+"accounts": patch
+---
+
+Forward fee payer URLs to JSON-RPC wallets.

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -3553,6 +3553,41 @@ describe.each(adapters)('$name', ({ adapter, name }: (typeof adapters)[number]) 
 
       expect(result.receipts?.[0]?.feePayer).toBe(feePayerAccount.address.toLowerCase())
     })
+
+    test('behavior: forwards provider feePayer URL to JSON-RPC wallets', async () => {
+      const wallet = Provider.create({ adapter: adapter(), chains: [chain] })
+      const address = await connect(wallet)
+      await fund(address)
+
+      const jsonRpcAdapter = Adapter.define({ name: 'JSON-RPC Test' }, () => ({
+        actions: {
+          createAccount: async () => ({ accounts: [{ address }] }),
+          loadAccounts: async () => ({ accounts: [{ address }] }),
+        },
+        getAccount: () => ({
+          account: { address, type: 'json-rpc' as const },
+          transport: custom({ request: (request) => wallet.request(request as never) }),
+        }),
+      }))
+      const provider = Provider.create({
+        adapter: jsonRpcAdapter,
+        chains: [chain],
+        feePayer: server.url,
+      })
+      await provider.request({ method: 'wallet_connect' })
+
+      const result = await provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [transfer('1.1')],
+            capabilities: { feePayer: true, sync: true },
+          },
+        ],
+      })
+
+      expect(result.receipts?.[0]?.feePayer).toBe(feePayerAccount.address.toLowerCase())
+    })
   })
 })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -245,6 +245,15 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
   }
 
+  function forwardFeePayer(
+    feePayer: TransactionParameters['feePayer'],
+    account: Awaited<Adapter.getAccount.ReturnType>['account'],
+  ) {
+    if (account.type === 'json-rpc' && feePayer !== undefined) return { feePayer }
+    if (feePayer) return { feePayer: true as const }
+    return {}
+  }
+
   async function prepareRootTransaction(parameters: TransactionParameters) {
     const { feePayer, ...rest } = parameters
     const selected = await getAdapterAccount({ address: parameters.from })
@@ -256,7 +265,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
     const request = {
       ...rest,
-      ...(feePayer ? { feePayer: true as const } : {}),
+      ...forwardFeePayer(feePayer, selected.account),
     }
     if (selected.account.type === 'json-rpc') return { client, request, selected }
     const prepared = await prepareTransactionRequest(client, {
@@ -349,7 +358,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
     return await sendTransaction(client, {
       ...rest,
-      ...(feePayer ? { feePayer: true as never } : {}),
+      ...forwardFeePayer(feePayer, selected.account),
     } as never)
   }
 
@@ -396,7 +405,7 @@ export function create(options: create.Options = {}): create.ReturnType {
     })
     const request = {
       ...rest,
-      ...(feePayer ? { feePayer: true as const } : {}),
+      ...forwardFeePayer(feePayer, selected.account),
     }
     if (selected.account.type === 'json-rpc')
       return (await client.request({


### PR DESCRIPTION
## Summary

Fixed fee sponsorship for hosted JSON-RPC wallets by forwarding the resolved fee payer URL through the wallet transport. Local accounts continue to receive the protocol-level boolean after Accounts configures its own relay client.

## Motivation

Hosted wallets broadcast through the adapter's JSON-RPC transport, bypassing the app-side viem transport. Accounts was replacing the resolved sponsor URL with `true` before calling that wallet, so a hosted wallet without the same provider default broadcast the transaction unsponsored and charged the connected wallet.

## Changes

- Preserved fee payer URLs and explicit opt-outs across JSON-RPC wallet boundaries.
- Kept boolean fee payer normalization for locally signed transactions.
- Added an end-to-end regression to the existing fee payer localnet suite.
- Added a generated patch changeset.

## Testing

- `pnpm check`
- `pnpm check:types`
- `pnpm test` — 994 passed, 1 skipped
- `pnpm build`
- Verified the new regression fails against the previous implementation and passes with the fix for both existing account adapters.