### PR TITLE
fix: preserve fill transaction capabilities

### DIFF
--- a/.changeset/polite-funds-return.md
+++ b/.changeset/polite-funds-return.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Preserved fill-transaction capabilities so insufficient balances return structured funding requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@
 
 ## Learned Workspace Facts
 
+- **Fill-transaction capabilities must survive request decoding** — `Provider` forwards decoded `eth_fillTransaction` parameters, so the transaction request schema must retain capabilities such as `errors` for relay recovery.
 - **Expo/Metro should get built entrypoints via `react-native` export conditions** — React Native consumers may resolve package `exports` before `default`, and loading `src/*.ts` directly can fail on `.js`-suffixed relative imports. For mobile consumers, add a `react-native` condition that points at `dist/*` entrypoints.
 - **Expo playgrounds under `pnpm` need a local app entry** — relying on Expo's default `expo/AppEntry` can resolve `../../App` from the symlinked package-store path instead of the playground directory. Set a local `main` (for example `./index.js`) and register the root component there.
 - **`zile dev` symlinked `dist/*` is not Metro-safe** — when local `dist/*.js` entrypoints symlink back to `src/*.ts`, Metro will follow them and choke on `.js`-suffixed relative imports inside source. For React Native playgrounds in this workspace, use a local Metro resolver shim (or real built files) instead of assuming symlinked `dist` is consumable.

--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -7,7 +7,7 @@
     "check:types": "tsc -b --noEmit",
     "dev": "vp dev",
     "gen:types": "wrangler types",
-    "postinstall": "pnpm gen:types",
+    "postinstall": "wrangler types",
     "build": "tsc -b && vp build",
     "preview": "vp preview"
   },

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -11,6 +11,54 @@ import * as Storage from './Storage.js'
 
 const address = '0x0000000000000000000000000000000000000001'
 
+describe('eth_fillTransaction', () => {
+  test('behavior: forwards Tempo-formatted request capabilities', async () => {
+    const capabilities: unknown[] = []
+    const request = tempo.formatters.transactionRequest.format(
+      {
+        capabilities: { balanceDiffs: false, errors: true },
+        from: address,
+        to: address,
+        type: 'tempo',
+      },
+      'fillTransaction',
+    )
+    const provider = Provider.create({
+      chains: [tempo],
+      storage: Storage.memory(),
+      transports: {
+        [tempo.id]: custom(
+          {
+            async request(request) {
+              if (request.method === 'eth_fillTransaction')
+                capabilities.push(
+                  (request.params?.[0] as { capabilities?: unknown } | undefined)?.capabilities,
+                )
+              throw new Error('capture complete')
+            },
+          },
+          { retryCount: 0 },
+        ),
+      },
+    })
+
+    await expect(
+      provider.request({
+        method: 'eth_fillTransaction',
+        params: [request as never],
+      }),
+    ).rejects.toThrow('capture complete')
+    expect(capabilities).toMatchInlineSnapshot(`
+      [
+        {
+          "balanceDiffs": false,
+          "errors": true,
+        },
+      ]
+    `)
+  })
+})
+
 describe('getMppxParameters', () => {
   test('error: rejects unsupported chain IDs', () => {
     const provider = Provider.create({ storage: Storage.memory() })

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -171,6 +171,7 @@ export const transactionRequest = z.object({
     z.array(z.object({ address: u.address(), storageKeys: z.array(u.hex()) })),
   ),
   calls: z.optional(z.readonly(z.array(call))),
+  capabilities: z.optional(z.record(z.string(), z.unknown())),
   chainId: z.optional(u.number()),
   data: z.optional(u.hex()),
   feePayer: z.optional(z.union([z.boolean(), z.string()])),


### PR DESCRIPTION
Preserve `eth_fillTransaction` capabilities during provider request decoding so the relay can return structured `requireFunds` data for insufficient balances. Adds coverage using Viem's Tempo formatter.
