### PR TITLE
fix: wait for access key revocation

### DIFF
--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -574,7 +574,7 @@ export function create(options: create.Options = {}): create.ReturnType {
       })
     } else {
       try {
-        await Actions.accessKey.revoke(getClient(), {
+        await Actions.accessKey.revokeSync(getClient(), {
           account: selected.account as TempoAccount.Account,
           accessKey: parameters.accessKeyAddress,
         })


### PR DESCRIPTION
Wait for access-key revocation receipts before removing local key state, preventing callers from observing stale on-chain metadata after `wallet_revokeAccessKey` returns.
