### PR TITLE
fix(postMessage): guard session warm-up on document availability

### DIFF
--- a/.changeset/postmessage-document-guard.md
+++ b/.changeset/postmessage-document-guard.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Skipped `postMessage` adapter session warm-up in partial `window`-like runtimes (e.g. React Native) that expose `window` without `document`, preventing `postMessage`/`tempoWallet` from throwing at creation.

--- a/src/core/adapters/postMessage/postMessage.test.ts
+++ b/src/core/adapters/postMessage/postMessage.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import { postMessage } from './postMessage.js'
+import { tempoWallet } from './tempoWallet.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('behavior: partial window-like runtime', () => {
+  // React Native / Expo expose `window` without the DOM (see AGENTS.md), so a
+  // `window`-only guard must not dereference bare `document`.
+  test('behavior: does not throw when `window` exists but `document` does not', () => {
+    vi.stubGlobal('window', { location: { origin: 'https://app.example' } })
+
+    expect(typeof document).toBe('undefined')
+    expect(() => tempoWallet()).not.toThrow()
+    expect(() =>
+      postMessage({ host: 'https://wallet.example', name: 'Wallet', rdns: 'com.example' }),
+    ).not.toThrow()
+  })
+
+  test('behavior: warms the session in a real browser-like window', () => {
+    vi.stubGlobal('window', { location: { origin: 'https://app.example' } })
+    vi.stubGlobal('document', { body: {} })
+
+    expect(() => tempoWallet()).not.toThrow()
+  })
+})

--- a/src/core/adapters/postMessage/postMessage.ts
+++ b/src/core/adapters/postMessage/postMessage.ts
@@ -246,7 +246,7 @@ export function postMessage(options: postMessage.Options): Adapter.Adapter {
 
   // Warm the wallet page and start the session before the first request.
   // `start()` connects in the background; failures surface on the next send.
-  if (typeof window !== 'undefined' && !target && document.body)
+  if (typeof window !== 'undefined' && typeof document !== 'undefined' && !target && document.body)
     try {
       ensure()
     } catch {}


### PR DESCRIPTION
## Problem

`postMessage.ts:249` reads `document.body` behind a `window`-only guard:

```ts
if (typeof window !== 'undefined' && !target && document.body)
```

In a runtime that exposes `window` without `document` — React Native and Expo — that read throws before the surrounding `try {} catch {}` can absorb it, so the session warm-up crashes instead of being skipped.

AGENTS.md:105 documents this exact footgun:

> React Native may expose `window` without browser event constructors… must guard on both `window` and [the capability] before calling browser-only helpers.

Line 106 states the storage variant of the same rule, which is what my #759 addresses. This is the DOM instance of it.

## Fix

Guard on `document` before touching `document.body`, matching the shape the rule prescribes and the sibling guard fixes #706 (`crypto.randomUUID`) and #734 (partial-window announcement) already use.

One line.

## Tests

Two cases in `src/core/adapters/postMessage/postMessage.test.ts`. Verified failing-first: before the change, the `window`-without-`document` case throws.

Suite goes 569 → 571 passing, 33 → 34 files.

## Changeset

`patch`, matching #706 and #734 — no new API, a crash becomes a skipped warm-up.

## Note on lint

`vp lint` reports two pre-existing warnings in `exchange.localnet.test.ts:599` and `postMessage.localnet.test.ts:609`. Neither is in my diff; both predate this change.

Localnet tests weren't run locally — they need a Docker RPC node, and this change is browser/RN-only with no localnet surface.
