### PR TITLE
fix: include credentials in identity requests

### DIFF
--- a/.changeset/sour-ducks-include.md
+++ b/.changeset/sour-ducks-include.md
@@ -2,4 +2,4 @@
 'accounts': patch
 ---
 
-Included browser credentials in server-backed WebAuthn ceremonies and OIDC identity token requests.
+Added opt-in browser credentials for server-backed WebAuthn ceremonies and OIDC identity token requests.

--- a/.changeset/sour-ducks-include.md
+++ b/.changeset/sour-ducks-include.md
@@ -1,0 +1,5 @@
+---
+'accounts': patch
+---
+
+Included browser credentials in server-backed WebAuthn ceremonies and OIDC identity token requests.

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -416,7 +416,7 @@ describe('wallet_connect', () => {
   describe('identity + auth', () => {
     afterEach(() => vi.unstubAllGlobals())
 
-    test('includes credentials when minting identity tokens', async () => {
+    test('uses the default credential mode when omitted', async () => {
       let request: RequestInit | undefined
       vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
         request = init
@@ -439,6 +439,43 @@ describe('wallet_connect', () => {
         adapter,
         identity: {
           audience: 'https://console.example.com',
+          issuer: 'https://wallet.example.com/oidc',
+        },
+        storage: Storage.memory(),
+      })
+
+      await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { identity: { email: true } } }],
+      })
+
+      expect(request?.credentials).toMatchInlineSnapshot(`undefined`)
+    })
+
+    test('includes configured credentials when minting identity tokens', async () => {
+      let request: RequestInit | undefined
+      vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
+        request = init
+        return Response.json({
+          idToken: 'eyJhbGciOiJub25lIn0.eyJlbWFpbCI6ImFsaWNlQGV4YW1wbGUuY29tIn0.sig',
+        })
+      })
+
+      const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+        actions: {
+          async createAccount() {
+            return { accounts: [{ address }] }
+          },
+          async loadAccounts() {
+            return { accounts: [{ address }] }
+          },
+        },
+      }))
+      const provider = Provider.create({
+        adapter,
+        identity: {
+          audience: 'https://console.example.com',
+          credentials: 'include',
           issuer: 'https://wallet.example.com/oidc',
         },
         storage: Storage.memory(),

--- a/src/core/Provider.test.ts
+++ b/src/core/Provider.test.ts
@@ -416,6 +416,42 @@ describe('wallet_connect', () => {
   describe('identity + auth', () => {
     afterEach(() => vi.unstubAllGlobals())
 
+    test('includes credentials when minting identity tokens', async () => {
+      let request: RequestInit | undefined
+      vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
+        request = init
+        return Response.json({
+          idToken: 'eyJhbGciOiJub25lIn0.eyJlbWFpbCI6ImFsaWNlQGV4YW1wbGUuY29tIn0.sig',
+        })
+      })
+
+      const adapter = Adapter.define({ name: 'Test Wallet', rdns: 'com.example.test' }, () => ({
+        actions: {
+          async createAccount() {
+            return { accounts: [{ address }] }
+          },
+          async loadAccounts() {
+            return { accounts: [{ address }] }
+          },
+        },
+      }))
+      const provider = Provider.create({
+        adapter,
+        identity: {
+          audience: 'https://console.example.com',
+          issuer: 'https://wallet.example.com/oidc',
+        },
+        storage: Storage.memory(),
+      })
+
+      await provider.request({
+        method: 'wallet_connect',
+        params: [{ capabilities: { identity: { email: true } } }],
+      })
+
+      expect(request?.credentials).toMatchInlineSnapshot(`"include"`)
+    })
+
     test('behavior: forwards identity.idToken into the auth verify request body', async () => {
       // Capture the body POSTed to the verify endpoint. The challenge endpoint
       // echoes the SDK-sent chainId into a valid SIWE message so the SDK's

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -2329,6 +2329,7 @@ async function mintIdentity(
       ...(body.nonce ? { nonce: body.nonce } : {}),
       subject: body.subject,
     }),
+    credentials: 'include',
     headers: { 'content-type': 'application/json' },
     method: 'POST',
   })

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -1475,8 +1475,10 @@ export function create(options: create.Options = {}): create.ReturnType {
                         const nonce =
                           (typeof email === 'object' ? email.nonce : undefined) ??
                           (auth ? parseAuthNonce(auth.message) : undefined)
-                        return await mintIdentity(options.identity.issuer, {
+                        return await mintIdentity({
                           audience,
+                          credentials: options.identity.credentials,
+                          issuer: options.identity.issuer,
                           nonce,
                           subject: accountAddress,
                         }).catch(() => undefined)
@@ -1955,6 +1957,8 @@ export declare namespace create {
       | {
           /** Audience (`aud`) bound into minted tokens. @default `location.origin` */
           audience?: string | undefined
+          /** Credential mode for token requests. @default "same-origin" */
+          credentials?: RequestCredentials | undefined
           /** OIDC issuer whose `/token` route mints the id token. */
           issuer: string
         }
@@ -2319,17 +2323,21 @@ function parseAuthNonce(message: string) {
  * without a wallet host, so the provider mints the token itself when
  * configured (see `create.Options.identity`).
  */
-async function mintIdentity(
-  issuer: string,
-  body: { audience: string; nonce?: string | undefined; subject: string },
-): Promise<{ email: string | null; idToken: string }> {
+async function mintIdentity(options: {
+  audience: string
+  credentials?: RequestCredentials | undefined
+  issuer: string
+  nonce?: string | undefined
+  subject: string
+}): Promise<{ email: string | null; idToken: string }> {
+  const { audience, credentials, issuer, nonce, subject } = options
   const res = await fetch(`${issuer.replace(/\/+$/, '')}/token`, {
     body: JSON.stringify({
-      audience: body.audience,
-      ...(body.nonce ? { nonce: body.nonce } : {}),
-      subject: body.subject,
+      audience,
+      ...(nonce ? { nonce } : {}),
+      subject,
     }),
-    credentials: 'include',
+    ...(credentials ? { credentials } : {}),
     headers: { 'content-type': 'application/json' },
     method: 'POST',
   })

--- a/src/core/WebAuthnCeremony.test.ts
+++ b/src/core/WebAuthnCeremony.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as WebAuthnCeremony from './WebAuthnCeremony.js'
+
+afterEach(() => vi.unstubAllGlobals())
 
 describe('from', () => {
   test('default: returns the ceremony', () => {
@@ -168,5 +170,25 @@ describe('local', () => {
     const { options: a } = await ceremony.getAuthenticationOptions()
     const { options: b } = await ceremony.getAuthenticationOptions()
     expect(a.publicKey!.challenge).not.toBe(b.publicKey!.challenge)
+  })
+})
+
+describe('server', () => {
+  test('includes credentials in ceremony requests', async () => {
+    let request: RequestInit | undefined
+    vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
+      request = init
+      return Response.json({ options: {} })
+    })
+
+    const ceremony = WebAuthnCeremony.server({ url: 'https://wallet.example.com/webauthn' })
+    await ceremony.getRegistrationOptions({ name: 'Test' })
+
+    expect({ credentials: request?.credentials, method: request?.method }).toMatchInlineSnapshot(`
+      {
+        "credentials": "include",
+        "method": "POST",
+      }
+    `)
   })
 })

--- a/src/core/WebAuthnCeremony.test.ts
+++ b/src/core/WebAuthnCeremony.test.ts
@@ -174,7 +174,7 @@ describe('local', () => {
 })
 
 describe('server', () => {
-  test('includes credentials in ceremony requests', async () => {
+  test('uses the default credential mode when omitted', async () => {
     let request: RequestInit | undefined
     vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
       request = init
@@ -182,6 +182,22 @@ describe('server', () => {
     })
 
     const ceremony = WebAuthnCeremony.server({ url: 'https://wallet.example.com/webauthn' })
+    await ceremony.getRegistrationOptions({ name: 'Test' })
+
+    expect(request?.credentials).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('includes configured credentials in ceremony requests', async () => {
+    let request: RequestInit | undefined
+    vi.stubGlobal('fetch', async (_input: string | URL, init?: RequestInit) => {
+      request = init
+      return Response.json({ options: {} })
+    })
+
+    const ceremony = WebAuthnCeremony.server({
+      credentials: 'include',
+      url: 'https://wallet.example.com/webauthn',
+    })
     await ceremony.getRegistrationOptions({ name: 'Test' })
 
     expect({ credentials: request?.credentials, method: request?.method }).toMatchInlineSnapshot(`

--- a/src/core/WebAuthnCeremony.ts
+++ b/src/core/WebAuthnCeremony.ts
@@ -172,9 +172,10 @@ export function server(options: server.Options): WebAuthnCeremony {
 
   async function request<returnType>(path: string, body: unknown): Promise<returnType> {
     const response = await fetch(`${url}${path}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
     })
     const json = await response.json()
     if (!response.ok) throw new Error((json as { error?: string }).error ?? 'Request failed')

--- a/src/core/WebAuthnCeremony.ts
+++ b/src/core/WebAuthnCeremony.ts
@@ -168,12 +168,12 @@ export declare namespace local {
  * ```
  */
 export function server(options: server.Options): WebAuthnCeremony {
-  const { url } = options
+  const { credentials, url } = options
 
   async function request<returnType>(path: string, body: unknown): Promise<returnType> {
     const response = await fetch(`${url}${path}`, {
       body: JSON.stringify(body),
-      credentials: 'include',
+      ...(credentials ? { credentials } : {}),
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
     })
@@ -205,6 +205,8 @@ export function server(options: server.Options): WebAuthnCeremony {
 
 export declare namespace server {
   type Options = {
+    /** Credential mode for ceremony requests. @default "same-origin" */
+    credentials?: RequestCredentials | undefined
     /** Base URL of the WebAuthn handler (e.g. `"https://example.com/webauthn"`). */
     url: string
   }


### PR DESCRIPTION
Includes browser credentials in server-backed WebAuthn ceremonies and OIDC identity token requests, allowing trusted cross-origin applications to reuse Wallet sessions.
