### PR TITLE
fix(storage): fall back to memory when IndexedDB is unavailable

### DIFF
--- a/.changeset/idb-storage-memory-fallback.md
+++ b/.changeset/idb-storage-memory-fallback.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Fell back to in-memory storage in `Storage.idb()` when IndexedDB is unavailable (e.g. React Native/Expo, some SSR), instead of throwing `ReferenceError: indexedDB is not defined` on the first read or write.

--- a/src/core/Storage.test.ts
+++ b/src/core/Storage.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vp/test'
+
+import * as Storage from './Storage.js'
+
+// In runtimes that expose `window` but not IndexedDB (React Native/Expo, some
+// SSR), `idb()` is still selected as the default storage. It must degrade to a
+// working in-memory adapter instead of throwing: idb-keyval treats an
+// `undefined` store as "use the default store", which opens IndexedDB and
+// throws `ReferenceError: indexedDB is not defined`.
+test('idb: degrades to in-memory storage when IndexedDB is unavailable', async () => {
+  expect(typeof indexedDB).toBe('undefined')
+
+  const storage = Storage.idb()
+
+  await storage.setItem('accounts', ['0xabc'])
+  expect(await storage.getItem('accounts')).toMatchInlineSnapshot(`
+    [
+      "0xabc",
+    ]
+  `)
+
+  await storage.removeItem('accounts')
+  expect(await storage.getItem('accounts')).toMatchInlineSnapshot(`null`)
+})

--- a/src/core/Storage.ts
+++ b/src/core/Storage.ts
@@ -156,9 +156,13 @@ export declare namespace cookie {
   type Options = from.Options
 }
 
-/** Creates an IndexedDB-backed storage adapter. Stores raw values (no JSON serialization). */
+/** Creates an IndexedDB-backed storage adapter. Stores raw values (no JSON serialization). Falls back to in-memory storage in runtimes without IndexedDB (e.g. React Native, some SSR). */
 export function idb(options: idb.Options = {}): Storage {
-  const store = typeof indexedDB !== 'undefined' ? createStore('tempo', 'store') : undefined
+  // idb-keyval treats an `undefined` store as "use the default store", which
+  // opens IndexedDB and throws where it is unavailable — so degrade to memory
+  // rather than passing `undefined` through.
+  if (typeof indexedDB === 'undefined') return memory(options)
+  const store = createStore('tempo', 'store')
   const storage = from(
     {
       async getItem(name) {


### PR DESCRIPTION
## Problem

`Storage.idb()` guards on `window` before selecting IndexedDB-backed storage, but never checks for `indexedDB` itself. In a runtime that exposes a partial `window` without IndexedDB — React Native and Expo, some SSR setups — `idb()` is still chosen as the default, and the first read or write throws `ReferenceError: indexedDB is not defined`.

The underlying cause is that idb-keyval treats an `undefined` store as "use the default store", which opens IndexedDB unconditionally. So the existing `typeof indexedDB !== 'undefined'` check inside the function never prevents anything — the delegation happens anyway.

AGENTS.md:106 already calls this out as a rule:

> React Native may expose `window` without IndexedDB — storage defaults that mean "browser" should guard on `indexedDB`, not `window`, or Expo/React Native can try to use IndexedDB-backed storage and throw at startup.

This change brings the code into line with that rule rather than introducing a new policy.

## Fix

`Storage.idb()` now falls back to the existing in-memory adapter when IndexedDB isn't available, instead of delegating to idb-keyval's default store.

Putting the fallback inside `idb()` fixes it at the root: all three default-storage call sites funnel through this function, so a partial-window runtime gets a working adapter — session persistence with structured-clone semantics via `memory()`'s `markStructuredClone` — rather than a startup crash. No changes to `Provider.ts`.

## Tests

`src/core/Storage.test.ts` asserts `typeof indexedDB === 'undefined'` as a precondition, then exercises set / get / remove through `idb()`. Verified failing-first: before the change the first `setItem` throws.

## Changeset

`patch`. No new API and no new capability for setups that already work — a crash becomes functioning degraded behaviour. This matches the bump used for the directly comparable guard fixes, #706 (`crypto.randomUUID` guard) and #734 (partial-window announcement guard).

## Note on the trade-off

An app that previously crashed loudly at startup will now silently persist to memory instead, so persistence across reloads won't happen in that runtime. That's the same way the window-guarded defaults already degrade for SSR, and it's what the existing `indexedDB` check was evidently meant to do.

If you'd rather fail loudly — a clear `Error('Storage.idb requires IndexedDB')` instead of degrading — that's a reasonable alternative, but it would leave the React Native default path crashing unless the three call sites also switch to `memory()`. Happy to take it that direction if you prefer.
