### PR TITLE
fix: use chain-aware SIWE verification clients

### DIFF
--- a/.changeset/siwe-chain-client.md
+++ b/.changeset/siwe-chain-client.md
@@ -1,0 +1,11 @@
+---
+"accounts": minor
+---
+
+Added chain-aware SIWE signature verification and surfaced RPC failures separately from invalid signatures.
+
+```ts
+Handler.auth({
+  getClient: (chainId) => clients.get(chainId)!,
+})
+```

--- a/.changeset/siwe-chain-client.md
+++ b/.changeset/siwe-chain-client.md
@@ -1,5 +1,5 @@
 ---
-"accounts": minor
+"accounts": patch
 ---
 
 Added chain-aware SIWE signature verification and surfaced RPC failures separately from invalid signatures.

--- a/src/server/internal/handlers/auth.test.ts
+++ b/src/server/internal/handlers/auth.test.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono'
-import { Secp256k1 } from 'ox'
+import { P256, Secp256k1 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { hashMessage } from 'viem'
+import { createClient, custom, hashMessage } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { parseSiweMessage } from 'viem/siwe'
+import { Account } from 'viem/tempo'
+import { tempoModerato } from 'viem/tempo/chains'
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vp/test'
 
 import { createServer } from '../../../../test/utils.js'
@@ -341,6 +343,88 @@ describe('verify (EOA, cookie mode)', () => {
     expect(await res.json()).toMatchInlineSnapshot(`
       {
         "error": "signature does not match address",
+      }
+    `)
+  })
+
+  test('resolves the verification client from the challenge chain', async () => {
+    const account = Account.fromHeadlessWebAuthn(P256.randomPrivateKey(), {
+      origin: 'http://wallet.example',
+      rpId: 'wallet.example',
+    })
+    const client = createClient({
+      chain: tempoModerato,
+      transport: custom({
+        request: async () => {
+          throw new Error('RPC unavailable')
+        },
+      }),
+    })
+    let chainId_seen: number | undefined
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await (async () => {
+      try {
+        const { app } = setup({
+          getClient: (chainId) => {
+            chainId_seen = chainId
+            return client
+          },
+        })
+        const { body: challengeBody } = await getChallenge(app, {
+          chainId: tempoModerato.id,
+        })
+        const message = challengeBody.message!
+        const signature = await account.signMessage({ message })
+        const res = await postVerify(app, { address: account.address, message, signature })
+
+        return {
+          body: await res.json(),
+          chainId: chainId_seen,
+          logs: log.mock.calls.map(([message]) => message),
+          status: res.status,
+        }
+      } finally {
+        log.mockRestore()
+      }
+    })()
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "signature verification unavailable",
+        },
+        "chainId": 42431,
+        "logs": [
+          "[accounts/auth] signature verification dependency failed",
+        ],
+        "status": 502,
+      }
+    `)
+  })
+
+  test('keeps malformed signatures as authentication errors', async () => {
+    let clientCalled = false
+    const { app } = setup({
+      getClient: () => {
+        clientCalled = true
+        throw new Error('unexpected client resolution')
+      },
+    })
+    const { body: challengeBody } = await getChallenge(app, { chainId: 1 })
+    const message = challengeBody.message!
+    const res = await postVerify(app, {
+      address: account.address,
+      message,
+      signature: '0xdeadbeef',
+    })
+
+    expect({ body: await res.json(), clientCalled, status: res.status }).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "error": "invalid signature",
+        },
+        "clientCalled": false,
+        "status": 401,
       }
     `)
   })

--- a/src/server/internal/handlers/auth.ts
+++ b/src/server/internal/handlers/auth.ts
@@ -1,6 +1,6 @@
 import { Hex } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
-import type { Address, Transport } from 'viem'
+import type { Address, Client, Transport } from 'viem'
 import { createClient, hashMessage, http, zeroAddress } from 'viem'
 import { verifyHash, verifyMessage } from 'viem/actions'
 import { createSiweMessage, generateSiweNonce, parseSiweMessage } from 'viem/siwe'
@@ -156,6 +156,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     cookie = true,
     cookieName = defaults.cookieName,
     domain,
+    getClient: getClient_option,
     identity = {},
     onAuthenticate,
     path = '/',
@@ -203,6 +204,7 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
   const resolveReqOrigin = (req: Request) => resolveOrigin(req, { pinnedOrigin, trustProxy })
 
   const client = createClient({ chain: tempo, transport })
+  const getClient = getClient_option ?? (() => client)
 
   const router = from(rest)
   const verifyPath = path === '/' ? '/' : path
@@ -301,26 +303,41 @@ export function auth(options: auth.Options = {}): auth.ReturnType {
     //     message. Tempo's chain override unwraps `SignatureEnvelope` for
     //     WebAuthn / P256 / keychain sigs and falls back to ECDSA for EOAs.
     let valid: boolean
-    try {
-      if (keyAuthorization) {
+    if (keyAuthorization) {
+      try {
         const decoded = KeyAuthorization.deserialize(keyAuthorization)
         if (!decoded.signature) return c.json({ error: 'key authorization missing signature' }, 400)
         if (Number(decoded.chainId) !== challenge.chainId)
           return c.json({ error: 'chainId mismatch' }, 400)
         if (!decoded.witness || decoded.witness !== hashMessage(message))
           return c.json({ error: 'witness mismatch' }, 401)
-        valid = await verifyHash(client, {
-          address,
-          hash: KeyAuthorization.getSignPayload(decoded),
-          signature: SignatureEnvelope.serialize(decoded.signature, {
-            magic: decoded.signature.type === 'webAuthn',
-          }),
-        })
-      } else {
-        valid = await verifyMessage(client, { address, message, signature })
+        try {
+          valid = await verifyHash(getClient(challenge.chainId), {
+            address,
+            hash: KeyAuthorization.getSignPayload(decoded),
+            signature: SignatureEnvelope.serialize(decoded.signature, {
+              magic: decoded.signature.type === 'webAuthn',
+            }),
+          })
+        } catch (error) {
+          console.error('[accounts/auth] signature verification dependency failed', error)
+          return c.json({ error: 'signature verification unavailable' }, 502)
+        }
+      } catch {
+        return c.json({ error: 'invalid signature' }, 401)
       }
-    } catch {
-      return c.json({ error: 'invalid signature' }, 401)
+    } else {
+      try {
+        SignatureEnvelope.deserialize(signature)
+      } catch {
+        return c.json({ error: 'invalid signature' }, 401)
+      }
+      try {
+        valid = await verifyMessage(getClient(challenge.chainId), { address, message, signature })
+      } catch (error) {
+        console.error('[accounts/auth] signature verification dependency failed', error)
+        return c.json({ error: 'signature verification unavailable' }, 502)
+      }
     }
     if (!valid) return c.json({ error: 'signature does not match address' }, 401)
 
@@ -470,6 +487,8 @@ export declare namespace auth {
     cookieName?: string | undefined
     /** Domain echoed into challenge messages. @default request `Host` header */
     domain?: string | undefined
+    /** Resolves the Viem client used to verify a SIWE signature for its chain. */
+    getClient?: ((chainId: number) => Client) | undefined
     /**
      * OIDC identity verification (verified email), enabled by default. A verify
      * request carrying an `idToken` is checked against the issuer's JWKS, with
@@ -548,10 +567,8 @@ export declare namespace auth {
      */
     store?: Kv.Kv | undefined
     /**
-     * Viem transport for the Tempo client used to verify signatures. The
-     * client is always built against the `tempo` chain — Tempo's
-     * `chain.verifyHash` natively understands `SignatureEnvelope` and
-     * falls back to ECDSA recovery for plain EOAs.
+     * Viem transport for the default Tempo verification client, built with Tempo signature
+     * handling. Ignored when `getClient` is provided.
      * @default `http()`
      */
     transport?: Transport | undefined


### PR DESCRIPTION
Adds a per-chain Viem client resolver to server auth and distinguishes upstream verification failures from invalid signatures. Unblocks https://github.com/tempoxyz/api/pull/1046.
