### PR TITLE
feat: add MACH deposit intent

### DIFF
--- a/.changeset/fuzzy-lions-buy.md
+++ b/.changeset/fuzzy-lions-buy.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Added the `mach` wallet deposit intent.

--- a/site/src/pages/docs/rpc/wallet_deposit.mdx
+++ b/site/src/pages/docs/rpc/wallet_deposit.mdx
@@ -24,7 +24,7 @@ type Request = {
     /** Display name shown in the deposit UI (e.g. the app name). */
     displayName?: string
     /** Preferred funding path to show first. */
-    intent?: 'applePay' | 'credits' | 'crypto' | 'faucet' | 'referralCode' | 'x'
+    intent?: 'applePay' | 'credits' | 'crypto' | 'faucet' | 'mach' | 'referralCode' | 'x'
     /** Token contract address to pre-fill. Omit to let the user choose. */
     token?: `0x${string}`
     /** Human-readable amount to pre-fill (e.g. `"1.5"`). */
@@ -48,12 +48,13 @@ type Response = {
 
 ## Example
 
+Request the wallet's MACH purchase path with the `mach` intent.
+
 ```ts
 const result = await provider.request({
   method: 'wallet_deposit',
   params: [{
-    token: '0x20c0000000000000000000000000000000000001',
-    value: '10',
+    intent: 'mach',
   }],
 })
 ```

--- a/src/core/Schema.test-d.ts
+++ b/src/core/Schema.test-d.ts
@@ -214,6 +214,15 @@ describe('Encoded', () => {
               amount?: string | undefined
               chainId?: Hex | undefined
               displayName?: string | undefined
+              intent?:
+                | 'applePay'
+                | 'credits'
+                | 'crypto'
+                | 'faucet'
+                | 'mach'
+                | 'referralCode'
+                | 'x'
+                | undefined
               token?: Hex | string | undefined
             },
           ]

--- a/src/core/zod/request.test.ts
+++ b/src/core/zod/request.test.ts
@@ -115,13 +115,14 @@ describe('validate', () => {
     `)
   })
 
-  test('default: validates wallet_deposit with amount and token symbol', () => {
+  test('default: validates wallet_deposit with MACH intent and pre-filled fields', () => {
     const result = RpcRequest.validate(Schema.Request, {
       method: 'wallet_deposit',
       params: [
         {
           amount: '50',
           displayName: 'DoorDash',
+          intent: 'mach',
           token: 'USDC',
         },
       ],
@@ -133,6 +134,7 @@ describe('validate', () => {
           {
             "amount": "50",
             "displayName": "DoorDash",
+            "intent": "mach",
             "token": "USDC",
           },
         ],

--- a/src/core/zod/rpc.ts
+++ b/src/core/zod/rpc.ts
@@ -1021,6 +1021,7 @@ export namespace wallet_deposit {
                 z.literal('credits'),
                 z.literal('crypto'),
                 z.literal('faucet'),
+                z.literal('mach'),
                 z.literal('referralCode'),
                 z.literal('x'),
               ]),


### PR DESCRIPTION
## Why

Apps need a typed way to request the Wallet-hosted MACH funding path through wallet_deposit.

## What

- Accept mach as a wallet_deposit intent.
- Cover the public type and runtime decoder.
- Document the request and add a patch changeset.