### PR TITLE
fix(Provider): guard EIP-6963 announcement on DOM event APIs

### DIFF
--- a/.changeset/announce-provider-dom-event-guard.md
+++ b/.changeset/announce-provider-dom-event-guard.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Skipped EIP-6963 provider announcement in partial `window`-like runtimes (e.g. React Native) that lack `window.dispatchEvent`/`window.addEventListener`, preventing `Provider.create` from throwing at startup.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -620,6 +620,67 @@ describe('wallet_connect', () => {
   })
 })
 
+describe('EIP-6963 announcement', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  // An explicit adapter sidesteps `Provider.create`'s default `dialog` adapter, which reads
+  // `window.location`/`window.isSecureContext` for unrelated reasons — this suite only exercises
+  // the EIP-6963 announcement guard. `rdns` must be unique per call: Provider.ts dedupes
+  // announcements through a module-level `announced` Set, so a fixed rdns would let one call (or
+  // vitest's automatic retry of a previous attempt) mask a later call's guard behavior.
+  function testAdapter(rdns: string) {
+    return Adapter.define({ name: 'Test Wallet', rdns }, () => ({
+      actions: {
+        async createAccount() {
+          return { accounts: [{ address }] }
+        },
+        async loadAccounts() {
+          return { accounts: [{ address }] }
+        },
+      },
+    }))
+  }
+
+  function uniqueRdns() {
+    return `com.example.test.${Math.random().toString(36).slice(2)}`
+  }
+
+  test('behavior: skips announcement in a partial window-like runtime (e.g. React Native)', () => {
+    // `window` aliased to an object without DOM event APIs, but with `CustomEvent`/
+    // `crypto.randomUUID` polyfilled for unrelated reasons — mirrors the reported React Native
+    // (Expo) environment.
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('CustomEvent', class {})
+    vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+    expect(() =>
+      Provider.create({ adapter: testAdapter(uniqueRdns()), storage: Storage.memory() }),
+    ).not.toThrow()
+  })
+
+  test('behavior: announces via mipd in a real browser-like window', () => {
+    const addEventListener = vi.fn()
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { addEventListener, dispatchEvent })
+    vi.stubGlobal(
+      'CustomEvent',
+      class {
+        detail: unknown
+        type: string
+        constructor(type: string, options?: { detail?: unknown }) {
+          this.type = type
+          this.detail = options?.detail
+        }
+      },
+    )
+    vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+    Provider.create({ adapter: testAdapter(uniqueRdns()), storage: Storage.memory() })
+
+    expect(dispatchEvent).toHaveBeenCalled()
+  })
+})
+
 describe('adapter actions', () => {
   test('behavior: explicit adapter action overrides provider default', async () => {
     const getAccount = vi.fn(() => {

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1821,6 +1821,8 @@ export function create(options: create.Options = {}): create.ReturnType {
 
   if (
     typeof window !== 'undefined' &&
+    typeof window.dispatchEvent === 'function' &&
+    typeof window.addEventListener === 'function' &&
     typeof CustomEvent !== 'undefined' &&
     typeof crypto.randomUUID === 'function'
   ) {


### PR DESCRIPTION
## Bug

`Provider.create()`'s EIP-6963 announcement guarded on `window`, `CustomEvent`, and `crypto.randomUUID`, but not on the DOM event APIs mipd's `announceProvider` actually calls:

```ts
export function announceProvider(detail) {
  const event = new CustomEvent('eip6963:announceProvider', { detail: Object.freeze(detail) })
  window.dispatchEvent(event)
  const handler = () => window.dispatchEvent(event)
  window.addEventListener('eip6963:requestProvider', handler)
  return () => window.removeEventListener('eip6963:requestProvider', handler)
}
```

In partial `window`-like runtimes (React Native/Expo, where `window` is aliased to `globalThis` and `CustomEvent`/`crypto.randomUUID` are polyfilled for unrelated reasons but no DOM event dispatching exists), all three existing guard conditions pass, `announceProvider` runs, and `window.dispatchEvent` throws `TypeError: undefined is not a function` — unhandled at the call site, taking down `Provider.create()` entirely for **any** adapter, not just the announcement.

## Fix

Extend the guard to also require `window.dispatchEvent` and `window.addEventListener` to be functions:

```ts
if (
  typeof window !== 'undefined' &&
  typeof window.dispatchEvent === 'function' &&
  typeof window.addEventListener === 'function' &&
  typeof CustomEvent !== 'undefined' &&
  typeof crypto.randomUUID === 'function'
) {
```

Browser behavior is unchanged. Non-DOM runtimes now silently skip the browser-only EIP-6963 announcement instead of crashing — that seemed like the only reasonable outcome here, since EIP-6963 injected-provider discovery has no meaning outside a DOM environment. Scope is intentionally limited to this guard; nothing else in `Provider.create()` changed.

## Tests

Added `src/core/Provider.test.ts` coverage (runs in the `lib/pure`/node project, not the browser suite, since a real browser already has `dispatchEvent`):
- asserts `Provider.create()` does not throw when `window` exists with `CustomEvent`/`crypto.randomUUID` but without `dispatchEvent`/`addEventListener`
- asserts the happy path still announces (`dispatchEvent` called) when `window` has both DOM event APIs

Both tests use an explicit test adapter (rather than relying on `Provider.create`'s default `dialog` adapter, which separately reads `window.location`/`window.isSecureContext` for unrelated reasons) and a randomly-generated `rdns` per call — `Provider.ts` dedupes announcements through a module-level `announced` Set, so a fixed `rdns` would let one test (or one of vitest's automatic retries of a prior attempt) mask another's guard behavior.

**Before the fix** (guard reverted locally): the "skips announcement" test fails consistently across all retries with `TypeError: window.dispatchEvent is not a function`, i.e. reproducing the exact crash from the issue.
**After the fix**: all 21 tests in the file pass, including both new cases.

Also ran `tsc -b --noEmit` (clean) and `pnpm check` (lint+fmt, 0 errors — the 2 warnings printed are pre-existing and in unrelated localnet test files).

Closes #730

---

Saw in the issue thread that @Osraka was considering picking this up — the approach here follows exactly what was outlined there (guard on `dispatchEvent`/`addEventListener`, keep browser behavior unchanged, focused regression test). Opened this since no PR had landed yet, but happy to hand off, adjust, or close in favor of theirs if they'd already started work I couldn't see.
