### PR TITLE
ci: switch to first-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Preview URL
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        uses: tempoxyz/gh-actions/actions/pr-comment@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           header: deploy-${{ matrix.worker.name }}
           message: |


### PR DESCRIPTION
## Summary

Switches this repository's workflows from third-party actions to the equivalent first-party composites in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions), pinned to a full commit SHA. Inputs and outputs are unchanged unless noted below.

| Before | After |
| --- | --- |
| `marocchino/sticky-pull-request-comment` | [`tempoxyz/gh-actions/actions/pr-comment`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/pr-comment) |

## Notes

- **pr-comment**: comments are matched by an HTML marker derived from `header`, so the first run on an already-open PR posts a fresh comment rather than editing the old one. Subsequent runs update it in place.

## Verification

- `actionlint` and `zizmor` (regular persona, offline) report no new findings after the change (actionlint 3 -> 3, zizmor 11 -> 11).
