### PR TITLE
feat: add client-side email domain validation

### DIFF
--- a/.changeset/quiet-emails-check.md
+++ b/.changeset/quiet-emails-check.md
@@ -1,0 +1,5 @@
+---
+'accounts': minor
+---
+
+Added a client-side email domain deliverability check for OTP dialogs.

--- a/src/core/Email.test.ts
+++ b/src/core/Email.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import { acceptsMail } from './Email.js'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('acceptsMail', () => {
+  test('accepts a domain with an MX record', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      Response.json({ Answer: [{ data: '10 mail.example.com.', type: 15 }], Status: 0 }),
+    )
+    vi.stubGlobal('fetch', fetch)
+
+    await expect(acceptsMail('person@example.com')).resolves.toMatchInlineSnapshot(`true`)
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  test('accepts an address record when the domain has no MX record', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ Status: 0 }))
+      .mockResolvedValueOnce(
+        Response.json({ Answer: [{ data: '192.0.2.1', type: 1 }], Status: 0 }),
+      )
+    vi.stubGlobal('fetch', fetch)
+
+    await expect(acceptsMail('person@example.com')).resolves.toMatchInlineSnapshot(`true`)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('rejects a nonexistent domain', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ Status: 3 })))
+
+    await expect(acceptsMail('person@example.xuz')).resolves.toMatchInlineSnapshot(`false`)
+  })
+
+  test('rejects a null MX domain', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(Response.json({ Answer: [{ data: '0 .', type: 15 }], Status: 0 })),
+    )
+
+    await expect(acceptsMail('person@example.com')).resolves.toMatchInlineSnapshot(`false`)
+  })
+
+  test('fails open when DNS is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unavailable')))
+
+    await expect(acceptsMail('person@example.com')).resolves.toMatchInlineSnapshot(`true`)
+  })
+})

--- a/src/core/Email.ts
+++ b/src/core/Email.ts
@@ -1,0 +1,45 @@
+type Answer = { data: string; type: number }
+
+type Response = {
+  Answer?: readonly Answer[] | undefined
+  Status: number
+}
+
+/** Checks client-side whether an email domain can receive mail using its MX or address records. */
+export async function acceptsMail(email: string) {
+  const domain = email.slice(email.lastIndexOf('@') + 1)
+
+  try {
+    const mx = await resolve(domain, 'MX')
+    if (mx.Status === 3) return false
+    if (mx.Status !== 0) return true
+
+    const exchanges = mx.Answer?.filter((answer) => answer.type === 15) ?? []
+    if (exchanges.length > 0) return exchanges.some((answer) => !answer.data.endsWith(' .'))
+
+    // RFC 5321 permits domains without MX records to receive mail at an A or
+    // AAAA address, so check those before rejecting the domain.
+    const a = await resolve(domain, 'A')
+    if (a.Status === 3) return false
+    if (a.Status !== 0) return true
+    if (a.Answer?.some((answer) => answer.type === 1)) return true
+
+    const aaaa = await resolve(domain, 'AAAA')
+    if (aaaa.Status === 3) return false
+    if (aaaa.Status !== 0) return true
+    return aaaa.Answer?.some((answer) => answer.type === 28) ?? false
+  } catch {
+    // DNS availability should not prevent legitimate users from receiving an
+    // OTP. The email provider remains the final authority when this check fails.
+    return true
+  }
+}
+
+async function resolve(domain: string, type: 'A' | 'AAAA' | 'MX') {
+  const url = new URL('https://cloudflare-dns.com/dns-query')
+  url.searchParams.set('name', domain)
+  url.searchParams.set('type', type)
+  const response = await fetch(url, { headers: { accept: 'application/dns-json' } })
+  if (!response.ok) throw new Error('DNS query failed')
+  return (await response.json()) as Response
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * as Adapter from './core/Adapter.js'
 export * as IntersectionObserver from './core/IntersectionObserver.js'
 export * as Dialog from './core/Dialog.js'
+export * as Email from './core/Email.js'
 export * as ExecutionError from './core/ExecutionError.js'
 export * as Keystore from './core/Keystore.js'
 export * as Messenger from './core/Messenger.js'


### PR DESCRIPTION
Add client-side `Email.acceptsMail` to the Accounts SDK for OTP dialogs. It checks MX records, supports the RFC 5321 A/AAAA fallback, rejects null MX and nonexistent domains, and fails open when DNS is unavailable.

Validation:
- `vp test src/core/Email.test.ts` (5 tests passed)
- `vp lint --fix src/core/Email.ts src/core/Email.test.ts src/index.ts`
- `tsc -b --noEmit`

Prompted by: @tmm