### PR TITLE
fix: classify expired transactions as rejected

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ overrides:
   js-yaml@^3: 3.15.1
   js-yaml@4: 4.3.1
   mermaid: 11.16.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   ox: 0.14.30
   postcss: 8.5.23
   protobufjs: 7.6.5
@@ -9039,8 +9039,8 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -23668,7 +23668,7 @@ snapshots:
   nan@2.24.0:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -24509,7 +24509,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,7 +76,7 @@ minimumReleaseAgeExclude:
   - ip-address@10.3.1
   - js-yaml@3.15.1
   - js-yaml@4.3.1
-  - nanoid@3.3.17
+  - nanoid@3.3.18
   - postcss@8.5.23
   - socket.io-parser@4.2.7
   - undici@7.29.0
@@ -132,7 +132,7 @@ overrides:
   js-yaml@^3: '3.15.1'
   js-yaml@4: '4.3.1'
   mermaid: '11.16.1'
-  'nanoid@<3.3.17': '3.3.17'
+  'nanoid@<3.3.18': '3.3.18'
   ox: 0.14.30
   postcss: '8.5.23'
   protobufjs: '7.6.5'

--- a/src/server/internal/handlers/utils.test.ts
+++ b/src/server/internal/handlers/utils.test.ts
@@ -1,0 +1,53 @@
+import { RpcRequest } from 'ox'
+import { describe, expect, test } from 'vp/test'
+
+import * as Utils from './utils.js'
+
+const request = RpcRequest.from({ id: 1, method: 'eth_sendRawTransaction', params: ['0x00'] })
+
+describe('rpcErrorJson', () => {
+  test('maps upstream expired transactions to a transaction-rejected error', () => {
+    const error = {
+      cause: {
+        code: -32603,
+        message: 'Revm error: transaction expired',
+      },
+    }
+
+    expect(Utils.rpcErrorJson(request, error)).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": -32003,
+          "data": {
+            "code": "transaction_expired",
+          },
+          "message": "Transaction expired.",
+        },
+        "id": 1,
+        "jsonrpc": "2.0",
+      }
+    `)
+  })
+
+  test('preserves unrelated upstream internal errors', () => {
+    const error = {
+      code: -32603,
+      data: { reason: 'database unavailable' },
+      message: 'Revm error: database unavailable',
+    }
+
+    expect(Utils.rpcErrorJson(request, error)).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": -32603,
+          "data": {
+            "reason": "database unavailable",
+          },
+          "message": "Revm error: database unavailable",
+        },
+        "id": 1,
+        "jsonrpc": "2.0",
+      }
+    `)
+  })
+})

--- a/src/server/internal/handlers/utils.ts
+++ b/src/server/internal/handlers/utils.ts
@@ -97,6 +97,22 @@ export function rpcErrorJson(request: RpcRequest.RpcRequest, error: unknown) {
     )
 
   const inner = resolveError(error)
+  if (
+    inner.code === RpcResponse.InternalError.code &&
+    inner.message !== undefined &&
+    /^Revm error: transaction expired\.?$/.test(inner.message)
+  )
+    return RpcResponse.from(
+      {
+        error: {
+          code: -32003,
+          data: { code: 'transaction_expired' },
+          message: 'Transaction expired.',
+        },
+      },
+      { request },
+    )
+
   const message = inner.message ?? (error as Error).message
   const code = inner.code ?? -32603
   const data = inner.data


### PR DESCRIPTION
## Summary

Classifies expired Tempo transactions as non-retryable transaction rejections instead of generic internal errors.

## Motivation

Tempo nodes currently surface expired transactions as JSON-RPC `-32603`, which makes a deterministic rejection appear retryable and prevents clients from identifying the failure reliably.

## Changes

- Mapped the exact upstream expired-transaction error to JSON-RPC `-32003` with the stable message `Transaction expired.` and `data.code` set to `transaction_expired`.
- Preserved unrelated upstream `-32603` errors without changing their message or data.
- Added focused mapping and non-mapping tests.

## Testing

- `pnpm test src/server/internal/handlers/utils.test.ts`
- `pnpm exec tsc -b --noEmit`
- `git diff --check`
