### PR TITLE
ci: open the release PR via github-sts

### DIFF
--- a/.github/sts/changesets.sts.yaml
+++ b/.github/sts/changesets.sts.yaml
@@ -1,0 +1,11 @@
+# Allow the release workflow (push to main) to mint a short-lived token
+# that opens and updates the "chore: version packages" release PR through
+# changesets/action, and pushes its version branch. Replaces the built-in
+# GITHUB_TOKEN so the org can turn off "Allow GitHub Actions to create and
+# approve pull requests".
+subject: repo:tempoxyz@211589300/accounts@1178309114:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/accounts/\.github/workflows/main\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,13 @@ jobs:
     needs: verify
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+    # The release commits (commitMode: github-api) and the release pull
+    # request are created with a short-lived GitHub App token minted via the
+    # github-sts action (authorized by .github/sts/changesets.sts.yaml); the
+    # built-in GITHUB_TOKEN is not allowed to create pull requests.
     permissions:
-      contents: write # to create release commits through changesets/action
-      issues: write # to post issue comments through changesets/action
-      pull-requests: write # to create or update the release pull request
+      contents: read # to clone repository contents
+      id-token: write # to request the OIDC token the STS exchange verifies
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -41,6 +44,12 @@ jobs:
         with:
           skip-cache: 'true' # avoid cache poisoning attacks
 
+      - name: Fetch GitHub token via STS
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: changesets
+
       - name: Create or update release pull request
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # 06245a4e0a36c064a573d4150030f5ec548e4fcc
@@ -50,7 +59,7 @@ jobs:
           commit: 'chore: version packages'
           version: pnpm changeset:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.sts.outputs.token }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. This repo's `changesets/action` step opens and updates the "chore: version packages" release PR with `secrets.GITHUB_TOKEN`, so it would stop working.

## Changes

- Mint a short-lived GitHub App token via the `tempoxyz/gh-actions/actions/github-sts` action (SHA-pinned) and hand it to `changesets/action` as `GITHUB_TOKEN`, so the release PR is opened by the STS App.
- Drop `pull-requests: write` from the job's built-in token and grant `id-token: write` (the OIDC exchange). Branch/tag pushes and GitHub-release creation are unaffected by the org setting, so those grants stay only where the job still needs them.
- Add `.github/sts/changesets.sts.yaml`: subject pinned to this repo's default branch with a `job_workflow_ref` claim check on this workflow, granting `contents: write` + `pull_requests: write`.

## Notes

- Bonus: version PRs opened by the STS App trigger `pull_request` workflows normally, so CI runs on them (built-in-token PRs never got checks).
- Requires the Tempo GitHub STS App to be installed on this repository.
- Verify on the next push to the default branch with pending changesets.
