### PR TITLE
fix: update device auth defaults

### DIFF
--- a/.changeset/green-dolphins-connect.md
+++ b/.changeset/green-dolphins-connect.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Updated Tempo Wallet CLI device-code defaults to use `/api/auth/device`.

--- a/site/src/pages/docs/cli/provider.mdx
+++ b/site/src/pages/docs/cli/provider.mdx
@@ -105,7 +105,7 @@ const provider = Provider.create({
 ### host
 
 - **Type:** `string`
-- **Default:** `'https://wallet.tempo.xyz/auth/device'`
+- **Default:** `'https://wallet.tempo.xyz/api/auth/device'`
 
 Base URL of the host's device-code endpoints. The CLI registers at `${host}/register`, opens the browser at `${host}/verify?user_code=<code>`, and polls `${host}/token` for completion.
 

--- a/src/cli/Provider.test.ts
+++ b/src/cli/Provider.test.ts
@@ -1,0 +1,32 @@
+import { vi } from 'vitest'
+import { beforeEach, expect, test } from 'vp/test'
+
+const mock = vi.hoisted(() => ({
+  cli: vi.fn(() => ({})),
+  create: vi.fn(() => ({})),
+  filesystem: vi.fn(() => ({})),
+}))
+
+vi.mock('../core/Provider.js', () => ({ create: mock.create }))
+vi.mock('./adapter.js', () => ({ cli: mock.cli }))
+vi.mock('./storage.js', () => ({ filesystem: mock.filesystem }))
+
+import { create } from './Provider.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test('defaults to the Tempo Wallet device-code endpoint', () => {
+  create({})
+
+  expect(mock.cli.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "host": "https://wallet.tempo.xyz/api/auth/device",
+        },
+      ],
+    ]
+  `)
+})

--- a/src/cli/Provider.ts
+++ b/src/cli/Provider.ts
@@ -8,7 +8,7 @@ import * as Storage from './storage.js'
  */
 export function create(options: create.Options): create.ReturnType {
   const {
-    host = 'https://wallet.tempo.xyz/auth/device',
+    host = 'https://wallet.tempo.xyz/api/auth/device',
     name,
     open,
     pollingInterval,
@@ -45,7 +45,7 @@ export declare namespace create {
     CoreProvider.create.Options & cli.Options,
     'adapter' | 'authorizeAccessKey' | 'host'
   > & {
-    /** Base URL of the wallet's device-code endpoints. @default "https://wallet.tempo.xyz/auth/device" */
+    /** Base URL of the wallet's device-code endpoints. @default "https://wallet.tempo.xyz/api/auth/device" */
     host?: string | undefined
   }
   export type ReturnType = CoreProvider.create.ReturnType

--- a/src/core/adapters/deviceCode/tempoWallet.ts
+++ b/src/core/adapters/deviceCode/tempoWallet.ts
@@ -7,7 +7,7 @@ export function tempoWallet(options: tempoWallet.Options): Adapter.Adapter {
     ...options,
     name: 'Tempo Wallet',
     rdns: 'xyz.tempo',
-    url: 'https://wallet.tempo.xyz/auth/device',
+    url: 'https://wallet.tempo.xyz/api/auth/device',
   })
 }
 


### PR DESCRIPTION
Updates the Accounts CLI provider and Tempo Wallet device-code preset to use `/api/auth/device` by default, matching the Wallet's current device authorization endpoints.
