### PR TITLE
feat: support multiple passkey credentials

### DIFF
--- a/.changeset/warm-passkeys-login.md
+++ b/.changeset/warm-passkeys-login.md
@@ -2,7 +2,7 @@
 'accounts': minor
 ---
 
-Consolidated passkey targeting under `credentialId`, which now accepts one or multiple credential IDs in `wallet_connect`.
+Added multiple-credential passkey targeting and exposed verified authenticator model identifiers to registration hooks.
 
 ```ts
 await provider.request({

--- a/.changeset/warm-passkeys-login.md
+++ b/.changeset/warm-passkeys-login.md
@@ -1,0 +1,12 @@
+---
+'accounts': minor
+---
+
+Consolidated passkey targeting under `credentialId`, which now accepts one or multiple credential IDs in `wallet_connect`.
+
+```ts
+await provider.request({
+  method: 'wallet_connect',
+  params: [{ capabilities: { credentialId: ['credential-a', 'credential-b'] } }],
+})
+```

--- a/.changeset/warm-passkeys-login.md
+++ b/.changeset/warm-passkeys-login.md
@@ -1,5 +1,5 @@
 ---
-'accounts': minor
+'accounts': patch
 ---
 
 Added multiple-credential passkey targeting and exposed verified authenticator model identifiers to registration hooks.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "mppx": "catalog:",
     "ox": "~0.14.30",
     "wata": "0.4.0",
-    "webauthx": "~0.1.1",
+    "webauthx": "~0.1.2",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0(react@19.2.8)(typescript@5.9.3)
       webauthx:
-        specifier: ~0.1.1
-        version: 0.1.1(typescript@5.9.3)(zod@4.3.6)
+        specifier: ~0.1.2
+        version: 0.1.2(typescript@5.9.3)(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -11280,8 +11280,8 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
-  webauthx@0.1.1:
-    resolution: {integrity: sha512-3jiskZl0jiTUoO8r3ySUYItdXNDBpfzxnxPx7XM0giF2dIY7S4KqHVbH04Qglz98nP8RaSV1/+3eDCx1s3WDiQ==}
+  webauthx@0.1.2:
+    resolution: {integrity: sha512-J0H9/BOW/aRtWa/rKsGjf1+YQ5xkfgycTT455fsHyqG4+hYJ5dPDrNcIXrjGnjBKGru/qxY75m68iHg27rHoUg==}
 
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
@@ -26974,7 +26974,7 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  webauthx@0.1.1(typescript@5.9.3)(zod@4.3.6):
+  webauthx@0.1.2(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       ox: 0.14.30(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:

--- a/site/src/pages/docs/api/local.mdx
+++ b/site/src/pages/docs/api/local.mdx
@@ -103,8 +103,8 @@ Discover existing accounts (e.g. via WebAuthn assertion or key lookup).
 declare function loadAccounts(parameters?: {
   /** Access key to grant during the ceremony. */
   authorizeAccessKey?: Adapter.authorizeAccessKey.Parameters | undefined
-  /** Restrict authentication to a specific credential (WebAuthn). */
-  credentialId?: string | undefined
+  /** Restrict authentication to one or more credentials (WebAuthn). */
+  credentialId?: string | readonly string[] | undefined
   /** Digest the caller asked the wallet to sign during the load-accounts ceremony. */
   digest?: Hex | undefined
   /**

--- a/site/src/pages/docs/api/webauthnceremony.from.mdx
+++ b/site/src/pages/docs/api/webauthnceremony.from.mdx
@@ -66,12 +66,10 @@ Get credential request options for `navigator.credentials.get(){:js}`.
 
 ```ts
 declare function getAuthenticationOptions(parameters?: {
-  /** Credential IDs to allow (restricts which credentials can be used). */
-  allowCredentialIds?: readonly string[] | undefined
   /** Challenge to use. */
   challenge?: Hex | undefined
-  /** Credential ID to restrict authentication to a specific credential. */
-  credentialId?: string | undefined
+  /** Credential ID or IDs to restrict authentication to. */
+  credentialId?: string | readonly string[] | undefined
   /** Mediation hint for passkey autofill / conditional UI. */
   mediation?: 'conditional' | 'optional' | 'required' | 'silent' | undefined
 } | undefined): Promise<{ options: Authentication.Options }>

--- a/site/src/pages/docs/rpc/wallet_connect.mdx
+++ b/site/src/pages/docs/rpc/wallet_connect.mdx
@@ -53,8 +53,8 @@ type ConnectLoginCapabilities = {
   method?: 'login'
   /** Optional digest to bind into the login ceremony. */
   digest?: `0x${string}`
-  /** Specific WebAuthn credential ID to authenticate with. */
-  credentialId?: string
+  /** WebAuthn credential ID or IDs to authenticate with. */
+  credentialId?: string | string[]
   /** Authorize an access key during the same ceremony. */
   authorizeAccessKey?: AuthorizeAccessKeyCapability
   /** SIWE round-trip configuration. See `Auth` below. */
@@ -286,7 +286,7 @@ const { accounts } = await provider.request({
 })
 ```
 
-The restriction applies to email *entry* only: an account whose email is
+The restriction applies to email _entry_ only: an account whose email is
 already verified still shares it, since your server may accept existing or
 invited users beyond the allowlist. Always enforce the policy server-side by
 verifying the `idToken`. An exact `address` takes precedence over `domains`.

--- a/site/src/pages/docs/server/handler.webAuthn.mdx
+++ b/site/src/pages/docs/server/handler.webAuthn.mdx
@@ -168,10 +168,10 @@ const handler = Handler.webAuthn({
 
 ### onRegister
 
-- **Type:** `(params: { credentialId: string; name: string; publicKey: string; request: Request }) => Response | Promise<Response> | void | Promise<void>`
+- **Type:** `(params: { aaguid?: string; credentialId: string; name: string; publicKey: string; request: Request }) => Response | Promise<Response> | void | Promise<void>`
 - **Optional**
 
-Called after a successful registration. `name` is the value passed to `POST /register/options`. Returning a `Response` merges its JSON body and status onto the default registration response; throwing surfaces as a `400` error response.
+Called after a successful registration. `aaguid` is the authenticator model identifier when reported, and `name` is the value passed to `POST /register/options`. Returning a `Response` merges its JSON body and status onto the default registration response; throwing surfaces as a `400` error response.
 
 ```ts twoslash
 import { Handler, Kv } from 'accounts/server'
@@ -180,8 +180,8 @@ const handler = Handler.webAuthn({
   kv: Kv.memory(),
   origin: 'https://example.com',
   rpId: 'example.com',
-  onRegister: ({ credentialId, name, publicKey }) => { // [!code focus]
-    console.log('Registered:', name, credentialId) // [!code focus]
+  onRegister: ({ aaguid, credentialId, name, publicKey }) => { // [!code focus]
+    console.log('Registered:', name, credentialId, aaguid) // [!code focus]
   }, // [!code focus]
 })
 ```

--- a/site/src/pages/docs/server/handler.webAuthn.mdx
+++ b/site/src/pages/docs/server/handler.webAuthn.mdx
@@ -171,7 +171,7 @@ const handler = Handler.webAuthn({
 - **Type:** `(params: { aaguid?: string; credentialId: string; name: string; publicKey: string; request: Request }) => Response | Promise<Response> | void | Promise<void>`
 - **Optional**
 
-Called after a successful registration. `aaguid` is the authenticator model identifier when reported, and `name` is the value passed to `POST /register/options`. Returning a `Response` merges its JSON body and status onto the default registration response; throwing surfaces as a `400` error response.
+Called after a successful registration. `aaguid` is the authenticator model identifier when reported, and `name` is the value passed to `POST /register/options`. Returning a `Response` merges its JSON body and status onto the default registration response. Throwing removes the new credential and surfaces as a `400` error response.
 
 ```ts twoslash
 import { Handler, Kv } from 'accounts/server'

--- a/src/core/Adapter.ts
+++ b/src/core/Adapter.ts
@@ -333,8 +333,8 @@ export declare namespace loadAccounts {
   type Parameters = {
     /** Grant an access key during the ceremony. */
     authorizeAccessKey?: authorizeAccessKey.Parameters | undefined
-    /** Credential ID to restrict authentication to a specific credential. */
-    credentialId?: string | undefined
+    /** Credential ID or IDs to restrict authentication to. */
+    credentialId?: string | readonly string[] | undefined
     /** Digest to sign. */
     digest?: Hex | undefined
     /**

--- a/src/core/Provider.browser.test.ts
+++ b/src/core/Provider.browser.test.ts
@@ -153,6 +153,36 @@ describe('wallet_connect', () => {
     expect(result.accounts[0]!.capabilities).toMatchInlineSnapshot(`{}`)
   })
 
+  test('behavior: login targets multiple credentials', async () => {
+    const provider = getProvider()
+
+    const first = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'register' } }],
+    })
+    const second = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { method: 'register' } }],
+    })
+    const credentialId = provider.store
+      .getState()
+      .accounts.flatMap((account) =>
+        'credential' in account && account.credential ? [account.credential.id] : [],
+      )
+
+    expect(credentialId.length).toMatchInlineSnapshot(`2`)
+
+    await provider.request({ method: 'wallet_disconnect' })
+
+    const result = await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { credentialId } }],
+    })
+    const registered = [first.accounts[0]!.address, second.accounts[0]!.address]
+
+    expect(registered.includes(result.accounts[0]!.address)).toMatchInlineSnapshot(`true`)
+  })
+
   test('behavior: register without digest returns empty capabilities', async () => {
     const provider = getProvider()
 

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -257,6 +257,38 @@ describe('getMppxParameters', () => {
 })
 
 describe('wallet_connect', () => {
+  test('behavior: forwards allowed credential IDs to the adapter', async () => {
+    const loadAccounts = vi.fn(async (_parameters?: Adapter.loadAccounts.Parameters) => ({
+      accounts: [{ address }] as const,
+    }))
+    const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+      actions: {
+        async createAccount() {
+          return { accounts: [{ address }] }
+        },
+        loadAccounts,
+      },
+    }))
+    const provider = Provider.create({ adapter, storage: Storage.memory() })
+
+    await provider.request({
+      method: 'wallet_connect',
+      params: [{ capabilities: { credentialId: ['cred-1', 'cred-2'] } }],
+    })
+
+    expect(loadAccounts.mock.calls[0]?.[0]).toMatchInlineSnapshot(`
+      {
+        "authorizeAccessKey": undefined,
+        "credentialId": [
+          "cred-1",
+          "cred-2",
+        ],
+        "digest": undefined,
+        "selectAccount": undefined,
+      }
+    `)
+  })
+
   test('behavior: validates auth before preparing access key material', async () => {
     const createKey = vi.fn(() => {
       throw new Error('createKey called')

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -752,8 +752,13 @@ export function create(options: create.Options = {}): create.ReturnType {
     if (capabilities && 'selectAccount' in capabilities && capabilities.selectAccount)
       return undefined
     if (capabilities && 'credentialId' in capabilities && capabilities.credentialId) {
+      if (Array.isArray(capabilities.credentialId) && capabilities.credentialId.length !== 1)
+        return undefined
+      const credentialId = Array.isArray(capabilities.credentialId)
+        ? capabilities.credentialId[0]
+        : capabilities.credentialId
       const account = state.accounts.find(
-        (a) => 'credential' in a && a.credential?.id === capabilities.credentialId,
+        (a) => 'credential' in a && a.credential?.id === credentialId,
       )
       return account?.address
     }

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -77,7 +77,7 @@ describe('Encoded', () => {
                 }
               | {
                   digest?: Hex | undefined
-                  credentialId?: string | undefined
+                  credentialId?: string | string[] | undefined
                   authorizeAccessKey?:
                     | {
                         address?: Hex | undefined

--- a/src/core/WebAuthnCeremony.test.ts
+++ b/src/core/WebAuthnCeremony.test.ts
@@ -44,6 +44,27 @@ describe('local', () => {
     expect(typeof options.publicKey!.challenge).toMatchInlineSnapshot(`"string"`)
   })
 
+  test('behavior: getAuthenticationOptions restricts authentication to multiple credentials', async () => {
+    const ceremony = WebAuthnCeremony.local({ rpId: 'example.com' })
+
+    const { options } = await ceremony.getAuthenticationOptions({
+      credentialId: ['Y3JlZC0x', 'Y3JlZC0y'],
+    })
+
+    expect(options.publicKey?.allowCredentials).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "Y3JlZC0x",
+          "type": "public-key",
+        },
+        {
+          "id": "Y3JlZC0y",
+          "type": "public-key",
+        },
+      ]
+    `)
+  })
+
   test('behavior: verifyRegistration stores credential and returns publicKey', async () => {
     const ceremony = WebAuthnCeremony.local({ rpId: 'example.com' })
 

--- a/src/core/WebAuthnCeremony.ts
+++ b/src/core/WebAuthnCeremony.ts
@@ -54,12 +54,10 @@ export declare namespace verifyRegistration {
 
 export declare namespace getAuthenticationOptions {
   type Parameters = {
-    /** Credential IDs to allow (restricts which credentials can be used). */
-    allowCredentialIds?: readonly string[] | undefined
     /** Challenge to use. */
     challenge?: `0x${string}` | undefined
-    /** Credential ID to restrict authentication to a specific credential. */
-    credentialId?: string | undefined
+    /** Credential ID or IDs to restrict authentication to. */
+    credentialId?: string | readonly string[] | undefined
     /** Mediation hint for passkey autofill / conditional UI. */
     mediation?: 'conditional' | 'optional' | 'required' | 'silent' | undefined
   }
@@ -124,10 +122,15 @@ export function local(options: local.Options = {}): WebAuthnCeremony {
     },
 
     async getAuthenticationOptions(parameters = {}) {
-      const { allowCredentialIds, challenge, credentialId } = parameters
+      const { challenge, credentialId } = parameters
       const { options } = Authentication.getOptions({
         challenge,
-        credentialId: (allowCredentialIds as string[] | undefined) ?? credentialId,
+        credentialId:
+          typeof credentialId === 'string'
+            ? credentialId
+            : credentialId
+              ? [...credentialId]
+              : undefined,
         rpId,
       })
       return { options }
@@ -189,8 +192,8 @@ export function server(options: server.Options): WebAuthnCeremony {
     },
 
     async getAuthenticationOptions(parameters = {}) {
-      const { allowCredentialIds, challenge, credentialId, mediation } = parameters
-      return request('/login/options', { allowCredentialIds, challenge, credentialId, mediation })
+      const { challenge, credentialId, mediation } = parameters
+      return request('/login/options', { challenge, credentialId, mediation })
     },
 
     async verifyAuthentication(response) {

--- a/src/core/adapters/webAuthn.ts
+++ b/src/core/adapters/webAuthn.ts
@@ -77,7 +77,7 @@ export function webAuthn(options: webAuthn.Options = {}): Adapter.Adapter {
         }
       },
       async loadAccounts(parameters = {}) {
-        const { selectAccount, digest } = parameters
+        const { digest, selectAccount } = parameters
 
         const credentialId = selectAccount
           ? undefined

--- a/src/core/zod/rpc.test.ts
+++ b/src/core/zod/rpc.test.ts
@@ -132,6 +132,25 @@ describe('transactionRequest.keyAuthorization', () => {
   })
 })
 
+describe('wallet_connect.capabilities.request: credentials', () => {
+  test('accepts multiple credential IDs for login', () => {
+    expect(
+      z.parse(Rpc.wallet_connect.capabilities.request, {
+        credentialId: ['cred-1', 'cred-2'],
+        method: 'login',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "credentialId": [
+          "cred-1",
+          "cred-2",
+        ],
+        "method": "login",
+      }
+    `)
+  })
+})
+
 describe('wallet_connect.capabilities.request: auth', () => {
   test('accepts string shorthand', () => {
     expect(

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -710,7 +710,7 @@ export namespace wallet_connect {
         }),
         z.object({
           digest: z.optional(u.hex()),
-          credentialId: z.optional(z.string()),
+          credentialId: z.optional(z.union([z.string(), z.array(z.string())])),
           authorizeAccessKey,
           auth,
           identity,
@@ -829,7 +829,7 @@ export namespace wallet_connect_strict {
         }),
         z.object({
           digest: z.optional(u.hex()),
-          credentialId: z.optional(z.string()),
+          credentialId: z.optional(z.union([z.string(), z.array(z.string())])),
           authorizeAccessKey,
           auth,
           identity,

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
-import { Cbor } from 'ox'
 
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
 import * as Kv from '../../Kv.js'
-import { getAaguid, type SessionPayload, webAuthn } from './webAuthn.js'
+import { type SessionPayload, webAuthn } from './webAuthn.js'
 
 let server: Server
 let ceremony: WebAuthnCeremony.WebAuthnCeremony
@@ -37,31 +36,6 @@ describe('POST /register/options', () => {
     const { options: a } = await ceremony.getRegistrationOptions({ name: 'Test' })
     const { options: b } = await ceremony.getRegistrationOptions({ name: 'Test' })
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
-  })
-})
-
-describe('getAaguid', () => {
-  test('extracts the authenticator model identifier', () => {
-    const authenticatorData = new Uint8Array(53)
-    authenticatorData.set(
-      [
-        0xfb, 0xfc, 0x30, 0x07, 0x15, 0x4e, 0x4e, 0xcc, 0x8c, 0x0b, 0x6e, 0x02, 0x05, 0x57, 0xd7,
-        0xbd,
-      ],
-      37,
-    )
-
-    const attestationObject = Cbor.encode({ authData: authenticatorData }, { as: 'Bytes' })
-
-    expect(getAaguid(attestationObject.buffer as ArrayBuffer)).toBe(
-      'fbfc3007-154e-4ecc-8c0b-6e020557d7bd',
-    )
-  })
-
-  test('omits an anonymous authenticator identifier', () => {
-    const attestationObject = Cbor.encode({ authData: new Uint8Array(53) }, { as: 'Bytes' })
-
-    expect(getAaguid(attestationObject.buffer as ArrayBuffer)).toBeUndefined()
   })
 })
 

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
 import * as Kv from '../../Kv.js'
-import { type SessionPayload, webAuthn } from './webAuthn.js'
+import { getAaguid, type SessionPayload, webAuthn } from './webAuthn.js'
 
 let server: Server
 let ceremony: WebAuthnCeremony.WebAuthnCeremony
@@ -36,6 +36,27 @@ describe('POST /register/options', () => {
     const { options: a } = await ceremony.getRegistrationOptions({ name: 'Test' })
     const { options: b } = await ceremony.getRegistrationOptions({ name: 'Test' })
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
+  })
+})
+
+describe('getAaguid', () => {
+  test('extracts the authenticator model identifier', () => {
+    const authenticatorData = new Uint8Array(53)
+    authenticatorData.set(
+      [
+        0xfb, 0xfc, 0x30, 0x07, 0x15, 0x4e, 0x4e, 0xcc, 0x8c, 0x0b, 0x6e, 0x02, 0x05, 0x57, 0xd7,
+        0xbd,
+      ],
+      37,
+    )
+
+    expect(getAaguid(authenticatorData.buffer as ArrayBuffer)).toBe(
+      'fbfc3007-154e-4ecc-8c0b-6e020557d7bd',
+    )
+  })
+
+  test('omits an anonymous authenticator identifier', () => {
+    expect(getAaguid(new Uint8Array(53).buffer as ArrayBuffer)).toBeUndefined()
   })
 })
 

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -1,9 +1,13 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
+import { vi } from 'vitest'
+import { Registration } from 'webauthx/server'
 
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
 import * as Kv from '../../Kv.js'
 import { type SessionPayload, webAuthn } from './webAuthn.js'
+
+vi.mock('webauthx/server', { spy: true })
 
 let server: Server
 let ceremony: WebAuthnCeremony.WebAuthnCeremony
@@ -169,6 +173,59 @@ describe('hooks', () => {
     expect(called).toBe(false)
 
     await hookServer.closeAsync()
+  })
+
+  test('behavior: onRegister rejection removes the credential', async () => {
+    const kv = Kv.memory()
+    await kv.set('challenge:0x01', { created: Date.now(), name: 'Test' })
+    const publicKey =
+      '0x04ab891400140fc4f8e941ce0ff90e419de9470acaca613bbd717a4775435031a7d884318e919fd3b3e5a631d866d8a380b44063e70f0c381ee16e0652f7f97554'
+    vi.mocked(Registration.verify).mockReturnValueOnce({
+      aaguid: 'fbfc3007-154e-4ecc-8c0b-6e020557d7bd',
+      credential: { publicKey },
+    } as never)
+    const hookServer = await createServer(
+      webAuthn({
+        kv,
+        origin: 'http://localhost',
+        rpId: 'localhost',
+        onRegister() {
+          throw new Error('Authenticator not allowed')
+        },
+      }).listener,
+    )
+
+    try {
+      const clientDataJSON = 'eyJjaGFsbGVuZ2UiOiJBUSJ9'
+      const response = await fetch(`${hookServer.url}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          attestationObject: 'AA',
+          clientDataJSON,
+          id: 'credential',
+          publicKey,
+          raw: {
+            authenticatorAttachment: null,
+            id: 'credential',
+            rawId: 'Y3JlZGVudGlhbA',
+            response: { clientDataJSON },
+            type: 'public-key',
+          },
+        }),
+      })
+
+      expect(response.status).toMatchInlineSnapshot(`400`)
+      expect(await response.json()).toMatchInlineSnapshot(`
+        {
+          "error": "Authenticator not allowed",
+        }
+      `)
+      expect(await kv.get('credential:credential')).toBeUndefined()
+      expect(await kv.get('challenge:0x01')).toBeUndefined()
+    } finally {
+      await hookServer.closeAsync()
+    }
   })
 
   test('behavior: onAuthenticate error does not call hook', async () => {

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -52,6 +52,25 @@ describe('POST /login/options', () => {
     const { options: b } = await ceremony.getAuthenticationOptions()
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
   })
+
+  test('behavior: restricts authentication to multiple credentials', async () => {
+    const { options } = await ceremony.getAuthenticationOptions({
+      credentialId: ['Y3JlZC0x', 'Y3JlZC0y'],
+    })
+
+    expect(options.publicKey?.allowCredentials).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "Y3JlZC0x",
+          "type": "public-key",
+        },
+        {
+          "id": "Y3JlZC0y",
+          "type": "public-key",
+        },
+      ]
+    `)
+  })
 })
 
 describe('POST /register', () => {

--- a/src/server/internal/handlers/webAuthn.test.ts
+++ b/src/server/internal/handlers/webAuthn.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vp/test'
+import { Cbor } from 'ox'
 
 import { createServer, type Server } from '../../../../test/utils.js'
 import * as WebAuthnCeremony from '../../../core/WebAuthnCeremony.js'
@@ -50,13 +51,17 @@ describe('getAaguid', () => {
       37,
     )
 
-    expect(getAaguid(authenticatorData.buffer as ArrayBuffer)).toBe(
+    const attestationObject = Cbor.encode({ authData: authenticatorData }, { as: 'Bytes' })
+
+    expect(getAaguid(attestationObject.buffer as ArrayBuffer)).toBe(
       'fbfc3007-154e-4ecc-8c0b-6e020557d7bd',
     )
   })
 
   test('omits an anonymous authenticator identifier', () => {
-    expect(getAaguid(new Uint8Array(53).buffer as ArrayBuffer)).toBeUndefined()
+    const attestationObject = Cbor.encode({ authData: new Uint8Array(53) }, { as: 'Bytes' })
+
+    expect(getAaguid(attestationObject.buffer as ArrayBuffer)).toBeUndefined()
   })
 })
 

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -161,23 +161,29 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       const userId = stored.userId
         ? Base64.fromBytes(Bytes.fromString(stored.userId), { pad: false, url: true })
         : undefined
-      const created = await createCredential(kv, `credential:${credentialId}`, {
+      const key = `credential:${credentialId}`
+      const created = await createCredential(kv, key, {
         publicKey,
         ...(userId ? { userId } : {}),
       })
       if (!created) throw new Error('Credential already exists')
 
-      const [hook] = await Promise.all([
-        onRegister?.({
-          ...(aaguid ? { aaguid } : {}),
-          credentialId,
-          name: stored.name,
-          publicKey,
-          request: c.req.raw,
-          ...(userId ? { userId } : {}),
-        }),
-        kv.delete(`challenge:${challenge}`),
-      ])
+      const hook = await (async () => {
+        try {
+          return await onRegister?.({
+            ...(aaguid ? { aaguid } : {}),
+            credentialId,
+            name: stored.name,
+            publicKey,
+            request: c.req.raw,
+            ...(userId ? { userId } : {}),
+          })
+        } catch (error) {
+          await Promise.all([kv.delete(key), kv.delete(`challenge:${challenge}`)])
+          throw error
+        }
+      })()
+      await kv.delete(`challenge:${challenge}`)
 
       // Successful registration is also a successful authentication for
       // the freshly-minted credential. Issue a session here so the
@@ -416,7 +422,11 @@ export declare namespace webAuthn {
      * best-effort `get` then `set` storage.
      */
     kv: Kv.Kv
-    /** Called after a successful registration. The returned response is merged onto the default JSON response. */
+    /**
+     * Called after a successful registration. The returned response is merged
+     * onto the default JSON response. Throwing rejects the request and removes
+     * the newly stored credential.
+     */
     onRegister?: (parameters: {
       /** Authenticator model identifier, when the authenticator reports one. */
       aaguid?: string | undefined

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -20,6 +20,14 @@ const defaults = {
 
 const sessionKey = (token: string) => `session:${token}`
 
+/** Extracts the authenticator model identifier from verified authenticator data. */
+export function getAaguid(authenticatorData: ArrayBuffer | undefined) {
+  if (!authenticatorData) return undefined
+  const value = Hex.fromBytes(new Uint8Array(authenticatorData).slice(37, 53)).slice(2)
+  if (value.length !== 32 || /^0+$/.test(value)) return undefined
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`
+}
+
 async function createCredential(
   kv: Kv.Kv,
   key: string,
@@ -153,6 +161,9 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       })
 
       const { publicKey } = result.credential
+      const aaguid = getAaguid(
+        (deserialized.raw.response as { authenticatorData?: ArrayBuffer }).authenticatorData,
+      )
       const credentialId = credential.id
       // Base64url-encode the userId we registered with so it matches
       // the `userHandle` shape the authenticator emits on `/login`.
@@ -168,6 +179,7 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
 
       const [hook] = await Promise.all([
         onRegister?.({
+          ...(aaguid ? { aaguid } : {}),
           credentialId,
           name: stored.name,
           publicKey,
@@ -416,6 +428,8 @@ export declare namespace webAuthn {
     kv: Kv.Kv
     /** Called after a successful registration. The returned response is merged onto the default JSON response. */
     onRegister?: (parameters: {
+      /** Authenticator model identifier, when the authenticator reports one. */
+      aaguid?: string | undefined
       credentialId: string
       /** The name provided during `/register/options` (e.g. user email). */
       name: string

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -1,4 +1,4 @@
-import { Base64, Bytes, Hex } from 'ox'
+import { Base64, Bytes, Cbor, Hex } from 'ox'
 import { Credential } from 'ox/webauthn'
 import {
   Authentication,
@@ -20,10 +20,12 @@ const defaults = {
 
 const sessionKey = (token: string) => `session:${token}`
 
-/** Extracts the authenticator model identifier from verified authenticator data. */
-export function getAaguid(authenticatorData: ArrayBuffer | undefined) {
-  if (!authenticatorData) return undefined
-  const value = Hex.fromBytes(new Uint8Array(authenticatorData).slice(37, 53)).slice(2)
+/** Extracts the authenticator model identifier from a verified attestation object. */
+export function getAaguid(attestationObject: ArrayBuffer) {
+  const { authData } = Cbor.decode<{ authData: Uint8Array }>(
+    new Uint8Array(attestationObject),
+  )
+  const value = Hex.fromBytes(authData.slice(37, 53)).slice(2)
   if (value.length !== 32 || /^0+$/.test(value)) return undefined
   return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`
 }
@@ -161,9 +163,7 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       })
 
       const { publicKey } = result.credential
-      const aaguid = getAaguid(
-        (deserialized.raw.response as { authenticatorData?: ArrayBuffer }).authenticatorData,
-      )
+      const aaguid = getAaguid(deserialized.attestationObject)
       const credentialId = credential.id
       // Base64url-encode the userId we registered with so it matches
       // the `userHandle` shape the authenticator emits on `/login`.

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -231,13 +231,13 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
       } = body as {
         allowCredentialIds?: string[]
         challenge?: Hex.Hex
-        credentialId?: string
+        credentialId?: string | string[]
         mediation?: string
       }
 
       const { challenge, options: authOptions } = Authentication.getOptions({
         challenge: requestChallenge,
-        credentialId: allowCredentialIds ?? credentialId,
+        credentialId: credentialId ?? allowCredentialIds,
         rpId,
       })
       const options = mediation ? { ...authOptions, mediation } : authOptions

--- a/src/server/internal/handlers/webAuthn.ts
+++ b/src/server/internal/handlers/webAuthn.ts
@@ -1,4 +1,4 @@
-import { Base64, Bytes, Cbor, Hex } from 'ox'
+import { Base64, Bytes, Hex } from 'ox'
 import { Credential } from 'ox/webauthn'
 import {
   Authentication,
@@ -19,16 +19,6 @@ const defaults = {
 } as const
 
 const sessionKey = (token: string) => `session:${token}`
-
-/** Extracts the authenticator model identifier from a verified attestation object. */
-export function getAaguid(attestationObject: ArrayBuffer) {
-  const { authData } = Cbor.decode<{ authData: Uint8Array }>(
-    new Uint8Array(attestationObject),
-  )
-  const value = Hex.fromBytes(authData.slice(37, 53)).slice(2)
-  if (value.length !== 32 || /^0+$/.test(value)) return undefined
-  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`
-}
 
 async function createCredential(
   kv: Kv.Kv,
@@ -162,8 +152,8 @@ export function webAuthn(options: webAuthn.Options): webAuthn.ReturnType {
         rpId,
       })
 
+      const { aaguid } = result
       const { publicKey } = result.credential
-      const aaguid = getAaguid(deserialized.attestationObject)
       const credentialId = credential.id
       // Base64url-encode the userId we registered with so it matches
       // the `userHandle` shape the authenticator emits on `/login`.


### PR DESCRIPTION
Allows `credentialId` to target one or multiple passkeys and exposes verified authenticator model identifiers through `onRegister`, enabling account selection and provider hints in Tempo Wallet.
