### PR TITLE
fix: route MPP clients through the requested chain

### DIFF
--- a/.changeset/tidy-cats-route.md
+++ b/.changeset/tidy-cats-route.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fixed MPP clients routing chain RPCs through the active chain instead of the requested chain.

--- a/src/core/Client.test.ts
+++ b/src/core/Client.test.ts
@@ -87,18 +87,12 @@ describe('caching', () => {
       chains: [tempoModerato, tempo],
       storage: Storage.memory(),
     })
-    provider_a.store.setState({
-      accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
-    })
-    provider_b.store.setState({
-      accounts: [{ address: '0x0000000000000000000000000000000000000002' }],
-    })
-    const client_a = Client.fromChainId(tempo.id, {
+    const client_a = Client.fromChainId(undefined, {
       chains: [tempo, tempoModerato],
       provider: provider_a,
       store,
     })
-    const client_b = Client.fromChainId(tempo.id, {
+    const client_b = Client.fromChainId(undefined, {
       chains: [tempo, tempoModerato],
       provider: provider_b,
       store,
@@ -107,58 +101,21 @@ describe('caching', () => {
     // The clients themselves must be distinct.
     expect(client_a).not.toBe(client_b)
 
-    // Wallet-owned methods must still route back to the provider that created
-    // each client.
-    const accounts_a = await client_a.request({ method: 'eth_accounts' })
-    const accounts_b = await client_b.request({ method: 'eth_accounts' })
-    expect(accounts_a).toMatchInlineSnapshot(`
-      [
-        "0x0000000000000000000000000000000000000001",
-      ]
-    `)
-    expect(accounts_b).toMatchInlineSnapshot(`
-      [
-        "0x0000000000000000000000000000000000000002",
-      ]
-    `)
+    // Each `eth_chainId` is routed back to its own provider's store, so the
+    // returned chain IDs must match each provider's `defaultChain`.
+    const chainId_a = await client_a.request({ method: 'eth_chainId' })
+    const chainId_b = await client_b.request({ method: 'eth_chainId' })
+    expect(chainId_a).toMatchInlineSnapshot(`"0x1079"`)
+    expect(chainId_b).toMatchInlineSnapshot(`"0xa5bf"`)
   })
 
-  test('behavior: same provider with different transports does not share cached clients', async () => {
+  test('behavior: different transports objects do not share cached clients', () => {
     const store = setup()
-    const provider = Provider.create({
-      adapter: secp256k1(),
-      chains: [tempo],
-      storage: Storage.memory(),
-    })
-    const transports_a = {
-      [tempo.id]: custom({
-        async request() {
-          return 'a'
-        },
-      }),
-    }
-    const transports_b = {
-      [tempo.id]: custom({
-        async request() {
-          return 'b'
-        },
-      }),
-    }
-    const a = Client.fromChainId(tempo.id, {
-      chains: [tempo],
-      provider,
-      store,
-      transports: transports_a,
-    })
-    const b = Client.fromChainId(tempo.id, {
-      chains: [tempo],
-      provider,
-      store,
-      transports: transports_b,
-    })
+    const transports_a = { [tempo.id]: http('https://a.example.com') }
+    const transports_b = { [tempo.id]: http('https://b.example.com') }
+    const a = Client.fromChainId(tempo.id, { chains: [tempo], store, transports: transports_a })
+    const b = Client.fromChainId(tempo.id, { chains: [tempo], store, transports: transports_b })
     expect(a).not.toBe(b)
-    expect(await a.request({ method: 'eth_chainId' })).toMatchInlineSnapshot(`"a"`)
-    expect(await b.request({ method: 'eth_chainId' })).toMatchInlineSnapshot(`"b"`)
   })
 
   test('behavior: same provider with different feePayer URLs gets different clients', () => {
@@ -245,31 +202,7 @@ describe('caching', () => {
   })
 })
 
-describe('walletTransport', () => {
-  test('default: routes chain RPCs through the requested chain transport', async () => {
-    const store = setup()
-    const provider = Provider.create({
-      adapter: secp256k1(),
-      chains: [tempoModerato, tempo],
-      storage: Storage.memory(),
-    })
-    const transports = {
-      [tempo.id]: custom({
-        async request() {
-          return '0x1079'
-        },
-      }),
-    }
-    const client = Client.fromChainId(tempo.id, {
-      chains: [tempo, tempoModerato],
-      provider,
-      store,
-      transports,
-    })
-    const result = await client.request({ method: 'eth_chainId' })
-    expect(result).toMatchInlineSnapshot(`"0x1079"`)
-  })
-
+describe('providerTransport', () => {
   test('behavior: returns empty accounts before connecting', async () => {
     const store = setup()
     const provider = Provider.create({
@@ -283,32 +216,18 @@ describe('walletTransport', () => {
   })
 
   test('behavior: fills transactions on the requested chain', async () => {
-    const requests: number[] = []
-    const transport = (chainId: number) =>
-      custom({
-        async request() {
-          requests.push(chainId)
-          return {}
-        },
-      })
+    const requests: unknown[] = []
     const store = setup()
-    const provider = Provider.create({
-      adapter: secp256k1(),
-      chains: [tempoModerato, tempo],
-      storage: Storage.memory(),
-      transports: {
-        [tempo.id]: transport(tempo.id),
-        [tempoModerato.id]: transport(tempoModerato.id),
+    const provider = {
+      async request(request: unknown) {
+        requests.push(request)
+        return {}
       },
-    })
+    } as never
     const client = Client.fromChainId(tempo.id, {
       chains: [tempo, tempoModerato],
       provider,
       store,
-      transports: {
-        [tempo.id]: transport(tempo.id),
-        [tempoModerato.id]: transport(tempoModerato.id),
-      },
     })
 
     await client.request({
@@ -318,51 +237,15 @@ describe('walletTransport', () => {
 
     expect(requests).toMatchInlineSnapshot(`
       [
-        4217,
-      ]
-    `)
-  })
-
-  test('behavior: waits for hydration before routing active-chain RPCs', async () => {
-    let hydrate = (_value: unknown) => {}
-    const persisted = new Promise<unknown>((resolve) => {
-      hydrate = resolve
-    })
-    const storage: Storage.Storage = {
-      async getItem<value>() {
-        return (await persisted) as value
-      },
-      removeItem() {},
-      setItem() {},
-    }
-    const requests: number[] = []
-    const transport = (chainId: number) =>
-      custom({
-        async request() {
-          requests.push(chainId)
-          return '0x0'
+        {
+          "method": "eth_fillTransaction",
+          "params": [
+            {
+              "chainId": 4217,
+              "to": "0x0000000000000000000000000000000000000001",
+            },
+          ],
         },
-      })
-    const provider = Provider.create({
-      adapter: secp256k1(),
-      chains: [tempo, tempoModerato],
-      storage,
-      transports: {
-        [tempo.id]: transport(tempo.id),
-        [tempoModerato.id]: transport(tempoModerato.id),
-      },
-    })
-
-    const result = provider.getClient().request({
-      method: 'eth_getBalance',
-      params: ['0x0000000000000000000000000000000000000001', 'latest'],
-    })
-    hydrate({ state: { chainId: tempoModerato.id }, version: 0 })
-
-    expect(await result).toMatchInlineSnapshot(`"0x0"`)
-    expect(requests).toMatchInlineSnapshot(`
-      [
-        42431,
       ]
     `)
   })

--- a/src/core/Client.test.ts
+++ b/src/core/Client.test.ts
@@ -87,6 +87,12 @@ describe('caching', () => {
       chains: [tempoModerato, tempo],
       storage: Storage.memory(),
     })
+    provider_a.store.setState({
+      accounts: [{ address: '0x0000000000000000000000000000000000000001' }],
+    })
+    provider_b.store.setState({
+      accounts: [{ address: '0x0000000000000000000000000000000000000002' }],
+    })
     const client_a = Client.fromChainId(tempo.id, {
       chains: [tempo, tempoModerato],
       provider: provider_a,
@@ -101,12 +107,20 @@ describe('caching', () => {
     // The clients themselves must be distinct.
     expect(client_a).not.toBe(client_b)
 
-    // Each `eth_chainId` is routed back to its own provider's store, so the
-    // returned chain IDs must match each provider's `defaultChain`.
-    const chainId_a = await client_a.request({ method: 'eth_chainId' })
-    const chainId_b = await client_b.request({ method: 'eth_chainId' })
-    expect(chainId_a).toMatchInlineSnapshot(`"0x1079"`)
-    expect(chainId_b).toMatchInlineSnapshot(`"0xa5bf"`)
+    // Provider-owned methods must still route back to the provider that
+    // created each client.
+    const accounts_a = await client_a.request({ method: 'eth_accounts' })
+    const accounts_b = await client_b.request({ method: 'eth_accounts' })
+    expect(accounts_a).toMatchInlineSnapshot(`
+      [
+        "0x0000000000000000000000000000000000000001",
+      ]
+    `)
+    expect(accounts_b).toMatchInlineSnapshot(`
+      [
+        "0x0000000000000000000000000000000000000002",
+      ]
+    `)
   })
 
   test('behavior: different transports objects do not share cached clients', () => {
@@ -203,23 +217,28 @@ describe('caching', () => {
 })
 
 describe('providerTransport', () => {
-  test('default: routes requests through the provider', async () => {
+  test('default: routes chain RPCs through the requested chain transport', async () => {
     const store = setup()
     const provider = Provider.create({
       adapter: secp256k1(),
       chains: [tempoModerato, tempo],
       storage: Storage.memory(),
     })
-    // Wire the client to chain ID `tempo.id` but route through a provider
-    // whose default chain is `tempoModerato`. The returned chain ID must
-    // come from the provider, not the requested chain.
+    const transports = {
+      [tempo.id]: custom({
+        async request() {
+          return '0x1079'
+        },
+      }),
+    }
     const client = Client.fromChainId(tempo.id, {
       chains: [tempo, tempoModerato],
       provider,
       store,
+      transports,
     })
     const result = await client.request({ method: 'eth_chainId' })
-    expect(result).toMatchInlineSnapshot(`"0xa5bf"`)
+    expect(result).toMatchInlineSnapshot(`"0x1079"`)
   })
 
   test('behavior: returns empty accounts before connecting', async () => {

--- a/src/core/Client.test.ts
+++ b/src/core/Client.test.ts
@@ -123,13 +123,42 @@ describe('caching', () => {
     `)
   })
 
-  test('behavior: different transports objects do not share cached clients', () => {
+  test('behavior: same provider with different transports does not share cached clients', async () => {
     const store = setup()
-    const transports_a = { [tempo.id]: http('https://a.example.com') }
-    const transports_b = { [tempo.id]: http('https://b.example.com') }
-    const a = Client.fromChainId(tempo.id, { chains: [tempo], store, transports: transports_a })
-    const b = Client.fromChainId(tempo.id, { chains: [tempo], store, transports: transports_b })
+    const provider = Provider.create({
+      adapter: secp256k1(),
+      chains: [tempo],
+      storage: Storage.memory(),
+    })
+    const transports_a = {
+      [tempo.id]: custom({
+        async request() {
+          return 'a'
+        },
+      }),
+    }
+    const transports_b = {
+      [tempo.id]: custom({
+        async request() {
+          return 'b'
+        },
+      }),
+    }
+    const a = Client.fromChainId(tempo.id, {
+      chains: [tempo],
+      provider,
+      store,
+      transports: transports_a,
+    })
+    const b = Client.fromChainId(tempo.id, {
+      chains: [tempo],
+      provider,
+      store,
+      transports: transports_b,
+    })
     expect(a).not.toBe(b)
+    expect(await a.request({ method: 'eth_chainId' })).toMatchInlineSnapshot(`"a"`)
+    expect(await b.request({ method: 'eth_chainId' })).toMatchInlineSnapshot(`"b"`)
   })
 
   test('behavior: same provider with different feePayer URLs gets different clients', () => {
@@ -251,6 +280,91 @@ describe('walletTransport', () => {
     const client = Client.fromChainId(tempo.id, { chains: [tempo], provider, store })
     const result = await client.request({ method: 'eth_accounts' })
     expect(result).toMatchInlineSnapshot(`[]`)
+  })
+
+  test('behavior: fills transactions on the requested chain', async () => {
+    const requests: number[] = []
+    const transport = (chainId: number) =>
+      custom({
+        async request() {
+          requests.push(chainId)
+          return {}
+        },
+      })
+    const store = setup()
+    const provider = Provider.create({
+      adapter: secp256k1(),
+      chains: [tempoModerato, tempo],
+      storage: Storage.memory(),
+      transports: {
+        [tempo.id]: transport(tempo.id),
+        [tempoModerato.id]: transport(tempoModerato.id),
+      },
+    })
+    const client = Client.fromChainId(tempo.id, {
+      chains: [tempo, tempoModerato],
+      provider,
+      store,
+      transports: {
+        [tempo.id]: transport(tempo.id),
+        [tempoModerato.id]: transport(tempoModerato.id),
+      },
+    })
+
+    await client.request({
+      method: 'eth_fillTransaction' as never,
+      params: [{ to: '0x0000000000000000000000000000000000000001' }] as never,
+    })
+
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        4217,
+      ]
+    `)
+  })
+
+  test('behavior: waits for hydration before routing active-chain RPCs', async () => {
+    let hydrate = (_value: unknown) => {}
+    const persisted = new Promise<unknown>((resolve) => {
+      hydrate = resolve
+    })
+    const storage: Storage.Storage = {
+      async getItem<value>() {
+        return (await persisted) as value
+      },
+      removeItem() {},
+      setItem() {},
+    }
+    const requests: number[] = []
+    const transport = (chainId: number) =>
+      custom({
+        async request() {
+          requests.push(chainId)
+          return '0x0'
+        },
+      })
+    const provider = Provider.create({
+      adapter: secp256k1(),
+      chains: [tempo, tempoModerato],
+      storage,
+      transports: {
+        [tempo.id]: transport(tempo.id),
+        [tempoModerato.id]: transport(tempoModerato.id),
+      },
+    })
+
+    const result = provider.getClient().request({
+      method: 'eth_getBalance',
+      params: ['0x0000000000000000000000000000000000000001', 'latest'],
+    })
+    hydrate({ state: { chainId: tempoModerato.id }, version: 0 })
+
+    expect(await result).toMatchInlineSnapshot(`"0x0"`)
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        42431,
+      ]
+    `)
   })
 })
 

--- a/src/core/Client.test.ts
+++ b/src/core/Client.test.ts
@@ -107,8 +107,8 @@ describe('caching', () => {
     // The clients themselves must be distinct.
     expect(client_a).not.toBe(client_b)
 
-    // Provider-owned methods must still route back to the provider that
-    // created each client.
+    // Wallet-owned methods must still route back to the provider that created
+    // each client.
     const accounts_a = await client_a.request({ method: 'eth_accounts' })
     const accounts_b = await client_b.request({ method: 'eth_accounts' })
     expect(accounts_a).toMatchInlineSnapshot(`
@@ -216,7 +216,7 @@ describe('caching', () => {
   })
 })
 
-describe('providerTransport', () => {
+describe('walletTransport', () => {
   test('default: routes chain RPCs through the requested chain transport', async () => {
     const store = setup()
     const provider = Provider.create({

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -53,7 +53,7 @@ export function fromChainId(
   if (!client) {
     const chain = chains.find((c) => c.id === id) ?? chains[0]!
     const base = transports?.[id] ?? http()
-    const transport_base = provider ? providerTransport(provider, base) : base
+    const transport_base = provider ? walletTransport(provider, base) : base
     const transport = feePayerUrl
       ? feePayerTransport(transport_base, feePayerUrl, precedence)
       : transport_base
@@ -78,7 +78,7 @@ export declare namespace fromChainId {
           precedence?: 'fee-payer-first' | 'user-first' | undefined
         }
       | undefined
-    /** Provider instance. When set, the transport routes requests through the provider first, falling back to HTTP for unknown methods. */
+    /** Provider instance. When set, wallet-owned methods route through the provider and all other RPCs use the requested chain transport. */
     provider?: ox_Provider.Provider | undefined
     /** Reactive state store. */
     store: Store.Store
@@ -88,16 +88,16 @@ export declare namespace fromChainId {
 }
 
 /**
- * Creates a transport that routes requests through the provider, falling
- * back to the given base transport for methods the provider proxies to RPC.
+ * Creates a transport that routes wallet-owned methods through the provider.
+ * All other RPCs use the configured transport for the requested chain.
  */
-function providerTransport(provider: ox_Provider.Provider, base: Transport): Transport {
+function walletTransport(provider: ox_Provider.Provider, base: Transport): Transport {
   return (params) => {
     const baseTransport = base(params)
     return {
       ...baseTransport,
       async request({ method, params: reqParams }) {
-        if (!isProviderMethod(method))
+        if (!isWalletMethod(method))
           return baseTransport.request({ method, params: reqParams } as never)
         return (provider as { request: EIP1193RequestFn }).request({
           method,
@@ -108,7 +108,7 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
   }
 }
 
-function isProviderMethod(method: string) {
+function isWalletMethod(method: string) {
   return (
     method.startsWith('wallet_') ||
     [

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -97,6 +97,8 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
     return {
       ...baseTransport,
       async request({ method, params: reqParams }) {
+        if (!isProviderMethod(method))
+          return baseTransport.request({ method, params: reqParams } as never)
         return (provider as { request: EIP1193RequestFn }).request({
           method,
           params: reqParams,
@@ -104,6 +106,22 @@ function providerTransport(provider: ox_Provider.Provider, base: Transport): Tra
       },
     } as ReturnType<Transport>
   }
+}
+
+function isProviderMethod(method: string) {
+  return (
+    method.startsWith('wallet_') ||
+    [
+      'eth_accounts',
+      'eth_fillTransaction',
+      'eth_requestAccounts',
+      'eth_sendTransaction',
+      'eth_sendTransactionSync',
+      'eth_signTransaction',
+      'eth_signTypedData_v4',
+      'personal_sign',
+    ].includes(method)
+  )
 }
 
 /**

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -14,7 +14,6 @@ import type * as Store from './Store.js'
 
 const defaultClients = new Map<string, Client>()
 const clients = new WeakMap<object, Map<string, Client>>()
-const clients_pair = new WeakMap<object, WeakMap<object, Map<string, Client>>>()
 
 /** Resolves a viem Client for a given chain ID (cached). */
 export function fromChainId(
@@ -35,21 +34,8 @@ export function fromChainId(
   })()
   const id = chainId ?? store.getState().chainId
   const key = `${id}:${provider ? 'p' : ''}:${feePayerOption === false ? 'no-fp' : (feePayerUrl ?? '')}:${precedence}`
+  const scope = provider ?? transports
   const cache = (() => {
-    if (provider && transports) {
-      let scopes = clients_pair.get(provider)
-      if (!scopes) {
-        scopes = new WeakMap()
-        clients_pair.set(provider, scopes)
-      }
-      let map = scopes.get(transports)
-      if (!map) {
-        map = new Map()
-        scopes.set(transports, map)
-      }
-      return map
-    }
-    const scope = provider ?? transports
     if (!scope) return defaultClients
     let map = clients.get(scope)
     if (!map) {
@@ -63,7 +49,7 @@ export function fromChainId(
     const chain = chains.find((c) => c.id === id) ?? chains[0]!
     const base = transports?.[id] ?? http()
     const transport_base = provider
-      ? walletTransport(provider, base, chainId === undefined ? undefined : chain.id)
+      ? providerTransport(provider, base, chainId === undefined ? undefined : chain.id)
       : base
     const transport = feePayerUrl
       ? feePayerTransport(transport_base, feePayerUrl, precedence)
@@ -89,7 +75,7 @@ export declare namespace fromChainId {
           precedence?: 'fee-payer-first' | 'user-first' | undefined
         }
       | undefined
-    /** Provider instance. When set, wallet-owned methods route through the provider and all other RPCs use the requested chain transport. */
+    /** Provider for account operations and active-chain requests. Explicit-chain RPCs use the matching transport. */
     provider?: ox_Provider.Provider | undefined
     /** Reactive state store. */
     store: Store.Store
@@ -99,10 +85,10 @@ export declare namespace fromChainId {
 }
 
 /**
- * Creates a transport that routes wallet-owned methods through the provider.
- * All other RPCs use the configured transport for the requested chain.
+ * Routes account operations through the provider and explicit-chain RPCs
+ * through the requested chain's transport.
  */
-function walletTransport(
+function providerTransport(
   provider: ox_Provider.Provider,
   base: Transport,
   chainId: number | undefined,
@@ -112,14 +98,8 @@ function walletTransport(
     return {
       ...baseTransport,
       async request({ method, params: reqParams }) {
-        if (!isWalletMethod(method)) {
-          if (chainId === undefined)
-            return (provider as { request: EIP1193RequestFn }).request({
-              method,
-              params: reqParams,
-            } as any)
+        if (chainId !== undefined && !usesProvider(method))
           return baseTransport.request({ method, params: reqParams } as never)
-        }
         const params = (() => {
           if (method !== 'eth_fillTransaction' || chainId === undefined) return reqParams
           const request = (reqParams as readonly unknown[] | undefined)?.[0]
@@ -135,7 +115,7 @@ function walletTransport(
   }
 }
 
-function isWalletMethod(method: string) {
+function usesProvider(method: string) {
   return (
     method.startsWith('wallet_') ||
     [

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -14,6 +14,7 @@ import type * as Store from './Store.js'
 
 const defaultClients = new Map<string, Client>()
 const clients = new WeakMap<object, Map<string, Client>>()
+const clients_pair = new WeakMap<object, WeakMap<object, Map<string, Client>>>()
 
 /** Resolves a viem Client for a given chain ID (cached). */
 export function fromChainId(
@@ -34,13 +35,21 @@ export function fromChainId(
   })()
   const id = chainId ?? store.getState().chainId
   const key = `${id}:${provider ? 'p' : ''}:${feePayerOption === false ? 'no-fp' : (feePayerUrl ?? '')}:${precedence}`
-  // Scope the cache by `provider` (preferred) or `transports`, falling back
-  // to a shared module-level map. The cache key only encodes a boolean for
-  // `provider`, so without scoping, two providers sharing the same chainId
-  // would hit each other's cached clients and route requests to the wrong
-  // adapter via `providerTransport`.
-  const scope = provider ?? transports
   const cache = (() => {
+    if (provider && transports) {
+      let scopes = clients_pair.get(provider)
+      if (!scopes) {
+        scopes = new WeakMap()
+        clients_pair.set(provider, scopes)
+      }
+      let map = scopes.get(transports)
+      if (!map) {
+        map = new Map()
+        scopes.set(transports, map)
+      }
+      return map
+    }
+    const scope = provider ?? transports
     if (!scope) return defaultClients
     let map = clients.get(scope)
     if (!map) {
@@ -53,7 +62,9 @@ export function fromChainId(
   if (!client) {
     const chain = chains.find((c) => c.id === id) ?? chains[0]!
     const base = transports?.[id] ?? http()
-    const transport_base = provider ? walletTransport(provider, base) : base
+    const transport_base = provider
+      ? walletTransport(provider, base, chainId === undefined ? undefined : chain.id)
+      : base
     const transport = feePayerUrl
       ? feePayerTransport(transport_base, feePayerUrl, precedence)
       : transport_base
@@ -91,17 +102,33 @@ export declare namespace fromChainId {
  * Creates a transport that routes wallet-owned methods through the provider.
  * All other RPCs use the configured transport for the requested chain.
  */
-function walletTransport(provider: ox_Provider.Provider, base: Transport): Transport {
+function walletTransport(
+  provider: ox_Provider.Provider,
+  base: Transport,
+  chainId: number | undefined,
+): Transport {
   return (params) => {
     const baseTransport = base(params)
     return {
       ...baseTransport,
       async request({ method, params: reqParams }) {
-        if (!isWalletMethod(method))
+        if (!isWalletMethod(method)) {
+          if (chainId === undefined)
+            return (provider as { request: EIP1193RequestFn }).request({
+              method,
+              params: reqParams,
+            } as any)
           return baseTransport.request({ method, params: reqParams } as never)
+        }
+        const params = (() => {
+          if (method !== 'eth_fillTransaction' || chainId === undefined) return reqParams
+          const request = (reqParams as readonly unknown[] | undefined)?.[0]
+          if (!request || typeof request !== 'object') return reqParams
+          return [{ ...request, chainId }]
+        })()
         return (provider as { request: EIP1193RequestFn }).request({
           method,
-          params: reqParams,
+          params,
         } as any)
       },
     } as ReturnType<Transport>

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -39,39 +39,17 @@ describe('getMppxParameters', () => {
   })
 
   test('behavior: routes chain RPCs to the requested chain', async () => {
-    const requests: number[] = []
-    const transport = (chainId: number) =>
-      custom({
-        async request({ method }) {
-          requests.push(chainId)
-          if (method === 'eth_chainId') return `0x${chainId.toString(16)}`
-          return '0x5208'
-        },
-      })
     const provider = Provider.create({
       chains: [tempo, tempoModerato],
       storage: Storage.memory(),
       transports: {
-        [tempo.id]: transport(tempo.id),
-        [tempoModerato.id]: transport(tempoModerato.id),
+        [tempoModerato.id]: custom({ request: async () => '0xa5bf' }),
       },
     })
     provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
 
     const client = await provider.getMppxParameters().getClient({ chainId: tempoModerato.id })
-
-    await client.request({ method: 'eth_chainId' })
-    await client.request({
-      method: 'eth_getBalance',
-      params: [address, 'latest'],
-    })
-
-    expect(requests).toMatchInlineSnapshot(`
-      [
-        42431,
-        42431,
-      ]
-    `)
+    expect(await client.request({ method: 'eth_chainId' })).toBe('0xa5bf')
   })
 
   test('behavior: resolves existing access key for connected account', async () => {

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -1,5 +1,7 @@
 import { Hex } from 'ox'
+import { custom } from 'viem'
 import { createSiweMessage } from 'viem/siwe'
+import { tempo, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import { accounts, privateKeys } from '../../test/config.js'
@@ -34,6 +36,42 @@ describe('getMppxParameters', () => {
       type: 'json-rpc',
     })
     expect((client as { account?: unknown }).account).toBeUndefined()
+  })
+
+  test('behavior: routes chain RPCs to the requested chain', async () => {
+    const requests: number[] = []
+    const transport = (chainId: number) =>
+      custom({
+        async request({ method }) {
+          requests.push(chainId)
+          if (method === 'eth_chainId') return `0x${chainId.toString(16)}`
+          return '0x5208'
+        },
+      })
+    const provider = Provider.create({
+      chains: [tempo, tempoModerato],
+      storage: Storage.memory(),
+      transports: {
+        [tempo.id]: transport(tempo.id),
+        [tempoModerato.id]: transport(tempoModerato.id),
+      },
+    })
+    provider.store.setState({ accounts: [{ address }], activeAccount: 0 })
+
+    const client = await provider.getMppxParameters().getClient({ chainId: tempoModerato.id })
+
+    await client.request({ method: 'eth_chainId' })
+    await client.request({
+      method: 'eth_getBalance',
+      params: [address, 'latest'],
+    })
+
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        42431,
+        42431,
+      ]
+    `)
   })
 
   test('behavior: resolves existing access key for connected account', async () => {


### PR DESCRIPTION
## Summary

- preserve provider routing when no chain is requested
- send ordinary RPCs to the requested chain transport when a chain is explicit
- keep account operations on the provider and fill transactions on the requested chain

This fixes MPP clients whose chain object matched the Challenge while RPC requests still used the wallet store's active chain.

## Testing

- `pnpm test src/core/Client.test.ts src/core/Provider.test.ts`
- `pnpm check:types`
- `pnpm check`