### PR TITLE
fix: preserve partial fee payer signing

### DIFF
--- a/.changeset/bright-fee-payers-sign.md
+++ b/.changeset/bright-fee-payers-sign.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Preserved partial fee payer requests when signing transactions without a configured fee payer service.

--- a/src/core/Provider.localnet.test.ts
+++ b/src/core/Provider.localnet.test.ts
@@ -1175,6 +1175,20 @@ describe.each(adapters)('$name', ({ adapter, name }: (typeof adapters)[number]) 
       expect(signed).toMatch(/^0x/)
     })
 
+    test('behavior: preserves partial fee payer requests without a configured fee payer', async () => {
+      const provider = Provider.create({ adapter: adapter(), chains: [chain] })
+
+      const connected = await connect(provider)
+      await fund(connected)
+
+      const signed = await provider.request({
+        method: 'eth_signTransaction',
+        params: [{ calls: [transferCall], feePayer: true }],
+      })
+
+      expect(signed).toMatch(/^0x78/)
+    })
+
     test('behavior: signed transaction can be sent via eth_sendRawTransactionSync', async () => {
       const provider = Provider.create({ adapter: adapter(), chains: [chain] })
 

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1076,7 +1076,10 @@ export function create(options: create.Options = {}): create.ReturnType {
                         chainId: decoded.chainId ?? state.chainId,
                         from: decoded.from ?? state.accounts[state.activeAccount]?.address,
                         ...(calls ? { calls } : {}),
-                        feePayer: resolveFeePayer(decoded.feePayer),
+                        feePayer:
+                          decoded.feePayer === true && !feePayerConfig
+                            ? true
+                            : resolveFeePayer(decoded.feePayer),
                       },
                       request,
                     )) satisfies Rpc.eth_signTransaction.Encoded['returns']

--- a/src/core/mppx.localnet.test.ts
+++ b/src/core/mppx.localnet.test.ts
@@ -25,6 +25,19 @@ const payment = ServerMppx.create({
   secretKey: 'test-secret-key-test-secret-key-32',
 })
 
+const sponsoredPayment = ServerMppx.create({
+  methods: [
+    tempo({
+      account: accounts[1]!,
+      currency: Addresses.pathUsd,
+      feePayer: accounts[0]!,
+      getClient: () => client,
+    }),
+  ],
+  realm: 'mppx-sponsored-test',
+  secretKey: 'sponsored-test-secret-key-32-bytes',
+})
+
 let server: Server
 
 beforeAll(async () => {
@@ -88,6 +101,44 @@ describe('mppx integration', () => {
 
     const res = await mppx.fetch(`${server.url}/fortune`)
     expect(res.status).toMatchInlineSnapshot(`200`)
+  })
+
+  test('pull mode preserves server-sponsored transactions', async () => {
+    const sponsoredServer = await createServer(async (req, res) => {
+      const result = await ServerMppx.toNodeListener(sponsoredPayment.charge({ amount: '1' }))(
+        req,
+        res,
+      )
+      if (result.status === 402) return
+      res.writeHead(200)
+      res.end()
+    })
+
+    try {
+      const provider = Provider.create({
+        adapter: headlessWebAuthn(),
+        chains: [chain],
+        mpp: false,
+      })
+      const address = await connect(provider)
+      await fund(address, '1')
+
+      const mppx = ClientMppx.create({
+        methods: [
+          clientTempo({
+            account: provider.getAccount(),
+            ...provider.getMppxParameters(),
+            mode: 'pull',
+          }),
+        ],
+        polyfill: false,
+      })
+
+      const res = await mppx.fetch(`${sponsoredServer.url}/fortune`)
+      expect(res.status).toMatchInlineSnapshot(`200`)
+    } finally {
+      await sponsoredServer.closeAsync()
+    }
   })
 
   test('mppx global front door uses provider access keys', async () => {
@@ -267,12 +318,12 @@ async function connect(provider: ReturnType<typeof Provider.create>) {
   return register.accounts[0]!.address
 }
 
-async function fund(address: `0x${string}`) {
+async function fund(address: `0x${string}`, amount = '10') {
   await Actions.token.transferSync(client, {
     account: accounts[0]!,
     feeToken: Addresses.pathUsd,
     to: address,
     token: Addresses.pathUsd,
-    amount: parseUnits('10', 6),
+    amount: parseUnits(amount, 6),
   })
 }


### PR DESCRIPTION
## Why

Accounts dropped `feePayer: true` from `eth_signTransaction` when no local fee payer service was configured, so server-sponsored MPP pull credentials were serialized as ordinary transactions and rejected.

## What

- Preserve explicit partial sponsorship only for transaction signing.
- Add localnet coverage for the serialized fee-payer shape and a sponsored MPP pull charge.