### PR TITLE
chore: update GitHub STS action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: changesets
 


### PR DESCRIPTION
## Summary

- Pin the GitHub STS action to `8819cf80bdcb39c36c34700e3f2ecc08bde54f23`.
- Route post-job token revocation through STS so GitHub and the D1 ownership ledger are updated together.
- Retain the action’s direct GitHub revocation fallback and ledger reconciliation.

Previous action revisions revoked tokens directly at GitHub, leaving their STS rows marked active until expiration. This pin includes tempoxyz/gh-actions#73 and the paired tempoxyz/github-sts#39 service behavior.

## Validation

- `actionlint` on the changed workflows
- `git diff --check`