### PR TITLE
test: preserve CLI connect capabilities

### DIFF
--- a/src/cli/Provider.localnet.test.ts
+++ b/src/cli/Provider.localnet.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Address, Hex } from 'ox'
 import { Hex as ox_Hex } from 'ox'
-import { type Address as ViemAddress, parseUnits } from 'viem'
+import { KeyAuthorization } from 'ox/tempo'
+import { type Address as ViemAddress, hashMessage, parseUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
 import { describe, expect, test, vi } from 'vp/test'
 import type * as z from 'zod/mini'
@@ -12,6 +13,7 @@ import { accounts, chain, getClient } from '../../test/config.js'
 import { createDeviceCodeHost, submitVerify } from '../../test/deviceCode.js'
 import { createJsonStorage, createServer } from '../../test/utils.js'
 import type * as Rpc from '../core/zod/rpc.js'
+import * as Handler from '../server/Handler.js'
 import * as Provider from './Provider.js'
 import * as Storage from './storage.js'
 
@@ -87,7 +89,9 @@ const transferCall = Actions.token.transfer.call({
 
 function connectCapabilities(host: ReturnType<typeof createDeviceCodeHost>, index: number) {
   const params = host.requests()[index]!.params as readonly {
-    capabilities?: Record<string, unknown> | undefined
+    capabilities?:
+      | NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']
+      | undefined
   }[]
   return params[0]?.capabilities
 }
@@ -149,6 +153,113 @@ describe('Provider.create', () => {
         }
       `)
     } finally {
+      await server.closeAsync()
+    }
+  })
+
+  test('behavior: preserves wallet_connect authorization capabilities', async () => {
+    const host = createDeviceCodeHost()
+    const server = await createServer(host.listener)
+    let listener: Parameters<typeof createServer>[0] | undefined
+    const authServer = await createServer((request, response) => {
+      if (!listener) {
+        const auth = Handler.auth({ origin: authServer.url })
+        listener = Handler.compose([auth], { path: '/auth' }).listener
+      }
+      return listener(request, response)
+    })
+
+    try {
+      const provider = Provider.create({
+        chains: [chain],
+        open: async (_url, prompt) => {
+          await submitVerify(prompt)
+        },
+        host: `${server.url}/auth/device`,
+        storage: createJsonStorage(),
+      })
+
+      const result = await provider.request({
+        method: 'wallet_connect',
+        params: [
+          {
+            capabilities: {
+              auth: {
+                resources: [
+                  'urn:nanocodex:memory:read',
+                  'urn:nanocodex:connector:github:repo:read',
+                ],
+                returnToken: true,
+                url: `${authServer.url}/auth`,
+              },
+              authorizeAccessKey: {
+                expiry,
+                keyType: accessKey.keyType,
+                publicKey: accessKey.publicKey,
+                scopes: [
+                  {
+                    address: Addresses.pathUsd,
+                    selector: 'transfer(address,uint256)',
+                  },
+                ],
+              },
+              identity: { email: true },
+              method: 'login',
+            },
+          },
+        ],
+      })
+
+      const capabilities = connectCapabilities(host, 0)
+      const connected = result.accounts[0]!.capabilities
+      const message = connected.personalSign?.message
+      expect({
+        auth: capabilities?.auth,
+        authToken: connected.auth?.token ? 'present' : 'missing',
+        identity: capabilities?.identity,
+        personalSign: {
+          keyAuthorization: connected.personalSign?.keyAuthorization ? 'present' : 'missing',
+          message: message ? 'present' : 'missing',
+          signature: connected.signature ? 'present' : 'missing',
+          witness:
+            message && connected.personalSign?.keyAuthorization
+              ? KeyAuthorization.deserialize(connected.personalSign.keyAuthorization).witness ===
+                hashMessage(message)
+              : false,
+        },
+        scopes: capabilities?.authorizeAccessKey?.scopes,
+      }).toMatchInlineSnapshot(`
+        {
+          "auth": {
+            "challenge": "${authServer.url}/auth/challenge",
+            "logout": "${authServer.url}/auth/logout",
+            "resources": [
+              "urn:nanocodex:memory:read",
+              "urn:nanocodex:connector:github:repo:read",
+            ],
+            "returnToken": true,
+            "verify": "${authServer.url}/auth",
+          },
+          "authToken": "present",
+          "identity": {
+            "email": true,
+          },
+          "personalSign": {
+            "keyAuthorization": "present",
+            "message": "present",
+            "signature": "present",
+            "witness": true,
+          },
+          "scopes": [
+            {
+              "address": "${Addresses.pathUsd}",
+              "selector": "transfer(address,uint256)",
+            },
+          ],
+        }
+      `)
+    } finally {
+      await authServer.closeAsync()
       await server.closeAsync()
     }
   })

--- a/test/deviceCode.ts
+++ b/test/deviceCode.ts
@@ -1,6 +1,7 @@
 import type { RequestListener } from 'node:http'
 import { Address, Hex, PublicKey } from 'ox'
-import { KeyAuthorization } from 'ox/tempo'
+import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
+import { hashMessage } from 'viem'
 import { Actions } from 'viem/tempo'
 import { Store, Wata, deviceCode } from 'wata/host'
 import { Server } from 'wata/server'
@@ -139,6 +140,7 @@ export async function submitVerify(
 
 async function signKeyAuthorization(
   parameters: NonNullable<Rpc.wallet_authorizeAccessKey.Decoded['params']>[number],
+  options: { witness?: Hex.Hex | undefined } = {},
 ) {
   return await root.signKeyAuthorization(
     {
@@ -149,6 +151,8 @@ async function signKeyAuthorization(
       chainId: parameters.chainId ?? BigInt(chain.id),
       expiry: parameters.expiry,
       ...(parameters.limits ? { limits: parameters.limits } : {}),
+      ...(parameters.scopes ? { scopes: parameters.scopes } : {}),
+      ...(options.witness ? { witness: options.witness } : {}),
     },
   )
 }
@@ -169,19 +173,44 @@ async function respondTo(
 ): Promise<unknown> {
   if (message.method === 'wallet_connect') {
     const [parameters] = z.decode(Rpc.wallet_connect.schema.params!, message.params as never) ?? []
-    const authorization = parameters?.capabilities?.authorizeAccessKey
+    const capabilities = parameters?.capabilities
+    const authorization = capabilities?.authorizeAccessKey
+    const personalSign = await resolvePersonalSign({
+      capabilities,
+      chainId: parameters?.chainId ?? chain.id,
+    })
+    const keyAuthorization = authorization
+      ? await signKeyAuthorization(
+          authorization,
+          personalSign ? { witness: hashMessage(personalSign.message) } : {},
+        )
+      : undefined
+    const signature = await (async () => {
+      if (!personalSign) return undefined
+      if (keyAuthorization) return SignatureEnvelope.serialize(keyAuthorization.signature)
+      return await root.signMessage({ message: personalSign.message })
+    })()
     return {
       accounts: [
         {
           address: root.address,
-          capabilities: authorization
-            ? {
-                keyAuthorization: KeyAuthorization.toRpc(await signKeyAuthorization(authorization)),
-                ...(options.username !== undefined ? { username: options.username } : {}),
-              }
-            : options.username !== undefined
-              ? { username: options.username }
-              : {},
+          capabilities: {
+            ...(keyAuthorization
+              ? { keyAuthorization: KeyAuthorization.toRpc(keyAuthorization) }
+              : {}),
+            ...(personalSign
+              ? {
+                  personalSign: {
+                    message: personalSign.message,
+                    ...(keyAuthorization
+                      ? { keyAuthorization: KeyAuthorization.serialize(keyAuthorization) }
+                      : {}),
+                  },
+                }
+              : {}),
+            ...(signature ? { signature } : {}),
+            ...(options.username !== undefined ? { username: options.username } : {}),
+          },
         },
       ],
     }
@@ -198,6 +227,29 @@ async function respondTo(
   }
   if (message.method === 'wallet_updateAccessKey') return await completeUpdate(message.params)
   throw new Error(`unsupported method \`${message.method}\``)
+}
+
+async function resolvePersonalSign(options: {
+  capabilities:
+    | NonNullable<NonNullable<Rpc.wallet_connect.Decoded['params']>[number]['capabilities']>
+    | undefined
+  chainId: number
+}) {
+  const { capabilities, chainId } = options
+  if (capabilities?.personalSign) return capabilities.personalSign
+  const auth = capabilities?.auth
+  if (!auth || typeof auth === 'string' || !auth.challenge) return undefined
+
+  const response = await fetch(auth.challenge, {
+    body: JSON.stringify({
+      chainId,
+      ...(auth.resources ? { resources: auth.resources } : {}),
+    }),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+  if (!response.ok) throw new Error(`auth challenge failed: ${response.status}`)
+  return (await response.json()) as { message: string }
 }
 
 /**


### PR DESCRIPTION
## Summary

- prove the WATA CLI device-code transport preserves SIWE resources, identity requests, and access-key call scopes
- exercise the complete witness-bound SIWE plus access-key ceremony and assert the initiating CLI receives an auth token
- make the shared device-code test wallet sign requested scopes and return the canonical TIP-1053 proof

This is intentionally stacked on #750. That PR already replaces the lossy legacy `CliAuth` projection with raw RPC forwarding, so no additional production protocol is needed.

## Validation

- `VITE_NODE_ENV=localnet VITE_NODE_TAG=latest pnpm test src/cli/Provider.localnet.test.ts`
- `VITE_NODE_ENV=localnet VITE_NODE_TAG=latest pnpm test src/core/adapters/deviceCode/deviceCode.localnet.test.ts`
- `pnpm check`
- `pnpm exec tsc -b --noEmit`