### PR TITLE
chore: add wata changeset

### DIFF
--- a/.changeset/calm-ravens-wait.md
+++ b/.changeset/calm-ravens-wait.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Updated `wata` to 0.4.1.


### PR DESCRIPTION
Adds the missing patch changeset for the Wata `0.4.1` dependency update merged in https://github.com/tempoxyz/accounts/pull/794.
