### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
           playwright: 'true'
 
       - name: Setup Docker
-        uses: docker/setup-docker-action@b2189fbf2a6592b51fee7cdd93ee2bfaeba733db # v5.1.0
+        uses: tempoxyz/gh-actions/vendor/docker/setup-docker-action@487be2d19b0ba9ae1903143016444ab752c3e939
 
       - name: Resolve Tempo image digest
         if: "!startsWith(matrix.tag, 'http')"


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/487be2d19b0ba9ae1903143016444ab752c3e939/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `docker/setup-docker-action` | [`tempoxyz/gh-actions/vendor/docker/setup-docker-action`](https://github.com/tempoxyz/gh-actions/tree/487be2d19b0ba9ae1903143016444ab752c3e939/vendor/docker/setup-docker-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 3 -> 3, zizmor 11 -> 11).
