### PR TITLE
fix: keep device-code approval polling alive

### DIFF
--- a/.changeset/calm-wallets-wait.md
+++ b/.changeset/calm-wallets-wait.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Keep device-code polling active while an approved RPC response is still being persisted.

--- a/src/core/adapters/deviceCode/deviceCode.localnet.test.ts
+++ b/src/core/adapters/deviceCode/deviceCode.localnet.test.ts
@@ -155,6 +155,43 @@ describe('deviceCode', () => {
     }
   })
 
+  test('behavior: retries while an approved response is being persisted', async () => {
+    const host = createDeviceCodeHost()
+    const server = await createServer(host.listener)
+    let intercepted = false
+
+    try {
+      const provider = createProvider({
+        fetch: async (input, init) => {
+          const url = input instanceof Request ? input.url : String(input)
+          if (!intercepted && url.endsWith('/token')) {
+            intercepted = true
+            return Response.json(
+              {
+                error: 'server_error',
+                error_description: 'approved but no response queued',
+              },
+              { status: 500 },
+            )
+          }
+          return await fetch(input, init)
+        },
+        url: `${server.url}/auth/device`,
+      })
+
+      const result = await provider.request(connectRequest())
+
+      expect({ address: result.accounts[0]?.address, intercepted }).toMatchInlineSnapshot(`
+        {
+          "address": "${root.address}",
+          "intercepted": true,
+        }
+      `)
+    } finally {
+      await server.closeAsync()
+    }
+  })
+
   test('behavior: times out while waiting for authorization', async () => {
     const host = createDeviceCodeHost({ pollingInterval: 10 })
     const server = await createServer(host.listener)

--- a/src/core/adapters/deviceCode/deviceCode.localnet.test.ts
+++ b/src/core/adapters/deviceCode/deviceCode.localnet.test.ts
@@ -155,17 +155,17 @@ describe('deviceCode', () => {
     }
   })
 
-  test('behavior: retries while an approved response is being persisted', async () => {
+  test('behavior: keeps retrying while an approved response is being persisted', async () => {
     const host = createDeviceCodeHost()
     const server = await createServer(host.listener)
-    let intercepted = false
+    let pendingApprovalResponses = 0
 
     try {
       const provider = createProvider({
         fetch: async (input, init) => {
           const url = input instanceof Request ? input.url : String(input)
-          if (!intercepted && url.endsWith('/token')) {
-            intercepted = true
+          if (pendingApprovalResponses < 3 && url.endsWith('/token')) {
+            pendingApprovalResponses++
             return Response.json(
               {
                 error: 'server_error',
@@ -181,10 +181,11 @@ describe('deviceCode', () => {
 
       const result = await provider.request(connectRequest())
 
-      expect({ address: result.accounts[0]?.address, intercepted }).toMatchInlineSnapshot(`
+      expect({ address: result.accounts[0]?.address, pendingApprovalResponses })
+        .toMatchInlineSnapshot(`
         {
           "address": "${root.address}",
-          "intercepted": true,
+          "pendingApprovalResponses": 3,
         }
       `)
     } finally {

--- a/src/core/adapters/deviceCode/deviceCode.ts
+++ b/src/core/adapters/deviceCode/deviceCode.ts
@@ -1,6 +1,7 @@
 import { Provider as core_Provider } from 'ox'
 import { DeviceCode, Transport, Wata, deviceCode as core_deviceCode } from 'wata'
 
+import { normalizePendingApprovalResponse } from '../../../internal/deviceCode.js'
 import type * as Adapter from '../../Adapter.js'
 import type * as Keystore from '../../Keystore.js'
 import { fromRequest } from '../internal/fromRequest.js'
@@ -92,21 +93,7 @@ export function deviceCode(options: deviceCode.Options): Adapter.Adapter {
 function retryPendingApproval(fetch: typeof globalThis.fetch): typeof globalThis.fetch {
   return async (input, init) => {
     const response = await fetch(input, init)
-    if (response.status !== 500) return response
-
-    const body = (await response
-      .clone()
-      .json()
-      .catch(() => undefined)) as { error?: unknown; error_description?: unknown } | undefined
-    if (
-      body?.error !== 'server_error' ||
-      body.error_description !== 'approved but no response queued'
-    )
-      return response
-
-    const headers = new Headers(response.headers)
-    headers.delete('content-length')
-    return Response.json({ error: 'authorization_pending' }, { headers, status: 400 })
+    return await normalizePendingApprovalResponse(response)
   }
 }
 

--- a/src/core/adapters/deviceCode/deviceCode.ts
+++ b/src/core/adapters/deviceCode/deviceCode.ts
@@ -46,7 +46,7 @@ export function deviceCode(options: deviceCode.Options): Adapter.Adapter {
       const wata = Wata.create({
         transports: [
           core_deviceCode({
-            ...(fetch !== undefined ? { fetch } : {}),
+            fetch: retryPendingApproval(fetch ?? globalThis.fetch.bind(globalThis)),
             ...(meta ? { meta } : {}),
             ...(pollingInterval !== undefined ? { pollingInterval } : {}),
             url,
@@ -87,6 +87,27 @@ export function deviceCode(options: deviceCode.Options): Adapter.Adapter {
       }
     },
   })
+}
+
+function retryPendingApproval(fetch: typeof globalThis.fetch): typeof globalThis.fetch {
+  return async (input, init) => {
+    const response = await fetch(input, init)
+    if (response.status !== 500) return response
+
+    const body = (await response
+      .clone()
+      .json()
+      .catch(() => undefined)) as { error?: unknown; error_description?: unknown } | undefined
+    if (
+      body?.error !== 'server_error' ||
+      body.error_description !== 'approved but no response queued'
+    )
+      return response
+
+    const headers = new Headers(response.headers)
+    headers.delete('content-length')
+    return Response.json({ error: 'authorization_pending' }, { headers, status: 400 })
+  }
 }
 
 export declare namespace deviceCode {

--- a/src/internal/deviceCode.test.ts
+++ b/src/internal/deviceCode.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vp/test'
+
+import { normalizePendingApprovalResponse } from './deviceCode.js'
+
+describe('normalizePendingApprovalResponse', () => {
+  test('default: converts the exact transient persistence error into a pending response', async () => {
+    const response = Response.json(
+      {
+        error: 'server_error',
+        error_description: 'approved but no response queued',
+      },
+      {
+        headers: { 'content-length': '999', 'x-request-id': 'approval-race' },
+        status: 500,
+      },
+    )
+
+    const normalized = await normalizePendingApprovalResponse(response)
+
+    expect({
+      body: await normalized.json(),
+      contentLength: normalized.headers.get('content-length'),
+      requestId: normalized.headers.get('x-request-id'),
+      status: normalized.status,
+    }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "authorization_pending",
+        },
+        "contentLength": null,
+        "requestId": "approval-race",
+        "status": 400,
+      }
+    `)
+  })
+
+  test.each([
+    {
+      name: 'a different status',
+      response: () =>
+        Response.json(
+          {
+            error: 'server_error',
+            error_description: 'approved but no response queued',
+          },
+          { status: 503 },
+        ),
+    },
+    {
+      name: 'a different error code',
+      response: () =>
+        Response.json(
+          {
+            error: 'temporarily_unavailable',
+            error_description: 'approved but no response queued',
+          },
+          { status: 500 },
+        ),
+    },
+    {
+      name: 'a different error description',
+      response: () =>
+        Response.json(
+          {
+            error: 'server_error',
+            error_description: 'provider unavailable',
+          },
+          { status: 500 },
+        ),
+    },
+    {
+      name: 'a non-JSON response',
+      response: () => new Response('provider unavailable', { status: 500 }),
+    },
+  ])('behavior: preserves $name', async ({ response }) => {
+    const original = response()
+
+    const normalized = await normalizePendingApprovalResponse(original)
+
+    expect(normalized).toBe(original)
+  })
+})

--- a/src/internal/deviceCode.ts
+++ b/src/internal/deviceCode.ts
@@ -1,0 +1,23 @@
+/**
+ * Converts Wata's transient approved-without-response state into the device-code
+ * polling signal understood by RFC 8628 consumers.
+ *
+ * @internal
+ */
+export async function normalizePendingApprovalResponse(response: Response): Promise<Response> {
+  if (response.status !== 500) return response
+
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => undefined)) as { error?: unknown; error_description?: unknown } | undefined
+  if (
+    body?.error !== 'server_error' ||
+    body.error_description !== 'approved but no response queued'
+  )
+    return response
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return Response.json({ error: 'authorization_pending' }, { headers, status: 400 })
+}

--- a/src/server/internal/handlers/deviceCode.test.ts
+++ b/src/server/internal/handlers/deviceCode.test.ts
@@ -1,15 +1,18 @@
 import { Base64, Bytes, Hash } from 'ox'
 import { describe, expect, test, vi } from 'vp/test'
+import { Store } from 'wata/host'
 
 import { deviceCode } from './deviceCode.js'
 
 const verifier = 'test-device-code-verifier-0123456789'
 
-function createHandler(validate = vi.fn(() => undefined)) {
+function createHandler(options: { store?: Store.Store | undefined } = {}) {
+  const validate = vi.fn(() => undefined)
   return {
     handler: deviceCode({
       html: { render: () => new Response('verify') },
       pollingInterval: 1,
+      ...(options.store ? { store: options.store } : {}),
       validate,
     }),
     validate,
@@ -129,6 +132,67 @@ describe('deviceCode', () => {
               },
               "id": 1,
               "jsonrpc": "2.0",
+            },
+          ],
+          "type": "rpc-responses",
+        },
+        "status": 200,
+      }
+    `)
+  })
+
+  test('behavior: keeps polls pending while an approved response is being persisted', async () => {
+    const backing = Store.memory()
+    const responseWrite = Promise.withResolvers<void>()
+    const resumeWrite = Promise.withResolvers<void>()
+    const store = Store.from({
+      delete: (key: string) => backing.delete(key),
+      async get<value = unknown>(key: string) {
+        const value = await backing.get<value>(key)
+        return value === undefined ? undefined : structuredClone(value)
+      },
+      async set(key: string, value: unknown, options?: { ttl?: number | undefined }) {
+        if (
+          key.startsWith('device:') &&
+          value !== null &&
+          typeof value === 'object' &&
+          'response' in value
+        ) {
+          responseWrite.resolve()
+          await resumeWrite.promise
+        }
+        await backing.set(key, structuredClone(value), options)
+      },
+    })
+    const { handler } = createHandler({ store })
+    const registered = await register(handler)
+
+    const verification = verify(handler, registered.user_code, { id: 1, result: '0x1' })
+    await responseWrite.promise
+
+    try {
+      await expect(token(handler, registered.device_code)).resolves.toMatchInlineSnapshot(`
+        {
+          "body": {
+            "error": "authorization_pending",
+          },
+          "status": 400,
+        }
+      `)
+    } finally {
+      resumeWrite.resolve()
+    }
+    await expect(verification.then((response) => response.status)).resolves.toMatchInlineSnapshot(
+      `200`,
+    )
+    await expect(token(handler, registered.device_code)).resolves.toMatchInlineSnapshot(`
+      {
+        "body": {
+          "payload": [
+            {
+              "id": 1,
+              "jsonrpc": "2.0",
+              "result": "0x1",
             },
           ],
           "type": "rpc-responses",

--- a/src/server/internal/handlers/deviceCode.test.ts
+++ b/src/server/internal/handlers/deviceCode.test.ts
@@ -171,13 +171,33 @@ describe('deviceCode', () => {
     await responseWrite.promise
 
     try {
-      await expect(token(handler, registered.device_code)).resolves.toMatchInlineSnapshot(`
-        {
-          "body": {
-            "error": "authorization_pending",
+      await expect(
+        Promise.all([
+          token(handler, registered.device_code),
+          token(handler, registered.device_code),
+          token(handler, registered.device_code),
+        ]),
+      ).resolves.toMatchInlineSnapshot(`
+        [
+          {
+            "body": {
+              "error": "authorization_pending",
+            },
+            "status": 400,
           },
-          "status": 400,
-        }
+          {
+            "body": {
+              "error": "authorization_pending",
+            },
+            "status": 400,
+          },
+          {
+            "body": {
+              "error": "authorization_pending",
+            },
+            "status": 400,
+          },
+        ]
       `)
     } finally {
       resumeWrite.resolve()

--- a/src/server/internal/handlers/deviceCode.ts
+++ b/src/server/internal/handlers/deviceCode.ts
@@ -159,7 +159,12 @@ export function deviceCode(options: deviceCode.Options): Handler {
       }
     })
 
-    return await normalizeRegisterResponse(await wata.fetch(request), request, path)
+    const response = await wata.fetch(request)
+    return await normalizeRegisterResponse(
+      await retryPendingApproval(response, request, path),
+      request,
+      path,
+    )
   })
 
   return router
@@ -226,6 +231,24 @@ function normalizeStore(store: Store.Store): Store.Store {
       ? { take: <value = unknown>(name: string) => store.take!<value>(key(name)) }
       : {}),
   })
+}
+
+async function retryPendingApproval(response: Response, request: Request, path: string) {
+  if (response.status !== 500 || new URL(request.url).pathname !== `${path}/token`) return response
+
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => undefined)) as { error?: unknown; error_description?: unknown } | undefined
+  if (
+    body?.error !== 'server_error' ||
+    body.error_description !== 'approved but no response queued'
+  )
+    return response
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return Response.json({ error: 'authorization_pending' }, { headers, status: 400 })
 }
 
 async function normalizeRegisterResponse(response: Response, request: Request, path: string) {

--- a/src/server/internal/handlers/deviceCode.ts
+++ b/src/server/internal/handlers/deviceCode.ts
@@ -1,6 +1,7 @@
 import { type DeviceCode, Store, Wata, deviceCode as core_deviceCode } from 'wata/host'
 import * as z from 'zod/mini'
 
+import { normalizePendingApprovalResponse } from '../../../internal/deviceCode.js'
 import { type Handler, from } from '../../Handler.js'
 
 const maxVerifyBodyBytes = 65_536
@@ -160,11 +161,11 @@ export function deviceCode(options: deviceCode.Options): Handler {
     })
 
     const response = await wata.fetch(request)
-    return await normalizeRegisterResponse(
-      await retryPendingApproval(response, request, path),
-      request,
-      path,
-    )
+    const pending =
+      new URL(request.url).pathname === `${path}/token`
+        ? await normalizePendingApprovalResponse(response)
+        : response
+    return await normalizeRegisterResponse(pending, request, path)
   })
 
   return router
@@ -231,24 +232,6 @@ function normalizeStore(store: Store.Store): Store.Store {
       ? { take: <value = unknown>(name: string) => store.take!<value>(key(name)) }
       : {}),
   })
-}
-
-async function retryPendingApproval(response: Response, request: Request, path: string) {
-  if (response.status !== 500 || new URL(request.url).pathname !== `${path}/token`) return response
-
-  const body = (await response
-    .clone()
-    .json()
-    .catch(() => undefined)) as { error?: unknown; error_description?: unknown } | undefined
-  if (
-    body?.error !== 'server_error' ||
-    body.error_description !== 'approved but no response queued'
-  )
-    return response
-
-  const headers = new Headers(response.headers)
-  headers.delete('content-length')
-  return Response.json({ error: 'authorization_pending' }, { headers, status: 400 })
 }
 
 async function normalizeRegisterResponse(response: Response, request: Request, path: string) {


### PR DESCRIPTION
## Motivation

Device-code approval can become visible before its RPC response finishes persisting. A token poll in that window receives `approved but no response queued` as a terminal 500 and aborts an otherwise successful wallet connection.

## Summary

- Treat the exact approved-without-response state as `authorization_pending` in the device-code client adapter
- Apply the same normalization in the hosted device-code handler
- Add client and persistence-delayed server regressions plus a patch changeset

## Key design considerations

- Match only the exact Wata partial-state error; preserve every other 5xx response
- Reuse the existing polling cadence and overall timeout so retries remain bounded
- Cover older hosts and newer Accounts-hosted handlers independently